### PR TITLE
Refactor pgadmin4 Package to include versions of Postgres as subpackages

### DIFF
--- a/pgadmin4.yaml
+++ b/pgadmin4.yaml
@@ -9,10 +9,10 @@ package:
     runtime:
       - libpq-${{vars.latest-pg-version}}
       - nodejs
+      - postfix
+      - py${{vars.py-version}}-setuptools
       - python-${{vars.py-version}}
       - sudo-rs
-      - postfix
-      - py${{vars.py-version}}-gunicorn
 
 vars:
   py-version: 3.13
@@ -38,10 +38,11 @@ environment:
       - busybox
       - glibc-locale-en
       - krb5-dev
+      - libcap-utils
       - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
-      - libpq-17
+      - libpq-${{vars.latest-pg-version}}
       - libtool
       - make
       - nasm
@@ -52,13 +53,12 @@ environment:
       - postgresql-${{vars.latest-pg-version}}-contrib
       - postgresql-${{vars.latest-pg-version}}-dev
       - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}-dev
       - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-dev
       - rust
       - yarn
       - yasm
       - zlib-dev
-      - libcap-utils
 
 var-transforms:
   - from: ${{package.version}}
@@ -94,7 +94,7 @@ pipeline:
       pip install --upgrade pip
       pip install -r requirements.txt
       pip install sphinx sphinxcontrib-youtube
-      pip install --no-cache-dir gunicorn==22.0.0
+      pip install --no-cache-dir gunicorn
       pip install -r web/regression/requirements.txt
 
       # Build documentation and ignore warnings
@@ -103,36 +103,29 @@ pipeline:
       # Build Python package
       make pip
 
+      # Create the /pgadmin4 directory and copy the source into it
       mkdir -p ${{targets.destdir}}/pgadmin4
       mkdir -p ${{targets.destdir}}/venv
       mkdir -p ${{targets.destdir}}/var/lib/pgadmin
       mkdir -p ${{targets.destdir}}/var/log/pgadmin
 
-      mkdir -p ${{targets.destdir}}/pgadmin4/pgadmin
-      ln -sf ${{targets.destdir}}/pgadmin4/web/pgadmin/utils ${{targets.destdir}}/pgadmin4/pgadmin/utils
-
       # Copy in the code and docs
-      cp -R web/ ${{targets.destdir}}/pgadmin4/
+      cp -R web/* ${{targets.destdir}}/pgadmin4
       cp -R docs/ ${{targets.destdir}}/pgadmin4/
       cp -R venv/ ${{targets.destdir}}/
       cp ./pkg/docker/run_pgadmin.py ${{targets.destdir}}/pgadmin4/
       cp ./pkg/docker/gunicorn_config.py ${{targets.destdir}}/pgadmin4/
       cp ./pkg/docker/entrypoint.sh ${{targets.destdir}}/entrypoint.sh
-      
-      touch ${{targets.destdir}}/pgadmin4/config_distro.py
-      chmod 755 ${{targets.destdir}}/pgadmin4/config_distro.py
 
       # License files
       cp -R ./LICENSE ${{targets.destdir}}/pgadmin4/
       cp -R ./DEPENDENCIES ${{targets.destdir}}/pgadmin4/
 
+      # entrypoint.sh script required files, permissions and path
+      touch ${{targets.destdir}}/pgadmin4/config_distro.py
+      chmod 755 ${{targets.destdir}}/pgadmin4/config_distro.py
       setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python${{vars.py-version}}
-
-      # # sed command causes errors trying to edit .pyc files in pycache
-      # rm -rf ${{targets.destdir}}/pgadmin4/venv/bin/__pycache*
-      # sed -i "s|/home/build|/pgadmin4|g" ${{targets.destdir}}/pgadmin4/venv/bin/*
-      # # allow site-packages
-      # sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/pgadmin4/venv/pyvenv.cfg
+      sed -i '1s|^.*|#!/venv/bin/python|' ${{targets.destdir}}/venv/bin/gunicorn
 
 subpackages:
   - range: pg-versions
@@ -164,15 +157,15 @@ test:
   environment:
     contents:
       packages:
-        - postgresql-17
-        - postgresql-17-client
+        - postgresql-${{vars.latest-pg-version}}
+        - postgresql-${{vars.latest-pg-version}}-client
         - py${{vars.py-version}}-setuptools
         - shadow
         - sudo-rs
         - curl
         - glibc-locale-en
     environment:
-      PYTHONPATH: /pgadmin4/web:/pgadmin4
+      PYTHONPATH: /pgadmin4
       PGADMIN_SETUP_EMAIL: admin@gmail.com
       PGADMIN_SETUP_PASSWORD: admin123
       PGDATA: /tmp/test_db
@@ -191,7 +184,7 @@ test:
       with:
         start: |
           env PATH="/venv/bin:$PATH" \
-           python${{vars.py-version}} /pgadmin4/web/pgAdmin4.py
+           python${{vars.py-version}} /pgadmin4/pgAdmin4.py
         expected_output: |
           Starting pgAdmin 4. Please navigate to http://127.0.0.1:5050 in your browser.
         error_strings: |

--- a/pgadmin4.yaml
+++ b/pgadmin4.yaml
@@ -6,15 +6,17 @@ package:
   copyright:
     - license: PostgreSQL
   dependencies:
-    provides:
-      - pgadmin4=${{package.full-version}}
     runtime:
-      - libpq-17
+      - libpq-${{vars.latest-pg-version}}
       - nodejs
       - python-${{vars.py-version}}
+      - sudo-rs
+      - postfix
+      - py${{vars.py-version}}-gunicorn
 
 vars:
   py-version: 3.13
+  latest-pg-version: 17
 
 data:
   - name: pg-versions
@@ -47,14 +49,16 @@ environment:
       - npm
       - openssl-dev
       - pkgconf-dev
-      - postgresql-17-contrib
-      - postgresql-17-dev
+      - postgresql-${{vars.latest-pg-version}}-contrib
+      - postgresql-${{vars.latest-pg-version}}-dev
       - py${{vars.py-version}}-pip
       - python-${{vars.py-version}}-dev
+      - py${{vars.py-version}}-setuptools
       - rust
       - yarn
       - yasm
       - zlib-dev
+      - libcap-utils
 
 var-transforms:
   - from: ${{package.version}}
@@ -90,6 +94,7 @@ pipeline:
       pip install --upgrade pip
       pip install -r requirements.txt
       pip install sphinx sphinxcontrib-youtube
+      pip install --no-cache-dir gunicorn==22.0.0
       pip install -r web/regression/requirements.txt
 
       # Build documentation and ignore warnings
@@ -99,35 +104,41 @@ pipeline:
       make pip
 
       mkdir -p ${{targets.destdir}}/pgadmin4
+      mkdir -p ${{targets.destdir}}/venv
       mkdir -p ${{targets.destdir}}/var/lib/pgadmin
       mkdir -p ${{targets.destdir}}/var/log/pgadmin
+
+      mkdir -p ${{targets.destdir}}/pgadmin4/pgadmin
+      ln -sf ${{targets.destdir}}/pgadmin4/web/pgadmin/utils ${{targets.destdir}}/pgadmin4/pgadmin/utils
 
       # Copy in the code and docs
       cp -R web/ ${{targets.destdir}}/pgadmin4/
       cp -R docs/ ${{targets.destdir}}/pgadmin4/
-      cp -R venv/ ${{targets.destdir}}/pgadmin4/
+      cp -R venv/ ${{targets.destdir}}/
       cp ./pkg/docker/run_pgadmin.py ${{targets.destdir}}/pgadmin4/
       cp ./pkg/docker/gunicorn_config.py ${{targets.destdir}}/pgadmin4/
       cp ./pkg/docker/entrypoint.sh ${{targets.destdir}}/entrypoint.sh
+      
+      touch ${{targets.destdir}}/pgadmin4/config_distro.py
+      chmod 755 ${{targets.destdir}}/pgadmin4/config_distro.py
 
       # License files
       cp -R ./LICENSE ${{targets.destdir}}/pgadmin4/
       cp -R ./DEPENDENCIES ${{targets.destdir}}/pgadmin4/
 
-      # sed command causes errors trying to edit .pyc files in pycache
-      rm -rf ${{targets.destdir}}/pgadmin4/venv/bin/__pycache*
-      sed -i "s|/home/build|/pgadmin4|g" ${{targets.destdir}}/pgadmin4/venv/bin/*
-      # allow site-packages
-      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/pgadmin4/venv/pyvenv.cfg
+      setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python${{vars.py-version}}
+
+      # # sed command causes errors trying to edit .pyc files in pycache
+      # rm -rf ${{targets.destdir}}/pgadmin4/venv/bin/__pycache*
+      # sed -i "s|/home/build|/pgadmin4|g" ${{targets.destdir}}/pgadmin4/venv/bin/*
+      # # allow site-packages
+      # sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/pgadmin4/venv/pyvenv.cfg
 
 subpackages:
   - range: pg-versions
     name: pgadmin4-pg${{range.key}}
     description: Postgres${{range.key}} version of ${{package.name}}
     dependencies:
-      provider-priority: ${{range.value}}
-      provides:
-        - pgadmin4-pg${{range.key}}
       runtime:
         - postgresql-${{range.key}}-contrib
         - postgresql-${{range.key}}-dev
@@ -161,7 +172,7 @@ test:
         - curl
         - glibc-locale-en
     environment:
-      PYTHONPATH: /pgadmin4
+      PYTHONPATH: /pgadmin4/web:/pgadmin4
       PGADMIN_SETUP_EMAIL: admin@gmail.com
       PGADMIN_SETUP_PASSWORD: admin123
       PGDATA: /tmp/test_db
@@ -179,7 +190,7 @@ test:
       working-directory: /pgadmin4
       with:
         start: |
-          env PATH="/pgadmin4/venv/bin:$PATH" \
+          env PATH="/venv/bin:$PATH" \
            python${{vars.py-version}} /pgadmin4/web/pgAdmin4.py
         expected_output: |
           Starting pgAdmin 4. Please navigate to http://127.0.0.1:5050 in your browser.

--- a/pgadmin4.yaml
+++ b/pgadmin4.yaml
@@ -1,9 +1,7 @@
-# pgAdmin4 17.0 is intended to support PostgreSQL 17.
-# https://github.com/pgadmin-org/pgadmin4/blob/28eb2c0b4bcb229763cb0e160953e15ef9921dd4/Dockerfile#L119-L155
 package:
-  name: pgadmin4-17
+  name: pgadmin4
   version: "8.14"
-  epoch: 1
+  epoch: 0
   description: "pgAdmin is the most popular and feature rich Open Source administration and development platform for PostgreSQL, the most advanced Open Source database in the world."
   copyright:
     - license: PostgreSQL
@@ -11,13 +9,22 @@ package:
     provides:
       - pgadmin4=${{package.full-version}}
     runtime:
-      - python-${{vars.py-version}}
-      - libpq-${{vars.pg-version}}
+      - libpq-17
       - nodejs
+      - python-${{vars.py-version}}
 
 vars:
   py-version: 3.13
-  pg-version: 17
+
+data:
+  - name: pg-versions
+    items:
+      12: '12'
+      13: '13'
+      14: '14'
+      15: '15'
+      16: '16'
+      17: '17'
 
 environment:
   contents:
@@ -32,7 +39,7 @@ environment:
       - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
-      - libpq-${{vars.pg-version}}
+      - libpq-17
       - libtool
       - make
       - nasm
@@ -40,8 +47,8 @@ environment:
       - npm
       - openssl-dev
       - pkgconf-dev
-      - postgresql-${{vars.pg-version}}-contrib
-      - postgresql-${{vars.pg-version}}-dev
+      - postgresql-17-contrib
+      - postgresql-17-dev
       - py${{vars.py-version}}-pip
       - python-${{vars.py-version}}-dev
       - rust
@@ -113,19 +120,41 @@ pipeline:
       # allow site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/pgadmin4/venv/pyvenv.cfg
 
-      # Copy the PG binaries
-      mkdir  -p ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}
-      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_dump ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
-      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_dumpall ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
-      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_restore ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
-      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/psql ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
+subpackages:
+  - range: pg-versions
+    name: pgadmin4-pg${{range.key}}
+    description: Postgres${{range.key}} version of ${{package.name}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - pgadmin4-pg${{range.key}}
+      runtime:
+        - postgresql-${{range.key}}-contrib
+        - postgresql-${{range.key}}-dev
+    pipeline:
+      - name: "Copy PG Binaries"
+        runs: |
+          # Copy the PG binaries
+          mkdir  -p ${{targets.destdir}}/usr/local/pgsql-${{range.key}}
+          ln -sf  /usr/libexec/postgresql${{range.key}}/pg_dump ${{targets.destdir}}/usr/local/pgsql-${{range.key}}/
+          ln -sf  /usr/libexec/postgresql${{range.key}}/pg_dumpall ${{targets.destdir}}/usr/local/pgsql-${{range.key}}/
+          ln -sf  /usr/libexec/postgresql${{range.key}}/pg_restore ${{targets.destdir}}/usr/local/pgsql-${{range.key}}/
+          ln -sf  /usr/libexec/postgresql${{range.key}}/psql ${{targets.destdir}}/usr/local/pgsql-${{range.key}}/
+    test:
+      pipeline:
+        - name: "stat symlink"
+          runs: |
+            stat /usr/local/pgsql-${{range.key}}/pg_dump
+            stat /usr/local/pgsql-${{range.key}}/pg_dumpall
+            stat /usr/local/pgsql-${{range.key}}/pg_restore
+            stat /usr/local/pgsql-${{range.key}}/psql
 
 test:
   environment:
     contents:
       packages:
-        - postgresql-${{vars.pg-version}}
-        - postgresql-${{vars.pg-version}}-client
+        - postgresql-17
+        - postgresql-17-client
         - py${{vars.py-version}}-setuptools
         - shadow
         - sudo-rs
@@ -145,12 +174,6 @@ test:
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
-    - name: "stat symlink"
-      runs: |
-        stat /usr/local/pgsql-${{vars.pg-version}}/pg_dump
-        stat /usr/local/pgsql-${{vars.pg-version}}/pg_dumpall
-        stat /usr/local/pgsql-${{vars.pg-version}}/pg_restore
-        stat /usr/local/pgsql-${{vars.pg-version}}/psql
     - name: "Start pgAdmin4 Server"
       uses: test/daemon-check-output
       working-directory: /pgadmin4

--- a/pgadmin4.yaml
+++ b/pgadmin4.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgadmin4
   version: "8.14"
-  epoch: 0
+  epoch: 2
   description: "pgAdmin is the most popular and feature rich Open Source administration and development platform for PostgreSQL, the most advanced Open Source database in the world."
   copyright:
     - license: PostgreSQL
@@ -194,7 +194,7 @@ test:
       with:
         start: |
           env PATH="/venv/bin:$PATH" \
-           python${{vars.py-version}} /pgAdmin4.py
+           python${{vars.py-version}} pgAdmin4.py
         expected_output: |
           Starting pgAdmin 4. Please navigate to http://127.0.0.1:5050 in your browser.
         error_strings: |

--- a/pgadmin4.yaml
+++ b/pgadmin4.yaml
@@ -56,6 +56,7 @@ environment:
       - py${{vars.py-version}}-setuptools
       - python-${{vars.py-version}}-dev
       - rust
+      - shadow
       - yarn
       - yasm
       - zlib-dev
@@ -109,6 +110,12 @@ pipeline:
       mkdir -p ${{targets.destdir}}/var/lib/pgadmin
       mkdir -p ${{targets.destdir}}/var/log/pgadmin
 
+      # Add the pgadmin user
+      useradd -r -u 5050 -g root -s /sbin/nologin pgadmin
+
+      # Set permissions for directories and files
+      chown -R pgadmin:root ${{targets.destdir}}/var/lib/pgadmin ${{targets.destdir}}/var/log/pgadmin
+
       # Copy in the code and docs
       cp -R web/* ${{targets.destdir}}/pgadmin4
       cp -R docs/ ${{targets.destdir}}/pgadmin4/
@@ -121,11 +128,15 @@ pipeline:
       cp -R ./LICENSE ${{targets.destdir}}/pgadmin4/
       cp -R ./DEPENDENCIES ${{targets.destdir}}/pgadmin4/
 
-      # entrypoint.sh script required files, permissions and path
+      # entrypoint.sh script required files, permissions, and path
       touch ${{targets.destdir}}/pgadmin4/config_distro.py
-      chmod 755 ${{targets.destdir}}/pgadmin4/config_distro.py
-      setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python${{vars.py-version}}
+      chown pgadmin:root ${{targets.destdir}}/pgadmin4/config_distro.py
+
+      # Update the gunicorn binary path
       sed -i '1s|^.*|#!/venv/bin/python|' ${{targets.destdir}}/venv/bin/gunicorn
+
+      # Allow Python to bind to low-numbered ports
+      setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python${{vars.py-version}}
 
 subpackages:
   - range: pg-versions
@@ -133,8 +144,7 @@ subpackages:
     description: Postgres${{range.key}} version of ${{package.name}}
     dependencies:
       runtime:
-        - postgresql-${{range.key}}-contrib
-        - postgresql-${{range.key}}-dev
+        - postgresql-${{range.key}}-client
     pipeline:
       - name: "Copy PG Binaries"
         runs: |
@@ -184,7 +194,7 @@ test:
       with:
         start: |
           env PATH="/venv/bin:$PATH" \
-           python${{vars.py-version}} /pgadmin4/pgAdmin4.py
+           python${{vars.py-version}} /pgAdmin4.py
         expected_output: |
           Starting pgAdmin 4. Please navigate to http://127.0.0.1:5050 in your browser.
         error_strings: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [x] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
