### PR TITLE
Build containerboot wrapper for Tailscale

### DIFF
--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -27,10 +27,12 @@ pipeline:
       deps: golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0
 
   - runs: |
+      ./build_dist.sh tailscale.com/cmd/containerboot
       ./build_dist.sh tailscale.com/cmd/tailscale
       ./build_dist.sh tailscale.com/cmd/tailscaled
 
   - runs: |
+      install -Dm755 containerboot ${{targets.destdir}}/usr/bin/containerboot
       install -Dm755 ${{package.name}} ${{targets.destdir}}/usr/bin/tailscale
       install -Dm755 ${{package.name}}d ${{targets.destdir}}/usr/sbin/tailscaled
 
@@ -51,6 +53,10 @@ test:
         tailscale --help
         tailscaled --version
         tailscaled --help
+    - name: Containerboot Test
+      runs: |
+        containerboot &
+        sleep 2
     - name: Tailscale Daemon Test
       runs: |
         tailscaled -tun=userspace-networking -socket=tailscaled.socket &

--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -1,7 +1,7 @@
 package:
   name: tailscale
   version: 1.78.1
-  epoch: 2
+  epoch: 3
   description: The easiest, most secure way to use WireGuard and 2FA.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Tailscale's upstream image uses the `containerboot` wrapper binary to streamline bringing up Tailscale in container environments.

This PR includes the binary to enable 1:1 entrypoints with the upstream image.

References:
- https://github.com/tailscale/tailscale/blob/de5683f7c61098337fe2825e2febe98b6809b291/Dockerfile#L71
- https://github.com/tailscale/tailscale/blob/de5683f7c61098337fe2825e2febe98b6809b291/build_docker.sh#L39-L55