### PR TITLE
chrony: disable NTS, MAC, MS-NTP unused or requires bootstrap

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: 4.6.1
-  epoch: 2
+  epoch: 3
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -14,10 +14,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gnutls-dev
       - libcap-dev
       - libseccomp-dev
-      - nettle-dev
       - systemd
       - texinfo
       - wolfi-baselayout
@@ -39,7 +37,6 @@ pipeline:
       	--disable-readline \
       	--with-user=chrony \
       	--with-sendmail=/usr/sbin/sendmail \
-      	--enable-ntp-signd \
       	--enable-scfilter
       make all docs
 


### PR DESCRIPTION
NTS, pre-shared MAC keys, MS-NTP allow to configure authenticated time
sources, but they require bootstrap of having accurate time to begin
with (to verify TLS certificates NotBefore/NotAfter) or it requires
sharing symmetric keys (which is impractical for public network
sources).

This is widely unused, as there is no specification on supporting this
with pools, and in public clouds local PTP, local time source over
trusted network, and finally falling back to public time sources is
the current mode of operation.

If need for these protocols arises, we can build a separate
sub-package with support for NTS, MAC, MS-NTP.

This removes 9 runtime dependencies.
