### PR TITLE
ignore non-release versions returned by release-monitor

### DIFF
--- a/ltrace.yaml
+++ b/ltrace.yaml
@@ -49,6 +49,10 @@ subpackages:
 
 update:
   enabled: true
+  # Release monitor started picking up 'dev' releases, from here: https://tracker.debian.org/pkg/ltrace.
+  # They have 'git' in the release, so we're ignoring them here.
+  ignore-regex-patterns:
+    - '.*git.*'
   release-monitor:
     identifier: 117364
 


### PR DESCRIPTION
release-monitor was returning test versions, which don't exist when attempting to download the source archive. Filter out the dev releases, which contain 'git' in the tag name:
- https://release-monitoring.org/project/117364
 - https://tracker.debian.org/pkg/ltrace

No epoch bump needed in this instance.