### PR TITLE
switch to use git: poller and pull source from gitlab

### DIFF
--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -1,6 +1,6 @@
 package:
   name: at-spi2-core
-  version: "2.55.0"
+  version: "2.55.0.1"
   epoch: 0
   description: Protocol definitions and daemon for D-Bus at-spi
   copyright:
@@ -30,10 +30,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 59604b2792fcdcc84db56e59c01ca1deeacb41e405dac3fcb57ada86d6cb122b
-      uri: https://download.gnome.org/sources/at-spi2-core/${{vars.mangled-package-version}}/at-spi2-core-${{package.version}}.tar.xz
+      repository: https://gitlab.gnome.org/GNOME/at-spi2-core
+      expected-commit: c067010874937bae7c01b316eee094fee683271b
+      tag: ${{package.version}}
 
   - uses: meson/configure
     with:
@@ -89,5 +90,18 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 7841
+  git: {}
+
+test:
+  pipeline:
+    - name: Binary and library tests
+      runs: |
+        test -f /usr/libexec/at-spi-bus-launcher
+        test -x /usr/libexec/at-spi-bus-launcher
+        test -f /usr/libexec/at-spi2-registryd
+        test -x /usr/libexec/at-spi2-registryd
+
+        test -f /usr/lib/libatspi.so.0.0.1
+        test -f /usr/lib/libatspi.so.0
+
+        test -d /usr/share/defaults/at-spi2


### PR DESCRIPTION
UpdateBot was failing to poll for updates. Switches to use it poller, as well as fetch source from GitLab