### PR TITLE
Add localstack

### DIFF
--- a/localstack.yaml
+++ b/localstack.yaml
@@ -171,6 +171,7 @@ test:
     contents:
       packages:
         - localstack-compat
+        - nodejs-18
   pipeline:
     - name: Check if Python venv properly installed
       runs: |

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -24,9 +24,9 @@ package:
       - iputils
       - libatomic
       - libexpat1
-      # pixz
+      - pixz
       - make
-      - nodejs #-18
+      - nodejs-18
       - npm
       - nss-passwords
       - openjdk-11-default-jvm
@@ -97,9 +97,9 @@ pipeline:
       # Include system site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
 
-  # - name: Install dependencies
-  #   runs: |
-  #     ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli awscli-local requests
+  - name: Install awslocal
+    runs: |
+      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli-local
 
   - name: Cleanup
     runs: |
@@ -176,6 +176,13 @@ test:
       runs: |
         source /opt/code/localstack/.venv/bin/activate
         python3 -m localstack.runtime.init BOOT
-    - name: Test entrypoint
-      runs: |
-        DEBUG=1 docker-entrypoint.sh
+        localstack --version | grep ${{package.version}}
+        localstack -h
+    - name: "start daemon"
+      uses: test/daemon-check-output
+      with:
+        start: docker-entrypoint.sh
+        timeout: 30
+        expected_output: |
+          LocalStack version
+          Ready

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -24,16 +24,16 @@ package:
       - iputils
       - libatomic
       - libexpat1
-      - pixz
       - make
       - nodejs-18
       - npm
       - nss-passwords
       - openjdk-11-default-jvm
       - openssl
+      - pixz
+      - procps
       - py${{vars.py-version}}-tzdata
       - python-${{vars.py-version}}
-      - procps
       - unzip
       - xz
       - zip

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -31,8 +31,8 @@ environment:
       - nodejs-18
       - npm
       - openssf-compiler-options
-      - py${{vars.py-version}}-pip
       - py${{vars.py-version}}-build
+      - py${{vars.py-version}}-pip
       - py${{vars.py-version}}-pytest
       - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -32,10 +32,12 @@ environment:
       - npm
       - openssf-compiler-options
       - py${{vars.py-version}}-pip
+      - py${{vars.py-version}}-build
       - py${{vars.py-version}}-pytest
       - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}
       - tzdata
+      - uv
 
 pipeline:
   - uses: git-checkout
@@ -46,19 +48,18 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/localstack
-      mkdir -p ${{targets.destdir}}/usr/share/localstack-core
       mkdir -p ${{targets.destdir}}/tmp/localstack
 
   - name: Build
     runs: |
-      make VENV_BIN="python%{{vars.py-version}} -m venv"
-      make install-runtime
-      make dist
+      python${{vars.py-version}} -m build
 
   - runs: |
+      # We use uv here as pip backtracks in resolution
+      uv venv -p python${{vars.py-version}} --seed
+      # Install the wheel from file with the runtime extras
+      uv pip install ./dist/localstack_core-${{package.version}}-py3-none-any.whl[runtime]
       mv .venv ${{targets.destdir}}/usr/share/localstack/
-      cp -avR localstack-core/* ${{targets.destdir}}/usr/share/localstack-core/
-      install -Dm644 pyproject.toml ${{targets.destdir}}/usr/share/localstack/pyproject.toml
 
   - runs: |
       # Fix venv paths
@@ -103,8 +104,6 @@ subpackages:
           for f in localstack localstack-supervisor localstack.bat; do
             ln -sf /usr/bin/$f "${{targets.contextdir}}"/opt/code/localstack/bin/$f
           done
-          ln -sf /usr/share/localstack-core "${{targets.contextdir}}"/opt/code/localstack/localstack-core
-          ln -sf /usr/share/localstack/pyproject.toml "${{targets.contextdir}}"/opt/code/localstack/pyproject.toml
       - name: Symlink Java 11
         runs: |
           mkdir -p "${{targets.contextdir}}"/var/lib/localstack/lib/java/11

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -31,6 +31,8 @@ package:
       - nss-passwords
       - openjdk-11-default-jvm
       - openssl
+      - py${{vars.py-version}}-tzdata
+      - python-${{vars.py-version}}
       - procps
       - unzip
       - xz
@@ -71,14 +73,22 @@ pipeline:
 
   - name: Build
     runs: |
-      python${{vars.py-version}} -m build
       make install-runtime
+      make entrypoints
+      python${{vars.py-version}} -m build
 
   - runs: |
       # We use uv here as pip backtracks in resolution
       uv venv -p python${{vars.py-version}} --seed
       # Install the wheel from file with the runtime extras
       uv pip install ./dist/localstack_core-${{package.version}}-py3-none-any.whl[runtime]
+
+      # copy the entry_points definition into .venv
+      install -m644 ./localstack-core/localstack_core.egg-info/entry_points.txt \
+        .venv/lib/python${{vars.py-version}}/site-packages/localstack_core-${{package.version}}.dist-info/entry_points.txt
+      echo -n "/usr/share/localstack/.venv/lib/python${{vars.py-version}}/site-packages/localstack_core-${{package.version}}.dist-info/entry_points.txt" \
+        >.venv/lib/python${{vars.py-version}}/site-packages/localstack_core-${{package.version}}.dist-info/entry_points_editable.txt
+
       mv .venv ${{targets.destdir}}/usr/share/localstack/
 
   - runs: |
@@ -101,7 +111,7 @@ pipeline:
     working-directory: bin
     runs: |
       mkdir -p "${{targets.contextdir}}"/usr/bin
-      for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+      for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor; do
         install -Dm755 $f ${{targets.contextdir}}/usr/bin/$f
       done
 

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -1,0 +1,133 @@
+package:
+  name: localstack
+  version: 4.0.3
+  epoch: 0
+  description: A fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline
+  copyright:
+    - license: Apache-2.0
+    - license: LicenseRef-LICENSE
+      license-path: LICENSE.txt
+    - license: LicenseRef-EULA
+      license-path: docs/end_user_license_agreement/README.md
+  dependencies:
+    runtime:
+      - corepack
+      - nodejs-18
+      - npm
+      - openjdk-11-default-jvm
+
+vars:
+  py-version: 3.11
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - nodejs-18
+      - npm
+      - openssf-compiler-options
+      - py${{vars.py-version}}-pip
+      - py3-supported-pytest
+      - py3-supported-tz
+      - python-${{vars.py-version}}
+      - tzdata
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/localstack/localstack
+      tag: v${{package.version}}
+      expected-commit: aa795ed1c04a8285c01c96aa7ab79c17489f5766
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/localstack
+      mkdir -p ${{targets.destdir}}/usr/share/localstack-core
+      mkdir -p ${{targets.destdir}}/tmp/localstack
+
+  - name: Build
+    runs: |
+      make install-runtime
+      make dist
+
+  - runs: |
+      mv .venv ${{targets.destdir}}/usr/share/localstack/
+      cp -avR localstack-core/* ${{targets.destdir}}/usr/share/localstack-core/
+      install -Dm644 pyproject.toml ${{targets.destdir}}/usr/share/localstack/pyproject.toml
+
+  - runs: |
+      # Fix venv paths
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share|g"
+      # Include system site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
+
+  # pip3 install --upgrade awscli awscli-local requests
+  - name: Cleanup
+    runs: |
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "*.pyc" -delete
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "__pycache__" -exec rm -rf {} +
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/lib/python${{vars.py-version}}/site-packages/ -type d -name "tests" -exec rm -rf {} +
+
+  - name: Install scripts
+    working-directory: bin
+    runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+        install -Dm755 $f ${{targets.contextdir}}/usr/bin/$f
+      done
+
+  - name: Mark community version
+    runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/lib/localstack
+      echo "${{package.version}} (Built by Chainguard)" > ${{targets.contextdir}}/usr/lib/localstack/.community-version
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - name: Symlink scripts
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+            ln -sf /usr/bin/$f "${{targets.contextdir}}"/usr/local/bin/$f
+          done
+      - name: Symlink binaries and libraries
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/opt/code/localstack/bin
+          ln -sf /usr/share/localstack/.venv "${{targets.contextdir}}"/opt/code/localstack/.venv
+          for f in localstack localstack-supervisor localstack.bat; do
+            ln -sf /usr/bin/$f "${{targets.contextdir}}"/opt/code/localstack/bin/$f
+          done
+          ln -sf /usr/share/localstack-core "${{targets.contextdir}}"/opt/code/localstack/localstack-core
+          ln -sf /usr/share/localstack/pyproject.toml "${{targets.contextdir}}"/opt/code/localstack/pyproject.toml
+      - name: Symlink Java 11
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/var/lib/localstack/lib/java/11
+          for f in bin conf legal lib release; do
+            ln -sf /usr/lib/jvm/java-11-openjdk/$f "${{targets.contextdir}}"/var/lib/localstack/lib/java/11/$f
+          done
+      - name: Symlink Python ${{vars.py-version}}
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/lib
+          ln -sf /usr/lib/python${{vars.py-version}} "${{targets.contextdir}}"/usr/local/lib/python${{vars.py-version}}
+      - name: Symlink Node
+        runs: |
+          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/node
+          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/nodejs
+          ln -sf /usr/bin/npm "${{targets.contextdir}}"/usr/local/bin/npm
+          ln -sf /usr/bin/npx "${{targets.contextdir}}"/usr/local/bin/npx
+          ln -sf /usr/bin/corepack "${{targets.contextdir}}"/usr/local/bin/corepack
+          mkdir -p "${{targets.contextdir}}"/usr/local/include
+          mkdir -p "${{targets.contextdir}}"/usr/local/lib/node_modules
+          ln -sf /usr/include/node "${{targets.contextdir}}"/usr/local/include/node
+          ln -sf /usr/lib/node_modules/npm "${{targets.contextdir}}"/usr/local/lib/node_modules/npm
+          ln -sf /usr/share/node_modules/corepack "${{targets.contextdir}}"/usr/local/lib/node_modules/corepack
+
+update:
+  enabled: true
+  github:
+    identifier: localstack/localstack
+    strip-prefix: v

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -11,11 +11,30 @@ package:
       license-path: docs/end_user_license_agreement/README.md
   dependencies:
     runtime:
+      - binutils
+      - ca-certificates-bundle
       - corepack
+      - coreutils
+      - curl
+      - git
+      - gnupg
+      - gnutar
+      - groff
+      - iproute2
+      - iputils
+      - libatomic
+      - libexpat1
+      # pixz
+      - make
       - nodejs #-18
       - npm
+      - nss-passwords
       - openjdk-11-default-jvm
-      - python-${{vars.py-version}}
+      - openssl
+      - procps
+      - unzip
+      - xz
+      - zip
 
 vars:
   py-version: 3.11
@@ -53,6 +72,7 @@ pipeline:
   - name: Build
     runs: |
       python${{vars.py-version}} -m build
+      make install-runtime
 
   - runs: |
       # We use uv here as pip backtracks in resolution
@@ -63,11 +83,14 @@ pipeline:
 
   - runs: |
       # Fix venv paths
-      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share|g"
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share/${{package.name}}|g"
       # Include system site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
 
-  # pip3 install --upgrade awscli awscli-local requests
+  # - name: Install dependencies
+  #   runs: |
+  #     ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli awscli-local requests
+
   - name: Cleanup
     runs: |
       find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "*.pyc" -delete
@@ -139,6 +162,10 @@ test:
       packages:
         - localstack-compat
   pipeline:
-    - runs: |
+    - name: Check if Python venv properly installed
+      runs: |
         source /opt/code/localstack/.venv/bin/activate
         python3 -m localstack.runtime.init BOOT
+    - name: Test entrypoint
+      runs: |
+        DEBUG=1 docker-entrypoint.sh

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -12,9 +12,10 @@ package:
   dependencies:
     runtime:
       - corepack
-      - nodejs-18
+      - nodejs #-18
       - npm
       - openjdk-11-default-jvm
+      - python-${{vars.py-version}}
 
 vars:
   py-version: 3.11
@@ -31,8 +32,8 @@ environment:
       - npm
       - openssf-compiler-options
       - py${{vars.py-version}}-pip
-      - py3-supported-pytest
-      - py3-supported-tz
+      - py${{vars.py-version}}-pytest
+      - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}
       - tzdata
 
@@ -50,6 +51,7 @@ pipeline:
 
   - name: Build
     runs: |
+      make VENV_BIN="python%{{vars.py-version}} -m venv"
       make install-runtime
       make dist
 
@@ -131,3 +133,13 @@ update:
   github:
     identifier: localstack/localstack
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - localstack-compat
+  pipeline:
+    - runs: |
+        source /opt/code/localstack/.venv/bin/activate
+        python3 -m localstack.runtime.init BOOT

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -148,6 +148,24 @@ subpackages:
         runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/lib
           ln -sf /usr/lib/python${{vars.py-version}} "${{targets.contextdir}}"/usr/local/lib/python${{vars.py-version}}
+    test:
+      pipeline:
+        - name: tests for script symlinks
+          runs: |
+            for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor; do
+              stat /usr/local/bin/$f
+            done
+            for f in localstack localstack-supervisor; do
+              stat /opt/code/localstack/bin/$f
+            done
+            for f in bin conf legal lib release; do
+              stat /var/lib/localstack/lib/java/11/$f
+            done
+        - name: test symlinks
+          runs: |
+            stat /opt/code/localstack/.venv
+            stat /usr/local/lib/python${{vars.py-version}}
+            stat /usr/local/lib/python${{vars.py-version}}
 
 update:
   enabled: true

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -70,13 +70,14 @@ pipeline:
 
   - name: Build
     runs: |
-      make install-runtime
-      make entrypoints
       python${{vars.py-version}} -m build
 
   - runs: |
       # We use uv here as pip backtracks in resolution
       uv venv -p python${{vars.py-version}} --seed
+      # install runtime and entrypoints
+      make install-runtime
+      make entrypoints
       # Install the wheel from file with the runtime extras
       uv pip install ./dist/localstack_core-${{package.version}}-py3-none-any.whl[runtime]
       uv pip install awscli-local
@@ -199,6 +200,6 @@ test:
       runs: |
         source /opt/code/localstack/.venv/bin/activate
         docker-entrypoint.sh &
-        sleep 3
+        sleep 5
         curl -s http://localhost:4566/_localstack/health | jq | grep -E 'community|s3'
         localstack status services --format=json | grep -i "available"

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -25,7 +25,6 @@ package:
       - libatomic
       - libexpat1
       - make
-      - nodejs-18
       - npm
       - nss-passwords
       - openjdk-11-default-jvm
@@ -49,8 +48,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - git
-      - nodejs-18
-      - npm
       - openssf-compiler-options
       - py${{vars.py-version}}-build
       - py${{vars.py-version}}-pip
@@ -100,6 +97,9 @@ pipeline:
   - name: Install awslocal
     runs: |
       ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli-local
+      # force reinstall to address cve in previous versions
+      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade --force-reinstall amazon-kclpy cryptography
+      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m localstack.cli.lpm install lambda-runtime
 
   - name: Cleanup
     runs: |
@@ -127,14 +127,14 @@ subpackages:
       - name: Symlink scripts
         runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin
-          for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+          for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor; do
             ln -sf /usr/bin/$f "${{targets.contextdir}}"/usr/local/bin/$f
           done
       - name: Symlink binaries and libraries
         runs: |
           mkdir -p "${{targets.contextdir}}"/opt/code/localstack/bin
           ln -sf /usr/share/localstack/.venv "${{targets.contextdir}}"/opt/code/localstack/.venv
-          for f in localstack localstack-supervisor localstack.bat; do
+          for f in localstack localstack-supervisor; do
             ln -sf /usr/bin/$f "${{targets.contextdir}}"/opt/code/localstack/bin/$f
           done
       - name: Symlink Java 11
@@ -147,18 +147,6 @@ subpackages:
         runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/lib
           ln -sf /usr/lib/python${{vars.py-version}} "${{targets.contextdir}}"/usr/local/lib/python${{vars.py-version}}
-      - name: Symlink Node
-        runs: |
-          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/node
-          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/nodejs
-          ln -sf /usr/bin/npm "${{targets.contextdir}}"/usr/local/bin/npm
-          ln -sf /usr/bin/npx "${{targets.contextdir}}"/usr/local/bin/npx
-          ln -sf /usr/bin/corepack "${{targets.contextdir}}"/usr/local/bin/corepack
-          mkdir -p "${{targets.contextdir}}"/usr/local/include
-          mkdir -p "${{targets.contextdir}}"/usr/local/lib/node_modules
-          ln -sf /usr/include/node "${{targets.contextdir}}"/usr/local/include/node
-          ln -sf /usr/lib/node_modules/npm "${{targets.contextdir}}"/usr/local/lib/node_modules/npm
-          ln -sf /usr/share/node_modules/corepack "${{targets.contextdir}}"/usr/local/lib/node_modules/corepack
 
 update:
   enabled: true
@@ -171,7 +159,6 @@ test:
     contents:
       packages:
         - localstack-compat
-        - nodejs-18
   pipeline:
     - name: Check if Python venv properly installed
       runs: |

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -178,6 +178,7 @@ test:
     contents:
       packages:
         - localstack-compat
+        - jq
   pipeline:
     - name: Check if Python venv properly installed
       runs: |
@@ -185,6 +186,7 @@ test:
         python3 -m localstack.runtime.init BOOT
         localstack --version | grep ${{package.version}}
         localstack -h
+        awslocal --version
     - name: "start daemon"
       uses: test/daemon-check-output
       with:
@@ -193,3 +195,10 @@ test:
         expected_output: |
           LocalStack version
           Ready
+    - name: do some curl tests
+      runs: |
+        source /opt/code/localstack/.venv/bin/activate
+        docker-entrypoint.sh &
+        sleep 3
+        curl -s http://localhost:4566/_localstack/health | jq | grep -E 'community|s3'
+        localstack status services --format=json | grep -i "available"

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -79,6 +79,7 @@ pipeline:
       uv venv -p python${{vars.py-version}} --seed
       # Install the wheel from file with the runtime extras
       uv pip install ./dist/localstack_core-${{package.version}}-py3-none-any.whl[runtime]
+      uv pip install awscli-local
 
       # copy the entry_points definition into .venv
       install -m644 ./localstack-core/localstack_core.egg-info/entry_points.txt \
@@ -88,18 +89,18 @@ pipeline:
 
       mv .venv ${{targets.destdir}}/usr/share/localstack/
 
+  - name: Install lambda-runtime
+    runs: |
+      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m localstack.cli.lpm install lambda-runtime
+
   - runs: |
       # Fix venv paths
       find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share/${{package.name}}|g"
-      # Include system site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
 
-  - name: Install awslocal
-    runs: |
-      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli-local
+  - runs: |
       # force reinstall to address cve in previous versions
       ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade --force-reinstall amazon-kclpy cryptography
-      ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m localstack.cli.lpm install lambda-runtime
 
   - name: Cleanup
     runs: |


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
