### PR TITLE
openjdk: revert to symlink for cacerts

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.25 # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only
@@ -90,9 +90,9 @@ pipeline:
       cp -r build/*-normal-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # copy to shared java cacerts store
+      # symlink to shared java cacerts store
       rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts \
+      ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
@@ -128,9 +128,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # copy to shared java cacerts store
+          # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          cp /etc/ssl/certs/java/cacerts \
+          ln -sf /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.13 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only
@@ -109,9 +109,9 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # copy to shared java cacerts store
+      # symlink to shared java cacerts store
       rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts \
+      ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
@@ -147,9 +147,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # copy to shared java cacerts store
+          # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          cp /etc/ssl/certs/java/cacerts \
+          ln -sf /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.5
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -115,9 +115,9 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # copy to shared java cacerts store
+      # symlink to shared java cacerts store
       rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts \
+      ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
@@ -152,9 +152,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # copy to shared java cacerts store
+          # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          cp /etc/ssl/certs/java/cacerts \
+          ln -sf /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.2
-  epoch: 2
+  epoch: 3
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later
@@ -115,9 +115,9 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # copy to shared java cacerts store
+      # symlink to shared java cacerts store
       rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts \
+      ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
@@ -152,9 +152,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # copy to shared java cacerts store
+          # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          cp /etc/ssl/certs/java/cacerts \
+          ln -sf /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-23
   version: 23.0.1
-  epoch: 2
+  epoch: 3
   description: OpenJDK 23
   copyright:
     - license: GPL-2.0-or-later
@@ -109,9 +109,9 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # copy to shared java cacerts store
+      # symlink to shared java cacerts store
       rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts \
+      ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
@@ -146,9 +146,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # copy to shared java cacerts store
+          # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          cp /etc/ssl/certs/java/cacerts \
+          ln -sf /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)


### PR DESCRIPTION
regression when refactoring for jre split

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
