### PR TITLE
glibc: test 2.41 alone, without any other packages.

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
-  version: 2.40
-  epoch: 4
+  version: 2.41
+  epoch: 0
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -57,10 +57,10 @@ environment:
     GCC_SPEC_FILE: /dev/null
 
 pipeline:
-  - uses: fetch
+  # glibc has no real tag or branch we can use for the 2.41 pre-release
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/libc/glibc-${{package.version}}.tar.xz
-      expected-sha256: 19a890175e9263d748f627993de6f4b1af9cd21e03f080e4bfb3a1fac10205a2
+      repository: https://sourceware.org/git/glibc.git
 
   - uses: patch
     with:


### PR DESCRIPTION
This is only for testing.