### PR TITLE
iproute2: add test for iface add

### DIFF
--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,10 +1,14 @@
 package:
   name: iproute2
   version: 6.12.0
-  epoch: 0
+  epoch: 1
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
+
+capabilities:
+  add:
+    - CAP_NET_ADMIN
 
 environment:
   contents:
@@ -117,3 +121,6 @@ test:
       runs: |
         # Show existing tunnels
         ip tunnel show
+    - name: "Test adding dummy interface"
+      runs: |
+        ip link add dev myinterface type dummy


### PR DESCRIPTION
This PR adds a test for `ip link add` by adding a dummy interface.
Leveraging the capabilities feature brought from Melange v0.19.0 we're able to add the required cap_net_admin capability to the test pipeline.