### PR TITLE
ruby3.x-sin_lru_redux: introduce new packages

### DIFF
--- a/ruby3.2-sin_lru_redux.yaml
+++ b/ruby3.2-sin_lru_redux.yaml
@@ -1,0 +1,114 @@
+package:
+  name: ruby3.2-sin_lru_redux
+  version: 2.5.0
+  epoch: 0
+  description: Efficient and thread-safe LRU cache.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cadenza-tech/sin_lru_redux.git
+      tag: v${{package.version}}
+      expected-commit: 98311965ed78fc2b50001932ad2b528eecba66c5
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: sin_lru_redux
+
+update:
+  enabled: true
+  github:
+    identifier: cadenza-tech/sin_lru_redux
+    strip-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '

--- a/ruby3.3-sin_lru_redux.yaml
+++ b/ruby3.3-sin_lru_redux.yaml
@@ -1,0 +1,114 @@
+package:
+  name: ruby3.3-sin_lru_redux
+  version: 2.5.0
+  epoch: 0
+  description: Efficient and thread-safe LRU cache.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cadenza-tech/sin_lru_redux.git
+      tag: v${{package.version}}
+      expected-commit: 98311965ed78fc2b50001932ad2b528eecba66c5
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: sin_lru_redux
+
+update:
+  enabled: true
+  github:
+    identifier: cadenza-tech/sin_lru_redux
+    strip-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '

--- a/ruby3.4-sin_lru_redux.yaml
+++ b/ruby3.4-sin_lru_redux.yaml
@@ -1,0 +1,114 @@
+package:
+  name: ruby3.4-sin_lru_redux
+  version: 2.5.0
+  epoch: 0
+  description: Efficient and thread-safe LRU cache.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cadenza-tech/sin_lru_redux.git
+      tag: v${{package.version}}
+      expected-commit: 98311965ed78fc2b50001932ad2b528eecba66c5
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: sin_lru_redux
+
+update:
+  enabled: true
+  github:
+    identifier: cadenza-tech/sin_lru_redux
+    strip-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '


### PR DESCRIPTION
Required for the latest version of fluent-plugin-kubernetes_metadata_filter: https://github.com/wolfi-dev/os/pull/39856

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
  - No such policy exists as far as I can tell