### PR TITLE
ruby*-lru_redux: add testing

### DIFF
--- a/ruby3.2-lru_redux.yaml
+++ b/ruby3.2-lru_redux.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-lru_redux
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: An efficient, thread safe LRU cache.
   copyright:
     - license: MIT
@@ -48,3 +48,67 @@ var-transforms:
     match: ^ruby(\d\.\d+)-.*
     replace: $1
     to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '

--- a/ruby3.3-lru_redux.yaml
+++ b/ruby3.3-lru_redux.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-lru_redux
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: An efficient, thread safe LRU cache.
   copyright:
     - license: MIT
@@ -48,3 +48,67 @@ var-transforms:
     match: ^ruby(\d\.\d+)-.*
     replace: $1
     to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '

--- a/ruby3.4-lru_redux.yaml
+++ b/ruby3.4-lru_redux.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-lru_redux
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: An efficient, thread safe LRU cache.
   copyright:
     - license: MIT
@@ -48,3 +48,67 @@ var-transforms:
     match: ^ruby(\d\.\d+)-.*
     replace: $1
     to: rubyMM
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'lru_redux'"
+    - name: Basic functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          # non thread safe
+          cache = LruRedux::Cache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '
+    - name: Basic threadsafe functionality test (adapted from project README)
+      runs: |
+        ruby -e '
+          require "lru_redux"
+
+          cache = LruRedux::ThreadSafeCache.new(100)
+          cache[:a] = "1"
+          cache[:b] = "2"
+
+          raise "Access failed" unless cache.to_a == [[:b, "2"], [:a, "1"]]
+
+          # note the order matters here, last accessed is first
+          cache[:a] # a pushed to front
+          # "1"
+          raise "Access failed" unless cache.to_a == [[:a, "1"], [:b, "2"]]
+
+          cache.delete(:a)
+          raise "Delete failed" unless cache.to_a == [[:b, "2"]]
+
+          cache.max_size = 200 # cache now stores 200 items
+          cache.clear # cache has no items
+
+          cache.getset(:a) { 1 }
+          raise "Getset failed" unless cache.to_a == [[:a, 1]]
+
+          # already set so don"t call block
+          cache.getset(:a) { 99 }
+          raise "Getset unexpectedly updated" unless cache.to_a == [[:a, 1]]
+        '


### PR DESCRIPTION
This is adapted from the README, and is the same as the tests for the `ruby*-sin_lru_redux` (which is a fork of `lru_redux`).