### PR TITLE
fix auto-updates and re-enable. Add tests

### DIFF
--- a/libmilter.yaml
+++ b/libmilter.yaml
@@ -1,6 +1,6 @@
 package:
   name: libmilter
-  version: 1.0.3
+  version: 8.18.1
   epoch: 0
   description: Sendmail Mail Filter API (Milter)
   copyright:
@@ -18,8 +18,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 90f5ae74c35a84808861933ba094201b901b70c6b2903684dcf39bdae8a5a1a2
-      uri: https://ftp.sendmail.org/sendmail.8.17.2.tar.gz
+      expected-sha256: cbf1f309c38e4806f7cf3ead24260f17d1fe8fb63256d13edb3cdd1a098f0770
+      uri: https://ftp.sendmail.org/sendmail.${{package.version}}.tar.gz
 
   - runs: |
       make -C libmilter MILTER_SOVER=${{package.version}}
@@ -43,6 +43,51 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # the library we fetch uses a different version to the melange package.version
   release-monitor:
     identifier: 4796
+
+test:
+  environment:
+    contents:
+      packages:
+        - libmilter-dev
+        - build-base
+  pipeline:
+    - name: Library verification
+      runs: |
+        test -f /usr/lib/libmilter.a
+        test -d /usr/include/libmilter
+        test -f /usr/include/libmilter/mfapi.h
+    - name: Basic functionality test
+      runs: |
+        cat <<EOF > test.c
+        #include <libmilter/mfapi.h>
+        #include <stdlib.h>
+
+        struct smfiDesc smfilter = {
+            "test_milter",    /* filter name */
+            SMFI_VERSION,     /* version code */
+            0,               /* flags */
+            NULL,            /* connection info filter */
+            NULL,            /* SMTP HELO command filter */
+            NULL,            /* envelope sender filter */
+            NULL,            /* envelope recipient filter */
+            NULL,            /* header filter */
+            NULL,            /* end of header */
+            NULL,            /* body block */
+            NULL,            /* end of message */
+            NULL,            /* message aborted */
+            NULL,            /* connection cleanup */
+        };
+
+        int main() {
+            // Try to init milter API
+            if (smfi_register(smfilter) == MI_FAILURE) {
+                return 1;
+            }
+            return 0;
+        }
+        EOF
+
+        gcc -o test test.c -lmilter
+        ./test


### PR DESCRIPTION
Old package. Melange version was not correct - using different version than the actual package was. No clear reason why. Also we were behind a version.

Update melange version to match the application version, enabled updates, and added test coverage.