### PR TITLE
openjdk24: Fix missing default symlink pipeline

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: 24_beta16
-  epoch: 3
+  epoch: 4
   description: OpenJDK 24 Early Access Package
   copyright:
     - license: GPL-2.0-or-later
@@ -136,10 +136,10 @@ subpackages:
     description: "OpenJDK 24 Java Runtime Environment"
     dependencies:
       runtime:
-        - ${{package.name}}-jre-base
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -204,6 +204,10 @@ subpackages:
       runtime:
         - java-common
         - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-24-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
   enabled: false


### PR DESCRIPTION
Remove dep to jre-base and add java-cacerts to jre subpackage

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
