### PR TITLE
Add flyway symlinks

### DIFF
--- a/flyway.yaml
+++ b/flyway.yaml
@@ -1,7 +1,7 @@
 package:
   name: flyway
   version: "11.2.0"
-  epoch: 0
+  epoch: 1
   description: "Flyway is a database migration tool to evolve your database schema easily and reliably across all your instances."
   copyright:
     - license: Apache-2.0

--- a/flyway.yaml
+++ b/flyway.yaml
@@ -143,6 +143,14 @@ pipeline:
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opentelemetry-sdk-extension-autoconfigure-spi-*.jar
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opentelemetry-semconv-*.jar
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/proto-google-cloud-storage-*.jar
+  
+  - name: Create symlinks for flyway
+    runs: |
+      ln -sf /usr/share/java/flyway ${{targets.destdir}}/flyway
+      mkdir -p ${{targets.destdir}}/opt/java/openjdk
+      for item in bin conf legal lib release; do
+        ln -sf /usr/lib/jvm/java-17-openjdk/$item ${{targets.destdir}}/opt/java/openjdk
+      done
 
   - uses: strip
 

--- a/flyway.yaml
+++ b/flyway.yaml
@@ -25,11 +25,11 @@ environment:
 
 vars:
   lib-core: "accessors-smart commons-text content-type gson jackson jansi jna json-smart lang-tag msal4j-persistence-extension nimbus-jose-jwt oauth2-oidc-sdk slf4j-nop stax2-api woodstox-core"
-  lib-aad: "accessors-smart azure content-type json-smart lang-tag msal4j nimbus-jose-jwt oauth2-oidc-sdk reactive-streams reactor slf4j-api"
+  lib-aad: "azure msal4j reactive-streams reactor slf4j-api"
   lib-oracle-wallet: "oraclepki osdt_cert osdt_core"
   drivers-core: "aws-secretsmanager-jdbc databricks-jdbc google-cloud-storage h2 hsqldb jaybird jffi jtds mariadb-java-client mssql-jdbc ojdbc8 postgresql singlestore-jdbc-client snowflake-jdbc sqlite-jdbc"
   drivers-cassandra: "HdrHistogram asm caffeine cassandra-jdbc-wrapper commons-collections4 commons-io commons-lang3 config java-driver jcip-annotations jnr metrics-core native-protocol semver4j"
-  drivers-gcp: "animal-sniffer-annotations annotations api-common auto-value-annotations checker-qual commons-codec conscrypt-openjdk-uber detector-resources-support error_prone_annotations failureaccess gax google-auth google-cloud-core google-cloud-monitoring google-cloud-spanner google-http-client grpc guava httpclient httpcore j2objc-annotations javax.annotation-api jsr305 listenablefuture opencensus opentelemetry perfmark-api proto protobuf-java re2j threetenbp"
+  drivers-gcp: "animal-sniffer-annotations annotations api-common auto-value-annotations checker-qual commons-codec conscrypt-openjdk-uber detector-resources-support error_prone_annotations failureaccess gax google-auth google-cloud-core google-cloud-monitoring google-cloud-spanner google-http-client grpc guava httpclient httpcore j2objc-annotations javax.annotation-api jsr305 listenablefuture opencensus perfmark-api proto protobuf-java re2j threetenbp"
   drivers-mongo: "bson flyway-experimental-mongodb mongodb-driver"
 
 pipeline:
@@ -139,11 +139,8 @@ pipeline:
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/grpc-google-cloud-storage-*.jar
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/grpc-opentelemetry-*.jar
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opencensus-proto-*.jar
-      rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opentelemetry-gcp-resources-*.jar
-      rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opentelemetry-sdk-extension-autoconfigure-spi-*.jar
-      rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/opentelemetry-semconv-*.jar
       rm ${{targets.contextdir}}/usr/share/java/flyway/drivers/gcp/proto-google-cloud-storage-*.jar
-  
+
   - name: Create symlinks for flyway
     runs: |
       ln -sf /usr/share/java/flyway ${{targets.destdir}}/flyway


### PR DESCRIPTION
Add symlinks to match `/flyway` and `/opt/java/openjdk` dirs and drop unneeded deps from `/flyway/lib/aad` and `/flyway/drivers/gcp` to match upstream flyway-11.2.0.

