### PR TITLE
Add yara-x patch to reduce virtual memory usage

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -68,6 +68,5 @@ test:
     - runs: |
         yr --help
         yr --version | grep ${{package.version}}
-
     - runs: |
         time -v mal --min-risk critical --min-file-risk critical scan yr /usr

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: 0.12.0
-  epoch: 4
+  epoch: 5
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -28,6 +28,10 @@ pipeline:
       expected-commit: d2b8358879c009f41f0e14847681f2f8dbe624cf
       tag: v${{package.version}}
 
+  - uses: patch
+    with:
+      patches: reservation.patch
+
   - name: Build base yara tool
     uses: cargo/build
     with:
@@ -48,6 +52,7 @@ test:
         - gcc
         - glibc-dev
         - pkgconf-dev
+        - malcontent
   pipeline:
     - runs: |
         cat <<EOF > test.c
@@ -63,3 +68,6 @@ test:
     - runs: |
         yr --help
         yr --version | grep ${{package.version}}
+
+    - runs: |
+        time -v mal --min-risk critical --min-file-risk critical scan yr /usr

--- a/yara-x/reservation.patch
+++ b/yara-x/reservation.patch
@@ -1,0 +1,27 @@
+yara-x leverages wasmtime which allocates 8GB of contiguous virutal memory when creating instances.
+These instances are used for yara-x's scanners and will cause crashes in environments like Cloud Run
+where the filesystem is in-memory or ulimit restrictions are present.
+
+This PR tweaks the WASM memory reservation configuration to lower the virtual memory usage.
+
+For more information, reference this yara-x Issue: https://github.com/VirusTotal/yara-x/issues/292
+or this wasmtime Issue: https://github.com/bytecodealliance/wasmtime/issues/3695
+Once yara-x makes these values configurable, this patch can be removed.
+
+diff --git a/lib/src/wasm/mod.rs b/lib/src/wasm/mod.rs
+index ccb95ccf..2c1ff750 100644
+--- a/lib/src/wasm/mod.rs
++++ b/lib/src/wasm/mod.rs
+@@ -720,6 +720,12 @@ lazy_static! {
+         config.native_unwind_info(false);
+
+         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
++        config.dynamic_memory_reserved_for_growth(0x20000000); // 512MB
++        config.guard_before_linear_memory(false);
++        config.static_memory_forced(false);
++        config.static_memory_guard_size(0x10000); // 64KB to match dynamic guard size
++        // Configures the maximum size, in bytes, where a linear memory is considered static, above which it’ll be considered dynamic
++        config.static_memory_maximum_size(0); // 0 is always dynamic
+         config.epoch_interruption(true);
+         config
+     };

--- a/yara-x/reservation.patch
+++ b/yara-x/reservation.patch
@@ -16,7 +16,7 @@ index ccb95ccf..2c1ff750 100644
          config.native_unwind_info(false);
 
          config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
-+        config.dynamic_memory_reserved_for_growth(0x20000000); // 512MB
++        config.dynamic_memory_reserved_for_growth(0x20000000); // 512MB; this defaults to 2GB (0x80000000)
 +        config.guard_before_linear_memory(false);
 +        config.static_memory_forced(false);
 +        config.static_memory_guard_size(0x10000); // 64KB to match dynamic guard size


### PR DESCRIPTION
This PR adds a yara-x patch to handle WASM memory management tweaks. By default, `wasmtime` is allocating 8GB of contiguous virtual memory each time a new scanner is created. This is fine except in cases where the file-system is in-memory or other virtual memory restrictions are present (e.g., in Cloud Run).

To avoid this, we can use dynamic allocation and drop the overall allocation and grow usage by a lower amount.

I specified `config.static_memory_guard_size` because its value is `2GB` by default and it cannot be lower than the default dynamic guard size of `64KB`.

I also added another test case to make sure that malcontent runs with the updated code. The real test will be running the updated API in an environment similar to Cloud Run.