### PR TITLE
enable auto-updates, update to latest version, switch to git poller a…

### DIFF
--- a/wasi-libc.yaml
+++ b/wasi-libc.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasi-libc
-  version: 21.0.0
-  epoch: 1
+  version: 25
+  epoch: 0
   description: "WASI libc implementation for WebAssembly"
   copyright:
     - license: Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND MIT AND CC0-1.0 AND BSD-2-Clause
@@ -9,6 +9,7 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - busybox
       - ca-certificates-bundle
       - clang-17
@@ -21,8 +22,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/WebAssembly/wasi-libc
-      tag: wasi-sdk-21
-      expected-commit: c5264e2bbe532994d06b039005f2af91bedcc1a6
+      tag: wasi-sdk-${{package.version}}
+      expected-commit: 574b88da481569b65a237cb80daf9a2d5aeaf82d
 
   - name: Build
     runs: |
@@ -34,8 +35,35 @@ pipeline:
 
 update:
   enabled: true
-  manual: true # version in fetch URL is different from package version
-  github:
-    identifier: WebAssembly/wasi-libc
+  git:
     strip-prefix: wasi-sdk-
-    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - clang-17
+  pipeline:
+    - name: Installation verification
+      runs: |
+        # Check sysroot directory structure
+        test -d /usr/share/wasi-sysroot/include/wasm32-wasi
+        test -d /usr/share/wasi-sysroot/lib/wasm32-wasi
+
+        # Verify critical headers
+        test -f /usr/share/wasi-sysroot/include/wasm32-wasi/wasi/api.h
+        test -f /usr/share/wasi-sysroot/lib/wasm32-wasi/libc.a
+        test -f /usr/share/wasi-sysroot/lib/wasm32-wasi/crt1.o
+    - name: Basic compilation test
+      runs: |
+        # Create minimal test program
+        cat <<EOF > test.c
+        int main() {
+            return 0;
+        }
+        EOF
+
+        # Compile with minimal flags
+        clang -v --target=wasm32-wasi \
+          --sysroot=/usr/share/wasi-sysroot \
+          -c test.c -o test.o


### PR DESCRIPTION
Was behind on updates, as they were originally disabled. Switched to use git poller, fixed up additional buildtime dep needed (requires both bash and busybox), and added melange test coverage.

Note, upstream uses a single major version as the release version - so this change is an intentional correction.

**Additional testing:**
Built 'rust-1.69' (oldest) and 'rust-1.84' (newest), wolfi packages with this as an updated buildtime dependency.