### PR TITLE
actions: automatically run withdraw workflow on main repo/branch

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -2,6 +2,10 @@ name: Withdraw packages
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "withdrawn-packages.txt"
 
 # Don't withdraw during builds, to prevent out of sync signatures.
 concurrency: build
@@ -11,6 +15,7 @@ permissions:
 
 jobs:
   withdraw:
+    if: github.repository == 'wolfi-dev/os'
     name: Withdraw packages
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Similar to chainguard-images repositories run withdraw-packages
workflow automatically upon push, to main branch, of wolfi-dev/os.

This removes the need for manual execution of the workflow, after
review/merge of package withdraw.
