### PR TITLE
New package rustfilt

### DIFF
--- a/rustfilt.yaml
+++ b/rustfilt.yaml
@@ -1,0 +1,49 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: rustfilt
+  version: "0.2.2_git20230531"
+  epoch: 0
+  description: Demangle Rust symbols
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - cargo-auditable
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/luser/rustfilt
+      branch: master
+      expected-commit: 8cf08c0680ebd17e7c1ae5c67227fa7026129af6
+
+  - uses: rust/cargobump
+
+  - runs: |
+      cargo auditable build --locked --release
+      install -Dm755 target/release/rustfilt "${{targets.destdir}}"/usr/bin/rustfilt
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: luser/rustfilt
+  schedule:
+    period: weekly
+    reason: No new upstream releases for a long time, but useful feature on master
+
+test:
+  environment:
+    contents:
+      packages:
+        - binutils
+  pipeline:
+    - name: Test symbols
+      runs: |
+        readelf --wide --symbols /usr/bin/rustfilt | rustfilt | grep rustc_demangle

--- a/rustfilt/cargobump-deps.yaml
+++ b/rustfilt/cargobump-deps.yaml
@@ -1,0 +1,3 @@
+packages:
+    - name: rustc-demangle
+      version: 0.1.24


### PR DESCRIPTION
This package is similar to c++filt for c++, but for rust. It helps to
demangle symbols names from gibberish to human readable function
names. This helps with static analysis of rust binaries, for example
to determine which crates got linked into a binary.

Packaging git snapshot to get this feature:
- https://github.com/luser/rustfilt/commit/4618d5f5a00e7c7cb6d71c5851c80e18f53a5509

Until the next upstream release is cut:
- https://github.com/luser/rustfilt/issues/23
