### PR TITLE
rebuild airflow for apache-airflow-providers-celery 3.8.5 version

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: 2.10.4
-  epoch: 2
+  epoch: 3
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -76,9 +76,11 @@ pipeline:
       pip3.12 uninstall --yes setuptools
 
       #GHSA-8w49-h785-mj3c/GHSA-8495-4g3g-x7pr/GHSA-27mf-ghqm-j3j8 fixes
+      # there was a regression introduced upstream (ref: https://github.com/apache/airflow/issues/45364)
+      # pin apache-airflow-providers-celery to 3.8.5 (remove in updates > 2.10.4)
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
-        aiohttp>=3.10.11 tornado>=6.4.2 statsd packaging
+        aiohttp>=3.10.11 tornado>=6.4.2 apache-airflow-providers-celery==3.8.5 statsd packaging
 
   - working-directory: ./airflow/www
     runs: |

--- a/airflow.yaml
+++ b/airflow.yaml
@@ -80,7 +80,7 @@ pipeline:
       # pin apache-airflow-providers-celery to 3.8.5 (remove in updates > 2.10.4)
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
-        aiohttp>=3.10.11 tornado>=6.4.2 apache-airflow-providers-celery==3.8.5 statsd packaging
+        aiohttp>=3.10.11 tornado>=6.4.2 statsd packaging
 
   - working-directory: ./airflow/www
     runs: |

--- a/airflow.yaml
+++ b/airflow.yaml
@@ -76,8 +76,6 @@ pipeline:
       pip3.12 uninstall --yes setuptools
 
       #GHSA-8w49-h785-mj3c/GHSA-8495-4g3g-x7pr/GHSA-27mf-ghqm-j3j8 fixes
-      # there was a regression introduced upstream (ref: https://github.com/apache/airflow/issues/45364)
-      # pin apache-airflow-providers-celery to 3.8.5 (remove in updates > 2.10.4)
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
         aiohttp>=3.10.11 tornado>=6.4.2 statsd packaging

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 18.1.0
-  epoch: 1
+  epoch: 2
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 18.1.0
-  epoch: 2
+  epoch: 1
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
      pin apache-airflow-providers-celery to 3.8.5 version
      
      there was a regression introduced via
      https://github.com/apache/airflow/issues/45364 and this commit
      apache-airflow-providers-celery to 3.8.5 version.
      
      Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>


EDIT: upstream noticed the regression and have yanked the 3.9.0 verison (ref: https://pypi.org/project/apache-airflow-providers-celery/#history)

building airflow again should pull in 3.8.5 version