### PR TITLE
Add liblmdb.so and liblmdb.so.0 symlinks

### DIFF
--- a/lmdb.yaml
+++ b/lmdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: lmdb
   version: 0.9.31
-  epoch: 2
+  epoch: 3
   description: Lightning Memory-Mapped Database
   copyright:
     - license: OLDAP-2.8
@@ -48,6 +48,11 @@ pipeline:
       make DESTDIR="${{targets.destdir}}"  prefix=/usr install
 
       install -Dm0644 *.pc -t ${{targets.destdir}}/usr/lib/pkgconfig
+
+      rm "${{targets.destdir}}"/usr/lib/liblmdb.so.0
+      ln -s /usr/lib/liblmdb.so.0.0.0 "${{targets.destdir}}"/usr/lib/liblmdb.so.0
+      rm "${{targets.destdir}}"/usr/lib/liblmdb.so
+      ln -s /usr/lib/liblmdb.so.0.0.0 "${{targets.destdir}}"/usr/lib/liblmdb.so
 
   - uses: strip
 


### PR DESCRIPTION
This is part of resolving https://github.com/chainguard-dev/customer-issues/issues/1975 where installing samba-client complains that liblmdb.so.0 is not a symlink:

```
# apk -q update && apk add -q samba-client
/sbin/ldconfig: /usr/lib/liblmdb.so.0 is not a symbolic link
```