### PR TITLE
Add the pkgconf test pipeline

### DIFF
--- a/audit.yaml
+++ b/audit.yaml
@@ -95,6 +95,7 @@ subpackages:
     description: audit dev
     test:
       pipeline:
+        - uses: test/pkgconf
         - uses: test/ldd-check
           with:
             packages: ${{package.name}}


### PR DESCRIPTION
The location of the .pc files in the audit package have changed so we can add the pkgconf test pipeline now, this resolves https://github.com/wolfi-dev/os/issues/37188.