### PR TITLE
samba: use the internal libldb library.

### DIFF
--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: 4.21.3
-  epoch: 0
+  epoch: 1
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -24,7 +24,6 @@ environment:
       - gnutls-dev
       - iniparser-dev
       - jansson-dev
-      - ldb-dev
       - libarchive-dev
       - libcap-dev
       - libtirpc-dev
@@ -41,7 +40,6 @@ environment:
       - pkgconf-dev
       - popt-dev
       - py3-dnspython
-      - py3-ldb
       - py3-markdown
       - py3-tdb
       - py3-tevent
@@ -466,6 +464,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libsmbconf.so.* "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libsmbldap.so.* "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libtevent-util.so.* "${{targets.contextdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libldb.so.* "${{targets.contextdir}}"/usr/lib
 
 update:
   enabled: true


### PR DESCRIPTION
As per https://lists.samba.org/archive/samba-announce/2024/000674.html , libldb is now shipped only as part of the samba source. Samba builds ldb by default during regular build, and with the current samba version we already had the library binaries in the `samba` binary package. Let's stop depending on the external ldb package - the only reverse-dependencies are samba and ldb itself.

For this, make sure we install libldb as part of `samba-libs` and not `samba` itself. This way packages such as `samba-client` will pull it in instantly and finally work as expected.

Was thinking of adding some provides, but I don't think those are necessary? The resolver knows how to resolve the dependency as-is. We'll have to think about what to do with the ldb package later (this can wait).
This is fixing the second part of: https://github.com/chainguard-dev/customer-issues/issues/1975