### PR TITLE
apache2: update epoch to 6 and add curl dependency; download httpd-fo…

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -28,6 +28,12 @@ environment:
       - wolfi-base
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: build-version
+
 pipeline:
   - uses: git-checkout
     with:
@@ -92,7 +98,7 @@ pipeline:
 
   - uses: fetch
     with:
-      uri: https://raw.githubusercontent.com/docker-library/httpd/master/2.4/alpine/httpd-foreground
+      uri: https://raw.githubusercontent.com/docker-library/httpd/master/${{vars.build-version}}/alpine/httpd-foreground
       expected-sha256: 003f4ca165cf0daa9721c907259d3ef6a7fd9017453079780c1ae91de96fa777
       extract: false
 
@@ -148,7 +154,6 @@ subpackages:
     pipeline:
       - runs: |
           set -x
-          export short_version=$(echo ${{package.version}} | cut -d. -f1-2)
 
           # Create necessary folders
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
@@ -225,8 +230,9 @@ subpackages:
             grep -E '^\s*CustomLog /proc/self/fd/1' /usr/local/apache2/conf/httpd.conf;
             grep -E '^\s*CustomLog /proc/self/fd/1' /usr/local/apache2/conf/extra/httpd-ssl.conf;
             grep -E '^\s*TransferLog /proc/self/fd/1$' /usr/local/apache2/conf/extra/httpd-ssl.conf;
-
-            adduser -D -H www-data
+            if ! id -u "www-data" > /dev/null 2>&1; then
+              adduser -S -G "www-data" "www-data"
+            fi
 
             httpd -M
 

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -18,7 +18,6 @@ environment:
       - automake
       - brotli-dev
       - build-base
-      - curl
       - libapr-dev
       - libxml2-dev
       - lua5.4-dev
@@ -90,7 +89,11 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
-
+  - uses: fetch
+    with:
+      uri: https://raw.githubusercontent.com/docker-library/httpd/master/2.4/alpine/httpd-foreground
+      expected-sha256: 003f4ca165cf0daa9721c907259d3ef6a7fd9017453079780c1ae91de96fa777
+      extract: false
 subpackages:
   - name: ${{package.name}}-dev
     description: "Apache HTTP Server (development headers)"
@@ -150,16 +153,14 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
-          mkdir -p "${{targets.contextdir}}"/usr/local/bin
 
           # Install necessary config files
           mkdir -p "${{targets.subpkgdir}}"/etc/apache2
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
 
-          # Download the `httpd-foreground` script from the official Docker image
-          curl -vk -L https://raw.githubusercontent.com/docker-library/httpd/master/${short_version}/alpine/httpd-foreground -o ${{targets.contextdir}}/usr/local/bin/httpd-foreground
-          chmod 0755 ${{targets.contextdir}}/usr/local/bin/httpd-foreground
+          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
+          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
           # Create symlinks
           ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
           ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: 2.4.62
-  epoch: 5
+  epoch: 6
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - automake
       - brotli-dev
       - build-base
+      - curl
       - libapr-dev
       - libxml2-dev
       - lua5.4-dev
@@ -142,21 +143,23 @@ subpackages:
     pipeline:
       - runs: |
           set -x
-
-          # Install the entrypoint script
-          install -Dm755 entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/entrypoint.sh
+          export short_version=$(echo ${{package.version}} | cut -d. -f1-2)
 
           # Create necessary folders
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
 
           # Install necessary config files
           mkdir -p "${{targets.subpkgdir}}"/etc/apache2
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
 
+          # Download the `httpd-foreground` script from the official Docker image
+          curl -vk -L https://raw.githubusercontent.com/docker-library/httpd/master/${short_version}/alpine/httpd-foreground -o ${{targets.contextdir}}/usr/local/bin/httpd-foreground
+          chmod 0755 ${{targets.contextdir}}/usr/local/bin/httpd-foreground
           # Create symlinks
           ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
           ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -89,11 +89,13 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
   - uses: fetch
     with:
       uri: https://raw.githubusercontent.com/docker-library/httpd/master/2.4/alpine/httpd-foreground
       expected-sha256: 003f4ca165cf0daa9721c907259d3ef6a7fd9017453079780c1ae91de96fa777
       extract: false
+
 subpackages:
   - name: ${{package.name}}-dev
     description: "Apache HTTP Server (development headers)"

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -231,7 +231,7 @@ subpackages:
             grep -E '^\s*CustomLog /proc/self/fd/1' /usr/local/apache2/conf/extra/httpd-ssl.conf;
             grep -E '^\s*TransferLog /proc/self/fd/1$' /usr/local/apache2/conf/extra/httpd-ssl.conf;
             if ! id -u "www-data" > /dev/null 2>&1; then
-              adduser -S -G "www-data" "www-data"
+              adduser -D -H "www-data"
             fi
 
             httpd -M


### PR DESCRIPTION
Updated the Apache2 package to allow the dynamic download of the entrypoint script called httpd-foreground and place it in a similar location to the upstream docker image here https://github.com/docker-library/httpd/blob/master/2.4/alpine/Dockerfile#L231