### PR TITLE
apache2: ignore -candidate tags

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -311,3 +311,5 @@ update:
   github:
     identifier: apache/httpd
     use-tag: true
+  ignore-regex-patterns:
+    - .*-candidate


### PR DESCRIPTION
We only want actual releases; see https://github.com/wolfi-dev/os/pull/40024 for an unwanted PR.