### PR TITLE
firefox: build from source tarball instead of hg

### DIFF
--- a/firefox.yaml
+++ b/firefox.yaml
@@ -1,7 +1,7 @@
 package:
   name: firefox
   version: "134.0.2"
-  epoch: 0
+  epoch: 1
   description: Firefox web browser
   copyright:
     - license: GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MPL-2.0
@@ -57,7 +57,6 @@ environment:
       - nodejs
       - pango-dev
       - pulseaudio-dev
-      - py3.11-mercurial
       - py3.11-pip # Matches Mach's recommended maximum Python version
       - python-3.11-dev # (3.12 definitely didn't work at the time of setting this)
       - rust
@@ -65,25 +64,15 @@ environment:
       - wasi-sdk-sysroot
       - wget
 
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: '_'
-    to: mangled-package-version
-  # We need the extract the major version
-  - from: ${{package.version}}
-    match: '\..'
-    replace: '$1'
-    to: major-version
-
 pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.mozilla.org/pub/firefox/releases/${{package.version}}/source/firefox-${{package.version}}.source.tar.xz
+      expected-sha256: 6c6eb7ff13fa689c5cace23a28533361d1ca29158329b6f1c2f2d1c91c53dd27
+
   - runs: |
       # Craft the name of the final distfile.
       distfile="obj-${{cross.triplet.gnu.glibc}}/dist/firefox-${{package.version}}.en-US.linux-${{build.arch}}.tar.bz2"
-
-      # Format and print release tag
-      RELEASE_TAG=FIREFOX_${{vars.mangled-package-version}}_RELEASE
-      echo "RELEASE_TAG=${RELEASE_TAG}"
 
       # Copy the library into the directory for the clang we're using currently
       mkdir -p /usr/lib/clang/${{vars.llvm-vers}}/lib/wasi/
@@ -94,11 +83,6 @@ pipeline:
       # with release repositories, so just extract what it does and do it
       # manually.
       # https://firefox-source-docs.mozilla.org/setup/linux_build.html
-      # Clone the repository. If the major version is changed, this needs to
-      # be updated.
-      echo "RUNNING: hg clone https://hg.mozilla.org/releases/mozilla-release/ -u ${RELEASE_TAG}"
-      hg clone https://hg.mozilla.org/releases/mozilla-release/ -u ${RELEASE_TAG}
-      cd mozilla-release
 
       # Don't set CPPFLAGS, bootstrap only accepts a single flag
       unset CPPFLAGS


### PR DESCRIPTION
The Mercurial `_RELEASE` tag seems to be created some time after the release has been made public on ftp.mozilla.org. release-monitoring.org uses ftp.mozilla.org as its source of truth, which generally means that we detect the new version and attempt to build the release before the tag has been published, resulting in build failures.

Switching to the release tarball should avoid manual intervention for every Firefox release, thereby decreasing the latency from upstream release to availability in Wolfi.  It has the additional advantage of future-proofing us against the planned migration to GitHub for development (though once that's occurred, we should examine whether consuming from GitHub directly would be appropriate).  (`wget` is probably also faster than `hg clone`, though I haven't confirmed this.)