### PR TITLE
fix: version bump for both logback jars to 1.5.13

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
   version: "24.10.4"
-  epoch: 0
+  epoch: 1
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0

--- a/nextflow/logback-core-1.5.13.patch
+++ b/nextflow/logback-core-1.5.13.patch
@@ -1,12 +1,14 @@
 diff --git a/modules/nextflow/build.gradle b/modules/nextflow/build.gradle
-index d7e40cf9d..13d7ea9b0 100644
+index 48fc98215..daa7fc584 100644
 --- a/modules/nextflow/build.gradle
 +++ b/modules/nextflow/build.gradle
-@@ -30,7 +30,7 @@ dependencies {
+@@ -29,8 +29,8 @@ dependencies {
+     api "org.slf4j:jcl-over-slf4j:2.0.7"
      api "org.slf4j:jul-to-slf4j:2.0.7"
      api "org.slf4j:log4j-over-slf4j:2.0.7"
-     api "ch.qos.logback:logback-classic:1.4.14"
+-    api "ch.qos.logback:logback-classic:1.4.14"
 -    api "ch.qos.logback:logback-core:1.4.14"
++    api "ch.qos.logback:logback-classic:1.5.13"
 +    api "ch.qos.logback:logback-core:1.5.13"
      api "org.codehaus.gpars:gpars:1.2.1"
      api("ch.artecat.grengine:grengine:3.0.2") { exclude group: 'org.codehaus.groovy' }


### PR DESCRIPTION
Related: [#4791](https://github.com/chainguard-dev/image-requests/issues/4792)

Add version bump for logback-classic and logback-core jars.
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
