### PR TITLE
add kubectl-images package

### DIFF
--- a/kubectl-images.yaml
+++ b/kubectl-images.yaml
@@ -13,6 +13,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 582899624f93be6e8728125396ab567ae914bd0d
 
+  # NOTE: there's is no active releases for past 2 years but it's a single go file with small deps and given we always build using latest go, this should be good.
   - uses: go/build
     with:
       packages: ./cmd/main.go

--- a/kubectl-images.yaml
+++ b/kubectl-images.yaml
@@ -1,0 +1,32 @@
+package:
+  name: kubectl-images
+  version: 0.6.3
+  epoch: 0
+  description: Show container images used in the cluster.
+  copyright:
+    - license: MIT
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chenjiandongx/kubectl-images
+      tag: v${{package.version}}
+      expected-commit: 582899624f93be6e8728125396ab567ae914bd0d
+
+  - uses: go/build
+    with:
+      packages: ./cmd/main.go
+      output: kubectl-images
+
+update:
+  enabled: true
+  github:
+    identifier: chenjiandongx/kubectl-images
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: basic test
+      runs: |
+        kubectl-images --version | grep ${{package.version}}
+        kubectl-images --help


### PR DESCRIPTION
for doing something like this on workstations and general troubleshooting. 
```bash
 $ kubectl images -n kube-system
[Summary]: 1 namespaces, 2 pods, 2 containers and 2 different images
+-----------------------------------------+------------------------+-----------------------------------------+
|                   Pod                   |       Container        |                  Image                  |
+-----------------------------------------+------------------------+-----------------------------------------+
| coredns-ccb96694c-hzg9g                 | coredns                | rancher/mirrored-coredns-coredns:1.12.0 |
+-----------------------------------------+------------------------+-----------------------------------------+
| local-path-provisioner-5cf85fd84d-tf2rv | local-path-provisioner | rancher/local-path-provisioner:v0.0.30  |
+-----------------------------------------+------------------------+-----------------------------------------+
```