### PR TITLE
openssl: cherry-pick upstream fix for CVE-2024-13176

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 5
+  epoch: 6
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,8 @@ pipeline:
       repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
       expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
+      cherry-picks: |
+        openssl-3.4/77c608f4c8857e63e98e66444e2e761c9627916f: Fix timing side-channel in ECDSA signature computation (fix for CVE-2024-13176)
 
   - uses: patch
     with:


### PR DESCRIPTION
Cherry picking fix as it's a low CVE with no point release prepared. I didn't cherry-pick the non-code changes since I don't think they're very relevant.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/8502


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
