### PR TITLE
proxysql: fix build error + add test

### DIFF
--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: 2.7.1
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later
@@ -37,22 +37,46 @@ pipeline:
       repository: https://github.com/sysown/proxysql
       tag: v${{package.version}}
       expected-commit: 2726c277102cde7555a36aeece60179c9f4e23e5
-    pipeline:
-      - runs: |
-          # Our default LDFLAGS cause an issue with proxysql. We need to add -fPIC.
-          export CFLAGS="${CFLAGS} -fPIC"
-          export CPPFLAGS="$CFLAGS"
-          export CXXFLAGS="$CFLAGS"
-          make -j$(nproc) GIT_VERSION=${{package.version}}-r${{package.epoch}}
-      - runs: |
-          mkdir -p ${{targets.destdir}}/usr/bin
-          mkdir -p ${{targets.destdir}}/etc
-          install -m 0755 src/proxysql ${{targets.destdir}}/usr/bin
-          install -m 0600 etc/proxysql.cnf ${{targets.destdir}}/etc
-      - uses: strip
+
+  - runs: make -j$(nproc) GIT_VERSION=${{package.version}}-r${{package.epoch}}
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/etc
+      install -m 0755 src/proxysql ${{targets.destdir}}/usr/bin
+      install -m 0600 etc/proxysql.cnf ${{targets.destdir}}/etc
+
+  - uses: strip
 
 update:
   enabled: true
   github:
     identifier: sysown/proxysql
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        proxysql --help
+        proxysql --version
+    - runs: |
+        #!/bin/bash
+
+        # Generate ProxySQL configuration
+        cat > ./proxysql.cnf <<EOF
+        admin_variables={
+            mysql_ssl=false
+        }
+        EOF
+
+        # Start ProxySQL
+        echo "Starting ProxySQL..."
+        proxysql --daemon --config-file=./proxysql.cnf
+
+        # Check the status of the previous command
+        if [ $? -ne 0 ]; then
+            echo "ProxySQL failed to start"
+            exit 1
+        else
+            echo "ProxySQL started successfully"
+        fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
looks like we have duplicate `pipeline.pipeline` in there but CI is not catching it.

- remove duplicate `pipeline.pipeline`
- test a version test to catch future failure
- build with `openssf-compiler-options`. Looks like the the previous issue has been resolved so i remove the workaround

![image](https://github.com/user-attachments/assets/dc8c63b4-6349-4bad-9775-c22b549c1219)


Fixes: https://github.com/wolfi-dev/os/issues/40062

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
