### PR TITLE
build ruby linked against jemalloc

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -99,6 +99,9 @@ subpackages:
 
   - name: "ruby-3.0-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - jemalloc-dev
     pipeline:
       - uses: split/dev
     test:

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 4
+  epoch: 5
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -20,6 +20,7 @@ environment:
       - expat-dev
       - gdbm-dev
       - git
+      - jemalloc-dev
       - libffi-dev
       - linux-headers
       - mpdecimal-dev
@@ -61,7 +62,8 @@ pipeline:
          --with-system-expat \
          --with-system-ffi \
          --with-system-libmpdec \
-         --without-ensurepip
+         --without-ensurepip \
+         --with-jemalloc
 
   - uses: autoconf/make
 

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 10
+  epoch: 11
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - expat-dev
       - gdbm-dev
+      - jemalloc-dev
       - libffi-dev
       - linux-headers
       - mpdecimal-dev
@@ -71,7 +72,8 @@ pipeline:
          --with-system-expat \
          --with-system-ffi \
          --with-system-libmpdec \
-         --without-ensurepip
+         --without-ensurepip \
+         --with-jemalloc
 
   - uses: autoconf/make
 

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -109,6 +109,9 @@ subpackages:
 
   - name: "ruby-3.1-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - jemalloc-dev
     pipeline:
       - uses: split/dev
     test:

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -121,6 +121,9 @@ subpackages:
 
   - name: "ruby-3.2-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - jemalloc-dev
     pipeline:
       - uses: split/dev
     test:

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 5
+  epoch: 6
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -24,6 +24,7 @@ environment:
       - glibc-dev
       - gmp-dev
       - gperf
+      - jemalloc-dev
       - libffi-dev
       - libxcrypt-dev
       - linux-headers
@@ -72,7 +73,8 @@ pipeline:
          --disable-rpath \
          --sysconfdir=/etc \
          --enable-mkmf-verbose \
-         --enable-yjit
+         --enable-yjit \
+         --with-jemalloc
 
   - uses: autoconf/make
 

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: "3.3.7"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -24,6 +24,7 @@ environment:
       - glibc-dev
       - gmp-dev
       - gperf
+      - jemalloc-dev
       - libffi-dev
       - libxcrypt-dev
       - linux-headers
@@ -70,7 +71,8 @@ pipeline:
          --disable-rpath \
          --sysconfdir=/etc \
          --enable-mkmf-verbose \
-         --enable-yjit
+         --enable-yjit \
+         --with-jemalloc
 
   - uses: autoconf/make
 

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -119,6 +119,9 @@ subpackages:
 
   - name: "ruby-3.3-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - jemalloc-dev
     pipeline:
       - uses: split/dev
     test:

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -130,6 +130,9 @@ subpackages:
 
   - name: "ruby-3.4-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - jemalloc-dev
     pipeline:
       - uses: split/dev
     test:

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.4
   version: 3.4.1
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -34,6 +34,7 @@ environment:
       - glibc-dev
       - gmp-dev
       - graphviz
+      - jemalloc-dev
       - libffi-dev
       - libxcrypt-dev
       - linux-headers
@@ -81,7 +82,8 @@ pipeline:
          --disable-rpath \
          --sysconfdir=/etc \
          --enable-mkmf-verbose \
-         --enable-yjit
+         --enable-yjit \
+         --with-jemalloc
 
   - uses: autoconf/make
 


### PR DESCRIPTION
this changes all our ruby to be linked against `jemalloc`. for applications like webapps (rails) or multithreaded workloads (puma), we see significant memory usage savings compared to malloc.

I don't know enough as to whether we should do this globally, since this introduces some size overhead to our binaries, so I'm going to leave it to the experts to yay or nay this.

if nay, we'd likely need a jemalloc enabled subpackage or something similar just for the sheer perf gains we see against any rails/puma app