### PR TITLE
libsdl2: add tag-filter as upstream are now publishing 3.x releases

### DIFF
--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -43,6 +43,7 @@ update:
   github:
     identifier: libsdl-org/SDL
     strip-prefix: release-
+    tag-filter: release-2
 
 test:
   environment:


### PR DESCRIPTION
Starting with
https://github.com/libsdl-org/SDL/releases/tag/release-3.2.0 earlier today.