### PR TITLE
libsdl3: SDL 3 is officially released; refresh update/checkout config

### DIFF
--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -1,6 +1,6 @@
 package:
   name: libsdl3
-  version: 3.1.8
+  version: 3.2.0
   epoch: 0
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
@@ -36,8 +36,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/libsdl-org/SDL
-      tag: preview-${{package.version}}
-      expected-commit: 22422f7748d5128135995ed34c8f8012861c7332
+      tag: release-${{package.version}}
+      expected-commit: 535d80badefc83c5c527ec5748f2a20d6a9310fe
 
   - uses: cmake/configure
 
@@ -64,8 +64,8 @@ update:
   enabled: true
   github:
     identifier: libsdl-org/SDL
-    strip-prefix: preview-
-    tag-filter-prefix: preview
+    strip-prefix: release-
+    tag-filter-prefix: release-3
     use-tag: true
 
 test:


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/releases/tag/release-3.2.0

Congrats to the SDL team!