### PR TITLE
Build libbpf with LIBDIR so pkgconf passes

### DIFF
--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbpf
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: GPL-2.0-only
@@ -32,11 +32,7 @@ pipeline:
   - uses: autoconf/make-install
     with:
       dir: src
-
-  - runs: |
-      # poor mans consolidation of the libs into /usr/lib64
-      mv "${{targets.destdir}}"/usr/lib64 "${{targets.destdir}}"/usr/lib
-      mv "${{targets.destdir}}"/usr/lib "${{targets.destdir}}"/usr/lib64
+      opts: LIBDIR="/usr/lib/"
 
   - uses: strip
 
@@ -47,6 +43,9 @@ subpackages:
     dependencies:
       runtime:
         - libbpf
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true
@@ -115,7 +114,3 @@ test:
 
         # Run the program to check if it can open the BPF object
         ./user_prog
-    - name: "Check pkg-config"
-      runs: |
-        pkg-config --exists libbpf
-        pkg-config --modversion libbpf


### PR DESCRIPTION
If `LIBDIR` is not set then the .pc files end up in `/usr/lib64/pkgconfig/`, as seen in https://github.com/wolfi-dev/os/issues/34322, which then causes the pkgconf test pipeline to fail. This resolves that issue and additionally fixes some failures with apk audit and the current version of the package.