### PR TITLE
package(kbd): add kbd package, add as dependency of systemd-init

### DIFF
--- a/kbd.yaml
+++ b/kbd.yaml
@@ -37,6 +37,8 @@ pipeline:
 
   - uses: autoconf/make-install
 
+  - uses: strip
+
 update:
   enabled: true
   release-monitor:

--- a/kbd.yaml
+++ b/kbd.yaml
@@ -5,9 +5,6 @@ package:
   description: Linux keyboard tools
   copyright:
     - license: GPL-2.0-or-later
-  resources:
-    cpu: 4
-    memory: 12Gi
 
 environment:
   contents:

--- a/kbd.yaml
+++ b/kbd.yaml
@@ -1,0 +1,52 @@
+package:
+  name: kbd
+  version: "2.7.1"
+  epoch: 0
+  description: Linux keyboard tools
+  copyright:
+    - license: GPL-2.0-or-later
+  resources:
+    cpu: 4
+    memory: 12Gi
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox-full
+      - coreutils
+      - linux-pam-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: cc4ad92a5e41689589e0a35e1c339b210679bb744dcec1b4088842e331756577
+      uri: https://www.kernel.org/pub/linux/utils/kbd/kbd-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-nls \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --datadir=/usr/share \
+        --htmldir=/usr/share/html/${{package.name}} \
+        --disable-static
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1492
+
+test:
+  pipeline:
+    - name: Verify kbd installation
+      runs: |
+        /usr/bin/loadkeys --version || exit 1
+        /usr/bin/loadkeys --help
+        /usr/bin/dumpkeys --version || exit 1
+        /usr/bin/dumpkeys --help


### PR DESCRIPTION
kbd is a dependency of systemd when used as pid1 to load keymaps
