### PR TITLE
feat(services): add service auto-enable in multiuser target

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -191,6 +191,9 @@ subpackages:
           install -Dm644 contrib/init/systemd/docker.socket "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           install -Dm644 contrib/init/systemd/docker.service "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           sed -i "s|\[Service\]|[Service]\nEnvironment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/docker.service
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
+          ln -sf ../docker.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshddocker.service"
+          ln -sf ../docker.socket "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshddocker.socket"
 
 update:
   enabled: true

--- a/docker.yaml
+++ b/docker.yaml
@@ -191,9 +191,8 @@ subpackages:
           install -Dm644 contrib/init/systemd/docker.socket "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           install -Dm644 contrib/init/systemd/docker.service "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           sed -i "s|\[Service\]|[Service]\nEnvironment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/docker.service
-          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
-          ln -sf ../docker.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/docker.service"
-          ln -sf ../docker.socket "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/docker.socket"
+          echo "enable docker.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/81-docker.preset"
+          echo "enable docker.socket" >> "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/81-docker.preset"
 
 update:
   enabled: true

--- a/docker.yaml
+++ b/docker.yaml
@@ -192,8 +192,8 @@ subpackages:
           install -Dm644 contrib/init/systemd/docker.service "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           sed -i "s|\[Service\]|[Service]\nEnvironment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/docker.service
           mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
-          ln -sf ../docker.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshddocker.service"
-          ln -sf ../docker.socket "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshddocker.socket"
+          ln -sf ../docker.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/docker.service"
+          ln -sf ../docker.socket "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/docker.socket"
 
 update:
   enabled: true

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "27.5.1"
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0

--- a/docker.yaml
+++ b/docker.yaml
@@ -188,6 +188,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system/
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system-preset/
           install -Dm644 contrib/init/systemd/docker.socket "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           install -Dm644 contrib/init/systemd/docker.service "${{targets.subpkgdir}}"/usr/lib/systemd/system/
           sed -i "s|\[Service\]|[Service]\nEnvironment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/docker.service

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -154,7 +154,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system-preset/
           install -Dm644  sshd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system
           echo "enable sshd.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/80-sshd.preset"
-
     dependencies:
       runtime:
         - systemd

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.9_p1
-  epoch: 3
+  epoch: 4
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -151,7 +151,10 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
           install -Dm644  sshd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          ln -sf ../sshd.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshd.service"
+
     dependencies:
       runtime:
         - systemd

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -154,7 +154,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
           install -Dm644  sshd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system
           ln -sf ../sshd.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshd.service"
-
     dependencies:
       runtime:
         - systemd

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -151,9 +151,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system
-          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
           install -Dm644  sshd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system
-          ln -sf ../sshd.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/sshd.service"
+          echo "enable sshd.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/80-sshd.preset"
+
     dependencies:
       runtime:
         - systemd

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -151,6 +151,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system-preset/
           install -Dm644  sshd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system
           echo "enable sshd.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/80-sshd.preset"
 

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -370,11 +370,17 @@ subpackages:
         - ${{package.name}}
         - tzdata
         - mount
+        - kbd
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc ${{targets.subpkgdir}}/sbin
-          ln -s ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
+          ln -sf ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
           ln -sf ../usr/share/zoneinfo/UTC ${{targets.subpkgdir}}/etc/localtime
+          ln -sf ../run/systemd/resolve/stub-resolv.conf "${{targets.subpkgdir}}/etc/resolv.conf"
+          ln -sf ../systemd-networkd.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-networkd.service"
+          ln -sf ../systemd-resolved.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-resolved.service"
+          touch "${{targets.subpkgdir}}/etc/machine-id"
     test:
       pipeline:
         - runs: |

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -369,6 +369,7 @@ subpackages:
       runtime:
         - ${{package.name}}
         - tzdata
+        - agetty
         - mount
         - kbd
         - agetty
@@ -534,5 +535,5 @@ test:
         rm test.c test_systemd
     - name: "Verify stanalone binaries removed"
       runs: |
-        STANDALONE_BINARIES=$(find / -name '*.standalone')
+        STANDALONE_BINARIES=$(find /usr -name '*.standalone' )
         test -z "${STANDALONE_BINARIES}"

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -374,12 +374,8 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc ${{targets.subpkgdir}}/sbin
-          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/"
-          ln -sf ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
-          ln -sf ../usr/share/zoneinfo/UTC ${{targets.subpkgdir}}/etc/localtime
-          ln -sf ../run/systemd/resolve/stub-resolv.conf "${{targets.subpkgdir}}/etc/resolv.conf"
-          ln -sf ../systemd-networkd.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-networkd.service"
-          ln -sf ../systemd-resolved.service "${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-resolved.service"
+          ln -s ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
+          ln -s ../run/systemd/resolve/stub-resolv.conf "${{targets.subpkgdir}}/etc/resolv.conf"
           touch "${{targets.subpkgdir}}/etc/machine-id"
     test:
       pipeline:

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.2"
-  epoch: 7
+  epoch: 8
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -371,6 +371,7 @@ subpackages:
         - tzdata
         - mount
         - kbd
+        - agetty
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc ${{targets.subpkgdir}}/sbin

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -383,7 +383,7 @@ subpackages:
       pipeline:
         - runs: |
             [ -f /sbin/init -a -x /sbin/init ]
-            [ -f /etc/localtime ]
+            grep "uninitialized" /etc/machine-id
 
   - name: "systemd-default-network"
     description: "Configure network to DHCP on default interfaces"

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -376,7 +376,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc ${{targets.subpkgdir}}/sbin
           ln -s ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
           ln -s ../run/systemd/resolve/stub-resolv.conf "${{targets.subpkgdir}}/etc/resolv.conf"
-          touch "${{targets.subpkgdir}}/etc/machine-id"
+          echo "uninitialized" > "${{targets.subpkgdir}}/etc/machine-id"
     test:
       pipeline:
         - runs: |


### PR DESCRIPTION
enable by default some services linking to multiuser.target
add /etc/machine-id to systemd-init, it's needed to bootstrap some services
add kbd dependency for systemd-init