### PR TITLE
ensure entrypoints are also packaged

### DIFF
--- a/gitlab-runner-17.8.yaml
+++ b/gitlab-runner-17.8.yaml
@@ -1,17 +1,25 @@
-# This tracks and the expected commit and tag used by Docker Machine.
-# This varies for each version of GitLab's runner and requires manual
-# intervention between updates.
-#
-# The Docker Machine Executor is deprecated https://gitlab.com/gitlab-org/gitlab/-/issues/498268
-#
-# This location is no longer valid for finding the machine version:
-# https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v${{package.version}}/.gitlab/ci/_common.gitlab-ci.yml?ref_type=tags#L17
-#
-# Until machine is fully removed, we're now checking for the latest version from the following link
-# https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/tags
 vars:
+  # This tracks and the expected commit and tag used by Docker Machine.
+  # This varies for each version of GitLab's runner and requires manual
+  # intervention between updates.
+  #
+  # The Docker Machine Executor is deprecated https://gitlab.com/gitlab-org/gitlab/-/issues/498268
+  #
+  # This location is no longer valid for finding the machine version:
+  # https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v${{package.version}}/.gitlab/ci/_common.gitlab-ci.yml?ref_type=tags#L17
+  #
+  # Until machine is fully removed, we're now checking for the latest version from the following link
+  # https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/tags
   machine-commit: 115286f8c18fc5ebb2181bb56a04ae23eef40135
   machine-tag: 0.16.2-gitlab.31
+  # This tracks and the expected commit and tag used by the base images.
+  # This varies for each version of GitLab's runner and requires manual
+  # intervention between updates.
+  #
+  # The base image repo is here: https://gitlab.com/gitlab-org/ci-cd/runner-tools/base-images
+  # The tag used in the specific version of runner can be found in this file: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/.gitlab/ci/_common.gitlab-ci.yml#L7
+  base-images-commit: 9e4f9750c3274ccc4156a5146da66c10ca5730e2
+  base-images-tag: 0.0.1
 
 var-transforms:
   - from: ${{package.version}}
@@ -23,7 +31,7 @@ package:
   name: gitlab-runner-17.8
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.8.0
-  epoch: 1
+  epoch: 2
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
@@ -56,6 +64,46 @@ subpackages:
           packages: ./apps/gitlab-runner-helper
           output: gitlab-runner-helper
           ldflags: -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+
+  - name: "gitlab-runner-oci-entrypoint-${{vars.major-minor-version}}"
+    description: "Gitlab-runner oci entrypoint"
+    dependencies:
+      provides:
+        - gitlab-runner-oci-entrypoint=${{package.full-version}}
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://gitlab.com/gitlab-org/ci-cd/runner-tools/base-images
+          tag: v${{vars.base-images-tag}}
+          expected-commit: ${{vars.base-images-commit}}
+          destination: ./base-images
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          cp ./base-images/dockerfiles/runner/alpine/entrypoint "${{targets.subpkgdir}}"/entrypoint
+          chmod 755 "${{targets.subpkgdir}}"/entrypoint
+
+  # As of 17.8, the entrypoint is now sourced from yet another repository
+  - name: "gitlab-runner-helper-oci-entrypoint-${{vars.major-minor-version}}"
+    description: "Gitlab-runner-helper oci entrypoint"
+    dependencies:
+      provides:
+        - gitlab-runner-helper-oci-entrypoint=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cp ./base-images/dockerfiles/runner-helper/scripts/gitlab-runner-build "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-build
+          cp ./base-images/dockerfiles/runner-helper/helpers/entrypoint "${{targets.subpkgdir}}"/entrypoint
+
+  - name: "gitlab-runner-helper-compat-${{vars.major-minor-version}}"
+    description: "Gitlab-runner-helper compat"
+    dependencies:
+      provides:
+        - gitlab-runner-helper-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          ln -sf /usr/bin/gitlab-runner "${{targets.subpkgdir}}"/usr/bin/gitlab-ci-multi-runner
+          ln -sf /usr/bin/miniperl "${{targets.subpkgdir}}"/usr/bin/perl
 
   - name: gitlab-docker-machine-${{vars.major-minor-version}}
     description: "Creates Docker hosts used by GitLab runner."


### PR DESCRIPTION
I'm not entirely sure why these weren't copied voer with the update bot