### PR TITLE
Build libvterm with options so pkgconf test passes

### DIFF
--- a/libvterm.yaml
+++ b/libvterm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvterm
   version: 0.3.3
-  epoch: 2
+  epoch: 3
   description: "Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator"
   copyright:
     - license: MIT
@@ -25,12 +25,17 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+    with:
+      opts: PREFIX=/usr LIBDIR=/usr/lib
 
 subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     description: ${{package.name}} dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: ${{package.name}}-static
     pipeline:


### PR DESCRIPTION
This fixes https://github.com/wolfi-dev/os/issues/37190.