### PR TITLE
glibc: switch to git and cherry-pick fix for CVE-2025-0395

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 4
+  epoch: 5
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -57,10 +57,13 @@ environment:
     GCC_SPEC_FILE: /dev/null
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/libc/glibc-${{package.version}}.tar.xz
-      expected-sha256: 19a890175e9263d748f627993de6f4b1af9cd21e03f080e4bfb3a1fac10205a2
+      expected-commit: 3d1aed874918c466a4477af1da35983ab036690e
+      repository: https://sourceware.org/git/glibc.git
+      tag: glibc-${{package.version}}
+      cherry-picks: |
+        release/2.40/master/7d4b6bcae91f29d7b4daf15bab06b66cf1d2217c: Fix underallocation of abort_msg_s struct (CVE-2025-0395)
 
   - uses: patch
     with:


### PR DESCRIPTION
Fix for CVE-2025-0395. PR for the advisory: https://github.com/wolfi-dev/advisories/pull/11351

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

