### PR TITLE
ruby3.x-rails-8.0-compat: new sub-packages

### DIFF
--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -1,12 +1,13 @@
 package:
   name: ruby3.2-rails-8.0
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
   dependencies:
     provides:
+      - rails=${{package.full-version}}
       - ruby${{vars.rubyMM}}-rails=${{package.full-version}}
     runtime:
       - gcc
@@ -45,20 +46,39 @@ pipeline:
     runs: |
       mkdir -p ${{targets.contextdir}}/usr/bin
       gem install ${{vars.gem}}-${{package.version}}.gem \
-        --bindir /tmp/bin/ \
-        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}.0/ \
+        --bindir /tmp/bin \
+        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}} \
         --no-document \
         --verbose \
         --version ${{package.version}}
 
-      mv /tmp/bin/rails ${{targets.contextdir}}/usr/bin/
+      # These are the binaries that rails provides that don't overlap with those already provided by ruby
+      for bin in nokogiri rackup rails thor; do
+        mv /tmp/bin/$bin ${{targets.contextdir}}/usr/bin/
+      done
 
   - uses: ruby/clean
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # Ruby expects user-installed gems/binaries in /usr/local/bundle
+          mkdir -p ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin
+          for bin in nokogiri rackup rails thor; do
+            ln -sf /usr/bin/$bin ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin/$bin
+          done
+
+          mkdir -p ${{targets.contextdir}}/usr/local
+          ln -sf /usr/share/ruby/gems/${{vars.rubyMM}} ${{targets.contextdir}}/usr/local/bundle
 
 test:
   environment:
     environment:
-      GEM_PATH: /usr/lib/ruby/gems/${{rubyMM}}.0/:/usr/share/ruby/gems/${{vars.rubyMM}}.0/
+      GEM_HOME: /usr/local/bundle
+    contents:  
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Test installation
       runs: rails --version

--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -82,6 +82,13 @@ test:
   pipeline:
     - name: Test installation
       runs: rails --version
+    - name: Test symlinks
+      runs: |
+        $GEM_HOME/bin/rails --version | grep ${{package.version}}
+
+        # New gems should go to $GEM_HOME which is linked to /usr/share/ruby/gems/...
+        gem install faraday # random gem not included in rails
+        ls /usr/share/ruby/gems/${{vars.rubyMM}}/gems | grep faraday
     - name: Test new app creation / run server
       uses: test/daemon-check-output
       with:

--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -76,7 +76,7 @@ test:
   environment:
     environment:
       GEM_HOME: /usr/local/bundle
-    contents:  
+    contents:
       packages:
         - ${{package.name}}-compat
   pipeline:

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -1,12 +1,13 @@
 package:
   name: ruby3.3-rails-8.0
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
   dependencies:
     provides:
+      - rails=${{package.full-version}}
       - ruby${{vars.rubyMM}}-rails=${{package.full-version}}
     runtime:
       - gcc
@@ -45,20 +46,39 @@ pipeline:
     runs: |
       mkdir -p ${{targets.contextdir}}/usr/bin
       gem install ${{vars.gem}}-${{package.version}}.gem \
-        --bindir /tmp/bin/ \
-        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}.0/ \
+        --bindir /tmp/bin \
+        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}} \
         --no-document \
         --verbose \
         --version ${{package.version}}
 
-      mv /tmp/bin/rails ${{targets.contextdir}}/usr/bin/
+      # These are the binaries that rails provides that don't overlap with those already provided by ruby
+      for bin in nokogiri rackup rails thor; do
+        mv /tmp/bin/$bin ${{targets.contextdir}}/usr/bin/
+      done
 
   - uses: ruby/clean
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # Ruby expects user-installed gems/binaries in /usr/local/bundle
+          mkdir -p ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin
+          for bin in nokogiri rackup rails thor; do
+            ln -sf /usr/bin/$bin ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin/$bin
+          done
+
+          mkdir -p ${{targets.contextdir}}/usr/local
+          ln -sf /usr/share/ruby/gems/${{vars.rubyMM}} ${{targets.contextdir}}/usr/local/bundle
 
 test:
   environment:
     environment:
-      GEM_PATH: /usr/lib/ruby/gems/${{rubyMM}}.0/:/usr/share/ruby/gems/${{vars.rubyMM}}.0/
+      GEM_HOME: /usr/local/bundle
+    contents:  
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Test installation
       runs: rails --version

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -82,6 +82,13 @@ test:
   pipeline:
     - name: Test installation
       runs: rails --version
+    - name: Test symlinks
+      runs: |
+        $GEM_HOME/bin/rails --version | grep ${{package.version}}
+
+        # New gems should go to $GEM_HOME which is linked to /usr/share/ruby/gems/...
+        gem install faraday # random gem not included in rails
+        ls /usr/share/ruby/gems/${{vars.rubyMM}}/gems | grep faraday
     - name: Test new app creation / run server
       uses: test/daemon-check-output
       with:

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -76,7 +76,7 @@ test:
   environment:
     environment:
       GEM_HOME: /usr/local/bundle
-    contents:  
+    contents:
       packages:
         - ${{package.name}}-compat
   pipeline:

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,12 +1,13 @@
 package:
   name: ruby3.4-rails-8.0
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
   dependencies:
     provides:
+      - rails=${{package.full-version}}
       - ruby${{vars.rubyMM}}-rails=${{package.full-version}}
     runtime:
       - gcc
@@ -45,23 +46,49 @@ pipeline:
     runs: |
       mkdir -p ${{targets.contextdir}}/usr/bin
       gem install ${{vars.gem}}-${{package.version}}.gem \
-        --bindir /tmp/bin/ \
-        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}.0/ \
+        --bindir /tmp/bin \
+        --install-dir ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}} \
         --no-document \
         --verbose \
         --version ${{package.version}}
 
-      mv /tmp/bin/rails ${{targets.contextdir}}/usr/bin/
+      # These are the binaries that rails provides that don't overlap with those already provided by ruby
+      for bin in nokogiri rackup rails thor; do
+        mv /tmp/bin/$bin ${{targets.contextdir}}/usr/bin/
+      done
 
   - uses: ruby/clean
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # Ruby expects user-installed gems/binaries in /usr/local/bundle
+          mkdir -p ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin
+          for bin in nokogiri rackup rails thor; do
+            ln -sf /usr/bin/$bin ${{targets.contextdir}}/usr/share/ruby/gems/${{vars.rubyMM}}/bin/$bin
+          done
+
+          mkdir -p ${{targets.contextdir}}/usr/local
+          ln -sf /usr/share/ruby/gems/${{vars.rubyMM}} ${{targets.contextdir}}/usr/local/bundle
 
 test:
   environment:
     environment:
-      GEM_PATH: /usr/lib/ruby/gems/${{rubyMM}}.0/:/usr/share/ruby/gems/${{vars.rubyMM}}.0/
+      GEM_HOME: /usr/local/bundle
+    contents:  
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Test installation
       runs: rails --version
+    - name: Test symlinks
+      runs: |
+        $GEM_HOME/bin/rails --version | grep ${{package.version}}
+
+        # New gems should go to $GEM_HOME which is linked to /usr/share/ruby/gems/...
+        gem install faraday # random gem not included in rails
+        ls /usr/share/ruby/gems/${{vars.rubyMM}}/gems | grep faraday
     - name: Test new app creation / run server
       uses: test/daemon-check-output
       with:

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -76,7 +76,7 @@ test:
   environment:
     environment:
       GEM_HOME: /usr/local/bundle
-    contents:  
+    contents:
       packages:
         - ${{package.name}}-compat
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adds `-compat` sub-packages for `rails` to align with the public `ruby` container image configuration.

Related: https://github.com/chainguard-dev/image-requests/issues/5160