### PR TITLE
kong: Enforce kong-manager version and artifact checksum

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong
   version: 3.9.0
-  epoch: 2
+  epoch: 3
   description: "The Kong Gateway - an API Gateway built on Nginx and OpenResty"
   copyright:
     - license: Apache-2.0

--- a/kong/http-archive.patch
+++ b/kong/http-archive.patch
@@ -1,11 +1,10 @@
-git diff
 diff --git a/build/repositories.bzl b/build/repositories.bzl
-index 4004b32f7..08a5d40cd 100644
+index 4004b32..875018e 100644
 --- a/build/repositories.bzl
 +++ b/build/repositories.bzl
-@@ -50,12 +50,9 @@ def github_cli_repositories():
+@@ -50,12 +50,10 @@ def github_cli_repositories():
          )
-
+ 
  def kong_github_repositories():
 -    maybe(
 -        github_release,
@@ -14,6 +13,8 @@ index 4004b32f7..08a5d40cd 100644
 -        repo = "kong/kong-manager",
 -        tag = KONG_VAR["KONG_MANAGER"],
 -        pattern = "release.tar.gz",
-+        url = "https://github.com/Kong/kong-manager/releases/download/nightly/release.tar.gz",
++        url = "https://github.com/Kong/kong-manager/releases/download/%s/release.tar.gz" % (KONG_VAR["KONG_MANAGER"]),
++        sha256 = "0e5028f8ecfcc611de8d0a015a1985d46fe207d09a87ffe644a2d19b189db70a,
          build_file_content = _DIST_BUILD_FILE_CONTENT,
      )
+ 


### PR DESCRIPTION
Enforces the version of kong-manager being deployed in the build and enforced the checksum of the artifact.

In this comment it's mentioned that the kong-manager version included in the build is always nightly, but this is not the case:
https://github.com/wolfi-dev/os/pull/38875#discussion_r1904825706

The commit referenced in the comment was sourced from a commit in the main branch:
https://github.com/Kong/kong/blob/df6cc598b65d4d205ae148812d0a673d2fc098b9/.requirements#L26

If you look at the release tag for Kong 3.9.0 you can see it's set to a static version:
https://github.com/Kong/kong/blob/3.9.0/.requirements

I've also added aSHA256 check of the artifact to ensure the integrity of the downloaded artifact.