### PR TITLE
Set an owner for abseil-cpp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,6 @@ Makefile   @wolfi-dev/foundations-squad
 pipelines/ @wolfi-dev/foundations-squad
 
 # These packages require approval from the Foundations squad.
+abseil-cpp.yaml      @wolfi-dev/foundations-squad
 openssh.yaml         @wolfi-dev/foundations-squad
 ca-certificates.yaml @wolfi-dev/foundations-squad


### PR DESCRIPTION
Let's codify the comment in the yaml file:

```
  1 # BEFORE UPDATING: Adding a new build of abseil-cpp into the archive at this
  2 # time may cause installs of packages that depend on abseil-cpp packages to
  3 # time out:
  4 #   https://github.com/chainguard-dev/melange/issues/1651
  5 # Until this issue is resolved, please request a PR approval for changes
  6 # to this file from the OS team.
```