### PR TITLE
audit - Split out the library from the daemon.

### DIFF
--- a/audit.yaml
+++ b/audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: audit
   version: 4.0.3
-  epoch: 1
+  epoch: 2
   description: User space tools for kernel auditing
   copyright:
     - license: LGPL-2.1-or-later
@@ -74,6 +74,33 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libaudit
+    description: c library for security auditing
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/lib*.so.* ${{targets.contextdir}}/usr/lib
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: libaudit
+
+  - name: py3-audit
+    description: python bindings for audit
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/python3.* ${{targets.contextdir}}/usr/lib
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            import: audit
+        - uses: test/ldd-check
+          with:
+            packages: py3-audit
+
   - name: audit-static
     pipeline:
       - uses: split/static
@@ -84,7 +111,6 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - audit
         - linux-headers
     description: audit dev
     test:
@@ -92,7 +118,7 @@ subpackages:
         - uses: test/pkgconf
         - uses: test/ldd-check
           with:
-            packages: ${{package.name}}
+            packages: audit-dev
 
   - name: audit-doc
     pipeline:
@@ -115,9 +141,6 @@ test:
         audisp-remote --help
         aureport --help
         ausearch --help
-    - uses: python/import
-      with:
-        import: audit
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}


### PR DESCRIPTION
systemd has a runtime dependency on libaudit, but does not need all of the other things.  So, split the libraries out into libaudit package.  Also split python3 bindings out of the "main" package as the audit deamon does not need them.
