### PR TITLE
Add a disabled pkgconf test for re2

### DIFF
--- a/re2.yaml
+++ b/re2.yaml
@@ -1,6 +1,6 @@
 package:
   name: re2
-  version: "2024.02.01"
+  version: "2024.02.01" # Please enable the pkgconf test on update
   epoch: 2
   description: Efficient, principled regular expression library
   copyright:
@@ -43,10 +43,17 @@ pipeline:
   - uses: strip
 
 subpackages:
+  #   test:
+  #     pipeline:
+  #       - uses: test/pkgconf:
   - name: re2-dev
     pipeline:
       - uses: split/dev
     description: re2 dev
+    dependencies:
+      runtime:
+        - abseil-cpp-dev
+        - icu-dev
 
 update:
   enabled: true


### PR DESCRIPTION
I was able to manually get the pkgconf test to run by using `debug -i` and installing the packages added as runtime dependencies, however getting the pkgconf test to pass in infra requires rebuilding the package which it currently fails to do. Instead of losing my work let's add the dependencies and the test as a comment.