### PR TITLE
wolfi-baselayout: add more top-level required directories

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 15
+  epoch: 16
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -38,7 +38,7 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local/lib tmp var/spool/cron opt run usr/lib; do
+      for i in bin dev etc etc/profile.d etc/secfixes.d home lib proc root var/log usr/bin usr/sbin usr/local/lib sys tmp var/spool/cron opt run usr/lib; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
 


### PR DESCRIPTION
To run unmodified containers fully read-only, without an overlayfs
layer, a few more directories are required as mountpoints. Also they
are always present on other distributions (e.g. Debian's base-files),
and/or always created by apko already.

Add following top-level directories:
- /dev for devpts mount-point, already created by apko
- /proc for procfs mount-point
- /sys for sysfs mount-point
