### PR TITLE
jitsu-2.8.6/fix GHSA-c76h-2ccp-4975

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.8.6"
-  epoch: 0
+  epoch: 1
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: GHSA-7m27-7ghc-44w9.patch
+      patches: GHSA-7m27-7ghc-44w9.patch GHSA-c76h-2ccp-4975.patch
 
   - runs: |
       pnpm install -r --unsafe-perm

--- a/jitsucom-jitsu/GHSA-c76h-2ccp-4975.patch
+++ b/jitsucom-jitsu/GHSA-c76h-2ccp-4975.patch
@@ -1,0 +1,25 @@
+From 9b6d7c5e8b23e20e60d03d85265e284679d304a6 Mon Sep 17 00:00:00 2001
+From: Kyle Steere <kyle.steere@chainguard.dev>
+Date: Fri, 24 Jan 2025 08:05:23 -0600
+Subject: [PATCH] fix GHSA-c76h-2ccp-4975
+
+---
+ package.json | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 0c0ec8c22..6508ed552 100644
+--- a/package.json
++++ b/package.json
+@@ -66,5 +66,8 @@
+     "services/*",
+     "cli/*",
+     "libs/*"
+-  ]
++  ],
++  "resolutions": {
++    "undici": "^6.21.1"
++  }
+ }
+--
+2.43.0


### PR DESCRIPTION
Fix:
undici: [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975)/[GHSA-c76h-2ccp-4975](https://github.com/advisories/GHSA-c76h-2ccp-4975)
