### PR TITLE
dotnet-8: depend on exact required version of bootstrap package, enable updates for bootstrap package

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -23,7 +23,7 @@ environment:
       - clang-15-default
       - cmake
       - curl
-      - dotnet-bootstrap-8
+      - dotnet-bootstrap-8=${{package.version}}
       - glibc-locale-en
       - icu-dev
       - krb5-dev

--- a/dotnet-bootstrap-8.yaml
+++ b/dotnet-bootstrap-8.yaml
@@ -53,7 +53,7 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: dotnet/dotnet
     strip-prefix: v


### PR DESCRIPTION
In https://github.com/wolfi-dev/os/commit/16b0aa183cb6e871d34e04db2cc1520ae00f62f3 the dotnet-8 package was split apart. The resultant `dotnet-8` package requires the exact same version of `dotnet-bootstrap-8` to build (as it contains the generated sources for the build) so (a) express that in metadata, and (b) enable updates for `-bootstrap-` so we don't have to manually bump it each time.