### PR TITLE
protobuf-c: bump epoch to rebuild against new libprotobuf

### DIFF
--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0 # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 14
+  epoch: 15
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Similar [issue](https://github.com/chainguard-images/images-private/actions/runs/12954900403/job/36137875040?pr=7131) as this reported in this PR https://github.com/wolfi-dev/os/pull/40015

`"resolving apk packages: for arch \"amd64\": solving \"apache-arrow=19.0.0-r0\" constraint: resolving \"apache-arrow-19.0.0-r0.apk\" deps:\nsolving \"so:libprotobuf.so.29.3.0\" constraint:   libprotobuf-3.29.3-r0.apk disqualified because \"3.29.3-r0\" does not satisfy \"libprotobuf=3.29.1-r0\""`
