### PR TITLE
libnvme: split out python bindings

### DIFF
--- a/libnvme.yaml
+++ b/libnvme.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvme
   version: 1.11.1
-  epoch: 0
+  epoch: 1
   description: C Library for NVM Express on Linux
   copyright:
     - license: LGPL-2.1-or-later
@@ -46,6 +46,22 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
+
+  - name: libnvme-python
+    description: Python bindings for libnvme
+    dependencies:
+      runtime:
+        - libnvme
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.subpkgdir}}"/usr/lib/
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            imports: |
+              import libnvme
 
 update:
   enabled: true


### PR DESCRIPTION
Previously, `libnvme` included its Python bindings in the main package, which brought in a Python dependency unnecessarily. If someone wants the Python bindings, they can use `libnvme-py` to get them.

The diff should show the change in `depends`

edit:

```
  	Dependencies: []string{
- 		"python-3.12-base",
```

...and the `-python` package has the dep instead.