### PR TITLE
chore(postgres): Add compat package for pgAdmin

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.6"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -44,6 +44,10 @@ var-transforms:
     match: '\.'
     replace: "_"
     to: mangled-package-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 pipeline:
   - uses: git-checkout
@@ -122,6 +126,19 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           for binary in ${{vars.client-tools}}; do
             ln -sf /usr/libexec/${{vars.mangled-package-name}}/${binary} ${{targets.subpkgdir}}/usr/bin/${binary}
+          done
+
+  - name: ${{package.name}}-pgadmin-compat
+    description: Provides pg${{vars.major-version}} client utils in pgAdmin's path
+    dependencies:
+      runtime:
+        - ${{package.name}}-client-base
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/pgsql-${{vars.major-version}}
+          for path in ${{targets.outdir}}/${{package.name}}-client-base/usr/libexec/${{vars.mangled-package-name}}/*; do
+            name=${path##*/}
+            ln -s /usr/libexec/${{vars.mangled-package-name}}/$name ${{targets.contextdir}}/usr/local/pgsql-${{vars.major-version}}/$name
           done
 
   - name: ${{package.name}}-contrib

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.2"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -44,6 +44,10 @@ var-transforms:
     match: '\.'
     replace: "_"
     to: mangled-package-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 pipeline:
   - uses: git-checkout
@@ -122,6 +126,19 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           for binary in ${{vars.client-tools}}; do
             ln -sf /usr/libexec/${{vars.mangled-package-name}}/${binary} ${{targets.subpkgdir}}/usr/bin/${binary}
+          done
+
+  - name: ${{package.name}}-pgadmin-compat
+    description: Provides pg${{vars.major-version}} client utils in pgAdmin's path
+    dependencies:
+      runtime:
+        - ${{package.name}}-client-base
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/pgsql-${{vars.major-version}}
+          for path in ${{targets.outdir}}/${{package.name}}-client-base/usr/libexec/${{vars.mangled-package-name}}/*; do
+            name=${path##*/}
+            ln -s /usr/libexec/${{vars.mangled-package-name}}/$name ${{targets.contextdir}}/usr/local/pgsql-${{vars.major-version}}/$name
           done
 
   - name: ${{package.name}}-contrib


### PR DESCRIPTION
Provides Postgres client utilities at the path used by pgAdmin
