### PR TITLE
add setgid to some postfix binaries

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -177,6 +177,8 @@ pipeline:
       done
       rm makedefs.out
 
+      # setgid bit for postqueue group when it exists
+      chmod 2755 ${{targets.contextdir}}/usr/sbin/postqueue ${{targets.contextdir}}/usr/sbin/postdrop
 
       # fix /etc/postfix/postfix-files so that "postfix set-permissions" can run
       sed -i \


### PR DESCRIPTION
Fixes: missing setgid permissions on postdrop related binaries in postfix