### PR TITLE
move xvfb-run to a separate package

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: 21.1.15
-  epoch: 0
+  epoch: 1
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -105,29 +105,6 @@ subpackages:
     dependencies:
       runtime:
         - mesa-libgallium
-
-  - name: xvfb-run
-    description: imlib2 dev
-    dependencies:
-      runtime:
-        - coreutils
-        - xauth
-        - mcookie
-    pipeline:
-      - uses: git-checkout
-        with:
-          repository: https://salsa.debian.org/xorg-team/xserver/xorg-server
-          branch: debian-unstable # reason we use branch instead of tag: https://github.com/wolfi-dev/os/pull/13691#issue-2154225731
-          expected-commit: 4766ab7d1cf447c173564ed8a6c74318f4189fa8
-      - working-directory: debian/local
-        pipeline:
-          - runs: |
-              install -Dm755 xvfb-run "${{targets.subpkgdir}}"/usr/bin/xvfb-run
-              install -D xvfb-run.1 "${{targets.subpkgdir}}"/usr/share/man/man1/xvfb-run.1
-    test:
-      pipeline:
-        - runs: |
-            xvfb-run --help
 
   - name: ${{package.name}}-common
     pipeline:

--- a/xvfb-run.yaml
+++ b/xvfb-run.yaml
@@ -1,0 +1,49 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: xvfb-run
+  version: 0_git20250126
+  epoch: 0
+  description: imlib2 dev
+  copyright:
+    - license: SGI-B-2.0
+  dependencies:
+    runtime:
+      - coreutils
+      - xauth
+      - mcookie
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://salsa.debian.org/xorg-team/xserver/xorg-server
+      branch: debian-unstable # reason we use branch instead of tag: https://github.com/wolfi-dev/os/pull/13691#issue-2154225731
+      expected-commit: 4c5d2ac2b36d6da2a5b0f5b87ad90f5409d1532d
+
+  - working-directory: debian/local
+    pipeline:
+      - runs: |
+          install -Dm755 xvfb-run "${{targets.contextdir}}"/usr/bin/xvfb-run
+          install -D xvfb-run.1 "${{targets.contextdir}}"/usr/share/man/man1/xvfb-run.1
+
+subpackages:
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: xvfb-run manpages
+
+test:
+  pipeline:
+    - runs: |
+        xvfb-run --help
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: poll based on branches not tags # https://github.com/wolfi-dev/os/pull/13691#issue-2154225731


### PR DESCRIPTION
    move xvfb-run to a separate package
    
    separate out xvfb-run subpackage into it's own package because it was
    using a separate source and upon new commit the sha validation was
    failing leading to build time errors.
    
    one solution was to stop validation of commit sha and clone using branches.
    
    this moves to a package package and we now poll the branches weekly
    using git backend. bot will keep on bumping it weekly if upstream
    receives any new commit.