### PR TITLE
fix(jupyterhub-k8s-hub): adds missing jupyterhub-singleuser bin

### DIFF
--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyterhub-k8s-hub
   version: "4.1.0"
-  epoch: 0
+  epoch: 1
   description: Zero to JupyterHub with Kubernetes
   copyright:
     - license: BSD-3-Clause
@@ -9,7 +9,9 @@ package:
     runtime:
       - configurable-http-proxy
       - iptables
+      - py3-jupyter-server
       - py3-jupyterhub
+      - py3-jupyterhub-bin
       - py3-jupyterhub-firstuseauthenticator
       - py3-jupyterhub-hmacauthenticator
       - py3-jupyterhub-idle-culler


### PR DESCRIPTION
Issue is being reported with this error:
```bash
ModuleNotFoundError: No module named 'jupyter_server'  
ImportError: Failed to import default single-user server. Make sure to install dependencies for your single-user server, e.g.                                                                                                         pip install jupyterlab
```

This is primarily coming from not having this package https://apk.chaindag.dev/https/packages.wolfi.dev/os/x86_64/py3.13-jupyterhub-bin-5.2.1-r2.apk@sha1:e7ed7305ac8bf65b0ef734fc31e0c3af90e7483f/usr/bin/jupyterhub-singleuser and this should probably fix it