### PR TITLE
new pkg: apptainer

### DIFF
--- a/apptainer.yaml
+++ b/apptainer.yaml
@@ -5,6 +5,9 @@ package:
   description: "Application containers for Linux"
   copyright:
     - license: BSD-3-Clause AND BSD-3-Clause-LBNL
+  dependencies:
+    runtime:
+      - squashfs-tools
 
 environment:
   contents:
@@ -64,6 +67,6 @@ test:
     - runs: |
         apptainer version
         apptainer help
-    # test adding remote. can't do build just yet because we dont have squashfs-tools pkg
     - runs: |
         apptainer remote add --no-login docker docker://docker.io
+        apptainer build alpine.sif docker://alpine

--- a/apptainer.yaml
+++ b/apptainer.yaml
@@ -1,0 +1,68 @@
+package:
+  name: apptainer
+  version: 1.3.6
+  epoch: 0
+  description: "Application containers for Linux"
+  copyright:
+    - license: BSD-3-Clause AND BSD-3-Clause-LBNL
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - cni-plugins
+      - cryptsetup
+      - go
+      - libseccomp-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apptainer/apptainer
+      tag: v${{package.version}}
+      expected-commit: 9725fd3ba6199e5eb2bbc1f343b788bad91eb4f0
+
+  - runs: |
+      export VERSION="${{package.version}}-r${{package.epoch}}"
+      ./mconfig \
+          --prefix=/usr \
+          --sysconfdir=/etc \
+          --libexecdir=/usr/lib \
+          --localstatedir=/var/lib \
+          -P release-stripped \
+          --without-suid
+
+      make -C builddir
+      make -C builddir install DESTDIR="${{targets.contextdir}}"
+
+  - uses: strip
+
+subpackages:
+  - name: "apptainer-doc"
+    description: "apptainer documentation"
+    pipeline:
+      - uses: split/manpages
+
+  - name: apptainer-bash-completion
+    description: apptainer bash completion
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/share"
+          mv "${{targets.destdir}}/usr/share/bash-completion" \
+            "${{targets.subpkgdir}}/usr/share/bash-completion"
+
+update:
+  enabled: true
+  github:
+    strip-prefix: v
+    identifier: apptainer/apptainer
+
+test:
+  pipeline:
+    - runs: |
+        apptainer version
+        apptainer help
+    # test adding remote. can't do build just yet because we dont have squashfs-tools pkg
+    - runs: |
+        apptainer remote add --no-login docker docker://docker.io

--- a/apptainer.yaml
+++ b/apptainer.yaml
@@ -26,6 +26,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 9725fd3ba6199e5eb2bbc1f343b788bad91eb4f0
 
+  - uses: go/bump
+    with:
+      deps: github.com/docker/docker@v25.0.6 github.com/opencontainers/runc@v1.1.14 golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0
+
   - runs: |
       echo "${{package.version}}-r${{package.epoch}}" >> VERSION
 
@@ -69,4 +73,4 @@ test:
         apptainer help
     - runs: |
         apptainer remote add --no-login docker docker://docker.io
-        apptainer build alpine.sif docker://alpine
+        apptainer build --sandbox /tmp/alpine.sif docker://alpine:latest

--- a/apptainer.yaml
+++ b/apptainer.yaml
@@ -24,7 +24,8 @@ pipeline:
       expected-commit: 9725fd3ba6199e5eb2bbc1f343b788bad91eb4f0
 
   - runs: |
-      export VERSION="${{package.version}}-r${{package.epoch}}"
+      echo "${{package.version}}-r${{package.epoch}}" >> VERSION
+
       ./mconfig \
           --prefix=/usr \
           --sysconfdir=/etc \

--- a/squashfs-tools.yaml
+++ b/squashfs-tools.yaml
@@ -9,15 +9,15 @@ package:
 environment:
   contents:
     packages:
+      - attr-dev
       - bash
+      - build-base
       - busybox
       - lz4-dev
-      - xz-dev
-      - zstd-dev
-      - zlib-dev
-      - attr-dev
-      - build-base
       - lzo-dev
+      - xz-dev
+      - zlib-dev
+      - zstd-dev
 
 pipeline:
   - uses: git-checkout
@@ -47,11 +47,15 @@ update:
   enabled: true
   github:
     identifier: plougher/squashfs-tools
-# test:
-#   pipeline:
-#     - runs: |
-#         apptainer version
-#         apptainer help
-#     # test adding remote. can't do build just yet because we dont have squashfs-tools pkg
-#     - runs: |
-#         apptainer remote add --no-login docker docker://docker.io
+
+test:
+  pipeline:
+    - runs: |
+        mksquashfs -version
+        unsquashfs -help
+
+    - runs: |
+        mkdir test_dir
+        echo "Hello, World!" > test_dir/test_file.txt
+        mksquashfs test_dir test.sfs
+        test -f test.sfs && echo "mksquashfs test passed" || echo "mksquashfs test failed"

--- a/squashfs-tools.yaml
+++ b/squashfs-tools.yaml
@@ -53,7 +53,6 @@ test:
     - runs: |
         mksquashfs -version
         unsquashfs -help
-
     - runs: |
         mkdir test_dir
         echo "Hello, World!" > test_dir/test_file.txt

--- a/squashfs-tools.yaml
+++ b/squashfs-tools.yaml
@@ -1,0 +1,57 @@
+package:
+  name: squashfs-tools
+  version: 4.6.1
+  epoch: 0
+  description: "Tools for squashfs, a highly compressed read-only filesystem for Linux"
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - lz4-dev
+      - xz-dev
+      - zstd-dev
+      - zlib-dev
+      - attr-dev
+      - build-base
+      - lzo-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/plougher/squashfs-tools
+      tag: ${{package.version}}
+      expected-commit: d8cb82d9840330f9344ec37b992595b5d7b44184
+
+  - runs: |
+      make -C squashfs-tools XZ_SUPPORT=1 LZO_SUPPORT=1 LZ4_SUPPORT=1 ZSTD_SUPPORT=1
+
+      make -C squashfs-tools \
+      		INSTALL_MANPAGES_DIR="${{targets.destdir}}/usr/share/man/man1" \
+      		INSTALL_PREFIX="${{targets.destdir}}/usr" \
+      		USE_PREBUILT_MANPAGES=y \
+      		install
+
+  - uses: strip
+
+subpackages:
+  - name: "squashfs-tools-doc"
+    description: "squashfs-tools documentation"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: plougher/squashfs-tools
+# test:
+#   pipeline:
+#     - runs: |
+#         apptainer version
+#         apptainer help
+#     # test adding remote. can't do build just yet because we dont have squashfs-tools pkg
+#     - runs: |
+#         apptainer remote add --no-login docker docker://docker.io


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

- add `squashfs-tools` which is a runtime dep for apptainer
- Need to echo a file named `VERSION` in order to use WOlfi's versioning (overriding in `script/get-version` script)

![image](https://github.com/user-attachments/assets/71235738-2f55-483e-848f-6012c019aecf)

- ~~can only do dummy test + a add remote test. can't do build yet because it requires squashfs-tools~~

Fixes: https://github.com/wolfi-dev/os/issues/40414

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
