### PR TITLE
Add the ldd-check test pipeline to some packages

### DIFF
--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -150,6 +150,11 @@ subpackages:
           mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
     options:
       no-provides: true
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: 'libstdc++-11-dev'
     dependencies:
@@ -168,6 +173,11 @@ subpackages:
           mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
           mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: 'gcc-11-default'
     description: 'Use GCC 11 as system gcc'

--- a/mesa.yaml
+++ b/mesa.yaml
@@ -1,7 +1,7 @@
 package:
   name: mesa
   version: "24.3.4"
-  epoch: 0
+  epoch: 1
   description: Mesa DRI OpenGL library
   copyright:
     - license: MIT AND SGI-B-2.0 AND BSL-1.0
@@ -138,10 +138,16 @@ subpackages:
     dependencies:
       runtime:
         - libglvnd
+        - mesa-libgallium
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/${{range.value}}.so* ${{targets.subpkgdir}}/usr/lib
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: mesa-${{range.key}}
 
   - range: transitive
     name: mesa-${{range.key}}

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: 1.27.3
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -186,6 +186,8 @@ subpackages:
     dependencies:
       provides:
         - nginx-mod-${{range.key}}=${{package.full-version}}
+      runtime:
+        - perl-dev
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules
@@ -209,6 +211,11 @@ subpackages:
               install -m644 -D stream.conf ${{targets.subpkgdir}}/etc/nginx/stream.d/
             ;;
           esac
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: nginx-mainline-src
     description: Nginx source code

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: 1.26.2
-  epoch: 1
+  epoch: 2
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -178,6 +178,8 @@ subpackages:
     dependencies:
       provides:
         - nginx-mod-${{range.key}}=${{package.full-version}}
+      runtime:
+        - perl-dev
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules
@@ -201,6 +203,11 @@ subpackages:
               install -m644 -D stream.conf ${{targets.subpkgdir}}/etc/nginx/stream.d/
             ;;
           esac
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: nginx-stable-src
     description: Nginx source code

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -207,6 +207,9 @@ subpackages:
   - range: _subpackages
     name: postfix-${{range.key}}
     description: "${{range.key}} map support for postfix"
+    dependencies:
+      runtime:
+        - mariadb-dev
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/postfix \
@@ -218,6 +221,11 @@ subpackages:
           	"${{targets.subpkgdir}}"/usr/lib/postfix/
           mv "${{targets.destdir}}"/etc/postfix/dynamicmaps.cf.d/$m \
           	"${{targets.subpkgdir}}"/etc/postfix/dynamicmaps.cf.d/
+    # test:
+    #   pipeline:
+    #     - uses: test/ldd-check
+    #       with:
+    #         packages: postfix-${{range.key}}
 
 update:
   enabled: true

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -211,6 +211,11 @@ subpackages:
       runtime:
         - mariadb-dev
     pipeline:
+      # test:
+      #   pipeline:
+      #     - uses: test/ldd-check
+      #       with:
+      #         packages: postfix-${{range.key}}:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/postfix \
                  "${{targets.contextdir}}"/etc/postfix/dynamicmaps.cf.d
@@ -221,11 +226,6 @@ subpackages:
           	"${{targets.subpkgdir}}"/usr/lib/postfix/
           mv "${{targets.destdir}}"/etc/postfix/dynamicmaps.cf.d/$m \
           	"${{targets.subpkgdir}}"/etc/postfix/dynamicmaps.cf.d/
-    # test:
-    #   pipeline:
-    #     - uses: test/ldd-check
-    #       with:
-    #         packages: postfix-${{range.key}}
 
 update:
   enabled: true


### PR DESCRIPTION
This adds the ldd-check test pipeline to some more packages. mesa requires a rebuild to pick up a dependency, as do both nginx packages. The postfix test is disabled because it fails to build from source - https://github.com/wolfi-dev/os/issues/40550.

