### PR TITLE
rename tensorflow-cpu to tensorflow-cpu-jupyter

### DIFF
--- a/tensorflow-cpu-jupyter.yaml
+++ b/tensorflow-cpu-jupyter.yaml
@@ -1,9 +1,9 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
-  name: tensorflow-cpu
+  name: tensorflow-cpu-jupyter
   version: 2.18.0
   epoch: 0
-  description: tensorflow-cpu
+  description: tensorflow-cpu with jupyter support
   copyright:
     - license: Apache-2.0
   target-architecture:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -5,3 +5,5 @@ mockery-3-r3.apk
 mockery-3-r4.apk
 mockery-3-r5.apk
 mockery-3-r6.apk
+tensorflow-cpu-0_git20250108-r0.apk
+tensorflow-cpu-2.18.0-r0.apk


### PR DESCRIPTION
    rename tensorflow-cpu to tensorflow-cpu-jupyter
    
    this commit renames tensorflow-cpu package to tensorflow-cpu-jupyter to
    be more explicit that this package provides jupyter support.
    
    this way we're future proof in case we require another tensorflow-cpu
    package.
    
    also withdraws tensorflow-cpu packages from index