### PR TITLE
libcap: add release-monitor filter to only find dotted versions, bump to 2.73

### DIFF
--- a/libcap.yaml
+++ b/libcap.yaml
@@ -78,6 +78,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 1569
+    version-filter-contains: .
 
 test:
   pipeline:

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,6 +1,6 @@
 package:
   name: libcap
-  version: "2.71"
+  version: "2.73"
   epoch: 0
   description: "POSIX 1003.1e capabilities"
   copyright:
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: git://git.kernel.org/pub/scm/libs/libcap/libcap.git
       tag: v1.${{package.version}}
-      expected-commit: c7dbcf0bc9ee3be8ca3a0abd7548a7005e3d5eb5
+      expected-commit: 6ef6a9d1e415c0b75e5acbcbcbfbda86d4ba6b91
 
   - runs: |
       set -x


### PR DESCRIPTION
This excludes the currently-incorrectly-reported-as-latest 20071031 and 20070813 versions.