### PR TITLE
fix(samba): removed problematic files/directories to address linter errors

### DIFF
--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: 4.21.3
-  epoch: 1
+  epoch: 2
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -96,6 +96,12 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+  - runs: |
+      rm -rf ${{targets.destdir}}/var/lib/samba/bind-dns
+      rm -rf ${{targets.destdir}}/usr/share/info/dir
+      rm -rf ${{targets.destdir}}/tmp/*
+      rm -rf ${{targets.destdir}}/var/empty/*
 
 subpackages:
   - name: samba-common


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixed: samba build error

Related: #40552

```
2025/01/27 10:50:43 INFO signing apk index at packages/aarch64/APKINDEX.tar.gz
2025/01/27 10:50:43 INFO signing index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
2025/01/27 10:50:43 INFO appending signature RSA256 to index packages/aarch64/APKINDEX.tar.gz
2025/01/27 10:50:43 INFO writing signed index to packages/aarch64/APKINDEX.tar.gz
2025/01/27 10:50:43 INFO signed index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
make[1]: Leaving directory '/Users/Desktop/work/os'
```