### PR TITLE
add openjdk-21-default-jdk package to nextflow

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,14 +1,14 @@
 package:
   name: nextflow
   version: "24.10.4"
-  epoch: 1
+  epoch: 2
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - busybox
+      - curl
       - coreutils
       - openjdk-21-jre
 
@@ -18,7 +18,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gradle
-      - openjdk-21
+      - openjdk-21-default-jdk
+      - docker-cli
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk

--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -8,18 +8,18 @@ package:
   dependencies:
     runtime:
       - bash
-      - curl
       - coreutils
-      - openjdk-21-jre
+      - curl
+      - openjdk-21-default-jdk
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
+      - docker-cli
       - gradle
       - openjdk-21-default-jdk
-      - docker-cli
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk

--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -22,7 +22,7 @@ environment:
       - openjdk-21-default-jdk
   environment:
     LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-21-openjdk
+    JAVA_HOME: /usr/lib/jvm/default-jvm
 
 pipeline:
   - uses: git-checkout
@@ -36,7 +36,6 @@ pipeline:
       patches: logback-core-1.5.13.patch commons-io-2.14.0.patch
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
       sed -i 's/jar\.enabled = false/jar.enabled = true/' build.gradle
       ./gradlew build -x test --no-daemon
       ./gradlew shadowJar -x test --no-daemon
@@ -88,7 +87,7 @@ test:
         - ${{package.name}}-compat
         - curl
     environment:
-      JAVA_HOME: /usr/lib/jvm/java-21-openjdk
+      JAVA_HOME: /usr/lib/jvm/default-jvm
   pipeline:
     - name: Test version command
       runs: |

--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -10,6 +10,7 @@ package:
       - bash
       - coreutils
       - curl
+      - docker-cli
       - openjdk-21-default-jdk
 
 environment:
@@ -17,7 +18,6 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - docker-cli
       - gradle
       - openjdk-21-default-jdk
   environment:


### PR DESCRIPTION
Add `docker-cli` and `openjdk-21-default-jdk` package to nextflow
https://github.com/chainguard-images/images-private/pull/6964#discussion_r1928982948

Related: [#4792](https://github.com/chainguard-dev/image-requests/issues/4792)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
