### PR TITLE
Fix(Update bot faliure): Use gitlab git repo for gtk.

### DIFF
--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -148,6 +148,7 @@ update:
   enabled: true
   ignore-regex-patterns:
     - (?i)[a-z] # Ignore tags that include any case letters
+    - 3\.[89]\d.* # Ignore tags that start with 3.8x.x or 3.9x.x upstream released whi this tag 4 years ago.
   git:
     tag-filter-prefix: 3.
 

--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-3
-  version: 3.24.43
-  epoch: 2
+  version: 3.24.48
+  epoch: 0
   description: The GTK+ Toolkit (v3)
   copyright:
     - license: LGPL-2.1-or-later
@@ -76,10 +76,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://download.gnome.org/sources/gtk+/${{vars.mangled-package-version}}/gtk+-${{package.version}}.tar.xz
-      expected-sha512: 2f208a353d94fa504088ab080006cb097de721ec934b69b5719af0f4c8c72d2aa9a68b47239feca1622ec67c7389be87023729ee6ad3580a87777f2bf9ed5375
+      repository: https://gitlab.gnome.org/GNOME/gtk.git
+      tag: ${{package.version}}
+      expected-commit: 4c6093959993f4de169f90b4b4fe3d74d1be5b90
 
   - uses: meson/configure
     with:
@@ -145,8 +146,10 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 311549
+  ignore-regex-patterns:
+    - (?i)[a-z] # Ignore tags that include any case letters
+  git:
+    tag-filter-prefix: 3.
 
 test:
   pipeline:


### PR DESCRIPTION
fix: https://github.com/chainguard-dev/internal-dev/issues/8742

Package Update to version 3.24.48

