### PR TITLE
Fix Gtk 4 update, Add tag filter prefix for gtk-4 to get only the v4 tags

### DIFF
--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-4
   version: "4.17.3"
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v4)
   copyright:
     - license: LGPL-2.1-or-later

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -166,7 +166,8 @@ update:
   enabled: true
   ignore-regex-patterns:
     - (?i)[a-z] # Ignore tags that include any case letters
-  git: {}
+  git:
+    tag-filter-prefix: "4."
 
 test:
   pipeline:


### PR DESCRIPTION
Add tag filter prefix for gtk-4 to get only the v4 tags