### PR TITLE
Add the ldd-check test pipeline

### DIFF
--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -73,6 +73,9 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
This passed when testing it locally:

```
025/01/27 10:18:41 INFO running step "test/ldd-check"
2025/01/27 10:18:41 WARN + '[' -d /home/build ]
2025/01/27 10:18:41 WARN + cd /home/build
2025/01/27 10:18:41 WARN + exit 0
2025/01/27 10:18:41 INFO running step "run ldd on provided files"
2025/01/27 10:18:41 WARN + '[' -d /home/build ]
2025/01/27 10:18:41 WARN + cd /home/build
2025/01/27 10:18:41 WARN + set +x
2025/01/27 10:18:41 INFO [ldd-check] Testing binaries in package py3.13-ml-metadata
2025/01/27 10:18:42 INFO PASS[ldd-check]: /usr/lib/python3.13/site-packages/ml_metadata/metadata_store/pywrap/metadata_store_extension.so
2025/01/27 10:18:43 INFO INFO[ldd-check]: tested 1 files with ldd. 1 passes. 0 fails.
```