### PR TITLE
pipelines: test/ldd-check: update description

### DIFF
--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -22,7 +22,7 @@ inputs:
     default: false
 
 pipeline:
-  - name: "run ldd on provided files"
+  - name: "check for missing library dependencies using ldd"
     runs: |
       set +x
       set -f


### PR DESCRIPTION
Files aren't always provided any longer, so the description is out-of-date. But also "run ldd" didn't really clarify the purpose of the test, just how we chose to implement it.
