### PR TITLE
Makefile: make debug/* also requires a key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ packages/$(ARCH)/%.apk: $(KEY)
 	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/)
 	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/
 
-debug/%:
+debug/%: $(KEY)
 	$(eval yamlfile := $*.yaml)
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \


### PR DESCRIPTION
We already have this dependency:

`package/%: $(KEY)`

Which ensures that we have local signing keys before buildng a package. But we don't have this for the `debug/%` target, so it fails in a fresh clone:

```
$ make debug/hello-wolfi
@SOURCE_DATE_EPOCH=1736467928 /usr/bin/melange build hello-wolfi.yaml --interactive --debug --package-append apk-tools --repository-append /tmp/os/packages --keyring-append local-melange.rsa.pub --signing-key local-melange.rsa --arch x86_64 --env-file build-x86_64.env --namespace wolfi --license 'Apache-2.0' --git-repo-url 'https://github.com/wolfi-dev/os' --generate-index false  --pipeline-dir ./pipelines/  -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os --source-dir ./hello-wolfi/
yamlfile is hello-wolfi.yaml
Building package hello-wolfi with version hello-wolfi-2.12.1-r6 from file hello-wolfi.yaml
2025/01/28 00:26:00 INFO git commit for build config not provided, attempting to detect automatically
2025/01/28 00:26:00 ERRO could not open signing key: stat local-melange.rsa: no such file or directory
make: *** [Makefile:109: debug/hello-wolfi] Error 1
```

Add it.
