### PR TITLE
ignore v3 and v2 branch tags by upstream which seems unstable for mockery

### DIFF
--- a/mockery.yaml
+++ b/mockery.yaml
@@ -1,7 +1,7 @@
 package:
   name: mockery
-  version: "3"
-  epoch: 6
+  version: "2.51.1"
+  epoch: 0
   description: A mock code autogenerator for Go
   copyright:
     - license: BSD-3-Clause
@@ -16,7 +16,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/vektra/mockery
-      expected-commit: b847fc8fb905bec13c428a1eecf308c28fbd094c
+      expected-commit: 52c9c252ccac8395039983e0b97d12ff3bdd9af3
       tag: v${{package.version}}
 
   - uses: go/build
@@ -27,6 +27,8 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '^v\d$'
   github:
     identifier: vektra/mockery
     strip-prefix: v

--- a/mockery.yaml
+++ b/mockery.yaml
@@ -28,7 +28,7 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '^v\d$'
+    - '^\d$'
   github:
     identifier: vektra/mockery
     strip-prefix: v

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,8 +1,7 @@
-py3-google-cloud-pubsub-2.25.0-r0.apk
-py3-google-cloud-pubsub-2.25.1-r0.apk
-py3-google-cloud-pubsub-2.25.2-r0.apk
-py3-google-cloud-pubsub-2.26.0-r0.apk
-py3-google-cloud-pubsub-2.26.1-r0.apk
-py3-google-cloud-pubsub-2.27.0-r0.apk
-py3-google-cloud-pubsub-2.27.1-r0.apk
-py3-google-cloud-pubsub-2.27.2-r0.apk
+mockery-3-r0.apk
+mockery-3-r1.apk
+mockery-3-r2.apk
+mockery-3-r3.apk
+mockery-3-r4.apk
+mockery-3-r5.apk
+mockery-3-r6.apk


### PR DESCRIPTION
avoid picking unstable v3 redundant branch tags.

The upstream has started tagging v2 and v3 branches twice a week with the same tag names. The automation is picking up v3 releases, which are still in alpha, while upstream continues to release stable v2 versions (latest being v2.51.1). https://github.com/vektra/mockery/tags

