### PR TITLE
fix(postgres): fix path of upstream docker entrypoint script by updating alpine version

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.6"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,7 @@ package:
 environment:
   environment:
     # Used to fetch docker scripts
-    ALPINE_VERSION: "3.19"
+    ALPINE_VERSION: "3.21"
   contents:
     packages:
       - autoconf

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.2"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,7 @@ package:
 environment:
   environment:
     # Used to fetch docker scripts
-    ALPINE_VERSION: "3.19"
+    ALPINE_VERSION: "3.21"
   contents:
     packages:
       - autoconf


### PR DESCRIPTION
So, our postgres packages/images broke because we are pulling in docker-entrypoint script from [here ](https://github.com/wolfi-dev/os/blob/36665e750d54a90d623007ddf212e8d7e08b0f0b/postgresql-17.yaml#L197)

```bash
https://raw.githubusercontent.com/docker-library/postgres/master/17/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o
```

It turns out that upstream [bumped](https://github.com/docker-library/postgres/commit/1075ab7060f7ee83f01db8bae699000994b5ed9f) the `ALPINE_VERSION` from 3.19 to 3.21 and we had no mechanism to detect it which led to 404 on doing this curl request and hence our entrypoint script was basically empty/404

https://apk.chaindag.dev/https/packages.wolfi.dev/os/aarch64/postgresql-17-oci-entrypoint-base-17.2-r1.apk@sha1:ca791f8f476f975606234db931c94f495f616adb/usr/libexec/postgresql17/docker-entrypoint.sh

This PR attempts to fix this
