### PR TITLE
cairo: add python3 to build dependencies

### DIFF
--- a/cairo.yaml
+++ b/cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: cairo
   version: 1.18.2
-  epoch: 1
+  epoch: 2
   description: A vector graphics library
   copyright:
     - license: LGPL-2.0-or-later OR MPL-1.1
@@ -23,6 +23,7 @@ environment:
       - libxrender-dev
       - meson
       - pixman-dev
+      - python3
       - xcb-util
       - xcb-util-dev
       - zlib-dev


### PR DESCRIPTION
Required to execute version.py during the build.

Fixes: #38647 