### PR TITLE
feat(package update and remove manual: true): gitlab-runner-17.8

### DIFF
--- a/gitlab-runner-17.8.yaml
+++ b/gitlab-runner-17.8.yaml
@@ -30,8 +30,8 @@ var-transforms:
 package:
   name: gitlab-runner-17.8
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
-  version: 17.8.0
-  epoch: 2
+  version: 17.8.3
+  epoch: 0
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitlab-runner
       tag: v${{package.version}}
-      expected-commit: e4f782b3301a3aca4957d9aa5a7db780d56ce80a
+      expected-commit: 690ce25c4e607e5f993cf439439ad6acc77952ba
 
   - uses: go/build
     with:
@@ -135,8 +135,6 @@ subpackages:
 
 update:
   enabled: true
-  # Requires manual steps when updating
-  manual: true
   git:
     strip-prefix: v
     tag-filter-prefix: v17.8

--- a/gitlab-runner-17.8.yaml
+++ b/gitlab-runner-17.8.yaml
@@ -46,6 +46,19 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 690ce25c4e607e5f993cf439439ad6acc77952ba
 
+  - name: Verify base-images-tag matches the expected upstream value
+    runs: |
+      # The build does not fail automatically if the extracted tag does not match the expected tag.
+      # Therefore, we manually verify that BASE_IMAGES_TAG matches the expected upstream value.
+      # This ensures consistency with the upstream configuration
+
+      BASE_IMAGES_TAG=$(cat ./.gitlab/ci/_common.gitlab-ci.yml | sed -n 's/.*RUNNER_IMAGES_VERSION: "\([0-9.]*\)".*/\1/p')
+
+      if [ "${{vars.base-images-tag}}" != "${BASE_IMAGES_TAG}" ]; then
+        echo "Expected BASE_IMAGES_TAG: ${{vars.base-images-tag}} but got: $BASE_IMAGES_TAG"
+        exit 1
+      fi
+
   - uses: go/build
     with:
       packages: .

--- a/gitlab-runner-17.8.yaml
+++ b/gitlab-runner-17.8.yaml
@@ -18,8 +18,8 @@ vars:
   #
   # The base image repo is here: https://gitlab.com/gitlab-org/ci-cd/runner-tools/base-images
   # The tag used in the specific version of runner can be found in this file: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/.gitlab/ci/_common.gitlab-ci.yml#L7
-  base-images-commit: 9e4f9750c3274ccc4156a5146da66c10ca5730e2
-  base-images-tag: 0.0.1
+  base-images-commit: 447dbe49323fc5d5b0f4fe08d54f557b5b5e90fe
+  base-images-tag: 0.0.4
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
removing the manual:true now so that automation can attempt to update some time which will result in some failures but most should pass. Instead of currently with manual:true where all updates need to be done manually

Package update to 17.8.3
