### PR TITLE
openssh: add snippets include for sshd as well

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.9_p1
-  epoch: 4
+  epoch: 5
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -169,6 +169,11 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ssh "${{targets.subpkgdir}}"/etc/
+          sed -i 's|\(^#Port\)|Include /etc/ssh/sshd_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/sshd_config
+    test:
+      pipeline:
+        - runs: |
+            grep -q 'Include /etc/ssh/sshd_config.d/\*.conf' /etc/ssh/sshd_config
 
 update:
   enabled: true

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -123,6 +123,10 @@ subpackages:
           mv "${{targets.destdir}}"/etc/ssh/ssh_config "${{targets.subpkgdir}}"/etc/ssh/
           mkdir -p "${{targets.subpkgdir}}"/etc/ssh/ssh_config.d
           sed -i 's|\(^# Host\)|Include /etc/ssh/ssh_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/ssh_config
+    test:
+      pipeline:
+        - runs: |
+            grep -q 'Include /etc/ssh/ssh_config.d/\*.conf' /etc/ssh/ssh_config
 
   - name: "openssh-server"
     description: "OpenSSH server"

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -126,6 +126,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
+            [ -d /etc/ssh/ssh_config.d ]
             grep -q 'Include /etc/ssh/ssh_config.d/\*.conf' /etc/ssh/ssh_config
 
   - name: "openssh-server"
@@ -169,10 +170,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ssh "${{targets.subpkgdir}}"/etc/
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d
           sed -i 's|\(^#Port\)|Include /etc/ssh/sshd_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/sshd_config
     test:
       pipeline:
         - runs: |
+            [ -d /etc/ssh/sshd_config.d ]
             grep -q 'Include /etc/ssh/sshd_config.d/\*.conf' /etc/ssh/sshd_config
 
 update:

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -126,8 +126,10 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            [ -d /etc/ssh/ssh_config.d ]
-            grep -q 'Include /etc/ssh/ssh_config.d/\*.conf' /etc/ssh/ssh_config
+            conf="/etc/ssh/ssh_config.d/_wolfi.conf"
+            trap "rm -f $conf" EXIT
+            echo "Tag YouAreIt" > "$conf"
+            ssh -G _ | grep -i '^Tag YouAreIt$'
 
   - name: "openssh-server"
     description: "OpenSSH server"
@@ -175,8 +177,10 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            [ -d /etc/ssh/sshd_config.d ]
-            grep -q 'Include /etc/ssh/sshd_config.d/\*.conf' /etc/ssh/sshd_config
+            conf="/etc/ssh/sshd_config.d/_wolfi.conf"
+            trap "rm -f $conf" EXIT
+            echo "Banner /does-not-exist" > "$conf"
+            sshd -T | grep -i 'Banner /does-not-exist'
 
 update:
   enabled: true

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -188,6 +188,7 @@ subpackages:
             conf="/etc/ssh/sshd_config.d/_wolfi.conf"
             trap "rm -f $conf" EXIT
             echo "Banner /does-not-exist" > "$conf"
+            ssh-keygen -A -q -N ""
             sshd -T | grep -i 'Banner /does-not-exist'
 
 update:

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -124,6 +124,10 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/ssh/ssh_config.d
           sed -i 's|\(^# Host\)|Include /etc/ssh/ssh_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/ssh_config
     test:
+      environment:
+        contents:
+          packages:
+            - openssh-client
       pipeline:
         - runs: |
             conf="/etc/ssh/ssh_config.d/_wolfi.conf"
@@ -175,6 +179,10 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d
           sed -i 's|\(^#Port\)|Include /etc/ssh/sshd_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/sshd_config
     test:
+      environment:
+        contents:
+          packages:
+            - openssh-server
       pipeline:
         - runs: |
             conf="/etc/ssh/sshd_config.d/_wolfi.conf"


### PR DESCRIPTION
- **openssh: add test case that snippets incude made it into openssh-client**
  

- **openssh: add snippets include for sshd as well**
  Add include configuration option to support loading configuration
  snippets in sshd_config (server) as well, similar to ssh_config
  (client).
  
  Also add tests that ensure that sed lines did in-fact work.
  
  This brings parity with Debian/Ubuntu systems.
  