### PR TITLE
Makefile: Declare .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,3 +218,5 @@ check-bootstrap:
 	$(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/ \
 		-k ${BOOTSTRAP_KEY} \
 		-r ${BOOTSTRAP_REPO}
+
+.PHONY: clean fetch-kernel dev-container local-wolfi dev-container-wolfi check-bootstrap


### PR DESCRIPTION
I somehow ended up with a `local-wolfi` directory in my build tree, likely a fat-fingered command, and found `make local-wolfi` didn't work because make though it was already up to date :)

There's a syntax for telling make that the target doesn't actually generate a file (or directory) of that name. Use it for all such targets.
