### PR TITLE
openjdk-8: update to latest icedtea corresponding to jdk8u442-b06

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -78,7 +78,7 @@ pipeline:
       - uses: fetch
         with:
           uri: https://icedtea.classpath.org/download/drops/icedtea8/3.34.0/openjdk-git.tar.xz
-          expected-sha512: bb2946bbea3e63cd9f4aea88e498403317d0c07b3e283a4789d142ecd2bc35547518ec6b2f3ea97a37b7aa469311ac0217dcca9ffa65cbbacd316dd1306e82fa
+          expected-sha512: 9897bf99ae97d015ef81706712588edf3445b4ad6f9cc3805244d9b1f6499c73290fc521c8aeebb849f3f55b2efa14b44fb0bb60ff6f2c75993fbb02ecaa9b2f
           extract: false
       - uses: fetch
         with:

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,6 +1,6 @@
 package:
   name: openjdk-8
-  version: 8.432.06 # this corresponds to same release as jdk8u432-ga / jdk8u432-b06
+  version: 8.442.06 # this corresponds to same release as jdk8u442-ga / jdk8u442-b06
   epoch: 0
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
@@ -70,14 +70,14 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://icedtea.classpath.org/download/source/icedtea-3.33.0.tar.xz
-      expected-sha512: ff2803f4be50ac11b6fa8b758c934357423a9cb9d7f41922486e062e1cfe565441af830a8698d67319e61ec0ee7e7de692749ccd18bd5b4c1bf078852c3d3862
+      uri: https://icedtea.classpath.org/download/source/icedtea-3.34.0.tar.xz
+      expected-sha512: 4607e20a3a1ca3a1b32d911480d977f7b923cd398a56874a1ece5c3b604ce427c9ea03f4909dbbf748b14d2c3a0e7fbebadec573921b4f5c68ff3d6a446060b6
 
   - working-directory: /home/build/icedtea-drops
     pipeline:
       - uses: fetch
         with:
-          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.33.0/openjdk-git.tar.xz
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.34.0/openjdk-git.tar.xz
           expected-sha512: bb2946bbea3e63cd9f4aea88e498403317d0c07b3e283a4789d142ecd2bc35547518ec6b2f3ea97a37b7aa469311ac0217dcca9ffa65cbbacd316dd1306e82fa
           extract: false
       - uses: fetch


### PR DESCRIPTION
We are pleased to announce the release of IcedTea 3.34.0!

The IcedTea project provides a harness to build the source code from
OpenJDK using Free Software build tools, along with additional
features such as the ability to build against system libraries and
support for alternative virtual machines and architectures beyond
those supported by OpenJDK.

This release updates our OpenJDK 8 support with the January 2025
security fixes from OpenJDK 8u442.

If you find an issue with the release, please report it to our bug
database (https://github.com/icedtea-git/icedtea/issues) under the
appropriate component. Development discussion takes place on the
distro-pkg-dev at openjdk.org mailing list and patches are always
welcome.

Full details of the release can be found below.

What's New?
===========
New in release 3.34.0 (2025-01-27):

* Import of OpenJDK 8 u442 build 06
  - JDK-8048003: test/compiler/8009761/Test8009761.java failed with: java.lang.RuntimeException: static java.lang.Object Test8009761.m3(boolean,boolean) not compiled
  - JDK-8058322: Zero name_index item of MethodParameters attribute cause MalformedParameterException.
  - JDK-8066708: JMXStartStopTest fails to connect to port 38112
  - JDK-8133287: (fs) java/nio/file/Files/probeContentType/ParallelProbes.java should use othervm mode
  - JDK-8189687: Swing: Invalid position of candidate pop-up of InputMethod in Hi-DPI on Windows
  - JDK-8209023: fix 2 compiler tests to avoid JDK-8208690
  - JDK-8239312: [macOS] javax/swing/JFrame/NSTexturedJFrame/NSTexturedJFrame.java
  - JDK-8260380: Upgrade to LittleCMS 2.12
  - JDK-8315731: Open source several Swing Text related tests
  - JDK-8335428: Enhanced Building of Processes
  - JDK-8335912: Add an operation mode to the jar command when extracting to not overwriting existing files
  - JDK-8336564: Enhance mask blit functionality redux
  - JDK-8338402: GHA: some of bundles may not get removed
  - JDK-8339133: [8u] Profiler crashes at guarantee(is_result_safe || is_in_asgct()): unsafe access to zombie method
  - JDK-8339180: Enhanced Building of Processes: Follow-on Issue
  - JDK-8339394: Bump update version of OpenJDK: 8u442
  - JDK-8339882: Replace ThreadLocalStorage::thread with Thread::current_or_null in jdk8 backport of JDK-8183925
  - JDK-8340815: Add SECURITY.md file
  - JDK-8342822: jdk8u432-b06 does not compile on AIX
  - JDK-8342841: [8u] Separate jdk_security_infra tests from jdk_tier1