### PR TITLE
qemu - ship ovmf vars for x86_64 and aarm64

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: 9.2.0
-  epoch: 1
+  epoch: 2
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -104,6 +104,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
           mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
           mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-secure-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
+
+          # i386 vars are same as format as x86_64, but this is easier for consumer.
+          cp "${{targets.destdir}}"/usr/share/qemu/edk2-i386-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-x86_64-vars.fd
     test:
       environment:
         contents:
@@ -142,6 +145,9 @@ subpackages:
           # This is the equivalent to QEMU_EFI.fd
           mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
           mv "${{targets.destdir}}"/usr/share/qemu/edk2-aarch64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
+
+          # arm vars are same as format as aarch64, but this is easier for consumer.
+          cp "${{targets.destdir}}"/usr/share/qemu/edk2-arm-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-aarch64-vars.fd
     test:
       environment:
         contents:


### PR DESCRIPTION
the shipped 60-edk2-aarch64.json and 60-edk2-x86_64.json files do correctly state that
 * edk2-i386-vars.fd is the nvram-template for x86_64
 * edk2-arm-vars.fd is the nvram-template for aarch64

But that was not clear to me as a consumer and I expected x86_64 vars file to be available.

This is wasteful of disk space, but more clear.
