### PR TITLE
pip-zipapp: updated to 25.0, fixed source repo, added tests

### DIFF
--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -1,6 +1,6 @@
 package:
   name: pip-zipapp
-  version: 24.3.1
+  version: 25.0
   epoch: 0
   description: "Pip as a python zipapp"
   copyright:
@@ -21,11 +21,14 @@ environment:
 # https://pypi.org/project/wheel/#files
 # https://pypi.org/project/flit-core/#files
 pipeline:
-  - uses: fetch
+  # Using their repo as it appears to be the authoritative source for https://bootstrap.pypa.io/pip/zipapp/, which
+  # doesn't always properly post the latest version. See https://github.com/chainguard-dev/internal-dev/issues/8712
+  - uses: git-checkout
     with:
-      uri: https://bootstrap.pypa.io/pip/zipapp/pip-${{package.version}}.pyz
-      expected-sha256: c59df64b826d5baa978829fd1e1b3ea2e748f73dce7cce58d09aa28a1c9323a7
-      extract: false
+      repository: https://github.com/pypa/get-pip
+      expected-commit: 3afa5f8ee29d02dd4d005b52858dad03e9c04e46
+      tag: ${{package.version}}
+      destination: get-pip
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.7.0-py3-none-any.whl"
@@ -56,16 +59,33 @@ pipeline:
       sdir=usr/share/${{package.name}}
       fname=${{package.name}}.pyz
       mkdir -p "$destd/$sdir"
-      cp "pip-${{package.version}}.pyz" "$destd/$sdir/$fname"
+      cp "get-pip/public/zipapp/pip-${{package.version}}.pyz" "$destd/$sdir/$fname"
       chmod 0644 "$destd/$sdir/$fname"
 
       mkdir -p "$destd/$sdir/wheels"
       cp *.whl "$destd/$sdir/wheels/"
+
+test:
+  environment:
+    contents:
+      packages:
+        - python3
+  pipeline:
+    - name: Ensure the zipapp can run using python
+      runs: |
+        python3 /usr/share/pip-zipapp/pip-zipapp.pyz --help | grep "Usage:"
+    - name: Ensure the zipapp can run standalone
+      runs: |
+        chmod +x /usr/share/pip-zipapp/pip-zipapp.pyz
+        /usr/share/pip-zipapp/pip-zipapp.pyz --help | grep "Usage:"
+    - name: Ensure the version matches
+      runs: |
+        /usr/share/pip-zipapp/pip-zipapp.pyz -V | grep "pip ${{package.version}}"
 
 update:
   enabled: true
   ignore-regex-patterns:
     - 'b'
   github:
-    identifier: pypa/pip
+    identifier: pypa/get-pip
     use-tag: true


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/internal-dev/issues/8712

Upstream's installation directions reference [a repo](https://bootstrap.pypa.io/pip/zipapp/) that doesn't seem to have reliably working updates (causing a failure to update to version 25.0). I found the website source at https://github.com/pypa/get-pip/tree/main/public and switched to using that instead. I also added tests to make sure it runs properly. 

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
