### PR TITLE
pipelines: test/compiler-hardening-check: Enable branchprotection check

### DIFF
--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -55,8 +55,6 @@ pipeline:
       # full cfprotection is x86 only for now
       if [ "${{build.arch}}" = "aarch64" ]; then
           arch_skip=--nocfprotection
-          # Disabled until glibc has been rebuilt to support it.
-          arch_skip="$arch_skip --nobranchprotection"
       fi
 
       # the branch protection check is ARM only for now

--- a/pipelines/test/hardening-check.yaml
+++ b/pipelines/test/hardening-check.yaml
@@ -31,6 +31,8 @@ pipeline:
           if [ "${{build.arch}}" = "aarch64" ]; then
               arch_skip=--nocfprotection
           fi
+          # the branch protection check is ARM only for now
+          [ "${{build.arch}}" = "aarch64" ] || arch_skip=--nobranchprotection
 
           hardening-check $arch_skip ${{inputs.args}} --color $1
       }


### PR DESCRIPTION
gcc/glibc now support it.
