### PR TITLE
fix(fluentd-kubernetes-daemonset): add missing systemd

### DIFF
--- a/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.1-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 1
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ subpackages:
         - libudev
         - libcurl-openssl4
         - libffi
+        - systemd
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.2-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 1
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ subpackages:
         - libudev
         - libcurl-openssl4
         - libffi
+        - systemd
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 1
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ subpackages:
         - libudev
         - libcurl-openssl4
         - libffi
+        - systemd
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.4-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 1
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ subpackages:
         - libudev
         - libcurl-openssl4
         - libffi
+        - systemd
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |


### PR DESCRIPTION
One of the use cases of this package is to be used with systemd fluentd plugin which depends on systemd-journal which in turn depends on systemd https://github.com/ledbettj/systemd-journal?tab=readme-ov-file#dependencies

This PR is a fix for it