### PR TITLE
Revert "glibc: Re-enable OpenSSF hardening"

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 7
+  epoch: 8
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -53,6 +53,8 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
+    # https://github.com/chainguard-dev/internal-dev/issues/7756
+    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
We're experiencing segfaults when loading certain binaries. Let's revert this while we root cause.

This reverts commit df86be4fa504a6ffc618ff13aff62ac21489cc38.
