### PR TITLE
pipelines: Add compiler/filter-openssf-flags

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.60.1
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -96,9 +96,11 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 646618687e4f9351b5fe19cce678c9cd4b011e74
 
-  - runs: |
-      gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"
-      sed -r 's/,?-z,now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
+  - uses: compiler/filter-openssf-flags
+    with:
+      compiler: gcc
+      spec-file-out: $GCC_SPEC_FILE
+      remove-flags: -Wl,-z,now
 
   # Install `invoke` (build) dependencies. We ultimately package with venv so
   # these won't leak into the package.

--- a/pipelines/compiler/filter-openssf-flags.yaml
+++ b/pipelines/compiler/filter-openssf-flags.yaml
@@ -1,0 +1,37 @@
+name: filter-openssf-flags
+
+inputs:
+  compiler:
+    description: The compiler executable name (e.g. gcc-12)
+    default: gcc
+  spec-file-out:
+    description: Where to write the filtered spec file. Set GCC_SPEC_FILE to this path for gcc to use it. You can use a relative path in this pipeline, but GCC_SPEC_FILE should have an absolute path.
+  remove-flags:
+    description: flags to filter out
+
+pipeline:
+  - runs: |
+      if [ -e "${{inputs.spec-file-out}}" ]; then
+        echo "ERROR: ${{inputs.spec-file-out}} exists, refusing to overwrite it." 1>&2
+        exit 1
+      fi
+      gccdir="$(GCC_SPEC_FILE=/dev/null ${{inputs.compiler}} --print-search-dirs | grep ^install: | cut -d' ' -f2)"
+      tmpspec=$(mktemp)
+      cp "$gccdir/openssf.spec" "${{inputs.spec-file-out}}"
+      cp "$gccdir/openssf.spec" "$tmpspec"
+      for flag in ${{inputs.remove-flags}}; do
+        # Comma separated, such as -Wl,foo,bar
+        if echo $flag | grep -q ','; then
+          switch=$(echo "$flag" | cut -d, -f1)
+          param=$(echo "$flag" | cut -d, -f2-)
+          sed -i -E "s|(${switch}(,[^\s,]*))*,${param}(,[^\s,])*|\2\3|" "$tmpspec"
+        # Exact matches
+        else
+          sed -i -E "s,(^|\s)(${flag})(\s|$), ," "$tmpspec"
+        fi
+        if diff "$tmpspec" "${{inputs.spec-file-out}}" > /dev/null; then
+          echo "ERROR: filter did not change spec file" 1>&2
+          exit 1
+        fi
+        cp "$tmpspec" "${{inputs.spec-file-out}}"
+      done


### PR DESCRIPTION
There are some compiler flags set by openssf.spec that can't be trivially removed. `-Wl,-z,now` is one such example, for which a copy and edit hack has been propagating. Let's create a pipeline for this so that we only have to maintain that code in one place.

Use of this should be discouraged if other options are available. But if the decision is between using this or disabling all openssf hardening flags, this is the better choice.

Make `datadog-agent` our first customer.