### PR TITLE
gcc, binutils, stress-ng, busybox: no-change rebuild against new glibc

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: 2.43.1
-  epoch: 2
+  epoch: 3
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: 2.43.1
-  epoch: 3
+  epoch: 4
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 0
+  epoch: 1
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 7
+  epoch: 8
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 5
+  epoch: 4
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/stress-ng.yaml
+++ b/stress-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: stress-ng
   version: 0.18.09
-  epoch: 0
+  epoch: 1
   description: "stress-ng will stress test a computer system in various selectable ways"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Added some old gcc packages as well. We need this to land after 2.41.