### PR TITLE
bump epochs to rebuild packages affected by glibc publication lag

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: "25.1.1"
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.3-async-http.yaml
+++ b/ruby3.3-async-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-async-http
   version: "0.87.0"
-  epoch: 0
+  epoch: 1
   description: A HTTP client and server library.
   copyright:
     - license: MIT

--- a/ruby3.4-async-http.yaml
+++ b/ruby3.4-async-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-async-http
   version: "0.87.0"
-  epoch: 0
+  epoch: 1
   description: A HTTP client and server library.
   copyright:
     - license: MIT


### PR DESCRIPTION
These failed post-submit build because of the mismatch between glibc and ld-linux, caused by a temporary partial publication.