### PR TITLE
gcc rebuild with old glibc, if it let us do that

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,8 @@
+#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: gcc
   version: 14.2.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -18,6 +19,12 @@ package:
 
 environment:
   contents:
+    # NB! accessing historic, but certified build of
+    # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
+    # any version of jitternetropy-library and get an ESV certificate
+    # for it.
+    build_repositories:
+      - https://packages.wolfi.dev/os
     packages:
       - bison
       - build-base
@@ -26,8 +33,11 @@ environment:
       - file
       - flex-dev
       - gawk
+      - glibc-dev~2.40
+      - glibc~2.40
       - gmp-dev
       - isl-dev
+      - ld-linux~2.40
       - make
       - mpc-dev
       - mpfr-dev


### PR DESCRIPTION
Check if gcc bootstrap works with old glibc.
