### PR TITLE
apache2: Add dep on busybox and remove unused file

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 0
+  epoch: 1
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -150,7 +150,7 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
-        - dash-binsh
+        - busybox # the httpd-foreground script calls `rm`
     pipeline:
       - runs: |
           set -x

--- a/apache2/entrypoint.sh
+++ b/apache2/entrypoint.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec httpd -DFOREGROUND "$@"


### PR DESCRIPTION
The new entry point is a script that runs `rm`. We had an image fail to test because the `rm` command did not exist, so add a dep on `busybox`.
    
`busybox` also provides a shell, so we can drop the `dash-binsh` dependency. The `dash-binsh` dependency was added along with the previous entrypoint script in commit 8dad232d60bca144b357cb652cb0865d6e351be7, so I conclude it is just there to handle the entrypoint, which busybox's shell handles fine.
    
