### PR TITLE
rm docker-cli from runtime dependency

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
   version: "24.10.4"
-  epoch: 3
+  epoch: 4
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,6 @@ package:
       - bash
       - busybox
       - curl
-      - docker-cli
       - glibc-locale-en
       - openjdk-21-default-jdk
 


### PR DESCRIPTION
Related [#7160](https://github.com/chainguard-images/images-private/pull/7160)

while building `nextflow-fips` package the build was failing due to an issue with OpenSSL cryptography. Specifically, the `oci_exec_test.check-go-fips` test reported:

`/home/user/tmp/tmp.XQMLxC/usr/bin/docker is NOT using cgo openssl cryptography`

This error occurred because the docker-cli within the FIPS image was not using the FIPS-compliant OpenSSL library. To resolve this, i'm removing the  docker-cli from the nextflow package and instead added at the image level. This will ensures that the non-FIPS image continues using docker-cli at runtime and FIPS image explicitly uses docker-cli-fips, ensuring compliance.