### PR TITLE
package for midnight-commander

### DIFF
--- a/midnight-commander.yaml
+++ b/midnight-commander.yaml
@@ -1,0 +1,63 @@
+package:
+  name: midnight-commander
+  version: "4.8.33"
+  epoch: 0
+  description: GNU Midnight Commander - terminal for admins of a certain age
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gettext
+      - glib-dev
+      - libtool
+      - m4
+      - pkgconf
+      - pkgconf-dev
+      - s-lang
+      - s-lang-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e7e21869da5a2651ebccce5274e47fb3e607eba6
+      repository: https://github.com/MidnightCommander/mc
+      tag: ${{package.version}}
+
+  - runs: |
+      aclocal
+      autoreconf -fiv
+      automake
+      ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: midnight-commander-doc
+    pipeline:
+      - uses: split/manpages
+    description: midnight-commander manpages
+
+update:
+  enabled: true
+  github:
+    identifier: MidnightCommander/mc
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        mc --help
+        # mc --version  ### This doesn't seem to work headless (complains about TERM env variable)


### PR DESCRIPTION
Added a new package for the fellow greybeards -- midnight commander!

Note that we already have an mc.yaml and mc command, so there is potentially a namespace collision for /usr/bin/mc which is absolutely not the same thing as mc.yaml (Multi-cloud Object Storage).