### PR TITLE
fix(minio-bitnami): update subpackage path to 2025/debian-12 and switch to manual updates

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -1,7 +1,12 @@
+# Set update to manual:true because we also need to verify the bitnami repo (https://github.com/bitnami/containers/tree/main/bitnami/minio)
+# for releases as you can see minio-bitnami-2025-compat is using hardcoded version-path: 2025/debian-12
+# till we have a way to track such subpackage updates in bitnami repo, we will keep it manual
+# Internal tracking issue here: https://github.com/chainguard-dev/internal-dev/issues/8397
+# For now, I have added a check to verify if the path exists in GitHub in subpackage pipeline
 package:
   name: minio
   version: "0.20250120.144907"
-  epoch: 0
+  epoch: 1
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later
@@ -12,6 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - curl
       - go
       - perl
 
@@ -37,13 +43,29 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: minio-bitnami-2024-compat
+  - name: minio-bitnami-2025-compat
     description: "compat package with bitnami/minio image"
     pipeline:
+      - name: Check if the 2025/debian-12 path exists in GitHub
+        runs: |
+          # Make sure we fail on any error
+          set -e
+
+          # The path we need to check
+          URL="https://github.com/bitnami/containers/tree/main/bitnami/minio/2025/debian-12"
+
+          # Grab the HTTP status from the first line (e.g., "HTTP/2 200")
+          # and extract the status code field (should be "200" if OK).
+          CODE="$(curl -sI "$URL" | head -n 1 | cut -d' ' -f2)"
+
+          if [ "$CODE" != "200" ]; then
+            echo "ERROR: The GitHub path '$URL' does not exist or is not accessible. HTTP status code: $CODE"
+            exit 1
+          fi
       - uses: bitnami/compat
         with:
           image: minio
-          version-path: 2024/debian-12
+          version-path: 2025/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/minio/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
@@ -67,6 +89,7 @@ subpackages:
 
 update:
   enabled: true
+  manual: true
   version-transform:
     - match: ^RELEASE\.(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})Z$
       replace: 0.${1}${2}${3}.${4}${5}${6}


### PR DESCRIPTION
- Switches from `2024/debian-12` to `2025/debian-12` for the Bitnami subpackage
- Sets update.manual to true for verifying Bitnami releases manually
- Adds a GitHub check to ensure the new path exists
- Includes curl in the environment for path verification


