### PR TITLE
bump mc package to rebuild bitnami compat

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mc
   version: "0.20250117.232550"
-  epoch: 0
+  epoch: 1
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - curl
       - go
       - perl
 
@@ -36,13 +37,27 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: mc-bitnami-2024-compat
+  - name: mc-bitnami-2025-compat
     description: "compat package with bitnami/minio-client image"
     pipeline:
+      - name: Check if the 2025/debian-12 path exists in GitHub
+        runs: |
+          # Make sure we fail on any error
+          set -e
+          # The path we need to check
+          URL="https://github.com/bitnami/containers/tree/main/bitnami/minio-client/2025/debian-12"
+          # Grab the HTTP status from the first line (e.g., "HTTP/2 200")
+          # and extract the status code field (should be "200" if OK).
+          CODE="$(curl $URL -s -o /dev/null -w "%{http_code}")"
+          if [ "$CODE" != "200" ]; then
+            echo "ERROR: The GitHub path '$URL' does not exist or is not accessible. HTTP status code: $CODE"
+            exit 1
+          fi
+          # in case of build please check the URL above and update the year.
       - uses: bitnami/compat
         with:
           image: minio-client
-          version-path: 2024/debian-12
+          version-path: 2025/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/minio-client/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami


### PR DESCRIPTION
    bump mc package to rebuild bitnami compat
    
    keeps update to true with a note to check the URL, this way it'll fail
    and during fixing the package we'll update the URL.