### PR TITLE
Add oath-toolkit package definition and build pipeline

### DIFF
--- a/oath-toolkit.yaml
+++ b/oath-toolkit.yaml
@@ -73,7 +73,6 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: oath-toolkit/oath-toolkit
+  git:
     strip-prefix: oath-toolkit-
     tag-filter-prefix: oath-toolkit-

--- a/oath-toolkit.yaml
+++ b/oath-toolkit.yaml
@@ -69,7 +69,30 @@ test:
         - build-base
   pipeline:
     - runs: |
-        make check
+        # Check if oathtool exists
+        if ! command -v oathtool >/dev/null; then
+          echo "oathtool not found"
+          exit 1
+        fi
+
+        # Generate a TOTP
+        secret="JBSWY3DPEHPK3PXP"
+        otp=$(oathtool --totp -b $secret)
+        echo "Generated OTP: $otp"
+
+        # Validate OTP length
+        if [ ${#otp} -ne 6 ]; then
+          echo "OTP length is incorrect"
+          exit 1
+        fi
+
+        # Check if the library is accessible
+        if ! ldconfig -p | grep -q liboath; then
+          echo "liboath not found"
+          exit 1
+        fi
+
+        echo "All tests passed."
 
 update:
   enabled: true

--- a/oath-toolkit.yaml
+++ b/oath-toolkit.yaml
@@ -1,0 +1,79 @@
+package:
+  name: oath-toolkit
+  version: 2.6.12
+  description: "The OATH Toolkit provides components for building one-time password authentication systems"
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bison
+      - build-base
+      - busybox
+      - clang
+      - gengetopt-dev
+      - gettext-dev
+      - gtk-2.0-dev
+      - gtk-doc
+      - help2man
+      - libgcrypt-dev
+      - libtool
+      - libxml2-dev
+      - pkgconf
+      - texinfo
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/oath-toolkit/oath-toolkit.git
+      tag: oath-toolkit-${{package.version}}
+      expected-commit: c872088aca029b4290b480002945c6a013d89086
+
+  - runs: ./bootstrap
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-static
+    pipeline:
+      - uses: split/static
+    description: ${{package.name}} static
+
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+      - uses: split/infodir
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    description: ${{package.name}} dev
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: gengetopt manpages
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+  pipeline:
+    - runs: |
+        make check
+
+update:
+  enabled: true
+  github:
+    identifier: oath-toolkit/oath-toolkit
+    strip-prefix: oath-toolkit-
+    tag-filter-prefix: oath-toolkit-


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
oath: new package
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
