### PR TITLE
Running an unnecessary test is not a failure

### DIFF
--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -39,5 +39,5 @@ pipeline:
         fi
       done
       if [ $pc_files = "false" ]; then
-        echo "No .pc files found in $dev_pkg please remove the pkgconf test" && exit 1
+        echo "No .pc files found in $dev_pkg please remove the pkgconf test"
       fi


### PR DESCRIPTION
The pkgconf test pipeline currently exits 1 if the test is not necessary. The test not being needed is certainly not a failure and we shouldn't block PRs for running a test that is unnecessary.

This also makes the pkgconf test pipeline consistent with the ldd-check one which doesn't exit 1 if the test is not needed.