### PR TITLE
glibc: Enable OpenSSF hardening, but w/o strict binding

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.136
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.120
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-8.0.404.yaml
+++ b/dotnet-8.0.404.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8.0.404
   version: 8.0.404
-  epoch: 1
+  epoch: 2
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.12"
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: 9.0.101
-  epoch: 2
+  epoch: 3
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-bootstrap-8.yaml
+++ b/dotnet-bootstrap-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-bootstrap-8
   version: "8.0.12"
-  epoch: 0
+  epoch: 1
   description: ".NET 8 SDK Bootstrap"
   copyright:
     - license: MIT

--- a/dotnet-bootstrap-9.yaml
+++ b/dotnet-bootstrap-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-bootstrap-9
   version: 9.0.0
-  epoch: 0
+  epoch: 1
   description: ".NET 9 SDK Bootstrap"
   copyright:
     - license: MIT

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 8
+  epoch: 9
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -53,8 +53,7 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
-    # https://github.com/chainguard-dev/internal-dev/issues/7756
-    GCC_SPEC_FILE: /dev/null
+    GCC_SPEC_FILE: /home/build/openssf.spec
 
 pipeline:
   - uses: git-checkout
@@ -68,6 +67,10 @@ pipeline:
   - uses: patch
     with:
       patches: Disable-AVX512VL.patch
+
+  - runs: |
+      gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"
+      sed -r 's/,?-z,now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
 
   - name: 'Set up build directory'
     runs: |

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: 3.10.0
-  epoch: 0
+  epoch: 1
   description: Python plotting package
   copyright:
     - license: PSF-2.0


### PR DESCRIPTION
Just for testing at the moment.