### PR TITLE
feat(jupyter-base-notebook): add jupyterhub py package dep

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: 7.3.2
-  epoch: 0
+  epoch: 1
   description: Jupyter Notebook
   dependencies:
     runtime:
@@ -20,11 +20,11 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/usr/local/bin
       mkdir -p ${{targets.contextdir}}/home/jovyan/.jupyter
       # install jupyterlab, nbclassic and notebook
+      pip install jupyterhub --prefix=/usr --root=${{targets.contextdir}}
       pip install jupyterlab --prefix=/usr --root=${{targets.contextdir}}
       pip install nbclassic --prefix=/usr --root=${{targets.contextdir}}
       pip install notebook --prefix=/usr --root=${{targets.contextdir}}
       # https://github.com/jupyter/docker-stacks/blob/9ffeb238dc8e363b5bddd779442b4f32d06aff0d/images/base-notebook/Dockerfile#L50 (else browser is not detected)
-      pip install jupyterlab
       jupyter server --generate-config
       cp /home/build/.jupyter/jupyter_server_config.py ${{targets.contextdir}}/home/jovyan/.jupyter/jupyter_server_config.py
       jupyter lab clean
@@ -34,7 +34,11 @@ test:
     contents:
       packages:
         - jq
+        - linux-pam
         - py3.12-pip
+        - jupyterhub-k8s-hub
+    environment:
+      JUPYTERHUB_SERVICE_URL: "127.0.0.1:8000"
   pipeline:
     - runs: |
         pip list | grep jupyterlab
@@ -86,6 +90,20 @@ test:
         expected_output: |
           extension was successfully linked
           extension was successfully loaded
+    - name: Run and test jupyterhub-singleuser
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          jupyterhub >/dev/null 2>&1 &
+          sleep 3
+        start: jupyterhub-singleuser
+        timeout: 30
+        expected_output: |
+          nbclassic | extension was successfully loaded.
+          notebook | extension was successfully loaded.
+          Serving notebooks from local directory: /home/build
+          is running at:
+          http://127.0.0.1:8888/lab
 
 update:
   enabled: true


### PR DESCRIPTION
Because the jupyter-base-notebook package resembles the upstream jupyter/base-notebook component, it should include the jupyterhub python package. In particular, upstream includes the jupyterhub-singleuser conda metapackage that aligns to the jupyterhub pypi package.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
