### PR TITLE
pipelines: test/compiler-hardening-check: Disable branchprotection check

### DIFF
--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -60,6 +60,12 @@ pipeline:
       # the branch protection check is ARM only for now
       [ "${{build.arch}}" = "aarch64" ] || arch_skip=--nobranchprotection
 
+      ### <DELETE WHEN GLIBC OPENSSF HARDENING IS RE-ENABLED>
+      if [ "${{build.arch}}" = "aarch64" ]; then
+          arch_skip="$arch_skip --nobranchprotection"
+      fi
+      ### </DELETE>
+
       # Test disabling hardening flags
       hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled && exit 1
 


### PR DESCRIPTION
We reverted the use of OpenSSF compiler options in glibc for now due to a regression, which makes the branchprotection check fail.
