### PR TITLE
Compile ruby-puma with ssl support

### DIFF
--- a/ruby3.4-puma.yaml
+++ b/ruby3.4-puma.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-puma
   version: "6.6.0"
-  epoch: 0
+  epoch: 1
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - git
+      - openssl-dev
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev
 


### PR DESCRIPTION
This resolves an issue where ruby3.4-puma will fail due to not being compiled with ssl support e.g.

```
55756e63b437:/work# puma -C config.rb
Puma starting in single mode...
* Puma version: 6.6.0 ("Return to Forever")
* Ruby version: ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux-gnu]
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 10
/usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/binder.rb:228:in 'block in Puma::Binder#parse': Puma compiled without SSL support (RuntimeError)
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/binder.rb:154:in 'Array#each'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/binder.rb:154:in 'Puma::Binder#parse'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/runner.rb:175:in 'Puma::Runner#load_and_bind'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/single.rb:44:in 'Puma::Single#run'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/launcher.rb:203:in 'Puma::Launcher#run'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/lib/puma/cli.rb:75:in 'Puma::CLI#run'
        from /usr/lib/ruby/gems/3.4.0/gems/puma-6.6.0/bin/puma:10:in '<top (required)>'
        from /usr/bin/puma:25:in 'Kernel#load'
        from /usr/bin/puma:25:in '<main>'
```