### PR TITLE
python-3.12: add CVE-2025-0938 fix

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.8
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -55,7 +55,8 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.12/9aa0deb2eef2655a1029ba228527b152353135b5: CVE-2024-12254 fix
+        3.12/9aa0deb2eef2655a1029ba228527b152353135b5: CVE-2024-12254
+        3.12/a7084f6075c9595ba60119ce8c62f1496f50c568: CVE-2025-0938
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
https://mail.python.org/archives/list/security-announce@python.org/thread/K4EUG6EKV6JYFIC24BASYOZS4M5XOQIB/ python/cpython#129526
