### PR TITLE
apache-tika: unbump jetty version

### DIFF
--- a/apache-tika-3.0.yaml
+++ b/apache-tika-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-tika-3.0
   version: 3.0.0
-  epoch: 9
+  epoch: 10
   description: The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).
   copyright:
     - license: Apache-2.0
@@ -36,7 +36,6 @@ pipeline:
 
   - uses: maven/pombump
     with:
-      patch-file: patches.yaml
       properties-file: pombump-properties.yaml
       pom: tika-parent/pom.xml
 

--- a/apache-tika-3.0/patches.yaml
+++ b/apache-tika-3.0/patches.yaml
@@ -1,5 +1,0 @@
-patches:
-  # CVE-2024-6763
-  - groupId: org.eclipse.jetty
-    artifactId: jetty-http
-    version: 12.0.12


### PR DESCRIPTION
jetty version 12 doesn't work according to https://github.com/apache/tika/blob/baffe3f8f94cbee2cd84e241e24a9372d883493d/tika-parent/pom.xml#L383-L389