### PR TITLE
Adds aws-s3-controller v1.0.21

### DIFF
--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -22,6 +22,11 @@ pipeline:
       packages: ./cmd/controller
       output: controller
 
+  - runs: |
+      mkdir -p ${{targets.contextdir}}
+      cp LICENSE ${{targets.contextdir}}/
+      cp ATTRIBUTION.md ${{targets.contextdir}}/
+
 subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by aws-s3-controller"

--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -47,4 +47,7 @@ update:
 
 test:
   pipeline:
-    - runs: stat /usr/bin/controller
+    - runs: |
+        stat /usr/bin/controller
+        controller --help 2>&1 | grep webhook
+        controller --aws-region us-east-1 2>&1 | grep -E 'session|token'

--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -1,0 +1,48 @@
+package:
+  name: aws-s3-controller
+  version: 1.0.21
+  epoch: 0
+  description: ACK service controller for Amazon Simple Storage Service (S3)
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2be16650fa025711d45f3f8042904e6ff0c211fd
+      repository: https://github.com/aws-controllers-k8s/s3-controller.git
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X main.version=v${{package.version}}
+        -X main.buildHash=$(git rev-parse HEAD)
+        -X main.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      packages: ./cmd/controller
+      output: controller
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by aws-s3-controller"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/bin
+          ln -sf /usr/bin/controller ${{targets.contextdir}}/bin/controller
+    test:
+      pipeline:
+        - runs: "[ \"$(stat -c '%N' /bin/controller 2>/dev/null)\" = \"'/gatus' -> '/usr/bin/controller'\" ]"
+
+update:
+  enabled: true
+  github:
+    identifier: aws-controllers-k8s/s3-controller
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: stat /usr/bin/controller

--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -34,7 +34,7 @@ subpackages:
           ln -sf /usr/bin/controller ${{targets.contextdir}}/bin/controller
     test:
       pipeline:
-        - runs: "[ \"$(stat -c '%N' /bin/controller 2>/dev/null)\" = \"'/gatus' -> '/usr/bin/controller'\" ]"
+        - runs: "[ \"$(stat -c '%N' /bin/controller 2>/dev/null)\" = \"'/bin/controller' -> '/usr/bin/controller'\" ]"
 
 update:
   enabled: true

--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -30,9 +30,6 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by aws-s3-controller"
-    dependencies:
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/bin


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
