### PR TITLE
feat(new-package): add op-geth package

### DIFF
--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -172,10 +172,6 @@ test:
             exit 1
           fi
 
-          curl --fail --silent --show-error -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' -H "Content-Type: application/json" http://127.0.0.1:8545 | grep -q "Geth"
-
-          echo "Geth RPC is responsive"
-
           pkill -f geth
 
 update:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -152,23 +152,31 @@ subpackages:
 
 test:
   pipeline:
-    - name: version and help tests for geth
-      runs: |
-        geth version | grep -qi "${{package.version}}-stable"
-        geth --help
-    - runs: |
-        geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock &
-        GETH_PID=$!
-        sleep 5  # Wait for Geth to initialize
+    - name: Test standalone as background process and check output
+      uses: test/daemon-check-output
+      with:
+        start: geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock
+        expected_output: |
+          Maximum peer count
+          HTTP server started
+          Writing custom genesis block
+          Using developer account
+        post: |
+          sleep 5
 
-        if ps | grep -q "[g]eth"; then
-          echo "Geth started successfully"
-        else
-          echo "Failed to start Geth"
-          exit 1
-        fi
+          # Check if the process is running
+          if ps aux | grep -q "[g]eth"; then
+            echo "Geth started successfully"
+          else
+            echo "Failed to start Geth"
+            exit 1
+          fi
 
-        kill $GETH_PID
+          curl --fail --silent --show-error -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' -H "Content-Type: application/json" http://127.0.0.1:8545 | grep -q "Geth"
+
+          echo "Geth RPC is responsive"
+
+          pkill -f geth
 
 update:
   enabled: true

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -6,9 +6,6 @@ package:
   copyright:
     - license: LGPL-3.0-or-later
     - license: GPL-3.0-or-later
-  dependencies:
-    runtime:
-      - coreutils
 
 environment:
   contents:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -152,27 +152,21 @@ subpackages:
 
 test:
   pipeline:
-    - name: Test standalone as background process and check output
-      uses: test/daemon-check-output
-      with:
-        start: geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock
-        expected_output: |
-          Maximum peer count
-          HTTP server started
-          Writing custom genesis block
-          Using developer account
-        post: |
-          sleep 5
-
-          # Check if the process is running
-          if ps aux | grep -q "[g]eth"; then
-            echo "Geth started successfully"
-          else
-            echo "Failed to start Geth"
-            exit 1
-          fi
-
-          pkill -f geth
+    - name: version and help tests for geth
+      runs: |
+        geth version | grep -qi "${{package.version}}-stable"
+        geth --help
+    - runs: |
+        geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock &
+        GETH_PID=$!
+        sleep 5  # Wait for Geth to initialize
+        if ps | grep -q "[g]eth"; then
+          echo "Geth started successfully"
+        else
+          echo "Failed to start Geth"
+          exit 1
+        fi
+        kill $GETH_PID
 
 update:
   enabled: true

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -50,12 +50,15 @@ subpackages:
             -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
           output: clef
     test:
+      environment:
+        contents:
+          packages:
+            - cmd:script
       pipeline:
         - runs: |
             clef --version
             clef --help
         - runs: |
-            apk add cmd:script
             script -q -c "clef init" /dev/null <<EOF
             ok
             1234567890

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -56,8 +56,7 @@ subpackages:
         - runs: |
             clef --version
             clef --help
-        - name: "Run clef init"
-          runs: |
+        - runs: |
             apk add cmd:script
             script -q -c "clef init" /dev/null <<EOF
             ok

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: 1.101411.7
+  version: 1.101500.0
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: b79c44a850e7a86b74e50bcdaca18690ba01783d
+      expected-commit: 9111c8f18ce514916105252f4530782e2ac2b598
       repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -151,6 +151,11 @@ subpackages:
             rlpdump -hex c0 | grep -q '\[\]' && echo "rlpdump hex test passed" || { echo "rlpdump hex test failed"; exit 1; }
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - jq
   pipeline:
     - name: version and help tests for geth
       runs: |
@@ -172,14 +177,16 @@ test:
           denied
         post: |
           sleep 5
-          # Check if the process is running
-          if ps aux | grep -q "[g]eth"; then
-            echo "Geth started successfully"
+          BLOCK_NUMBER=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://127.0.0.1:8545/ | jq -r '.result')
+
+          BLOCK_NUMBER_DECIMAL=$((BLOCK_NUMBER))
+
+          if [[ "$BLOCK_NUMBER" == "0x0" ]]; then
+            echo "Error: Block number is still 0x0, indicating no blocks have been mined."
+            exit 1  # Fail the pipeline
           else
-            echo "Failed to start Geth"
-            exit 1
+            echo "Success: Ethereum node is responding with block number $BLOCK_NUMBER (decimal: $BLOCK_NUMBER_DECIMAL)."
           fi
-          pkill -f geth
 
 update:
   enabled: true

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -27,8 +27,6 @@ pipeline:
     with:
       deps: |-
         github.com/golang-jwt/jwt/v4@v4.5.1
-        golang.org/x/crypto@v0.31.0
-        golang.org/x/net@v0.33.0
         github.com/hashicorp/go-retryablehttp@v0.7.7
 
   - uses: go/build

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -50,7 +50,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - cmd:script
+            - util-linux-misc
       pipeline:
         - runs: |
             clef --version
@@ -156,17 +156,30 @@ test:
       runs: |
         geth version | grep -qi "${{package.version}}-stable"
         geth --help
-    - runs: |
-        geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock &
-        GETH_PID=$!
-        sleep 5  # Wait for Geth to initialize
-        if ps | grep -q "[g]eth"; then
-          echo "Geth started successfully"
-        else
-          echo "Failed to start Geth"
-          exit 1
-        fi
-        kill $GETH_PID
+    - name: "Testing geth process"
+      uses: test/daemon-check-output
+      with:
+        start: geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock
+        expected_output: |
+          Maximum peer count
+          HTTP server started
+          Writing custom genesis block
+          Using developer account
+        error_strings: |
+          "panic"
+          "fatal"
+          failed
+          denied
+        post: |
+          sleep 5
+          # Check if the process is running
+          if ps aux | grep -q "[g]eth"; then
+            echo "Geth started successfully"
+          else
+            echo "Failed to start Geth"
+            exit 1
+          fi
+          pkill -f geth
 
 update:
   enabled: true

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - busybox
-      - make
 
 environment:
   contents:
@@ -51,7 +50,7 @@ subpackages:
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
             -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
-            # TODO: Verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
+          # TODO: Verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
           output: clef
     test:
       pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -32,7 +32,7 @@ pipeline:
         github.com/golang-jwt/jwt/v4@v4.5.1
         golang.org/x/crypto@v0.31.0
         golang.org/x/net@v0.33.0
-        github.com/hashicorp/go-retryablehttp@0.7.7
+        github.com/hashicorp/go-retryablehttp@v0.7.7
 
   - uses: go/build
     with:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -39,11 +39,6 @@ pipeline:
       packages: ./cmd/geth
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-        -X github.com/ethereum/go-ethereum/version.gitTag=$(git name-rev --tags --name-only $(git rev-parse HEAD))
-        -X github.com/ethereum/go-ethereum/internal/version.gitCommit=$(git rev-parse HEAD)
-
-        -X github.com/ethereum/go-ethereum/internal/version.gitTag=v${{package.version}}
-        -X github.com/ethereum/go-ethereum/internal/version.gitCommit=$(git rev-parse HEAD)
       output: geth
 
 subpackages:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: 1.101411.6
+  version: 1.101411.7
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 50b3422b9ac682a8fa503c4f409339a9bff69717
+      expected-commit: b79c44a850e7a86b74e50bcdaca18690ba01783d
       repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -68,17 +68,16 @@ subpackages:
             clef --help
       # Cannot create a functional test because clef requires an interactive shell and dynamic input
         # - runs: |
-        #     apk add py3-pexpect
         #     cat <<EOF > .clef_init.exp
         #     #!/usr/bin/expect -f
         #     spawn ./build/bin/clef init
-        #     py3-pexpect "Enter 'ok' to proceed:"
+        #     expect "Enter 'ok' to proceed:"
         #     send "ok\r"
-        #     py3-pexpect "Password:"
+        #     expect "Password:"
         #     send "1234567890\r"
-        #     py3-pexpect "Repeat password:"
+        #     expect "Repeat password:"
         #     send "1234567890\r"
-        #     py3-pexpect eof
+        #     expect eof
         #     EOF
           
         #     chmod +x .clef_init.exp

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -39,6 +39,7 @@ pipeline:
       packages: ./cmd/geth
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+        -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
       output: geth
 
 subpackages:
@@ -113,7 +114,7 @@ test:
   pipeline:
     - name: version and help tests for geth
       runs: |
-        geth version
+        geth version | grep -qi "${{package.version}}-stable"
         geth --help
 
 update:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -66,18 +66,25 @@ subpackages:
         - runs: |
             clef --version
             clef --help
-        - runs: |
-            expect <<EOF
-            spawn clef init
-            expect "Enter 'ok' to proceed:"
-            send "ok\r"
-            expect "Password:"
-            send "1234567890\r"
-            expect "Repeat password:"
-            send "1234567890\r"
-            expect eof
-            EOF
-            test -f /home/laborant/.clef/masterseed.json && echo "Clef init successful" || { echo "Clef init failed"; exit 1; }
+      # Cannot create a functional test because clef requires an interactive shell and dynamic input
+        # - runs: |
+        #     apk add py3-pexpect
+        #     cat <<EOF > .clef_init.exp
+        #     #!/usr/bin/expect -f
+        #     spawn ./build/bin/clef init
+        #     py3-pexpect "Enter 'ok' to proceed:"
+        #     send "ok\r"
+        #     py3-pexpect "Password:"
+        #     send "1234567890\r"
+        #     py3-pexpect "Repeat password:"
+        #     send "1234567890\r"
+        #     py3-pexpect eof
+        #     EOF
+          
+        #     chmod +x .clef_init.exp
+        #     ./clef_init.exp
+
+        #     test -f /root/.clef/masterseed.json && echo "Clef init successful" || { echo "Clef init failed"; exit 1; }
 
   - name: ${{package.name}}-abigen
     pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -32,12 +32,18 @@ pipeline:
         github.com/golang-jwt/jwt/v4@v4.5.1
         golang.org/x/crypto@v0.31.0
         golang.org/x/net@v0.33.0
+        github.com/hashicorp/go-retryablehttp@0.7.7
 
   - uses: go/build
     with:
       packages: ./cmd/geth
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+        -X github.com/ethereum/go-ethereum/version.gitTag=$(git name-rev --tags --name-only $(git rev-parse HEAD))
+        -X github.com/ethereum/go-ethereum/internal/version.gitCommit=$(git rev-parse HEAD)
+
+        -X github.com/ethereum/go-ethereum/internal/version.gitTag=v${{package.version}}
+        -X github.com/ethereum/go-ethereum/internal/version.gitCommit=$(git rev-parse HEAD)
       output: geth
 
 subpackages:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -8,16 +8,13 @@ package:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
-      - busybox
+      - coreutils
 
 environment:
   contents:
     packages:
       - ca-certificates
-      - gcc
-      - git
       - linux-headers
-      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -66,24 +63,15 @@ subpackages:
         - runs: |
             clef --version
             clef --help
-      # Cannot create a functional test because clef requires an interactive shell and dynamic input
-        # - runs: |
-        #     cat <<EOF > .clef_init.exp
-        #     #!/usr/bin/expect -f
-        #     spawn ./build/bin/clef init
-        #     expect "Enter 'ok' to proceed:"
-        #     send "ok\r"
-        #     expect "Password:"
-        #     send "1234567890\r"
-        #     expect "Repeat password:"
-        #     send "1234567890\r"
-        #     expect eof
-        #     EOF
-          
-        #     chmod +x .clef_init.exp
-        #     ./clef_init.exp
-
-        #     test -f /root/.clef/masterseed.json && echo "Clef init successful" || { echo "Clef init failed"; exit 1; }
+        - name: "Run clef init"
+          runs: |
+            apk add cmd:script
+            script -q -c "clef init" /dev/null <<EOF
+            ok
+            1234567890
+            1234567890
+            EOF
+            test -f /root/.clef/masterseed.json && echo "Clef init successful" || { echo "Clef init failed"; exit 1; }
 
   - name: ${{package.name}}-abigen
     pipeline:
@@ -157,6 +145,7 @@ subpackages:
         - runs: |
             evm --version
             evm --help
+            evm run --code 0x 2>/dev/null && echo "Success" || echo "Failed"
 
   - name: ${{package.name}}-rlpdump
     pipeline:
@@ -168,6 +157,8 @@ subpackages:
       pipeline:
         - runs: |
             rlpdump --help
+            echo "c0" | rlpdump | grep -q '"c"' && echo "rlpdump stdin test passed" || { echo "rlpdump stdin test failed"; exit 1; } # Test: Decode hex "c0" using stdin and validate output
+            rlpdump -hex c0 | grep -q '\[\]' && echo "rlpdump hex test passed" || { echo "rlpdump hex test failed"; exit 1; }
 
 test:
   pipeline:
@@ -175,6 +166,19 @@ test:
       runs: |
         geth version | grep -qi "${{package.version}}-stable"
         geth --help
+    - runs: |
+        geth --dev --nodiscover --maxpeers 0 --http --http.addr "127.0.0.1" --http.port "8545" --http.api "eth,net,web3" --allow-insecure-unlock &
+        GETH_PID=$!
+        sleep 5  # Wait for Geth to initialize
+
+        if ps | grep -q "[g]eth"; then
+          echo "Geth started successfully"
+        else
+          echo "Failed to start Geth"
+          exit 1
+        fi
+
+        kill $GETH_PID
 
 update:
   enabled: true

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,10 +1,11 @@
 package:
   name: op-geth
-  version: "1.101411.6"
+  version: 1.101411.6
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
     - license: LGPL-3.0-or-later
+    - license: GPL-3.0-or-later
   dependencies:
     runtime:
       - busybox
@@ -36,12 +37,21 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/geth
+      # TODO: The following ldflags set the gitTag for the main package and all subpackages.
+      # verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
         -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
       output: geth
 
 subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by upstream"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/bin
+          ln -sf /usr/bin/geth ${{targets.subpkgdir}}/bin/geth
+
   - name: ${{package.name}}-clef
     pipeline:
       - uses: go/build
@@ -50,13 +60,24 @@ subpackages:
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
             -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
-          # TODO: Verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
           output: clef
     test:
       pipeline:
         - runs: |
             clef --version
             clef --help
+        - runs: |
+            expect <<EOF
+            spawn clef init
+            expect "Enter 'ok' to proceed:"
+            send "ok\r"
+            expect "Password:"
+            send "1234567890\r"
+            expect "Repeat password:"
+            send "1234567890\r"
+            expect eof
+            EOF
+            test -f /home/laborant/.clef/masterseed.json && echo "Clef init successful" || { echo "Clef init failed"; exit 1; }
 
   - name: ${{package.name}}-abigen
     pipeline:
@@ -72,6 +93,18 @@ subpackages:
         - runs: |
             abigen --version
             abigen --help
+            echo 'Testing abigen with a sample ABI...'
+
+            echo '[{"inputs":[],"name":"retrieve","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]' > test.abi
+
+            abigen --abi test.abi --pkg main --type TestContract --out test.go
+
+            if [ ! -s test.go ]; then
+              echo "Error: test.go was not generated correctly!"
+              exit 1
+            fi
+
+            echo "abigen test passed successfully!"
 
   - name: ${{package.name}}-devp2p
     pipeline:
@@ -87,6 +120,22 @@ subpackages:
         - runs: |
             devp2p --version
             devp2p --help
+        - runs: |
+            devp2p key generate mynode.key
+
+            # Verify that the key was created and contains a valid hex string
+            if [ ! -f "mynode.key" ]; then
+              echo "Error: mynode.key was not created!" >&2
+              exit 1
+            fi
+
+            KEY_CONTENT=$(cat mynode.key)
+            if ! echo "$KEY_CONTENT" | grep -qE '^[a-f0-9]{64}$'; then
+              echo "Error: Invalid key format in mynode.key" >&2
+              exit 1
+            fi
+
+            echo "Successfully generated and validated mynode.key"
 
   - name: ${{package.name}}-evm
     pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: "1.101411.6"
+  version: "1.14.13"
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 50b3422b9ac682a8fa503c4f409339a9bff69717
+      expected-commit: eb00f1694c9265f6909c19995a535eef246dcf1e
       repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: "1.14.13"
+  version: "1.101411.6 "
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
@@ -22,8 +22,8 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: eb00f1694c9265f6909c19995a535eef246dcf1e
-      repository: https://github.com/ethereum/go-ethereum
+      expected-commit: 50b3422b9ac682a8fa503c4f409339a9bff69717
+      repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 
   - uses: go/build

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,0 +1,126 @@
+package:
+  name: op-geth
+  version: "1.101411.5"
+  epoch: 0
+  description: The go-ethereum command line interface
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - busybox
+      - make
+
+environment:
+  contents:
+    packages:
+      - ca-certificates
+      - gcc
+      - git
+      - linux-headers
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 82acd5af46d4352203353399a465b3ce142ede24
+      repository: https://github.com/ethereum-optimism/op-geth
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/geth
+      ldflags: |
+        -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
+        -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
+        -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      output: geth
+
+subpackages:
+  - name: ${{package.name}}-clef
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/clef
+          ldflags: |
+            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
+            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          output: clef
+    test:
+      pipeline:
+        - runs: |
+            clef --version
+            clef --help
+
+  - name: ${{package.name}}-abigen
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/abigen
+          output: abigen
+          ldflags: |
+            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
+            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    test:
+      pipeline:
+        - runs: |
+            abigen --version
+            abigen --help
+
+  - name: ${{package.name}}-devp2p
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/devp2p
+          ldflags: |
+            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
+            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          output: devp2p
+    test:
+      pipeline:
+        - runs: |
+            devp2p --version
+            devp2p --help
+
+  - name: ${{package.name}}-evm
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/evm
+          ldflags: |
+            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
+            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          output: evm
+    test:
+      pipeline:
+        - runs: |
+            evm --version
+            evm --help
+
+  - name: ${{package.name}}-rlpdump
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/rlpdump
+          output: rlpdump
+    test:
+      pipeline:
+        - runs: |
+            rlpdump --help
+
+test:
+  pipeline:
+    - name: version and help tests for geth
+      runs: |
+        geth version
+        geth --help
+
+update:
+  enabled: true
+  github:
+    identifier: ethereum-optimism/op-geth
+    strip-prefix: v
+    tag-filter: v

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -31,7 +31,6 @@ pipeline:
       packages: ./cmd/geth
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-        -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
       output: geth
 
 subpackages:
@@ -42,7 +41,6 @@ subpackages:
           packages: ./cmd/clef
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: clef
     test:
       pipeline:
@@ -58,7 +56,6 @@ subpackages:
           output: abigen
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
     test:
       pipeline:
         - runs: |
@@ -72,7 +69,6 @@ subpackages:
           packages: ./cmd/devp2p
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: devp2p
     test:
       pipeline:
@@ -87,7 +83,6 @@ subpackages:
           packages: ./cmd/evm
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: evm
     test:
       pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -23,7 +23,7 @@ pipeline:
   - uses: git-checkout
     with:
       expected-commit: eb00f1694c9265f6909c19995a535eef246dcf1e
-      repository: https://github.com/ethereum-optimism/op-geth
+      repository: https://github.com/ethereum/go-ethereum
       tag: v${{package.version}}
 
   - uses: go/build

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -26,6 +26,13 @@ pipeline:
       repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/golang-jwt/jwt/v4@v4.5.1
+        golang.org/x/crypto@v0.31.0
+        golang.org/x/net@v0.33.0
+
   - uses: go/build
     with:
       packages: ./cmd/geth

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -30,9 +30,8 @@ pipeline:
     with:
       packages: ./cmd/geth
       ldflags: |
-        -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
-        -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
-        -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+        -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
       output: geth
 
 subpackages:
@@ -42,9 +41,8 @@ subpackages:
         with:
           packages: ./cmd/clef
           ldflags: |
-            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
-            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: clef
     test:
       pipeline:
@@ -59,9 +57,8 @@ subpackages:
           packages: ./cmd/abigen
           output: abigen
           ldflags: |
-            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
-            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
     test:
       pipeline:
         - runs: |
@@ -74,9 +71,8 @@ subpackages:
         with:
           packages: ./cmd/devp2p
           ldflags: |
-            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
-            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: devp2p
     test:
       pipeline:
@@ -90,9 +86,8 @@ subpackages:
         with:
           packages: ./cmd/evm
           ldflags: |
-            -X github.com/ethereum-optimism/op-geth/internal/version.gitCommitID=$(git rev-parse HEAD)
-            -X github.com/ethereum-optimism/op-geth/internal/version.version=${{package.version}}
-            -X github.com/ethereum-optimism/op-geth/internal/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum-optimism/op-geth/version.OPGethMeta=v${{package.version}}
           output: evm
     test:
       pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: "1.101411.5"
+  version: "1.101411.6 "
   epoch: 0
   description: The go-ethereum command line interface
   copyright:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 82acd5af46d4352203353399a465b3ce142ede24
+      expected-commit: 50b3422b9ac682a8fa503c4f409339a9bff69717
       repository: https://github.com/ethereum-optimism/op-geth
       tag: v${{package.version}}
 

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -50,6 +50,8 @@ subpackages:
           packages: ./cmd/clef
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
+            # TODO: Verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
           output: clef
     test:
       pipeline:
@@ -65,6 +67,7 @@ subpackages:
           output: abigen
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
     test:
       pipeline:
         - runs: |
@@ -78,6 +81,7 @@ subpackages:
           packages: ./cmd/devp2p
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
           output: devp2p
     test:
       pipeline:
@@ -92,6 +96,7 @@ subpackages:
           packages: ./cmd/evm
           ldflags: |
             -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
+            -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}
           output: evm
     test:
       pipeline:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,6 +1,6 @@
 package:
   name: op-geth
-  version: "1.101411.6 "
+  version: "1.101411.6"
   epoch: 0
   description: The go-ethereum command line interface
   copyright:

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -42,13 +42,6 @@ pipeline:
       output: geth
 
 subpackages:
-  - name: ${{package.name}}-compat
-    description: "Compatibility package to place binaries in the location expected by upstream"
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/bin
-          ln -sf /usr/bin/geth ${{targets.subpkgdir}}/bin/geth
-
   - name: ${{package.name}}-clef
     pipeline:
       - uses: go/build

--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -35,7 +35,7 @@ pipeline:
     with:
       packages: ./cmd/geth
       # TODO: The following ldflags set the gitTag for the main package and all subpackages.
-      # verify if params.gitTag is needed or can be removed in future builds and change ldflags to new path when the next stable version is released and if auto-bump fails
+      # verify if params.gitTag is needed or can be removed in future builds and change the ldflags to new path when the next stable version is released and if auto-bump fails
       ldflags: |
         -X github.com/ethereum/go-ethereum/version.gitTag=v${{package.version}}
         -X github.com/ethereum/go-ethereum/params.gitTag=v${{package.version}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: [#4316](https://github.com/chainguard-dev/image-requests/issues/4316)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
