### PR TITLE
test/hardening-check: also re-enable branchprotection skip

### DIFF
--- a/pipelines/test/hardening-check.yaml
+++ b/pipelines/test/hardening-check.yaml
@@ -34,6 +34,12 @@ pipeline:
           # the branch protection check is ARM only for now
           [ "${{build.arch}}" = "aarch64" ] || arch_skip=--nobranchprotection
 
+          ### <DELETE WHEN GLIBC OPENSSF HARDENING IS RE-ENABLED>
+          if [ "${{build.arch}}" = "aarch64" ]; then
+            arch_skip="$arch_skip --nobranchprotection"
+          fi
+          ### </DELETE>
+
           hardening-check $arch_skip ${{inputs.args}} --color $1
       }
 


### PR DESCRIPTION
Similar to compiler-hardening-check, also re-enable skipping
branchprotection in the hardening-check, as for example busybox
testing currently fails.
