### PR TITLE
openssl: prefix libs with 'openssl-'

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -5,7 +5,7 @@ package:
   #
   #       https://chainguard.engineering/docs/packages/playbooks/core-components/openssl-updates/
   version: "3.6.2"
-  epoch: 3
+  epoch: 4
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -160,8 +160,11 @@ subpackages:
       pipeline:
         - uses: test/docs
 
-  - name: "libcrypto3"
+  - name: "openssl-libcrypto3"
     description: "OpenSSL libcrypto library"
+    dependencies:
+      provides:
+        - libcrypto3=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -174,8 +177,11 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: "libssl3"
+  - name: "openssl-libssl3"
     description: "OpenSSL libssl library"
+    dependencies:
+      provides:
+        - libssl3=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -223,12 +229,12 @@ test:
   pipeline:
     - uses: test/hardening-check
       with:
-        package-match: "^openssl$\\|libssl3"
+        package-match: "^openssl$\\|openssl-libssl3"
     - uses: test/hardening-check
       with:
         # jitterentropy is without CF protection so far
         args: "--nocfprotection"
-        package-match: "^libcrypto3$"
+        package-match: "^openssl-libcrypto3$"
     - runs: |
         openssl --version
         openssl --help


### PR DESCRIPTION
When people search for openssl in our SBOMs they're typically meaning to search for libssl and libcrypt which are not showing up in the search.  It's not immediately obvious that libssl and libcrypt are from openssl or that someone should search that when they're just looking for information about openssl. This prefixes the library packages with openssl so that they're more easily discovered.