### PR TITLE
Symlink some shared objects for ldd

### DIFF
--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 4
+  epoch: 5
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -104,7 +104,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv ${{targets.destdir}}/usr/lib/* ${{targets.subpkgdir}}/usr/lib
+          cd ${{targets.subpkgdir}}
+          ln -s freerdp2/liburbdrc-client.so usr/lib/liburbdrc-client.so
+          ln -s freerdp2/librdpgfx-client.so usr/lib/librdpgfx-client.so
     description: freerdp library
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: ${{subpkg.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
As documented in https://github.com/wolfi-dev/os/issues/41300 the ldd-check test pipeline, which just uses ldd, would fail for freerdp because these two objects were not found.