### PR TITLE
Add tailscale-compat subpackage

### DIFF
--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -24,13 +24,13 @@ pipeline:
 
   - runs: |
       ./build_dist.sh tailscale.com/cmd/containerboot
-      ./build_dist.sh tailscale.com/cmd/tailscale
-      ./build_dist.sh tailscale.com/cmd/tailscaled
+      ./build_dist.sh tailscale.com/cmd/${{package.name}}
+      ./build_dist.sh tailscale.com/cmd/${{package.name}}d
 
   - runs: |
-      install -Dm755 containerboot ${{targets.destdir}}/usr/bin/containerboot
-      install -Dm755 ${{package.name}} ${{targets.destdir}}/usr/bin/tailscale
-      install -Dm755 ${{package.name}}d ${{targets.destdir}}/usr/sbin/tailscaled
+      install -Dm755 containerboot "${{targets.destdir}}"/usr/bin/containerboot
+      install -Dm755 ${{package.name}} "${{targets.destdir}}"/usr/bin/${{package.name}}
+      install -Dm755 ${{package.name}}d "${{targets.destdir}}"/usr/sbin/${{package.name}}d
 
   - uses: strip
 
@@ -39,10 +39,11 @@ subpackages:
     description: "Compatability package to provide parity with upstream Tailscale binary locations"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          ln -sf ${{targets.destdir}}/usr/bin/containerboot ${{targets.subpkgdir}}/usr/local/bin/containerboot
-          ln -sf ${{targets.destdir}}/usr/bin/tailscale ${{targets.subpkgdir}}/usr/local/bin/tailscale
-          ln -sf ${{targets.destdir}}/usr/bin/tailscaled ${{targets.subpkgdir}}/usr/local/bin/tailscaled
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/sbin
+          ln -sf /usr/bin/containerboot "${{targets.subpkgdir}}"/usr/local/bin/containerboot
+          ln -sf /usr/bin/${{package.name}} "${{targets.subpkgdir}}"/usr/local/bin/${{package.name}}
+          ln -sf /usr/sbin/${{package.name}}d "${{targets.subpkgdir}}"/usr/local/sbin/${{package.name}}d
 
 update:
   enabled: true
@@ -51,14 +52,26 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Verify Tailscale Version
       runs: |
+        # Package tests
         tailscale version
         tailscale --version
         tailscale --help
         tailscaled --version
         tailscaled --help
+
+        # Compat validity tests
+        stat /usr/local/bin/containerboot
+        stat /usr/local/bin/tailscale
+        stat /usr/local/sbin/tailscaled
+        /usr/local/bin/tailscale --version
+        /usr/local/sbin/tailscaled --version
     - name: Containerboot Test
       runs: |
         containerboot &

--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -1,7 +1,7 @@
 package:
   name: tailscale
   version: "1.80.0"
-  epoch: 0
+  epoch: 1
   description: The easiest, most secure way to use WireGuard and 2FA.
   copyright:
     - license: BSD-3-Clause
@@ -33,6 +33,16 @@ pipeline:
       install -Dm755 ${{package.name}}d ${{targets.destdir}}/usr/sbin/tailscaled
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatability package to provide parity with upstream Tailscale binary locations"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf ${{targets.destdir}}/usr/bin/containerboot ${{targets.subpkgdir}}/usr/local/bin/containerboot
+          ln -sf ${{targets.destdir}}/usr/bin/tailscale ${{targets.subpkgdir}}/usr/local/bin/tailscale
+          ln -sf ${{targets.destdir}}/usr/bin/tailscaled ${{targets.subpkgdir}}/usr/local/bin/tailscaled
 
 update:
   enabled: true


### PR DESCRIPTION
This PR adds a `-compat` subpackage for Tailscale so that we can land the built binaries in an expected location (`/usr/local/bin` in this case).