### PR TITLE
feat: Validate vars correctness in GitLab CNG package

### DIFF
--- a/gitlab-cng-17.8.yaml
+++ b/gitlab-cng-17.8.yaml
@@ -1,7 +1,5 @@
-# These variables track the tag and expected commit for GitLab components that
-# require manual intervention for updates. Please refer to the variables
-# manifest that aligns with the CNG release tag set in the CNG package version
-# below. The manifest can be found here:
+# Please refer to the variables below manifest that aligns with the CNG release tag set in the CNG package version.
+# The manifest can be found here:
 # - https://gitlab.com/gitlab-org/build/CNG/-/blob/v<PACKAGE VERSION HERE>/ci_files/variables.yml
 # # Additionally, the latest 'gitaly-backup' package (part of gitlab-cng), must be built first.
 vars:
@@ -34,7 +32,7 @@ package:
   name: gitlab-cng-17.8
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "17.8.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -66,6 +64,33 @@ pipeline:
       repository: https://gitlab.com/gitlab-org/build/CNG.git
       tag: v${{package.version}}
       expected-commit: 1640297ebd6cda3f3cf545bf4ce5fadefb25df98
+
+  - name: Verify all the vars tags are uptodate with the upstream
+    runs: |
+      REGISTRY_TAG=$(sed -n 's/.*GITLAB_CONTAINER_REGISTRY_VERSION: *v\([^"]*\).*/\1/p' ./ci_files/variables.yml | sed 's/-gitlab//')
+      INDEXER_TAG=$(sed -n 's/.*GITLAB_ELASTICSEARCH_INDEXER_VERSION: *v\([^"]*\).*/\1/p' ./ci_files/variables.yml)
+      EXPORTER_TAG=$(sed -n 's/.*GITLAB_EXPORTER_VERSION: *\([^"]*\).*/\1/p' ./ci_files/variables.yml)
+      LOGGER_TAG=$(sed -n 's/.*GITLAB_LOGGER_VERSION: *v\([^"]*\).*/\1/p' ./ci_files/variables.yml)
+      MAILROOM_TAG=$(sed -n 's/.*MAILROOM_VERSION: *\([^"]*\).*/\1/p' ./ci_files/variables.yml)
+      SHELL_TAG=$(sed -n 's/.*GITLAB_SHELL_VERSION: *v\([^"]*\).*/\1/p' ./ci_files/variables.yml)
+
+      check_version() {
+        local vars_name=$1
+        local expected_value=$2
+        local actual_value=$3
+
+        if [ "$expected_value" != "$actual_value" ]; then
+          echo "Error: Expected $vars_name: $expected_value but got: $actual_value"
+          exit 1
+        fi
+      }
+      # Run checks
+      check_version "registry-tag" "${{vars.registry-tag}}" "$REGISTRY_TAG"
+      check_version "indexer-tag" "${{vars.indexer-tag}}" "$INDEXER_TAG"
+      check_version "exporter-tag" "${{vars.exporter-tag}}" "$EXPORTER_TAG"
+      check_version "logger-tag" "${{vars.logger-tag}}" "$LOGGER_TAG"
+      check_version "mailroom-tag" "${{vars.mailroom-tag}}" "$MAILROOM_TAG"
+      check_version "shell-tag" "${{vars.shell-tag}}" "$SHELL_TAG"
 
 data:
   # Used to create all of the *-scripts subpackages from the CNG repo.


### PR DESCRIPTION
- Added a validation pipeline to check if all variable tags (`registry-tag`, `indexer-tag`, `exporter-tag`, `logger-tag`, `mailroom-tag`, and `shell-tag`) match the expected upstream versions.
- Ensures that the automated package update fails if the vars do not align with upstream values, preventing mismatches and inconsistencies.
- Bumped epoch to `1` to reflect this change in package updates.