### PR TITLE
fix(python): Support binding to ports less than 1024

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.9"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -24,6 +24,7 @@ environment:
       - ca-certificates-bundle
       - expat-dev
       - gdbm-dev
+      - libcap-utils
       - libffi-dev
       - libx11-dev
       - linux-headers
@@ -40,12 +41,12 @@ environment:
 # creates helpfull python3.M and 3.M variables
 var-transforms:
   - from: ${{package.name}}
-    match: '-'
-    replace: ''
+    match: "-"
+    replace: ""
     to: python
   - from: ${{package.version}}
     match: (\d).(\d+).(\d+)
-    replace: '$1.$2'
+    replace: "$1.$2"
     to: pyversion
 
 pipeline:
@@ -194,6 +195,29 @@ subpackages:
             done
 
             rm -Rf "$d"
+
+  - name: "${{package.name}}-privileged-netbindservice"
+    description: "Allows Python to bind to ports less than 1024"
+    options:
+      # This replaces the Python binary and depends on base. We don't want
+      # to generate any dependencies or provide anything that would clash
+      # with the rest of Python
+      no-depends: true
+      no-provides: true
+    dependencies:
+      replaces:
+        - ${{package.name}}-base
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/bin"
+          cp "${{targets.outdir}}/${{package.name}}-base/usr/bin/${{vars.python}}" "${{targets.contextdir}}/usr/bin/"
+          setcap cap_net_bind_service=+eip "${{targets.contextdir}}/usr/bin/${{vars.python}}"
+    test:
+      pipeline:
+        - runs: |
+            stat "/usr/bin/${{vars.python}}"
 
   - name: "${{package.name}}-tk"
     dependencies:

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.2"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -24,6 +24,7 @@ environment:
       - ca-certificates-bundle
       - expat-dev
       - gdbm-dev
+      - libcap-utils
       - libffi-dev
       - libx11-dev
       - linux-headers
@@ -194,6 +195,29 @@ subpackages:
             done
 
             rm -Rf "$d"
+
+  - name: "${{package.name}}-privileged-netbindservice"
+    description: "Allows Python to bind to ports less than 1024"
+    options:
+      # This replaces the Python binary and depends on base. We don't want
+      # to generate any dependencies or provide anything that would clash
+      # with the rest of Python
+      no-depends: true
+      no-provides: true
+    dependencies:
+      replaces:
+        - ${{package.name}}-base
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/bin"
+          cp "${{targets.outdir}}/${{package.name}}-base/usr/bin/${{vars.python}}" "${{targets.contextdir}}/usr/bin/"
+          setcap cap_net_bind_service=+eip "${{targets.contextdir}}/usr/bin/${{vars.python}}"
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/bin/${{vars.python}}
 
   - name: "${{package.name}}-tk"
     dependencies:


### PR DESCRIPTION
Introduces subpackage with capabilities set to bind to privileged ports

Currently needed by pgAdmin