### PR TITLE
wip(file.yaml): test patch for bug #612

### DIFF
--- a/file.yaml
+++ b/file.yaml
@@ -1,7 +1,7 @@
 package:
   name: file
   version: "5.46"
-  epoch: 1
+  epoch: 2
   description: "file-type identification utility"
   copyright:
     - license: BSD-2-Clause
@@ -29,6 +29,15 @@ pipeline:
       repository: https://github.com/file/file.git
       tag: FILE${{vars.mangled-package-version}}
       expected-commit: b310a0c2d3e4a1c12d579ad5c0266f1092a91340
+
+  # TODO: trying to patch https://bugs.astron.com/view.php?id=612
+  # while waiting for a release from upstream.
+  # The patch resembles the commits:
+  # - cd534c3a08c28ccd8701c900d9c45b8d278212d8
+  # - b874d520c592ecd55ebcae0d662dc6e54f5c5414
+  - uses: patch
+    with:
+      patches: 612.patch
 
   - runs: |
       autoreconf -vif

--- a/file/612.patch
+++ b/file/612.patch
@@ -1,0 +1,48 @@
+diff --git a/src/apprentice.c b/src/apprentice.c
+index cf040cdd..c77001f3 100644
+--- a/src/apprentice.c
++++ b/src/apprentice.c
+@@ -32,7 +32,7 @@
+ #include "file.h"
+ 
+ #ifndef	lint
+-FILE_RCSID("@(#)$File: apprentice.c,v 1.356 2024/11/27 15:37:00 christos Exp $")
++FILE_RCSID("@(#)$File: apprentice.c,v 1.363 2025/01/25 16:11:03 christos Exp $")
+ #endif	/* lint */
+ 
+ #include "magic.h"
+@@ -341,7 +341,11 @@ get_standard_integer_type(const char *l, const char **t)
+ {
+ 	int type;
+ 
+-	if (isalpha(CAST(unsigned char, l[1]))) {
++	if (l[0] == '\0')
++		return FILE_INVALID;
++	if (l[1] == '\0')
++		return FILE_INVALID;
++	else if (isalpha(CAST(unsigned char, l[1]))) {
+ 		switch (l[1]) {
+ 		case 'C':
+ 			/* "dC" and "uC" */
+@@ -2391,6 +2395,12 @@ parse(struct magic_set *ms, struct magic_entry *me, const char *file,
+ 		}
+ 		break;
+ 	}
++
++	if (*l == '\0') {
++		file_magwarn(ms, "incomplete magic `%s'", line);
++		return -1;
++	}
++
+ 	/*
+ 	 * Grab the value part, except for an 'x' reln.
+ 	 */
+@@ -3377,7 +3387,7 @@ check_buffer(struct magic_set *ms, struct magic_map *map, const char *dbname)
+ 	int i, needsbyteswap;
+ 
+ 	entries = CAST(uint32_t, map->len / sizeof(struct magic));
+-	if (entries < MAGIC_SETS + 1) {
++	if (entries < MAGIC_SETS) {
+ 		file_error(ms, 0, "Too few magic entries %u in `%s'",
+ 		    entries, dbname);
+ 		return -1;


### PR DESCRIPTION
The patch refers the commits:
- cd534c3a08c28ccd8701c900d9c45b8d278212d8
- b874d520c592ecd55ebcae0d662dc6e54f5c5414

based on the update about the fix on bug tracker [1].

1. https://bugs.astron.com/view.php?id=612#c4156

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
