### PR TITLE
withdraw package prometheus-jmx-exporter-httpserver

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,2 +1,3 @@
 zetasql-2024.06.1-r2.apk
 zetasql-dev-2024.06.1-r2.apk
+prometheus-jmx-exporter-httpserver-1.0.1-r0.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,1 @@
-zetasql-2024.06.1-r2.apk
-zetasql-dev-2024.06.1-r2.apk
 prometheus-jmx-exporter-httpserver-1.0.1-r0.apk


### PR DESCRIPTION
Withdraw package prometheus-jmx-exporter-httpserver:
1. There is no manifest for it.
2. [REF commit](https://github.com/wolfi-dev/os/commit/b7328e0c6685f8366516234bb5f2ff447fa3e1c3) as it is no longer needed as a separate apk.
3. [prometheus-jmx-exporter ](https://github.com/wolfi-dev/os/blob/main/prometheus-jmx-exporter.yaml#L49)still uses it in tests so it's confusing for future travellers.