### PR TITLE
add package for bitnami/jmx-exporter

### DIFF
--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -13,12 +13,9 @@ environment:
       - ca-certificates
       - curl
       - maven
-      - openjdk-17-default-jdk
+      - openjdk-${{vars.java-version}}-default-jdk
       - procps
       - zlib
-  environment:
-    LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 var-transforms:
   # Extract the major version from the package version.
@@ -26,6 +23,10 @@ var-transforms:
     match: ^(\d+).*
     replace: $1
     to: major-version
+
+vars:
+  java-version: 17
+  debian-version: 12
 
 pipeline:
   - uses: git-checkout
@@ -52,11 +53,10 @@ pipeline:
     # Bitnami doesn't like symlinks
     runs: |
       cp -R ./examples ${{targets.destdir}}/opt/bitnami/jmx-exporter/
-      cp ./LICENSE ${{targets.destdir}}/opt/bitnami/jmx-exporter/
 
       # Copy the Java 17 installation into /opt/bitnami/java
       for item in bin conf include jre legal lib release; do
-        cp -R /usr/lib/jvm/java-17-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
+        cp -R /usr/lib/jvm/java-${{vars.java-version}}-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
       done
 
       # Copy built JARs for agent and standalone server
@@ -68,16 +68,14 @@ pipeline:
   - uses: bitnami/compat
     with:
       image: jmx-exporter
-      version-path: ${{vars.major-version}}/debian-12
+      version-path: ${{vars.major-version}}/debian-${{vars.debian-version}}
 
 test:
   environment:
     contents:
       packages:
         - curl
-        - openjdk-17-default-jdk
-    environment:
-      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+        - openjdk-${{vars.java-version}}-default-jvm
   pipeline:
     - name: run-minimal-jmx-test
       runs: |

--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -1,0 +1,114 @@
+package:
+  name: jmx-exporter-bitnami
+  version: "1.1.0"
+  epoch: 0
+  description: "Bitnami for Prometheus JMX Exporter"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates
+      - curl
+      - maven
+      - openjdk-17-default-jvm
+      - procps
+      - zlib
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+var-transforms:
+  # Extract the major version from the package version.
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/jmx_exporter
+      tag: ${{package.version}}
+      expected-commit: 00fd35dc2e0a03eefe49ef1182280fc9319bbe70
+
+  - name: build-intall-jars
+    # Build the project using Maven
+    runs: |
+      ./mvnw clean package -DskipTests
+
+  - name: create-required-dirs
+    # Create the required directories for a Bitnami-like layout
+    runs: |
+      mkdir -p ${{targets.contextdir}}/opt/bitnami
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/jmx-exporter
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/java
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/jmx-exporter/licenses
+      mkdir -p ${{targets.contextdir}}/tmp/bitnami/pkg/cache/
+
+  - name: symlinks-and-copy-files
+    runs: |
+      cp -R ./examples ${{targets.destdir}}/opt/bitnami/jmx-exporter/
+      cp ./LICENSE ${{targets.destdir}}/opt/bitnami/jmx-exporter/
+
+      # Symlink the Java 17 installation into /opt/bitnami/java
+      for item in bin conf include jre legal lib release; do
+        ln -sf /usr/lib/jvm/java-17-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
+      done
+
+      # Copy built JARs for agent and standalone server
+      cp ./jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-${{package.version}}.jar \
+          ${{targets.destdir}}/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar
+      cp ./jmx_prometheus_standalone/target/jmx_prometheus_standalone-${{package.version}}.jar \
+          ${{targets.destdir}}/opt/bitnami/jmx-exporter/jmx_prometheus_standalone.jar
+
+  - uses: bitnami/compat
+    with:
+      image: jmx-exporter
+      version-path: ${{vars.major-version}}/debian-12
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-17-default-jvm
+        - curl
+    environment:
+      ES_JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+      ES_USER: elasticsearch
+  pipeline:
+    - name: run-minimal-jmx-test
+      runs: |
+        set -ex
+
+        # Create a minimal config for the JMX Exporter in standalone mode.
+        mkdir -p /tmp/jmx-exporter-test
+        cat <<EOF > /tmp/jmx-exporter-test/config.yaml
+        hostPort: localhost:9999
+        rules:
+          - pattern: ".*"
+        EOF
+
+        # Launch the standalone exporter on port 7071, referencing our config file.
+        java -jar /opt/bitnami/jmx-exporter/jmx_prometheus_standalone.jar \
+             7071 /tmp/jmx-exporter-test/config.yaml &
+        STANDALONE_PID=$!
+
+        # Allow the exporter time to start
+        sleep 5
+
+        # Verify the JMX Exporter is still running
+        kill -0 "$STANDALONE_PID" 2>/dev/null \
+          || (echo "Error: JMX Exporter (standalone) failed to start." >&2; exit 1)
+
+        # Check that /metrics is available and contains a known metric
+        curl -s http://127.0.0.1:7071/metrics | grep -q "jmx_exporter_build_info" \
+          || (echo "Error: Expected metric 'jmx_exporter_build_info' not found." >&2; exit 1)
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/jmx_exporter
+    tag-filter: 1.

--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -74,11 +74,10 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17-default-jvm
         - curl
+        - openjdk-17-default-jdk
     environment:
-      ES_JAVA_HOME: /usr/lib/jvm/java-17-openjdk
-      ES_USER: elasticsearch
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
     - name: run-minimal-jmx-test
       runs: |

--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -13,7 +13,7 @@ environment:
       - ca-certificates
       - curl
       - maven
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - procps
       - zlib
   environment:

--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -48,14 +48,15 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/opt/bitnami/jmx-exporter/licenses
       mkdir -p ${{targets.contextdir}}/tmp/bitnami/pkg/cache/
 
-  - name: symlinks-and-copy-files
+  - name: copy-files-to-dest
+    # Bitnami doesn't like symlinks
     runs: |
       cp -R ./examples ${{targets.destdir}}/opt/bitnami/jmx-exporter/
       cp ./LICENSE ${{targets.destdir}}/opt/bitnami/jmx-exporter/
 
-      # Symlink the Java 17 installation into /opt/bitnami/java
+      # Copy the Java 17 installation into /opt/bitnami/java
       for item in bin conf include jre legal lib release; do
-        ln -sf /usr/lib/jvm/java-17-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
+        cp -R /usr/lib/jvm/java-17-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
       done
 
       # Copy built JARs for agent and standalone server


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
