### PR TITLE
Fix keyutils-dev

### DIFF
--- a/keyutils.yaml
+++ b/keyutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: keyutils
   version: 1.6.3
-  epoch: 5
+  epoch: 6
   description: Linux Key Management Utilities
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later
@@ -41,6 +41,11 @@ pipeline:
         LIBDIR=/usr/lib \
         USRLIBDIR=/usr/lib \
         install
+
+      # Work around a bug in melange with absolute symlinks:
+      # https://github.com/chainguard-dev/melange/issues/1775
+      rm "${{targets.destdir}}/usr/lib/libkeyutils.so"
+      ln -s libkeyutils.so.1 "${{targets.destdir}}/usr/lib/libkeyutils.so"
 
   - uses: strip
 


### PR DESCRIPTION
There is an absolute symlink that is tripping up melange's SCA when run with bubblewrap.

https://github.com/chainguard-dev/melange/issues/1775