### PR TITLE
fix(collectd.yaml): Revert adding runtime dependencies to satisfy ldd-check

### DIFF
--- a/collectd.yaml
+++ b/collectd.yaml
@@ -6,14 +6,10 @@
 package:
   name: collectd
   version: 5.12.0
-  epoch: 5
+  epoch: 6
   description: "The system statistics collection daemon."
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - openjdk-17-default-jdk
-      - perl-dev
 
 environment:
   contents:
@@ -189,6 +185,3 @@ test:
         collectdmon --version
         collectdmon --help
     - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}


### PR DESCRIPTION
Added @ https://github.com/wolfi-dev/os/pull/41001/commits/dd357b26ae060a048b0f950c389c71e18afb83b9 as
part or PR https://github.com/wolfi-dev/os/pull/41001 but this causes downstream issues for packages dependent on collectd.

Example: Package metric-collector-for-apache-cassandra-4.1 depends on collectd but package is not installable as a result.

This was highlighted as part of an image build which attempts to install openjdk-11-default-jvm-bcfips but collectd already depends on openjdk-17-default-jdk
resulting in this conflict.

```
failed to build layer image for "amd64": installing apk packages: installing packages: installing openjdk-11-default-jvm-bcfips (ver:11.0.26-r0 arch:x86_64): unable to install files for pkg openjdk-11-default-jvm-bcfips: writing header for "usr/lib/jvm/default-jvm": conflicting file "usr/lib/jvm/default-jvm" in "openjdk-17-default-jdk" has different origin "openjdk-17" != "openjdk-11-bcfips" in
│ "openjdk-11-default-jvm-bcfips"
```

While the inclusion of the runtime dependency is valid and the addition of the ldd-check test is needed, we need to consider collectd being installed with openjdk-11 too.

Signed-off-by: philroche <phil.roche@chainguard.dev>
