### PR TITLE
fix(py3-cassandra-medusa): add missing poetry binary

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.23.0"
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - py${{vars.py-version}}-poetry
+      - py${{vars.py-version}}-poetry-bin
 
 vars:
   py-version: 3.11
@@ -105,8 +105,12 @@ test:
       packages:
         - grpc-health-probe
   pipeline:
-    - runs: medusa --version
-    - runs: |
+    - name: Test poetry binary is in PATH
+      runs: poetry --version
+    - name: Test medusa version
+      runs: medusa --version
+    - name: Test medusa server run
+      runs: |
         set +e
         fail() { echo "$@" 1>&2; exit 1; }
         out=$(/home/cassandra/.venv/bin/python${{vars.py-version}} -m medusa.service.grpc.server 2>&1)


### PR DESCRIPTION
Poetry binary have been moved [1] to its own binary package, so use that as runtime dependency.
Cassandra Medusa needs `poetry` binary.

1. https://github.com/wolfi-dev/os/commit/a875d40d6670d39ac8f9a18be6898f66406bd338