### PR TITLE
kong: use Bazel 7 for builds, fixing FTBFS

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong
   version: 3.9.0
-  epoch: 2
+  epoch: 3
   description: "The Kong Gateway - an API Gateway built on Nginx and OpenResty"
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
   contents:
     packages:
       - bash
-      - bazel
+      - bazel<8
       - bubblewrap
       - build-base
       - busybox


### PR DESCRIPTION
Upstream haven't updated for Bazel 8 yet
(https://github.com/Kong/kong/blob/master/.bazelversion is `7.3.1` currently), and it's causing build failures.

Fixes: #41410