### PR TITLE
percona-server-9.0: fetch boost from archive.boost.io, fixing FTBFS

### DIFF
--- a/percona-server-9.0.yaml
+++ b/percona-server-9.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.0
   version: 9.0.1.1
-  epoch: 0
+  epoch: 1
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later
@@ -64,7 +64,7 @@ pipeline:
     pipeline:
       - uses: fetch
         with:
-          uri: https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2
+          uri: https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2
           expected-sha256: fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
 
   - uses: git-checkout


### PR DESCRIPTION
Boost have migrated away from jfrog.io.

Fixes: #41413