### PR TITLE
spdx-tools-java: add missing build deps, fixing FTBFS

### DIFF
--- a/spdx-tools-java.yaml
+++ b/spdx-tools-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdx-tools-java
   version: 1.1.8
-  epoch: 2
+  epoch: 3
   description: SPDX Command Line Tools using the Spdx-Java-Library
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,8 @@ environment:
   contents:
     packages:
       - busybox
+      - fontconfig-dev
+      - freetype-dev
       - maven
       - openjdk-17-default-jdk
       - ttf-dejavu


### PR DESCRIPTION
These were previously pulled in by `openjdk-17-default-jvm`.

Fixes: #41417