### PR TITLE
opensearch-2: build with older version of gradle to fix FTBFS

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-2
   version: 2.18.0
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - gradle
+      - gradle<8.12
       - openjdk-17-default-jdk
       - patch
       - unzip


### PR DESCRIPTION
The upstream commit to move to Gradle 8.12 hasn't been released yet: https://github.com/opensearch-project/OpenSearch/commit/de832d74a658e393bc3252ff5d62ff9d6ec9f3e6

Fixes: #41411