### PR TITLE
rsyslog: add other plugins and expand tests

### DIFF
--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -23,10 +23,6 @@ environment:
       - flex
       - flex-dev
       - gnutls-dev
-      # - liblognorm-dev
-      # - czmq-dev
-      # - byacc
-      # - bsd-compat-headers
       - hiredis
       - hiredis-dev
       - iproute2
@@ -76,7 +72,6 @@ data:
       mmdblookup: mmdblookup
       mmfields: mmfields
       mmjsonparse: mmjsonparse
-      # mmnormalize: mmnormalize
       mmpstrucdata: mmpstrucdata
       mmrm1stspace: mmrm1stspace
       mmsequence: mmsequence
@@ -94,7 +89,6 @@ data:
       tls: lmnsd_gtls
       udpspoof: omudpspoof
       uxsock: omuxsock
-      # zmq: imczmq,omczmq
       imdocker: imdocker
       clickhouse: omclickhouse
 
@@ -202,7 +196,6 @@ subpackages:
         - rsyslog-mmdblookup
         - rsyslog-mmfields
         - rsyslog-mmjsonparse
-        # - rsyslog-mmnormalize
         - rsyslog-mmpstrucdata
         - rsyslog-mmrm1stspace
         - rsyslog-mmsequence
@@ -220,7 +213,6 @@ subpackages:
         - rsyslog-tls
         - rsyslog-udpspoof
         - rsyslog-uxsock
-        # - rsyslog-zmq
         - rsyslog-imdocker
         - rsyslog-clickhouse
     pipeline:

--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,10 +1,12 @@
 package:
   name: rsyslog
   version: 8.2412.0
-  epoch: 3
+  epoch: 2
   description: a Rocket-fast SYStem for LOG processing
   copyright:
-    - license: Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later
+    - license: Apache-2.0
+    - license: GPL-3.0-or-later
+    - license: LGPL-3.0-or-later
 
 environment:
   contents:

--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: 8.2412.0
-  epoch: 1
+  epoch: 2
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -9,27 +9,42 @@ package:
 environment:
   contents:
     packages:
+      - binutils
+      - bison
       - bison
       - build-base
       - busybox
       - ca-certificates-bundle
       - curl-dev
+      - file
       - flex
+      - flex-dev
+      - iproute2
       - libestr-dev
       - libfastjson-dev
       - libgcrypt-dev
       - liblogging-dev
+      - libpq
       - librelp-dev
       - libssl3
       - libsystemd
       - libtool
       - libuuid
+      - lsb-release-minimal
       - pkgconf
       - pkgconf-dev
+      - postgresql-dev
       - py3-docutils
+      - python3
       - systemd-dev
       - util-linux-dev
+      - valgrind-dev
       - zlib-dev
+
+data:
+  - name: plugins
+    items:
+      pgsql: ompgsql
 
 pipeline:
   - uses: git-checkout
@@ -48,7 +63,8 @@ pipeline:
         --enable-imptcp \
         --enable-mmjsonparse \
         --enable-mmutf8fix \
-        --enable-omstdout
+        --enable-omstdout \
+        --enable-pgsql
 
   - uses: autoconf/make
 
@@ -63,6 +79,28 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - range: plugins
+    name: rsyslog-${{range.key}}
+    description: rsyslog plugin for ${{range.key}}
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib/rsyslog/
+          mv ${{targets.destdir}}/usr/lib/rsyslog/*${{range.value}}* ${{targets.contextdir}}/usr/lib/rsyslog/
+    test:
+      pipeline:
+        - runs: stat /usr/lib/rsyslog/*${{range.value}}.so
+
+  - name: rsyslog-plugins-all
+    dependencies:
+      runtime:
+        - rsyslog-pgsql
+    pipeline:
+      - runs: mkdir -p ${{targets.contextdir}}
+    description: Virtual package that installs all rsyslog plugins
+
   - name: rsyslog-config
     pipeline:
       - runs: |

--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: 8.2412.0
-  epoch: 2
+  epoch: 3
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -9,6 +9,8 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - binutils
       - bison
       - bison
@@ -19,23 +21,41 @@ environment:
       - file
       - flex
       - flex-dev
+      - gnutls-dev
+      # - liblognorm-dev
+      # - czmq-dev
+      # - byacc
+      # - bsd-compat-headers
+      - hiredis
+      - hiredis-dev
       - iproute2
+      - krb5-dev
+      - libdbi-dev
       - libestr-dev
       - libfastjson-dev
       - libgcrypt-dev
+      - libgcrypt-dev
       - liblogging-dev
+      - libmaxminddb-dev
+      - libnet-dev
       - libpq
       - librelp-dev
       - libssl3
       - libsystemd
       - libtool
       - libuuid
+      # - mariadb-connector-c-dev
+      - linux-headers
       - lsb-release-minimal
+      - mysql
+      - mysql-dev
+      - net-snmp-dev
       - pkgconf
       - pkgconf-dev
       - postgresql-dev
       - py3-docutils
       - python3
+      - rabbitmq-c-dev
       - systemd-dev
       - util-linux-dev
       - valgrind-dev
@@ -45,6 +65,39 @@ data:
   - name: plugins
     items:
       pgsql: ompgsql
+      crypto: lmcry_gcry
+      elasticsearch: omelasticsearch
+      gssapi: lmgssutil,imgssapi,omgssapi
+      hiredis: omhiredis
+      http: omhttp,fmhttp
+      libdbi: omlibdbi
+      mmanon: mmanon
+      mmaudit: mmaudit
+      mmcount: mmcount
+      mmdblookup: mmdblookup
+      mmfields: mmfields
+      mmjsonparse: mmjsonparse
+      # mmnormalize: mmnormalize
+      mmpstrucdata: mmpstrucdata
+      mmrm1stspace: mmrm1stspace
+      mmsequence: mmsequence
+      mmsnmptrapd: mmsnmptrapd
+      mmtaghostname: mmtaghostname
+      mmutf8fix: mmutf8fix
+      mysql: ommysql
+      pmaixforwardedfrom: pmaixforwardedfrom
+      pmlastmsg: pmlastmsg
+      pmsnare: pmsnare
+      rabbitmq: omrabbitmq
+      relp: imrelp,omrelp
+      snmp: omsnmp
+      testing: omtesting
+      tls: lmnsd_gtls
+      udpspoof: omudpspoof
+      uxsock: omuxsock
+      # zmq: imczmq,omczmq
+      imdocker: imdocker
+      clickhouse: omclickhouse
 
 pipeline:
   - uses: git-checkout
@@ -53,18 +106,52 @@ pipeline:
       repository: https://github.com/rsyslog/rsyslog
       tag: v${{package.version}}
 
+  # TODO: Add more options
+  # --enable-mmnormalize \ TODO: Needs liblognorm-dev
+  # --enable-omczmq \ Needs czmq-dev
+  # --enable-imczmq \ Needs czmq-dev
   - uses: autoconf/configure
     with:
       opts: |
         --prefix=/usr \
+        --enable-largefile \
+        --enable-gssapi-krb5 \
+        --enable-mysql \
+        --enable-pgsql \
+        --enable-libdbi \
+        --enable-snmp \
         --enable-elasticsearch \
-        --enable-relp \
-        --enable-impstats \
-        --enable-imptcp \
-        --enable-mmjsonparse \
+        --enable-omhttp \
+        --enable-clickhouse \
+        --enable-gnutls \
+        --enable-mail \
+        --enable-imdiag \
         --enable-mmutf8fix \
+        --enable-mmcount \
+        --enable-mmsequence \
+        --enable-mmdblookup \
+        --enable-mmfields \
+        --enable-mmpstrucdata \
+        --enable-mmtaghostname \
+        --enable-mmjsonparse \
+        --enable-mmaudit \
+        --enable-mmanon \
+        --enable-mmrm1stspace \
+        --enable-relp \
+        --enable-imfile \
+        --enable-imptcp \
+        --enable-impstats \
+        --enable-omprog \
+        --enable-omudpspoof \
         --enable-omstdout \
-        --enable-pgsql
+        --enable-pmlastmsg \
+        --enable-pmaixforwardedfrom \
+        --enable-pmsnare \
+        --enable-omuxsock \
+        --enable-mmsnmptrapd \
+        --enable-omrabbitmq \
+        --enable-omhiredis \
+        --enable-imdocker
 
   - uses: autoconf/make
 
@@ -88,15 +175,55 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/lib/rsyslog/
-          mv ${{targets.destdir}}/usr/lib/rsyslog/*${{range.value}}* ${{targets.contextdir}}/usr/lib/rsyslog/
+          PLUGINS="$(echo "${{range.value}}" | tr ',' ' ')"
+          for plugin in $PLUGINS; do
+            mv ${{targets.destdir}}/usr/lib/rsyslog/${plugin}.so ${{targets.contextdir}}/usr/lib/rsyslog/
+          done
     test:
       pipeline:
-        - runs: stat /usr/lib/rsyslog/*${{range.value}}.so
+        - runs: |
+            PLUGINS="$(echo "${{range.value}}" | tr ',' ' ')"
+            for plugin in $PLUGINS; do
+              stat /usr/lib/rsyslog/${plugin}.so
+            done
 
   - name: rsyslog-plugins-all
     dependencies:
       runtime:
         - rsyslog-pgsql
+        - rsyslog-crypto
+        - rsyslog-elasticsearch
+        - rsyslog-gssapi
+        - rsyslog-hiredis
+        - rsyslog-http
+        - rsyslog-libdbi
+        - rsyslog-mmanon
+        - rsyslog-mmaudit
+        - rsyslog-mmcount
+        - rsyslog-mmdblookup
+        - rsyslog-mmfields
+        - rsyslog-mmjsonparse
+        # - rsyslog-mmnormalize
+        - rsyslog-mmpstrucdata
+        - rsyslog-mmrm1stspace
+        - rsyslog-mmsequence
+        - rsyslog-mmsnmptrapd
+        - rsyslog-mmtaghostname
+        - rsyslog-mmutf8fix
+        - rsyslog-mysql
+        - rsyslog-pmaixforwardedfrom
+        - rsyslog-pmlastmsg
+        - rsyslog-pmsnare
+        - rsyslog-rabbitmq
+        - rsyslog-relp
+        - rsyslog-snmp
+        - rsyslog-testing
+        - rsyslog-tls
+        - rsyslog-udpspoof
+        - rsyslog-uxsock
+        # - rsyslog-zmq
+        - rsyslog-imdocker
+        - rsyslog-clickhouse
     pipeline:
       - runs: mkdir -p ${{targets.contextdir}}
     description: Virtual package that installs all rsyslog plugins

--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -13,7 +13,6 @@ environment:
       - automake
       - binutils
       - bison
-      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -34,7 +33,6 @@ environment:
       - libestr-dev
       - libfastjson-dev
       - libgcrypt-dev
-      - libgcrypt-dev
       - liblogging-dev
       - libmaxminddb-dev
       - libnet-dev
@@ -44,7 +42,6 @@ environment:
       - libsystemd
       - libtool
       - libuuid
-      # - mariadb-connector-c-dev
       - linux-headers
       - lsb-release-minimal
       - mysql
@@ -244,9 +241,22 @@ update:
     use-tag: true
 
 test:
+  environment:
+    contents:
+      packages:
+        - rsyslog-plugins-all
+        - rsyslog-config
   pipeline:
     - runs: |
         rsyslogd -v
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}
+    - name: Test rsyslogd
+      uses: test/daemon-check-output
+      with:
+        start: "rsyslogd -n -d -f /etc/rsyslog.conf"
+        timeout: 5
+        expected_output: |
+          RSYSLOGD INITIALIZED
+        post: rsyslogd -N1 2>&1 | grep -qi "validation run"


### PR DESCRIPTION
See: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/rsyslog/APKBUILD

rsyslog supports lots of other systems so in order to enable those, some build-time deps are needed. Also introduce a new `plugins` subpackages so those can be `apk add`able individually. `rsyslog-plugins-all` may needed for the image. (Similar structure as `openldap` package building)