### PR TITLE
Add usrmerge-baselayout for aiding in usrmerge

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.6"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -61,16 +61,9 @@ pipeline:
         ln -s ../usr/bin/coreutils bin/$i
       done
 
-      # Busybox doesn't have these, but coreutils does.
-      for i in chroot env nohup stdbuf timeout; do
-        ln -s ../usr/bin/coreutils bin/$i
-      done
-
-      rm usr/bin/chroot
-      ln -s ../bin/coreutils usr/sbin/chroot
-
       # shouldn't be here, but you never know...
-      rm -f usr/bin/groups
+      [ -e usr/bin/groups -o -L usr/bin/groups ] &&
+        { echo "FATAL: usr/bin/groups existed. comment says it shouldnt"; exit 1; }
 
 subpackages:
   - name: "coreutils-doc"

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "33"
-  epoch: 3
+  epoch: 4
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -51,13 +51,6 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
-
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/sbin
-      for i in lsmod rmmod insmod modinfo modprobe depmod; do
-        ln -sf ../bin/kmod ${{targets.destdir}}/usr/sbin/$i
-      done
 
   - uses: strip
 

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.2"
-  epoch: 13
+  epoch: 14
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -94,6 +94,10 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/lib
       mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.destdir}}/lib/
+
+      # this was providing duplicate 'init' to systemd-init which provides /sbin/init
+      # The /usr/sbin/ path assumes mergedusr
+      rm ${{targets.destdir}}/usr/sbin/init
 
 subpackages:
   - range: standalone-binaries

--- a/usrmerge-baselayout.yaml
+++ b/usrmerge-baselayout.yaml
@@ -1,0 +1,41 @@
+package:
+  name: usrmerge-baselayout
+  version: 1.0
+  epoch: 0
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -s usr/bin ${{targets.destdir}}/bin
+      ln -s usr/bin ${{targets.destdir}}/sbin
+      ln -s bin ${{targets.destdir}}/usr/sbin
+
+      touch ${{targets.destdir}}/usr/bin/.placeholder
+
+test:
+  pipeline:
+    - runs: |
+        set +x
+        fail() { echo "FATAL:" "$@" 1>&2; exit 1; }
+
+        [ -d /usr/bin ] &&
+          echo "PASS:" "/usr/bin is a dir" ||
+          fail "/usr/bin doesn't exist or is not a dir. seriously."
+
+        for p in /bin /sbin /usr/sbin; do
+          [ -L "$p" ] &&
+            echo "PASS: $p is a link" ||
+              fail "$p is not a link"
+          [ "$p" -ef /usr/bin ] &&
+            echo "PASS: $p points to /usr/bin" ||
+              fail "$p is not the same as /usr/bin"
+        done
+
+update:
+  enabled: false
+  exclude-reason: "this is the upstream"


### PR DESCRIPTION
3 symlinks, one dir.  pure gold.

This is entirely banking on a comment in apko pkg/tarfs/fs.go being correct.
https://github.com/chainguard-dev/apko/blob/main/pkg/tarfs/fs.go#L111

> // special case, if the target already exists, and it is a symlink to a directory, we can accept it as is
> // otherwise, we need to create the directory.

If it is correct, then this new package paired with some sneaky re-ordering as seen https://github.com/chainguard-dev/apko/pull/1516 might be nice.