### PR TITLE
chore(samba): bump epoch and add tests for samba-client

### DIFF
--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: 4.21.3
-  epoch: 1
+  epoch: 2
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -199,6 +199,11 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/samba/smbspool_krb5_wrapper "${{targets.contextdir}}"/usr/lib
     test:
+      environment:
+        contents:
+          packages:
+            - samba-server
+            - libauth-samba
       pipeline:
         - runs: |
             dbwrap_tool --version
@@ -220,6 +225,13 @@ subpackages:
             smbget --help
             smbtree --version
             smbtree --help
+        - name: Test Samba client
+          runs: |
+            mkdir -p /var/lib/samba/private/ /var/log/samba /var/run/samba /etc/samba
+            touch /etc/samba/smb.conf
+            smbd
+            sleep 1
+            smbclient -L 127.0.0.1
 
   - name: samba-server-libs
     description: Samba libraries shared by server and windbind


### PR DESCRIPTION
Samba needs to be rebuilt from the rebuilt py3-event version [1] to solve build-time and runtime issues.

Furhtermore a new test for samba-client has been added with this commit.

The current published py3-tevent content differs from the one generated from current builds. With the published version samba fails to build with the error:
```
2025/02/07 11:01:33 ERRO failed to build package: unable to build guest: unable to generate image: installing apk packages: installing packages: installing py3-tevent (ver:0.16.2-r0 arch:x86_64): unable to install files for pkg py3-tevent: unable to install file over existing one, different contents:
usr/lib/python3.13/site-packages/talloc.cpython-313-x86_64-linux-gnu.so
```

Also, at runtime samba-client panics with:
```
$ apk add --no-cache samba-client >/dev/null && smbclient -L 127.0.0.1

Can't load /etc/samba/smb.conf - run testparm to debug it Bad talloc magic value - unknown value
=============================================================== INTERNAL ERROR: Bad talloc magic value - unknown value in smbclient () () pid 1 (4.21.3)
If you are running a recent Samba version, and if you think this problem is not yet fixed in the latest versions, please consider reporting this bug, see https://wiki.samba.org/index.php/Bug_Reporting =============================================================== PANIC (pid 1): Bad talloc magic value - unknown value in 4.21.3 BACKTRACE: 14 stack frames:
 #0 /usr/lib/samba/libgenrand-private-samba.so(log_stack_trace+0x44)
[0x7fe75f5bf814]
 #1 /usr/lib/samba/libgenrand-private-samba.so(smb_panic+0x15)
[0x7fe75f5bfab5]
 #2 /usr/lib/libtalloc.so.2(+0x5a08) [0x7fe75f5a3a08]
 #3 /usr/lib/libtalloc.so.2(talloc_named_const+0x30) [0x7fe75f5a4260]
 #4 /usr/lib/samba/libgse-private-samba.so(resolve_name_list+0x6b)
[0x7fe75eb5b38b]
 #5 /usr/lib/samba/liblibsmb-private-samba.so(+0x1805e) [0x7fe75f9fd05e]
 #6 /usr/lib/samba/liblibsmb-private-samba.so(cli_connect_nb+0x7c)
[0x7fe75fa00f5c]
 #7 /usr/lib/samba/liblibsmb-private-samba.so(+0x396f4) [0x7fe75fa1e6f4]
 #8 /usr/lib/samba/liblibsmb-private-samba.so(+0x39d67) [0x7fe75fa1ed67]
 #9 /usr/lib/samba/liblibsmb-private-samba.so(cli_cm_open+0xa7)
[0x7fe75fa1ef17]
 #10 smbclient(main+0xb9d) [0x5572699730dd]
 #11 /lib/libc.so.6(+0x26188) [0x7fe75f300188]
 #12 /lib/libc.so.6(__libc_start_main+0x8b) [0x7fe75f30024b]
 #13 smbclient(_start+0x25) [0x557269973d65]
Can not dump core: corepath not set up
```

1. https://github.com/wolfi-dev/os/pull/41586