### PR TITLE
bazel-6: switch update backend to release-monitor

### DIFF
--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -49,10 +49,11 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: bazelbuild/bazel
-    strip-prefix: v
-    tag-filter: "6."
+  ignore-regex-patterns:
+    - '^[^6]'
+  release-monitor:
+    identifier: 15227
+    version-filter-contains: 6.
 
 test:
   environment:


### PR DESCRIPTION
There are too many tags in the upstream repo for the `github` backend to find any 6.x versions, and the build doesn't use `git-checkout` so the `git` backend doesn't know which repo to query.