### PR TITLE
clickhouse-24.10: convert to git update backend

### DIFF
--- a/clickhouse-24.10.yaml
+++ b/clickhouse-24.10.yaml
@@ -96,8 +96,7 @@ update:
   enabled: true
   ignore-regex-patterns:
     - '-stable$'
-  github:
-    identifier: ClickHouse/ClickHouse
+  git:
     tag-filter-prefix: v24.10.
     strip-prefix: v
     strip-suffix: -stable


### PR DESCRIPTION
This ensures that we will continue to find updates even once this is no longer the most recent release.