### PR TITLE
Refactor superset package to include entrypoint scripts

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: 4.1.1
-  epoch: 1
+  epoch: 2
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
   dependencies:
     runtime:
       - openssl
-      - python-3.11
+      - python-${{vars.python-version}}
 
 environment:
   contents:
@@ -30,10 +30,13 @@ environment:
       - npm
       - nvm
       - openldap-dev
-      - py3-sqlparse
-      - py3.11-pip
-      - python-3.11-dev
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-sqlparse
+      - python-${{vars.python-version}}-dev
       - zlib-dev
+
+vars:
+  python-version: 3.11
 
 pipeline:
   - uses: git-checkout
@@ -89,6 +92,18 @@ pipeline:
       cp -r ./superset ${{targets.destdir}}/app/
       cp setup.py MANIFEST.in README.md ${{targets.destdir}}/app/
       cp superset-frontend/package.json ${{targets.destdir}}/app/superset-frontend/
+
+  # Need to run ./docker/docker-ci.sh as entrypoint for image, so replicating upstream image 1:1
+  # https://github.com/apache/superset/blob/4.1.1/Dockerfile#L179
+  - name: copy-entrypoint-scripts
+    runs: |
+      mkdir -p ${{targets.destdir}}/app/docker
+      cp ./docker/docker-bootstrap.sh  ${{targets.destdir}}/app/docker/
+      cp ./docker/docker-frontend.sh  ${{targets.destdir}}/app/docker/
+      cp ./docker/docker-init.sh  ${{targets.destdir}}/app/docker/
+      mkdir -p ${{targets.destdir}}/app/docker/entrypoints
+      cp  ./docker/run-server.sh ${{targets.destdir}}/app/docker/entrypoints/
+      cp  ./docker/docker-ci.sh  ${{targets.destdir}}/app/docker/entrypoints/
 
 update:
   enabled: true

--- a/superset.yaml
+++ b/superset.yaml
@@ -93,17 +93,20 @@ pipeline:
       cp setup.py MANIFEST.in README.md ${{targets.destdir}}/app/
       cp superset-frontend/package.json ${{targets.destdir}}/app/superset-frontend/
 
-  # Need to run ./docker/docker-ci.sh as entrypoint for image, so replicating upstream image 1:1
+subpackages:
+  # Upstream image runs ./docker/docker-ci.sh as entrypoint
   # https://github.com/apache/superset/blob/4.1.1/Dockerfile#L179
-  - name: copy-entrypoint-scripts
-    runs: |
-      mkdir -p ${{targets.destdir}}/app/docker
-      cp ./docker/docker-bootstrap.sh  ${{targets.destdir}}/app/docker/
-      cp ./docker/docker-frontend.sh  ${{targets.destdir}}/app/docker/
-      cp ./docker/docker-init.sh  ${{targets.destdir}}/app/docker/
-      mkdir -p ${{targets.destdir}}/app/docker/entrypoints
-      cp  ./docker/run-server.sh ${{targets.destdir}}/app/docker/entrypoints/
-      cp  ./docker/docker-ci.sh  ${{targets.destdir}}/app/docker/entrypoints/
+  - name: ${{package.name}}-entrypoint
+    description: "Compatibility package to copy entrypoint scripts"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/app/docker
+          cp ./docker/docker-bootstrap.sh  ${{targets.destdir}}/app/docker/
+          cp ./docker/docker-frontend.sh  ${{targets.destdir}}/app/docker/
+          cp ./docker/docker-init.sh  ${{targets.destdir}}/app/docker/
+          mkdir -p ${{targets.destdir}}/app/docker/entrypoints
+          cp  ./docker/run-server.sh ${{targets.destdir}}/app/docker/entrypoints/
+          cp  ./docker/docker-ci.sh  ${{targets.destdir}}/app/docker/entrypoints/
 
 update:
   enabled: true


### PR DESCRIPTION
Related to issue: https://github.com/orgs/chainguard-dev/projects/45/views/62?pane=issue&itemId=92280016&issue=chainguard-dev%7Ccustomer-issues%7C1954

Looking at [this comment](https://github.com/chainguard-dev/customer-issues/issues/1954#issuecomment-2616627375) made by @sschubertchainguard, we need to point to `docker-ci.sh` as the entrypoint which points to [/app/docker/docker-init.sh](https://github.com/apache/superset/blob/4.1.1/docker/docker-init.sh) as well as the current entrypoint (`run-server.sh`) that we have right now. 
Doing this we don't have to create admin user by ourselves and we also resolve the difference we see in superset-pod running different scripts.(cgr.dev image Vs upstream)

[entrypoint in upstream codebase](https://github.com/apache/superset/blob/4.1.1/Dockerfile#L179)
Image PR to update entrypoint: https://github.com/chainguard-images/images-private/pull/7410