### PR TITLE
Add ACL/xattr mapping config for melange init

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.19.4"
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -55,7 +55,7 @@ if ! grep -q 9p /proc/filesystems; then
 fi
 
 # Setup default mountpoint for 9p shared dir
-mount -t 9p -otrans=virtio -oversion=9p2000.L -osecurity_model=mapped-xattr -oposixacl=on -omsize=104857600 defaultshare /mnt/
+mount -t 9p -o trans=virtio -o version=9p2000.L -o security_model=mapped-xattr -o posixacl=on -o msize=104857600 defaultshare /mnt/
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then

--- a/melange/init
+++ b/melange/init
@@ -55,7 +55,7 @@ if ! grep -q 9p /proc/filesystems; then
 fi
 
 # Setup default mountpoint for 9p shared dir
-mount -t 9p -otrans=virtio -oversion=9p2000.L  defaultshare /mnt/
+mount -t 9p -otrans=virtio -oversion=9p2000.L -osecurity_model=mapped-xattr -oposixacl=on -omsize=104857600 defaultshare /mnt/
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then


### PR DESCRIPTION
This PR adds additional mount options for the transient 9p mount when handling microVM builds in Melange.

We want to handle ACLs and xattr mappings appropriately.