### PR TITLE
Allow test/ldd-check to resolve shared objects in the same python module, run newly passing tests

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -44,5 +44,11 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+  - uses: test/ldd-check
+    with:
+      packages: ${{package.name}}
+
 update:
   enabled: false

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -46,9 +46,9 @@ pipeline:
 
 test:
   pipeline:
-  - uses: test/ldd-check
-    with:
-      packages: ${{package.name}}
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: false

--- a/kserve.yaml
+++ b/kserve.yaml
@@ -127,6 +127,15 @@ subpackages:
         - name: "test entrypoint usage"
           runs: |
             /storage-initializer/scripts/initializer-entrypoint --help
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
+
+test:
+  pipeline:
+  - uses: test/ldd-check
+    with:
+      packages: ${{package.name}}
 
 update:
   enabled: true

--- a/kserve.yaml
+++ b/kserve.yaml
@@ -129,13 +129,13 @@ subpackages:
             /storage-initializer/scripts/initializer-entrypoint --help
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
 test:
   pipeline:
-  - uses: test/ldd-check
-    with:
-      packages: ${{package.name}}
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -86,6 +86,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-earlystopping/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-tfevent-metricscollector
     description: Kubeflow Katib tfevent-metricscollector
@@ -105,6 +110,11 @@ subpackages:
           cp -r ./pkg ${{targets.subpkgdir}}/opt/katib/pkg
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cd ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-hyperband
     description: Kubeflow Katib suggestion-hyperband
@@ -124,6 +134,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-hyperband/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-hyperopt
     description: Kubeflow Katib suggestion-hyperopt
@@ -142,6 +157,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-hyperopt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-nas-darts
     description: Kubeflow Katib suggestion-nas-darts
@@ -160,6 +180,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-darts/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-nas-enas
     description: Kubeflow Katib suggestion-nas-enas
@@ -179,6 +204,11 @@ subpackages:
           cp -r ./pkg ${{targets.subpkgdir}}/opt/katib/pkg
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cd ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-optuna-enas
     description: Kubeflow Katib suggestion-optuna-enas
@@ -197,6 +227,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-optuna/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-pbt-enas
     description: Kubeflow Katib suggestion-pbt-enas
@@ -215,6 +250,11 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-pbt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
   - name: katib-suggestion-skopt-enas
     description: Kubeflow Katib suggestion-skopt-enas
@@ -234,6 +274,18 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-skopt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
+
+
+test:
+  pipeline:
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -90,7 +90,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-tfevent-metricscollector
     description: Kubeflow Katib tfevent-metricscollector
@@ -114,7 +114,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-hyperband
     description: Kubeflow Katib suggestion-hyperband
@@ -138,7 +138,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-hyperopt
     description: Kubeflow Katib suggestion-hyperopt
@@ -161,7 +161,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-nas-darts
     description: Kubeflow Katib suggestion-nas-darts
@@ -184,7 +184,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-nas-enas
     description: Kubeflow Katib suggestion-nas-enas
@@ -208,7 +208,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-optuna-enas
     description: Kubeflow Katib suggestion-optuna-enas
@@ -231,7 +231,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-pbt-enas
     description: Kubeflow Katib suggestion-pbt-enas
@@ -254,7 +254,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
   - name: katib-suggestion-skopt-enas
     description: Kubeflow Katib suggestion-skopt-enas
@@ -278,8 +278,7 @@ subpackages:
       pipeline:
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
-
+            packages: ${{subpkg.name}}
 
 test:
   pipeline:

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -127,6 +127,9 @@ subpackages:
             ls /bitnami/mlflow-basic-auth/ | grep "basic_auth.ini"
             run-script --version
             run-script --help
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
 
 test:
   environment:
@@ -139,6 +142,9 @@ test:
         export PATH="/usr/share/mlflow/bin:${PATH}"
         python3 ./test-mlflow.py
         mlflow ui & sleep 5; curl -vsL localhost:5000
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -129,7 +129,7 @@ subpackages:
             run-script --help
         - uses: test/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
 
 test:
   environment:

--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -90,11 +90,12 @@ pipeline:
           return 0
         fi
 
-        if [[ "$f" =~ python.*site-packages ]]; then
-          [ -n "$ld_library_path" ] && ld_library_path=$ld_library_path:
-          ld_library_path=$(dirname "$f")
-          vmsg "Added python site package directory to ld_library_path, result is $ld_library_path"
-        fi
+        case "$f" in
+          *python*site-packages*)
+            [ -n "$ld_library_path" ] && ld_library_path=$ld_library_path:
+            ld_library_path=$(dirname "$f")
+            vmsg "Added python site package directory to ld_library_path, result is $ld_library_path"
+        esac
 
         LD_LIBRARY_PATH=$ld_library_path ldd "$f" >$outf 2>$errf || rc=$?
 

--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -79,6 +79,8 @@ pipeline:
       check_file() {
         local f="$1" insist_dyn="$2" rc="0"
         local outf="$tmpd/ldd.stdout" errf="$tmpd/ldd.sterr"
+        local ld_library_path=$LD_LIBRARY_PATH
+
         if [ ! -e "$f" ]; then
           failormsg "$insist_dyn" "$f: did not exist"
           return 0
@@ -88,7 +90,13 @@ pipeline:
           return 0
         fi
 
-        ldd "$f" >$outf 2>$errf || rc=$?
+        if [[ "$f" =~ python.*site-packages ]]; then
+          [ -n "$ld_library_path" ] && ld_library_path=$ld_library_path:
+          ld_library_path=$(dirname "$f")
+          vmsg "Added python site package directory to ld_library_path, result is $ld_library_path"
+        fi
+
+        LD_LIBRARY_PATH=$ld_library_path ldd "$f" >$outf 2>$errf || rc=$?
 
         if [ $rc -eq 1 ]; then
           if grep -q 'not a dynamic executable' "$errf"; then


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/issues/41002, https://github.com/wolfi-dev/os/issues/40838, https://github.com/wolfi-dev/os/issues/41304, https://github.com/wolfi-dev/os/issues/41305

These are cases where a python module brings a shared object with it, and then that shared object links against a 2nd shared object brought by the same module.
In this case SO1 links against SO2 using just the library name (instead of a relative path), which the python interpreter allows by loading objects in the same directory before looking elsewhere. LDD doesn't do this by default.

Related: https://github.com/wolfi-dev/os/issues/40831, https://github.com/wolfi-dev/os/issues/40843, https://github.com/wolfi-dev/os/issues/40842

These have cases of this but they also have some other ldd failures unrelated to python stuff.
