### PR TITLE
convert a couple of version streamed packages to git update backend

### DIFF
--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -252,10 +252,9 @@ data:
 
 update:
   enabled: true
-  github:
-    identifier: kubernetes/kubernetes
+  git:
     strip-prefix: v
-    tag-filter: v1.32.
+    tag-filter-prefix: v1.32.
 
 test:
   pipeline:

--- a/mattermost-10.4.yaml
+++ b/mattermost-10.4.yaml
@@ -102,10 +102,9 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: mattermost/mattermost
+  git:
     strip-prefix: v
-    tag-filter: v10.4
+    tag-filter-prefix: v10.4
 
 test:
   environment:


### PR DESCRIPTION
This will avoid them encountering update failures once they are no longer the most recent upstream version.