### PR TITLE
trurl: fix doc subpkg

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.12.0"
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -60,6 +60,10 @@ subpackages:
     description: "headers for libcurl"
     pipeline:
       - uses: split/dev
+      # cd2nroff is needed by trurl
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mv scripts/cd2nroff "${{targets.contextdir}}"/usr/bin
     dependencies:
       runtime:
         - brotli-dev

--- a/trurl.yaml
+++ b/trurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: trurl
   version: "0.16"
-  epoch: 1
+  epoch: 2
   description: 'trurl is a command line tool for URL parsing and manipulation.'
   copyright:
     - license: curl
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - curl-dev
+      - perl
 
 pipeline:
   - uses: git-checkout
@@ -26,11 +27,18 @@ pipeline:
 
   - uses: strip
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/man/man1
+      cd2nroff trurl.md > "${{targets.destdir}}"/usr/share/man/man1/trurl.1
+
 subpackages:
   - name: "trurl-doc"
     description: "documentation for trurl"
     pipeline:
       - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

- update `curl` package to put cd2nroff binary to `curl-dev` subpkg. This align with what Alpine is doing.
- use cd2nroff to generate manpages for trurl.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/41479

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
