### PR TITLE
build opentelemetry-cpp with GRPC on

### DIFF
--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: "1.19.0"
-  epoch: 0
+  epoch: 1
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ environment:
       - curl-dev
       - gcc
       - glibc-dev
-      - gtest-dev
+      - grpc-dev
       - icu-dev
       - make
       - openssl-dev
@@ -35,9 +35,10 @@ pipeline:
 
   - uses: cmake/configure
     with:
+      # NOTE: DWITH_OTLP_GRPC=ON is required for ingress-nginx <= 1.12 versions (ref: https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/8933841f0a7f8737f61404cf0a64acf6b079c8a5/instrumentation/nginx/README.md#dependencies-for-building)
       opts: |
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_GRPC=OFF \
         -DWITH_PROMETHEUS=OFF \
         -DWITH_ELASTICSEARCH=OFF \
         -DBUILD_TESTING=OFF \


### PR DESCRIPTION
    build opentelemetry-cpp with GRPC on
    
    opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h is
    required for building ingress-nginx 1.12 with opentelemetry support.
    
    turn WITH_OTLP_GRPC cmake option to ON via this commit

ref: https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/8933841f0a7f8737f61404cf0a64acf6b079c8a5/instrumentation/nginx/README.md#dependencies-for-building

and we get nginx otel support via building `ingress-nginx-opentelemetry-plugin-x.y` package along with `ingress-nginx-controller-x.y` package. 