### PR TITLE
add rpm2cpio package

### DIFF
--- a/rpm2cpio.yaml
+++ b/rpm2cpio.yaml
@@ -34,8 +34,10 @@ test:
     contents:
       packages:
         - curl
+        - jq
   pipeline:
     - runs: |
         rpm2cpio
-        curl -L -o yq.rpm https://kojipkgs.fedoraproject.org//packages/yq/4.43.1/5.fc40/src/yq-4.43.1-5.fc40.src.rpm
-        rpm2cpio yq.rpm | grep -i fedora
+        export COSIGN_VERSION=$(curl -s --retry 5 "https://api.github.com/repos/sigstore/cosign/releases/latest" | jq -r ".tag_name" | sed 's/v//')
+        curl -fsSL --retry 5 -o cosign.rpm https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-${COSIGN_VERSION}-1.${{build.arch}}.rpm
+        rpm2cpio cosign.rpm | cpio -idmv

--- a/rpm2cpio.yaml
+++ b/rpm2cpio.yaml
@@ -30,6 +30,12 @@ update:
   exclude-reason: single script file which hasn't been updated in last 10 years.
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
   pipeline:
     - runs: |
         rpm2cpio
+        curl -L -o yq.rpm https://kojipkgs.fedoraproject.org//packages/yq/4.43.1/5.fc40/src/yq-4.43.1-5.fc40.src.rpm
+        rpm2cpio yq.rpm | grep -i fedora

--- a/rpm2cpio.yaml
+++ b/rpm2cpio.yaml
@@ -1,0 +1,35 @@
+package:
+  name: rpm2cpio
+  version: 14.2.0
+  epoch: 0
+  description: Convert .rpm files to cpio format
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - libarchive-tools
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://raw.githubusercontent.com/freebsd/freebsd-ports/refs/heads/main/archivers/rpm2cpio/files/rpm2cpio
+      expected-sha256: 2841bacdadde2a9225ca387c52259d6007762815468f621253ebb537d6636a00
+      extract: false
+
+  - runs: |
+      install -Dm755 rpm2cpio ${{targets.destdir}}/usr/bin/rpm2cpio
+      sed -i 's/tar/bsdtar/g' ${{targets.destdir}}/usr/bin/rpm2cpio
+
+update:
+  enabled: false
+  exclude-reason: single script file which hasn't been updated in last 10 years.
+
+test:
+  pipeline:
+    - runs: |
+        rpm2cpio


### PR DESCRIPTION
adds rpm2cpio 

(similar to wait-for-it script) 

coming from https://github.com/freebsd/freebsd-ports/blob/main/archivers/rpm2cpio/files/rpm2cpio and uses bsdtar because gnutar doesn't recognized the flag. 