### PR TITLE
glibc: add test for compatibility with gcc

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -615,6 +615,11 @@ subpackages:
         - empty
 
 test:
+  environment:
+    contents:
+      packages:
+        - gcc
+        - glibc-dev
   pipeline:
     - runs: |
         # Ensure locales are excluded from glibc
@@ -634,6 +639,19 @@ test:
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}
+    - name: Confirm that we're still compatible with current gcc
+      runs: |
+        # This was a problem due to some legacy fix-includes in gcc that interfered
+        # with new glibc private symbols.  Let's make sure that doesn't break again
+        cat <<EOF >gcc_test.cc
+        #include <thread>
+        #include <future>
+        int main(void)
+        {
+          return 0;
+        }
+        EOF
+        g++ -o test_build gcc_test.cc
 
 update:
   enabled: true


### PR DESCRIPTION
Add the test for the issue we missed when trying to release 2.41 prematurely. There is a very very very low chance this will happen again, but I still think it's a good idea to add a test. In case something similar is broken with pthreads once again.

This can land as-is, doesn't actually require the new glibc. Confirmed to be failing with a straight rebuild of glibc without fixing gcc fix-includes.