### PR TITLE
test(iproute2): re-add ip link add test

### DIFF
--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -6,10 +6,10 @@ package:
   copyright:
     - license: GPL-2.0-or-later
 
-# disable capabilities until bots support them as causing parsing errors, enable test below when fixed
-# capabilities:
-#   add:
-#     - CAP_NET_ADMIN
+capabilities:
+  add:
+    - CAP_NET_ADMIN
+
 environment:
   contents:
     packages:
@@ -60,10 +60,6 @@ update:
   release-monitor:
     identifier: 1392
 
-# disable capabilities until bots support them as causing parsing errors
-# - name: "Test adding dummy interface"
-#   runs: |
-#     ip link add dev myinterface type dummy
 test:
   environment:
     contents:
@@ -128,3 +124,6 @@ test:
       runs: |
         # Show existing tunnels
         ip tunnel show
+    - name: "Test adding dummy interface"
+      runs: |
+        ip link add dev myinterface type dummy


### PR DESCRIPTION
This PR re-adds the `ip link add` test and declares the cap_net_admin required for the new test case to execute.