### PR TITLE
provide up to the major-minor, instead of pinning to the revision

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 1
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0
@@ -119,7 +119,7 @@ subpackages:
         - debezium-connector-spanner-${{vars.major-minor-version}}
         - debezium-connector-vitess-${{vars.major-minor-version}}
       provides:
-        - debezium-connectors-all=${{package.full-version}}
+        - debezium-connectors-all=${{vars.major-minor-version}}
     description: Virtual package that installs all Debezium connectors
 
   - range: components
@@ -181,7 +181,7 @@ subpackages:
         - ${{package.name}}-core
         - ${{package.name}}-scripting
       provides:
-        - debezium-components-all=${{package.full-version}}
+        - debezium-components-all=${{vars.major-minor-version}}
     description: Virtual package that installs all Debezium components
 
   - name: debezium-connect-compat


### PR DESCRIPTION
providing the full version means the `all` subpackage constrains down to the revision.

since this package also often depends on the oci entrypoint for the image, it means the two need to be versioned identical. this isn't often the case, and can lead to issues like this:

```
Multiple packages match with different versions: debezium-connector-informix-3.0 (3.0.7-r0) and debezium-connect-entrypoint-3.0 (3.0.7-r1)"
```

