### PR TITLE
Add preset for containerd.service

### DIFF
--- a/containerd-2.yaml
+++ b/containerd-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-2
   version: "2.0.2"
-  epoch: 1
+  epoch: 2
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -78,10 +78,12 @@ subpackages:
         - systemd
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system/
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system/
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system-preset/
           install -Dm644 containerd.service "${{targets.subpkgdir}}"/usr/lib/systemd/system/containerd.service
           sed -i "s|/usr/local/bin|/usr/bin|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/containerd.service
           sed -i "s|/sbin|/usr/sbin|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/containerd.service
+          echo "enable containerd.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/81-containerd.preset"
 
 update:
   enabled: true


### PR DESCRIPTION
Such that it starts when needed. Sort of expected it to have a .socket
unit tbh.
