### PR TITLE
Out of date base allows missing bump, rebump

### DIFF
--- a/containerd-2.yaml
+++ b/containerd-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-2
   version: "2.0.2"
-  epoch: 2
+  epoch: 3
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
CVE remediation, and custom change, both bumped the epoch to the same
value, which merges just fine by github.

See how https://github.com/wolfi-dev/os/commit/80e1cb31cbe2096d7df4f508db4bce350c891049 didn't built any new binaries, despite the underlying PR had an epoch bump.