### PR TITLE
Unwedge debezium

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0

--- a/debezium-connect-entrypoint-3.0.yaml
+++ b/debezium-connect-entrypoint-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connect-entrypoint-3.0
   version: "3.0.7"
-  epoch: 1
+  epoch: 2
   description: Helper package to provide necessary files for the Debezium images
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: "3.0.7"
-  epoch: 0
+  epoch: 2
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We withdrew this package and reverted the change, so automation reused an epoch version, which means we're trying to re-upload the same APK, which won't work.