### PR TITLE
java-cacerts: update to 20241121 bundle

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -1,8 +1,8 @@
 package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
-  version: "20240705"
-  epoch: 0
+  version: "20241121"
+  epoch: 1
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
@@ -14,7 +14,7 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates
+      - ca-certificates=${{package.full-version}}
       - p11-kit-trust
       - wolfi-base
 
@@ -36,4 +36,6 @@ pipeline:
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 332224


### PR DESCRIPTION
Update java-cacerts to 20241121 bundle, also attempt to enable updates
to it, with lockstep against ca-certs.

If this doesn't work, we should just rebuild/refetch ca-certificates
in java-cacerts from scratch. Due to build-dependency cycles we can't
do it all in ca-certificates itself, but we should be able to redo it
again.
