### PR TITLE
Fix doc subpkg smartypants + openblas

### DIFF
--- a/openblas.yaml
+++ b/openblas.yaml
@@ -2,7 +2,7 @@
 package:
   name: openblas
   version: "0.3.29"
-  epoch: 0
+  epoch: 1
   description: fast BSD-licensed BLAS based on gotoBLAS2, with LAPACK
   copyright:
     - license: BSD-3-Clause
@@ -88,7 +88,13 @@ subpackages:
   - name: openblas-doc
     pipeline:
       - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/doc/${{package.name}}
+          mv Changelog.txt TargetList.txt USAGE.md "${{targets.contextdir}}"/usr/share/doc/${{package.name}}/
     description: openblas manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
   - name: liblapack
     pipeline:

--- a/smartypants.yaml
+++ b/smartypants.yaml
@@ -1,7 +1,7 @@
 package:
   name: smartypants
   version: 2.0.1
-  epoch: 3
+  epoch: 4
   description: Translate plain ASCII punctuation characters into “smart” typographic punctuation HTML entities
   copyright:
     - license: BSD-3-Clause
@@ -33,13 +33,22 @@ pipeline:
   - name: Python Install
     uses: python/install
 
+  # generate manpages
+  - runs: make -C docs man
+
   - uses: strip
 
 subpackages:
   - name: smartypants-doc
     pipeline:
       - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/man/man1
+          mv docs/_build/man/smartypants.1 "${{targets.contextdir}}"/usr/share/man/man1/smartypants.1
     description: smartypants manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/41473 
Fixes: https://github.com/wolfi-dev/os/issues/41468

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
