### PR TITLE
mosquitto: Fix tests to exit 1 when failing

### DIFF
--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -182,7 +182,6 @@ test:
 
         if [ "$RECEIVED_MESSAGE" == "$MESSAGE" ]; then
             echo "Test Passed: Message received correctly."
-            exit 0
         else
             echo "Test Failed: Message not received correctly."
             exit 1

--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -182,8 +182,10 @@ test:
 
         if [ "$RECEIVED_MESSAGE" == "$MESSAGE" ]; then
             echo "Test Passed: Message received correctly."
+            exit 0
         else
             echo "Test Failed: Message not received correctly."
+            exit 1
         fi
 
         # Clean up


### PR DESCRIPTION
Currently a failing test still effectively `exit 0`s and so a failing test will not be caught.

