### PR TITLE
fixup test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,9 @@ $(dbg_targets): debug/%: $(KEY)
 	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_DEBUG_OPTS) --source-dir ./$(*)/)
 	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_DEBUG_OPTS) --source-dir ./$(*)/
 
-testdbg_targets = $(foreach name,$(pkgs),test/$(name))
+test_targets = $(foreach name,$(pkgs),test/$(name))
 $(test_targets): test/%: $(KEY)
+	@mkdir -p ./$(*)/
 	$(eval yamlfile := $*.yaml)
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
 	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"


### PR DESCRIPTION
test target was broken by my previous commit.  It used the wrong variable and dropped a 'mkdir'.