### PR TITLE
keycloak: skip ProtoStream Schema Compat check (fixing an FTBFS)

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: "26.1.2"
-  epoch: 1
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -61,7 +61,7 @@ pipeline:
       # Gross hack to work around broken NAPI ast-grep module that has
       # undefined symbol: static_assert
       export LD_PRELOAD=/tmp/preload.so
-      ./mvnw clean install -DskipTests=true -Pdistribution -q
+      ./mvnw clean install -DskipTests=true -Pdistribution -q -DskipProtoLock=true
       unset LD_PRELOAD
 
       mkdir -p ${{targets.destdir}}/usr/share/java


### PR DESCRIPTION
There may be a discrepancy between the ProtoStream schema and its implementation when building Keycloak directly from a git tag, which is what we do.  Upstream suggests that these builds should use -DskipProtoLock=true (see keycloak/issues/37148).  This is what's being done here.

Fixes: #41649

Related: https://github.com/keycloak/keycloak/issues/37148
Related: https://github.com/chainguard-dev/enterprise-packages/pull/13888