### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/R-DBI.yaml
+++ b/R-DBI.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-DBI
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: A database interface (DBI) definition for communication between R and RDBMSs
   copyright:
     - license: LGPL-2.1-only


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
