### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/R-proxy.yaml
+++ b/R-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-proxy
   version: 0.4.27
-  epoch: 0
+  epoch: 1
   description: Distance and similarity measures
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
