### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/R-showtext.yaml
+++ b/R-showtext.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-showtext
   version: 0.9.7
-  epoch: 0
+  epoch: 1
   description: Using Fonts More Easily in R Graphs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
