### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/R-showtextdb.yaml
+++ b/R-showtextdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-showtextdb
   version: 3.0
-  epoch: 0
+  epoch: 1
   description: Providing font files that can be used by the showtext package
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
