### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/asciidoctor.yaml
+++ b/asciidoctor.yaml
@@ -1,7 +1,7 @@
 package:
   name: asciidoctor
   version: 2.0.23
-  epoch: 0
+  epoch: 1
   description: A fast, open source text processor and publishing toolchain, written in Ruby, for converting AsciiDoc content to HTML 5, DocBook 5, and other formats.
   copyright:
     - paths:


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
