### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: configurable-http-proxy
   version: "4.6.3"
-  epoch: 0
+  epoch: 1
   description: "HTTP parser written against llparse"
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
