### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/container-entrypoint.yaml
+++ b/container-entrypoint.yaml
@@ -1,7 +1,7 @@
 package:
   name: container-entrypoint
   version: 0.1.0
-  epoch: 1
+  epoch: 2
   description: Simple entrypoint script for containers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
