### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/dumb-init.yaml
+++ b/dumb-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: dumb-init
   version: 1.2.5
-  epoch: 3
+  epoch: 4
   description: "minimal init system for Linux containers"
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
