### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-ubuntu
   version: 0.869
-  epoch: 1
+  epoch: 2
   description: Ubuntu font family
   copyright:
     - license: LicenseRef-ubuntu-font


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
