### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/fontsproto.yaml
+++ b/fontsproto.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontsproto
   version: 2.1.3
-  epoch: 1
+  epoch: 2
   description: X.org fontsproto
   copyright:
     - license: MIT-open-group


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
