### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,7 +1,7 @@
 package:
   name: hiredis
   version: 1.2.0
-  epoch: 1
+  epoch: 2
   description: Minimalistic C client for Redis
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
