### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/jansson.yaml
+++ b/jansson.yaml
@@ -1,7 +1,7 @@
 package:
   name: jansson
   version: "2.14"
-  epoch: 2
+  epoch: 3
   description: lightweight JSON library
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
