### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/krb5-conf.yaml
+++ b/krb5-conf.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5-conf
   version: "1.0"
-  epoch: 3
+  epoch: 4
   description: Shared krb5.conf for both MIT krb5 and heimdal
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
