### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdbi
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   description: "Database independent abstraction layer for C"
   copyright:
     - license: LGPL-2.1-or-later


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
