### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 5
+  epoch: 6
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
