### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libmd.yaml
+++ b/libmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmd
   version: 1.1.0
-  epoch: 2
+  epoch: 3
   description: Message Digest functions from BSD systems
   copyright:
     - license: CC-PDDC


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
