### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libnet.yaml
+++ b/libnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnet
   version: "1.3"
-  epoch: 2
+  epoch: 3
   description: A generic networking API that provides access to several protocols
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
