### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libtree.yaml
+++ b/libtree.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtree
   version: "3.1.1"
-  epoch: 0
+  epoch: 1
   description: "ldd as a tree."
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
