### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/libxcomposite.yaml
+++ b/libxcomposite.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcomposite
   version: 0.4.6
-  epoch: 3
+  epoch: 4
   description: X11 Composite extension library
   copyright:
     - license: MIT
@@ -14,12 +14,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - docbook-xml
       - libtool
       - libx11-dev
       - libxext-dev
       - libxfixes-dev
       - pkgconf-dev
       - util-macros
+      - xmlto
       - xorgproto
 
 pipeline:


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
