### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/lua-resty-ipmatcher.yaml
+++ b/lua-resty-ipmatcher.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-ipmatcher
   version: 0.6.1
-  epoch: 4
+  epoch: 5
   description: "High-performance match IP address for Nginx + Lua"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
