### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/neuvector-db.yaml
+++ b/neuvector-db.yaml
@@ -2,7 +2,7 @@ package:
   name: neuvector-db
   version: 0.0.0
   # Increment daily
-  epoch: 0
+  epoch: 1
   description: NeuVector vulnerability database for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
