### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/neuvector-prometheus-exporter.yaml
+++ b/neuvector-prometheus-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-prometheus-exporter
   version: 1.1.0.0
-  epoch: 0
+  epoch: 1
   description: Python client for the Prometheus monitoring system.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
