### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/npm-lodash.yaml
+++ b/npm-lodash.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm-lodash
   version: 4.17.21
-  epoch: 1
+  epoch: 2
   description: "A modern JavaScript utility library delivering modularity, performance & extras"
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
