### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/pigz.yaml
+++ b/pigz.yaml
@@ -1,7 +1,7 @@
 package:
   name: pigz
   version: 2.8
-  epoch: 1
+  epoch: 2
   description: "Parallel implementation of gzip"
   copyright:
     - license: Zlib


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
