### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/py3-jupyter-lsp.yaml
+++ b/py3-jupyter-lsp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyter-lsp
   version: 2.2.5
-  epoch: 0
+  epoch: 1
   description: Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
