### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/tinyxml2.yaml
+++ b/tinyxml2.yaml
@@ -2,7 +2,7 @@
 package:
   name: tinyxml2
   version: 10.0.0
-  epoch: 1
+  epoch: 2
   description: Simple, small and efficient C++ XML parser
   copyright:
     - license: Zlib


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
