### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/ttf-dejavu.yaml
+++ b/ttf-dejavu.yaml
@@ -1,7 +1,7 @@
 package:
   name: ttf-dejavu
   version: 2.37
-  epoch: 3
+  epoch: 4
   description: Font family based on the Bitstream Vera Fonts with a wider range of characters
   copyright:
     - license: Bitstream-Vera # https://dejavu-fonts.github.io/License.html


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
