### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-base
   version: 1
-  epoch: 6
+  epoch: 7
   description: "Wolfi base metapackage"
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
