### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-keys
   version: 1
-  epoch: 8
+  epoch: 9
   description: "Wolfi signing keyring"
   copyright:
     - license: MIT


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
