### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 4
+  epoch: 5
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
