### PR TITLE
wolfictl bump for apk fetch BAD archive

### DIFF
--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: 1.5.6
-  epoch: 5
+  epoch: 6
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only


### PR DESCRIPTION
Due to past bugs there is invalid metadata in the apkindex for the
size attribute. Rebuild and reindex affected packages.
See: #30234

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
