### PR TITLE
couple tests for logstash-core-plugin-api

### DIFF
--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -58,6 +58,49 @@ pipeline:
 vars:
   gem: logstash-core-plugin-api
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby${{vars.rubyMM}}-logstash-core
+  pipeline:
+    - name: Basic require test
+      runs: |
+        ruby <<EOF-
+        require 'logstash/core/plugin_api/version'
+
+        puts "Logstash Core Plugin API version: #{Logstash::Core::PluginApi::VERSION}"
+        EOF-
+    - name: Test plugin functionality
+      runs: |
+        ruby <<EOF-
+        require 'logstash/core/plugin_api/version'
+        require 'logstash/filters/base'
+
+        class TestFilter < Logstash::Filters::Base
+          config_name 'test_filter'
+
+          def register
+            # No-op
+          end
+
+          def filter(event)
+            # No-op
+            event
+          end
+        end
+
+        # Verify that the plugin can be registered
+        Logstash::Plugin.register(:filter, 'test_filter', TestFilter)
+
+        # Verify that the plugin can be instantiated
+        filter = Logstash::Plugin.lookup(:filter, 'test_filter').new({})
+        raise 'Failed to instantiate the test filter plugin' if filter.nil?
+
+        puts 'Logstash Core Plugin API functionality test passed'
+
+        EOF-
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
