### PR TITLE
dhcping: split manpages into -docs package, add tests

### DIFF
--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -1,7 +1,7 @@
 package:
   name: dhcping
   version: 1.2
-  epoch: 3
+  epoch: 4
   description: dhcp daemon ping program
   copyright:
     - license: BSD-2-Clause
@@ -36,6 +36,21 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: "dhcping manpages"
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: false


### PR DESCRIPTION
Split manpages into a separate package and use test/docs, run test/ldd-check on the dhcping binary

dhcping doesn't have a --version or --help flag that exits successfully while doing nothing