### PR TITLE
go-1.24: add new go major release

### DIFF
--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,0 +1,188 @@
+package:
+  name: go-1.24
+  version: "1.24.0"
+  epoch: 0
+  description: "the Go programming language"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - go=${{package.full-version}}
+    runtime:
+      - bash
+      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
+      - build-base
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go-1.22 # https://go.dev/doc/go1.24#bootstrap
+
+# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
+var-transforms:
+  - from: ${{package.version}}
+    match: \_
+    replace: ""
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/golang/go
+      tag: go${{package.version}}
+      expected-commit: 3901409b5d0fb7c85a3e6730a59943cc93b2835c
+
+  - uses: patch
+    with:
+      patches: |
+        cmd-go-always-emit-ldflags-version-information.patch
+        change-default-telemetry-from-local-to-off.patch
+
+  - runs: |
+      cd src
+      ./make.bash -v
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin "${{targets.destdir}}"/usr/lib/go/bin "${{targets.destdir}}"/usr/share/doc/go
+
+      for bin in go gofmt; do
+        install -Dm755 bin/$bin "${{targets.destdir}}"/usr/lib/go/bin/$bin
+        ln -s /usr/lib/go/bin/$bin "${{targets.destdir}}"/usr/bin/
+      done
+
+      cp -a pkg lib "${{targets.destdir}}"/usr/lib/go/
+      cp -r doc misc "${{targets.destdir}}"/usr/share/doc/go
+      cp -a src "${{targets.destdir}}"/usr/lib/go/
+      cp -p go.env "${{targets.destdir}}"/usr/lib/go/go.env
+
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/obj
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/bootstrap
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/api
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/*/cmd
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/api
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/go_bootstrap
+      rm -rf "${{targets.destdir}}"/usr/lib/go/src/cmd/dist/dist
+
+      # Remove tests from /usr/lib/go/src, not needed at runtime
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.rc" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.pem" \) \
+        -exec rm -rf \{\} \+
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-doc"
+    description: "go documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: golang/go
+    strip-prefix: go
+    tag-filter: go1.24
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+  pipeline:
+    - name: Test Go installation
+      runs: |
+        # Write a simple "Hello World" Go program
+        cat <<EOF > hello.go
+        package main
+        import "fmt"
+        func main() {
+            fmt.Println("Hello World")
+        }
+        EOF
+
+        # Format the Go program
+        go fmt hello.go
+
+        # Run the Go program and check the output
+        go run hello.go | grep "Hello World"
+        go version
+        go help
+        gofmt --help
+    - name: Test Go cross-compilation
+      runs: |
+        # Build the Go program for a different OS/architecture
+        GOOS=freebsd GOARCH=amd64 go build hello.go
+    - name: Test Go with cgo
+      runs: |
+        # Write a Go program that uses cgo
+        cat <<EOF > hello_cgo.go
+        package main
+        /*
+        #include <stdlib.h>
+        #include <stdio.h>
+        void hello() {
+            printf("%s\\n", "Hello from cgo!");
+            fflush(stdout);
+        }
+        */
+        import "C"
+        func main() {
+            C.hello()
+        }
+        EOF
+
+        # Run the Go program with cgo and check the output
+        go run hello_cgo.go | grep "Hello from cgo!"
+    - name: Test telemetry settings
+      runs: |
+        fail() { echo "FAIL:" "$@" 1>&2; exit 1; }
+
+        tmpd=$(mktemp -d)
+        trap "rm -R '$tmpd'" EXIT
+        export HOME="$tmpd/home"
+        mkdir "$HOME"
+
+        out=$(go telemetry) || fail "'go telemetry' exited $?"
+        [ "$out" = "off" ] ||
+          fail "go telemetry output '$out'. expected 'off'"
+
+        cfgdir="$HOME/.config/go/telemetry"
+        if [ -d "$cfgdir" ]; then
+          fail "$cfgdir was created by running 'go telemetry'"
+        fi
+
+        go telemetry on ||
+          fail "'go telemetry on' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after 'on' exited $?"
+        [ "$out" = "on" ] ||
+          fail "go telemetry after 'on' output '$out'. expected 'on'"
+
+        [ -f "$cfgdir/mode" ] ||
+          fail "ERROR: 'go telemetry on' did not write ~/${cfgdir#$HOME/}"
+
+        go telemetry local ||
+          fail "'go telemetry local' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after 'local' exited $?"
+        [ "$out" = "local" ] ||
+          fail "go telemetry after 'local' output '$out'. expected 'on'"
+
+        go telemetry off ||
+          fail "explicit 'go telemetry off' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
+        [ "$out" = "off" ] ||
+          fail "go telemetry after explicit off output '$out'. expected 'off'"

--- a/go-1.24/change-default-telemetry-from-local-to-off.patch
+++ b/go-1.24/change-default-telemetry-from-local-to-off.patch
@@ -1,0 +1,48 @@
+From bccdae45d85882dc2fb2fafa80b8b2997f561fe3 Mon Sep 17 00:00:00 2001
+From: Scott Moser <smoser@brickies.net>
+Date: Wed, 13 Nov 2024 14:01:30 -0500
+Subject: [PATCH] Change default telemetry setting from 'local' to 'off'
+
+Go 1.23 introduced a telemetry feature that collects local audit data
+about the Go toolchain, storing it by default in
+$HOME/.config/go/telemetry. While this data is not sent externally by
+default, the local storage path can trigger security alerts in tools
+like Falco, as it writes to a sensitive location under /root.
+
+The behavior can be disabled with 'go telemetry off', which writes
+to the config file above, but that means the user needs to do so
+before calling 'go' in any other manner.  Doing so for a container
+is non-obvious.  We could build /root/.config/go/telemetry into
+a 'go' image, but that would still provide a problem for any user
+other than uid 0.
+
+There is no mechanism to change the behavior "system wide" or an
+environment variable that can set the value.
+
+See https://github.com/golang/go/issues/68960 and
+https://github.com/golang/go/issues/69113. The second one requests that
+env GOTELEMETRY=off would disable telemetry. That would be easy for us
+to utilize but it was rejected upstream.
+
+Instead, we just change the default value returned if there is no
+.config/go/telemetry/mode file present.
+---
+ src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go b/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
+index dd7a63c816..cc4d08f651 100644
+--- a/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
++++ b/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
+@@ -127,7 +127,7 @@ func (d Dir) Mode() (string, time.Time) {
+ 	}
+ 	data, err := os.ReadFile(d.modefile)
+ 	if err != nil {
+-		return "local", time.Time{} // default
++		return "off", time.Time{} // default
+ 	}
+ 	mode := string(data)
+ 	mode = strings.TrimSpace(mode)
+-- 
+2.43.0
+

--- a/go-1.24/cmd-go-always-emit-ldflags-version-information.patch
+++ b/go-1.24/cmd-go-always-emit-ldflags-version-information.patch
@@ -1,0 +1,35 @@
+From b9f7deea41be0adeff7eee35f29ee096b9f2ff20 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+Date: Thu, 2 May 2024 18:16:47 +0100
+Subject: [PATCH] cmd/go: always emit ldflags version information
+
+Even when -trimpath is active, emit full ldflags in the version
+information ELF note. Vulnerability scanners typically parse ldflags
+field to detect main package version, thus binaries that are built
+with -trimpath are currently actively evading vulnerability scanners.
+
+Fixes: https://github.com/golang/go/issues/63432
+
+Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+---
+ src/cmd/go/internal/load/pkg.go | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
+index 1549800afb..010d60a9d1 100644
+--- a/src/cmd/go/internal/load/pkg.go
++++ b/src/cmd/go/internal/load/pkg.go
+@@ -2393,9 +2393,7 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+ 		// determine whether they may refer to system paths. If we do that, we can
+ 		// redact only those paths from the recorded -ldflags setting and still
+ 		// record the system-independent parts of the flags.
+-		if !cfg.BuildTrimpath {
+-			appendSetting("-ldflags", ldflags)
+-		}
++		appendSetting("-ldflags", ldflags)
+ 	}
+ 	if cfg.BuildMSan {
+ 		appendSetting("-msan", "true")
+-- 
+2.43.0
+

--- a/hello-world-golang.yaml
+++ b/hello-world-golang.yaml
@@ -1,7 +1,7 @@
 package:
   name: hello-world-golang
   version: 1.3
-  epoch: 8
+  epoch: 9
   description: Simple go application that prints 'hello world' in a loop when built and invoked.
   copyright:
     - license: Apache-2.0

--- a/hey.yaml
+++ b/hey.yaml
@@ -1,7 +1,7 @@
 package:
   name: hey
   version: 0.1.4
-  epoch: 19
+  epoch: 20
   description: HTTP load generator, ApacheBench (ab) replacement
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
mainly bootstrap change used go.122 now  https://go.dev/doc/go1.24#bootstrap

Fixes: #42477