### PR TITLE
fix: gobump packages is not required field, so make it so it is not.

### DIFF
--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -49,16 +49,12 @@ pipeline:
         go mod graph
       fi
 
-      # Packages and replaces are optional, so if not given, we don't pass them.
-      packagesString=""
-      if [ ! -z "${{inputs.deps}}" ]; then
-        packagesString="--packages ${{inputs.deps}}"
-      fi
-
-      replacesString=""
-      if [ ! -z "${{inputs.replaces}}" ]; then
-        replacesString="--replaces ${{inputs.replaces}}"
-      fi
-
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
-      gobump ${packagesString} ${replacesString} --tidy=${{inputs.tidy}} --skip-initial-tidy=${{inputs.skip-initial-tidy}} --show-diff=${{inputs.show-diff}} --go-version=${GO_VERSION} --compat=${{inputs.tidy-compat}}
+      gobump \
+        --packages="${{inputs.deps}}" \
+        --replaces="${{inputs.replaces}}" \
+        --tidy="${{inputs.tidy}}" \
+        --skip-initial-tidy="${{inputs.skip-initial-tidy}}" \
+        --show-diff="${{inputs.show-diff}}" \
+        --go-version="${GO_VERSION}" \
+        --compat="${{inputs.tidy-compat}}"

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -1,66 +1,54 @@
 name: Bump go deps to a certain version
-
-# Leave go off here, some packages pin to an older version. Let's just assume this gets injected elsewhere.
+# do not include 'go' in 'needs.packages'.
+# some packages pin to an older version; assume it gets injected elsewhere.
 needs:
   packages:
     - git
     - gobump
 
 inputs:
-  deps:
-    description: The deps to bump, space separated
   modroot:
     description: The root of the module
     default: .
+  deps:
+    description: "A space-separated list of packages to update (go bump --packages)"
+  replaces:
+    description: "A space-separated list of packages to replace"
+  bump-file:
+    description: "Filename containing the list of packages to update / replace"
   go-version:
     description: "The go version to set the go.mod syntax to"
     default: ""
-  replaces:
-    description: "The replaces to add to the go.mod file"
   tidy:
     default: true
     description: Run go mod tidy command before and after the bump
+  tidy-compat:
+    description: "Set the go version for which the tidied go.mod and go.sum files should be compatible"
+    default: ""
   skip-initial-tidy:
     default: false
     description: Skip the initial go mod tidy command
   show-diff:
     default: false
     description: Show the difference between the go.mod file before and after the bump
-  tidy-compat:
-    description: "Set the go version for which the tidied go.mod and go.sum files should be compatible"
-    default: ""
   show-dependency-graph:
     default: false
     description: Display a dependency graph of the go.mod file under the modroot
 
 pipeline:
   - runs: |
-      deps="${{inputs.deps}}"
-      replaces="${{inputs.replaces}}"
-      if [ -z "$deps" ] && [ -z "$replaces" ]; then
-        echo "Both 'deps' and 'replaces' are empty.  At least one is required."
-        exit 1
-      fi
-
       cd "${{inputs.modroot}}"
-      # todo rawlingsj: Remove this once we have a new gobump version that does this for us
-      # if ${{inputs.go-version}} is not set, we use the go version of the current environment
-      if [ -z "${{inputs.go-version}}" ]; then
-        GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
-      else
-        GO_VERSION=${{inputs.go-version}}
-      fi
-      
+
       if [ "${{inputs.show-dependency-graph}}" = "true" ]; then
         go mod graph
       fi
 
-      # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
       gobump \
-        ${deps:+--packages="$deps"} \
-        ${replaces:+--replaces="$replaces"} \
+        --packages="${{inputs.deps}}" \
+        --replaces="${{inputs.replaces}}" \
+        --bump-file="${{inputs.bump-file}}" \
         --tidy="${{inputs.tidy}}" \
+        --compat="${{inputs.tidy-compat}}" \
         --skip-initial-tidy="${{inputs.skip-initial-tidy}}" \
         --show-diff="${{inputs.show-diff}}" \
-        --go-version="${GO_VERSION}" \
-        --compat="${{inputs.tidy-compat}}"
+        --go-version="${{inputs.go-version}}"

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -35,8 +35,14 @@ inputs:
 
 pipeline:
   - runs: |
-      cd "${{inputs.modroot}}"
+      deps="${{inputs.deps}}"
+      replaces="${{inputs.replaces}}"
+      if [ -z "$deps" ] && [ -z "$replaces" ]; then
+        echo "Both 'deps' and 'replaces' are empty.  At least one is required."
+        exit 1
+      fi
 
+      cd "${{inputs.modroot}}"
       # todo rawlingsj: Remove this once we have a new gobump version that does this for us
       # if ${{inputs.go-version}} is not set, we use the go version of the current environment
       if [ -z "${{inputs.go-version}}" ]; then
@@ -51,8 +57,8 @@ pipeline:
 
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
       gobump \
-        --packages="${{inputs.deps}}" \
-        --replaces="${{inputs.replaces}}" \
+        ${deps:+--packages="$deps"} \
+        ${replaces:+--replaces="$replaces"} \
         --tidy="${{inputs.tidy}}" \
         --skip-initial-tidy="${{inputs.skip-initial-tidy}}" \
         --show-diff="${{inputs.show-diff}}" \

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -9,7 +9,6 @@ needs:
 inputs:
   deps:
     description: The deps to bump, space separated
-    required: true
   modroot:
     description: The root of the module
     default: .
@@ -50,5 +49,16 @@ pipeline:
         go mod graph
       fi
 
+      # Packages and replaces are optional, so if not given, we don't pass them.
+      packagesString=""
+      if [ ! -z "${{inputs.deps}}" ]; then
+        packagesString="--packages ${{inputs.deps}}"
+      fi
+
+      replacesString=""
+      if [ ! -z "${{inputs.replaces}}" ]; then
+        replacesString="--replaces ${{inputs.replaces}}"
+      fi
+
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
-      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --skip-initial-tidy=${{inputs.skip-initial-tidy}} --show-diff=${{inputs.show-diff}} --go-version=${GO_VERSION} --compat=${{inputs.tidy-compat}}
+      gobump ${packagesString} ${replacesString} --tidy=${{inputs.tidy}} --skip-initial-tidy=${{inputs.skip-initial-tidy}} --show-diff=${{inputs.show-diff}} --go-version=${GO_VERSION} --compat=${{inputs.tidy-compat}}


### PR DESCRIPTION
gobump tool does not require `packages` to be a specified field, so remove a requirement from the go bump pipeline.
https://github.com/chainguard-dev/gobump/blob/main/cmd/gobump/root.go#L34

