### PR TITLE
new package: go-tools, including goimports

### DIFF
--- a/crossplane-provider-keycloak.yaml
+++ b/crossplane-provider-keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-keycloak
   version: 1.7.0
-  epoch: 5
+  epoch: 6
   description: Official Keycloak Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - busybox
       - curl
       - go
+      - goimports
       - gzip
       - terraform
   environment:
@@ -38,7 +39,6 @@ pipeline:
     runs: |
       export GOBIN="$GOPATH/bin"
       export PATH=$PATH:$GOPATH/bin
-      go install golang.org/x/tools/cmd/goimports@latest
       go run cmd/generator/main.go $(pwd)
       make generate
 

--- a/go-tools.yaml
+++ b/go-tools.yaml
@@ -64,4 +64,3 @@ subpackages:
               echo $output
               exit 1
             fi
-

--- a/go-tools.yaml
+++ b/go-tools.yaml
@@ -1,0 +1,67 @@
+package:
+  name: go-tools
+  version: "0.30.0"
+  epoch: 0
+  description: Virtual package to install Go tools from golang.org/x/tools.
+  copyright:
+    - license: BSD-3-Clause
+  checks:
+    disabled:
+      - empty
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/golang/tools
+      tag: v${{package.version}}
+      expected-commit: 09747cdf594a7924dcecb506312be3bd6e437962
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: golang/tools
+    strip-prefix: v
+    use-tag: true
+
+data:
+  - name: cmds
+    items:
+      goimports: updates your Go import lines, adding missing ones and removing unreferenced ones.
+      gonew: starts a new Go module by copying a template module.
+      godoc: extracts and generates documentation for Go programs.
+
+subpackages:
+  - range: cmds
+    name: ${{range.key}}
+    description: ${{range.value}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/${{range.key}}
+          output: ${{range.key}}
+    test:
+      pipeline:
+        - runs: |
+            set +e
+            output=$(${{range.key}} --help 2>&1)
+            exit_status=$?
+            set -e
+
+            # Check if the exit status is 2
+            if [ $exit_status -eq 2 ]; then
+              echo "Exit status is 2"
+            else
+              echo "Exit status was $exit_status, want 2"
+              exit 1
+            fi
+
+            # Check if the output contains the command name
+            if echo "$output" | grep -q "${{range.key}}"; then
+              echo "Output contains '${{range.key}}'"
+            else
+              echo "Output does not contain '${{range.key}}':"
+              echo $output
+              exit 1
+            fi
+


### PR DESCRIPTION
Mainly I wanted to package `goimports`, but there were [other tools in that repo](https://github.com/golang/tools/tree/master/cmd) that it seemed might be useful. If we find more, we can add them easily.