### PR TITLE
Adding a provides key to the spark compat

### DIFF
--- a/spark-3.5-scala-2.12.yaml
+++ b/spark-3.5-scala-2.12.yaml
@@ -165,6 +165,10 @@ subpackages:
 
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - spark-compat
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/spark-3.5-scala-2.12.yaml
+++ b/spark-3.5-scala-2.12.yaml
@@ -166,7 +166,6 @@ subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
-      provider-priority: ${{range.value}}
       provides:
         - spark-compat
     pipeline:

--- a/spark-3.5-scala-2.12.yaml
+++ b/spark-3.5-scala-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5-scala-2.12
   version: 3.5.4
-  epoch: 0
+  epoch: 1
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5-scala-2.12.yaml
+++ b/spark-3.5-scala-2.12.yaml
@@ -167,7 +167,7 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
       provides:
-        - spark-compat
+        - spark-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -78,7 +78,7 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
       provides:
-        - spark-compat
+        - spark-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5-scala-2.13
   version: 3.5.4
-  epoch: 30
+  epoch: 31
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -76,7 +76,6 @@ subpackages:
 
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
-    dependencies:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5-scala-2.13
   version: 3.5.4
-  epoch: 31
+  epoch: 30
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -77,8 +77,6 @@ subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
-      provides:
-        - spark-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -77,7 +77,6 @@ subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
-      provider-priority: ${{range.value}}
       provides:
         - spark-compat
     pipeline:

--- a/spark-3.5-scala-2.13.yaml
+++ b/spark-3.5-scala-2.13.yaml
@@ -76,6 +76,10 @@ subpackages:
 
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - spark-compat
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Add provide for spark compat
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug


The spark-operator relies on the spark compat package which has now changed name since the refactoring of spark-3.5 into separate scala versions. This change adds a provide key so that when used the package name doesn't lead to issues with advisories
