### PR TITLE
add a font test pipeline and have ~25 pacakges use it

### DIFF
--- a/font-abyssinica.yaml
+++ b/font-abyssinica.yaml
@@ -32,3 +32,7 @@ update:
   github:
     identifier: silnrsi/font-abyssinica
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-alias.yaml
+++ b/font-alias.yaml
@@ -41,3 +41,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 15059
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-amiri.yaml
+++ b/font-amiri.yaml
@@ -31,3 +31,7 @@ update:
   enabled: true
   github:
     identifier: aliftype/amiri
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-droid.yaml
+++ b/font-droid.yaml
@@ -73,3 +73,7 @@ subpackages:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-ipa.yaml
+++ b/font-ipa.yaml
@@ -34,3 +34,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: Non-semanic versioning and 3rd party hosting
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-liberation.yaml
+++ b/font-liberation.yaml
@@ -41,3 +41,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 16833
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-linux-libertine.yaml
+++ b/font-linux-libertine.yaml
@@ -36,3 +36,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 1826
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lklug.yaml
+++ b/font-lklug.yaml
@@ -34,3 +34,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-beng-assamese.yaml
+++ b/font-lohit-beng-assamese.yaml
@@ -48,3 +48,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: The project seems to be inactive
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-beng-bengali.yaml
+++ b/font-lohit-beng-bengali.yaml
@@ -48,3 +48,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: The project seems to be inactive
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-beng-extra.yaml
+++ b/font-lohit-beng-extra.yaml
@@ -46,3 +46,7 @@ pipeline:
 
 update:
   enabled: false
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-guru.yaml
+++ b/font-lohit-guru.yaml
@@ -37,3 +37,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-knda.yaml
+++ b/font-lohit-knda.yaml
@@ -37,3 +37,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-misc-cyrillic.yaml
+++ b/font-misc-cyrillic.yaml
@@ -47,3 +47,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 17220
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-misc.yaml
+++ b/font-misc.yaml
@@ -37,3 +37,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 17214
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-noto-cjk.yaml
+++ b/font-noto-cjk.yaml
@@ -43,3 +43,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: they use a different versioning scheme
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-noto-emoji.yaml
+++ b/font-noto-emoji.yaml
@@ -37,3 +37,7 @@ update:
   github:
     identifier: googlefonts/noto-emoji
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-opensans.yaml
+++ b/font-opensans.yaml
@@ -31,3 +31,7 @@ update:
 
   github:
     identifier: googlefonts/opensans
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-padauk.yaml
+++ b/font-padauk.yaml
@@ -38,3 +38,7 @@ update:
   github:
     identifier: silnrsi/font-padauk
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-sony-misc.yaml
+++ b/font-sony-misc.yaml
@@ -47,3 +47,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 17217
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-tlwg.yaml
+++ b/font-tlwg.yaml
@@ -53,3 +53,7 @@ update:
   github:
     identifier: tlwg/fonts-tlwg
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -37,3 +37,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-unfonts-core.yaml
+++ b/font-unfonts-core.yaml
@@ -31,3 +31,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No releases or tags
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-wqy-zenhei.yaml
+++ b/font-wqy-zenhei.yaml
@@ -48,3 +48,7 @@ pipeline:
 update:
   enabled: false
   exclude-reason: No source to watch for the new versions
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -1,0 +1,50 @@
+name: fonts
+
+needs:
+  packages:
+    - file
+    - py3-fonttools
+
+pipeline:
+  - name: font usability test
+    runs: |
+      # Get our font package name
+      font_pkg=$(basename ${{targets.contextdir}})
+      # Find all font files installed by this font_pkg
+      cd /
+      font_files=false
+      # Test font files
+      for font_file in $(apk info -L "$font_pkg" | grep "^usr/share/fonts/"); do
+        if [ -f /"$font_file" ]; then
+          case /"$font_file" in
+            *.alias|*.dir)
+              # Check file type
+              file /"$font_file" | grep -i ": ASCII text"
+              font_files=true
+            ;;
+            *.gz)
+              # Check file type
+              zcat /"$font_file" | file - | grep -i ": .*font"
+              font_files=true
+            ;;
+            *)
+              # Ensure that file thinks this is a font
+              file /"$font_file" | grep -i ": .*font"
+              # Print some information about this font, if it is a real font
+              fonttools ttx -y 0 -l /"$font_file"
+              font_files=true
+            ;;
+          esac
+        fi
+      done
+      # Make sure this isn't an empty package
+      if [ "$font_files" = "false" ] || [ $(apk info -L "$font_pkg" | wc -l) -le 3 ]; then
+        echo "See:"
+        apk info -L "$font_pkg"
+        echo "This package [$font_pkg] is completely empty (i.e. installs no files)."
+        echo "Please check the package build for proper fonts installation, and either:"
+        echo "  (a) fix the package build to actually include some fonts, or"
+        echo "  (b) remove the test/fonts pipeline (if for some reason we want an empty fonts package), or"
+        echo "  (c) remove the package entirely"
+        exit 1
+      fi 


### PR DESCRIPTION
Added a new pipeline for testing fonts.  Ensure that some files get installed in the /usr/share/fonts directory, and use the file command to check their magic file type.  Also, use fonttest to display some information about them.  Fail whenever any of that doesn't work.  Added a bunch of invocations of this to some font packages where this currently works.