### PR TITLE
add emptypackage test pipeline

### DIFF
--- a/font-samyak.yaml
+++ b/font-samyak.yaml
@@ -39,7 +39,14 @@ subpackages:
           cd ${{range.key}}
           mkdir -p "${{targets.subpkgdir}}"/usr/share/fonts/samyak
           install -D -m644 *.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/samyak
+    test:
+      pipeline:
+        - uses: test/fonts
 
 update:
   enabled: false
   exclude-reason: No releases or tags
+
+test:
+  pipeline:
+    - uses: test/emptypackage

--- a/pipelines/test/emptypackage.yaml
+++ b/pipelines/test/emptypackage.yaml
@@ -6,7 +6,9 @@ pipeline:
       # Get our empty package name
       pkg=$(basename ${{targets.contextdir}})
       # Make sure this is an empty package
-      if [ $(apk info -L "$pkg" | wc -l) -le 3 ]; then
+      # Skip the "contains:" line and any empty lines
+      # We're only really expecting a single spdx.json file in an empty package
+      if [ $(apk info -L "$pkg" | grep -v " contains:$" | grep -v "^$" wc -l) -le 1 ] && (apk info -L "$pkg" | grep -q ".spdx.json$"); then
         echo "Package [$pkg] seems to be empty, as expected"
       else
         echo "Expected this package [$pkg] to be empty, but it isn't:"

--- a/pipelines/test/emptypackage.yaml
+++ b/pipelines/test/emptypackage.yaml
@@ -8,7 +8,7 @@ pipeline:
       # Make sure this is an empty package
       # Skip the "contains:" line and any empty lines
       # We're only really expecting a single spdx.json file in an empty package
-      if [ $(apk info -L "$pkg" | grep -v " contains:$" | grep -v "^$" wc -l) -le 1 ] && (apk info -L "$pkg" | grep -q ".spdx.json$"); then
+      if [ $(apk info -L "$pkg" | grep -v " contains:$" | grep -v "^$" | wc -l) -le 1 ] && (apk info -L "$pkg" | grep -q ".spdx.json$"); then
         echo "Package [$pkg] seems to be empty, as expected"
       else
         echo "Expected this package [$pkg] to be empty, but it isn't:"

--- a/pipelines/test/emptypackage.yaml
+++ b/pipelines/test/emptypackage.yaml
@@ -1,0 +1,14 @@
+name: emptypackage
+
+pipeline:
+  - name: empty package check
+    runs: |
+      # Get our empty package name
+      pkg=$(basename ${{targets.contextdir}})
+      # Make sure this is an empty package
+      if [ $(apk info -L "$pkg" | wc -l) -le 3 ]; then
+        echo "Package [$pkg] seems to be empty, as expected"
+      else
+        echo "Expected this package [$pkg] to be empty, but it isn't:"
+        apk info -L "$pkg"
+      fi 


### PR DESCRIPTION
We actually have a couple hundred "empty" packages in wolfi, where "empty" means that the only think shipped in the APK is the spdx json sbom file.

There are some good reasons to have "empty" packages -- such as source packages that ship all of their goodness in subpackages, or virtual packages that just depend on others, etc.  For these, let's at least test that a package that's expected to be empty, stays empty.  Thus, we'll fail if an empty package starts shipping files, unexpectedly.

In a separate PR, I'll submit some tests for our current empty packages, to use this pipeline.  This will help tremendously toward our goal of 100% package test coverage.  (In that, what do you test, in an empty package?)