### PR TITLE
Do not fail and pass on the same file

### DIFF
--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -72,8 +72,11 @@ pipeline:
           echo "> $ ldd $f"
           sed 's,^,> ,' "$outf"
         fi
-        [ -z "$missing" ] || fail "$f: missing ${missing# }"
-        pass "$f"
+        if [ -n "$missing" ]; then
+            fail "$f: missing ${missing# }"
+        else
+            pass "$f"
+        fi
       }
 
       check_file() {


### PR DESCRIPTION
When running the ldd-check test pipeline on some packages we'll see some confusing output like the following:

```
2025/02/12 09:09:57 INFO PASS[ldd-check]: /usr/lib/collectd/irq.so
2025/02/12 09:09:57 INFO FAIL[ldd-check]: /usr/lib/collectd/java.so: missing libjvm.so
2025/02/12 09:09:57 INFO PASS[ldd-check]: /usr/lib/collectd/java.so
2025/02/12 09:09:57 INFO PASS[ldd-check]: /usr/lib/collectd/load.so
```

Now if the ldd-check fails for one .so file we won't send it to the pass function.