### PR TITLE
pinball-2: sbinmerge apktools

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,16 +1,19 @@
 package:
   name: apk-tools
   version: 2.14.4
-  epoch: 2
+  epoch: 3
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - merged-sbin
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/4325ca278487afbfe85a38c1d32d81bb2d3de208
     packages:
       - build-base
       - busybox
@@ -37,7 +40,7 @@ pipeline:
       make LUA="lua5.3" V=1
 
   - runs: |
-      make LUA="lua5.3" V=1 DESTDIR="${{targets.destdir}}" install
+      make LUA="lua5.3" V=1 DESTDIR="${{targets.destdir}}" SBINDIR=/usr/bin LIBDIR=/usr/lib install
 
       install -d "${{targets.destdir}}"/var/lib/apk
       install -d "${{targets.destdir}}"/var/cache/misc
@@ -70,8 +73,8 @@ subpackages:
     description: "Lua module for libapk"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr
-          mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/lua "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
         - uses: test/ldd-check

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,13 +1,18 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 16
+  epoch: 17
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ca-certificates-bundle
+    provides:
+      - merged-sbin
+      #- merged-bin
+      #- merged-usrsbin
+      #- merged-lib
 
 environment:
   contents:
@@ -38,9 +43,21 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin dev etc etc/profile.d etc/secfixes.d home lib proc root var/log usr/bin usr/sbin usr/local/lib sys tmp var/spool/cron opt run usr/lib; do
+      for i in dev etc etc/profile.d etc/secfixes.d home lib proc root var/log usr/bin usr/local/lib sys tmp var/spool/cron opt run usr/lib; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
+
+      # split-usr
+      # mkdir -p ${{targets.destdir}}/sbin
+      mkdir -p ${{targets.destdir}}/bin
+      mkdir -p ${{targets.destdir}}/usr/sbin
+      mkdir -p ${{targets.destdir}}/lib
+
+      # usr-merge
+      ln -s usr/bin ${{targets.destdir}}/sbin
+      # ln -s usr/bin ${{targets.destdir}}/bin
+      # ln -s bin ${{targets.destdir}}/usr/sbin
+      # ln -s usr/lib ${{targets.destdir}}/usr/lib
 
       for i in lib64 usr/lib64 usr/local/lib64; do
         ln -s lib "${{targets.destdir}}"/${i}
@@ -64,11 +81,6 @@ pipeline:
       chmod 755 "${{targets.destdir}}"/var/empty
 
 test:
-  environment:
-    contents:
-      packages:
-        - bash
-        - coreutils
   pipeline:
     - name: "Files exist"
       runs: |
@@ -76,7 +88,7 @@ test:
         test -f /etc/shadow
         test -f /etc/os-release
         test -f /etc/host.conf
-        test -f /var/empty
+        test -d /var/empty
     - name: "Scanner expectations"
       runs: |
         # This tells scanners which feed to look at.


### PR DESCRIPTION
- **Implement usrmerge for binaries**
  This only converts /sbin directory alone.
  
  This implements usrmerge for binaries. See:
  - https://github.com/orgs/wolfi-dev/discussions/40270
  

- **apk-tools: migrate sbin**
  