### PR TITLE
feat: build openssh with pam support

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "9.9_p2"
-  epoch: 0
+  epoch: 1
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -19,6 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libedit-dev
+      - linux-pam-dev
       - openssl-dev
       - wolfi-baselayout
       - zlib-dev
@@ -55,6 +56,7 @@ pipeline:
          --with-default-path='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
          --with-privsep-user=sshd \
          --with-ssl-engine \
+         --with-pam \
          --with-libedit
 
   - uses: autoconf/make
@@ -193,6 +195,29 @@ subpackages:
             echo "Banner /does-not-exist" > "$conf"
             ssh-keygen -A -q -N ""
             sshd -T | grep -i 'Banner /does-not-exist'
+
+  - name: "openssh-pam-config"
+    description: "OpenSSH server pam configuration"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/pam.d
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d
+          mkdir -p "${{targets.subpkgdir}}"/etc/skel # may be needed for the pam_mkhomedir module to work, TBD
+          install -Dm644 sshd.pam "${{targets.subpkgdir}}"/etc/pam.d/sshd
+          echo "UsePAM yes" >> "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d/pam.conf
+    dependencies:
+      runtime:
+        - linux-pam
+        - openssh-server
+    test:
+      environment:
+        contents:
+          packages:
+            - linux-pam
+            - openssh-server
+      pipeline:
+        - runs: |
+            test -f /etc/pam.d/sshd
 
 update:
   enabled: true

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -205,10 +205,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/skel # may be needed for the pam_mkhomedir module to work, TBD
           install -Dm644 sshd.pam "${{targets.subpkgdir}}"/etc/pam.d/sshd
           echo "UsePAM yes" >> "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d/pam.conf
-    dependencies:
-      runtime:
-        - linux-pam
-        - openssh-server
     test:
       environment:
         contents:

--- a/openssh/sshd.pam
+++ b/openssh/sshd.pam
@@ -1,0 +1,41 @@
+# PAM configuration for sshd on Wolfi.
+
+# Standard base authentication.
+auth required pam_unix.so nullok
+auth required pam_nologin.so
+auth required pam_env.so
+
+# Disallow non-root logins when /etc/nologin exists.
+account required pam_nologin.so
+
+# Standard base authorization.
+account required pam_unix.so
+account required pam_nologin.so
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+session required pam_mkhomedir.so
+
+# Set the loginuid process attribute.
+session required pam_loginuid.so
+
+# Standard base session setup and teardown.
+session include base-session-noninteractive
+
+# Set up user limits from /etc/security/limits.conf.
+session required pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session required pam_env.so
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+
+# Standard base password updating.
+password required pam_unix.so nullok sha512 shadow


### PR DESCRIPTION
- Compiles openssh with pam support.
- Adds a base line Wolfi sshd pam config and optional subpackage to use it.

TODO: there's an issue with mkhomedir_helper.so where it won't create home directories correctly.