### PR TITLE
sbinmerge utillinux

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,16 +1,19 @@
 package:
   name: apk-tools
   version: 2.14.4
-  epoch: 2
+  epoch: 3
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - wolfi-baselayout>=20230201-r17
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/b61fefc3152afab7885421fa1e68d5f29d5f9771
     packages:
       - build-base
       - busybox
@@ -37,7 +40,7 @@ pipeline:
       make LUA="lua5.3" V=1
 
   - runs: |
-      make LUA="lua5.3" V=1 DESTDIR="${{targets.destdir}}" install
+      make LUA="lua5.3" V=1 DESTDIR="${{targets.destdir}}" SBINDIR=/usr/bin LIBDIR=/usr/lib install
 
       install -d "${{targets.destdir}}"/var/lib/apk
       install -d "${{targets.destdir}}"/var/cache/misc
@@ -70,8 +73,8 @@ subpackages:
     description: "Lua module for libapk"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr
-          mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/lua "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
         - uses: test/ldd-check

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,12 +1,14 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 0
+  epoch: 1
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only
   dependencies:
     provider-priority: 10
+    runtime:
+      - wolfi-baselayout>=20230201-r17
   scriptlets:
     trigger:
       paths:
@@ -26,6 +28,8 @@ var-transforms:
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/ab2c3135bc7f641cdc53a783903a97501a6d4cd1
     packages:
       - build-base
       - busybox
@@ -63,7 +67,6 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/tmp
       mkdir -p "${{targets.destdir}}"/var/cache/misc
       mkdir -p "${{targets.destdir}}"/bin
-      mkdir -p "${{targets.destdir}}"/sbin
       mkdir -p "${{targets.destdir}}"/etc
       mkdir -p "${{targets.destdir}}"/usr/share/man/man1
       chmod 1777 "${{targets.destdir}}"/tmp
@@ -72,6 +75,8 @@ pipeline:
 
       mkdir -p "${{targets.destdir}}"/etc/busybox-paths.d
       ./busybox --list-path > "${{targets.destdir}}"/etc/busybox-paths.d/busybox
+      # sbin-merge
+      sed 's|^sbin|usr/bin|' -i "${{targets.destdir}}"/etc/busybox-paths.d/busybox
 
 subpackages:
   - name: busybox-full
@@ -79,6 +84,8 @@ subpackages:
       provides:
         - busybox=${{package.full-version}}
       provider-priority: 5
+      runtime:
+        - wolfi-baselayout>=20230201-r17
     options:
       no-commands: true
     pipeline:
@@ -103,6 +110,8 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/etc/busybox-paths.d
           ./busybox --list-path > "${{targets.subpkgdir}}"/etc/busybox-paths.d/busybox-full
+          # sbin-merge
+          sed 's|^sbin|usr/bin|' -i "${{targets.subpkgdir}}"/etc/busybox-paths.d/busybox-full
     scriptlets:
       trigger:
         paths:

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.40.4"
-  epoch: 1
+  epoch: 2
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -9,6 +9,8 @@ package:
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/ab2c3135bc7f641cdc53a783903a97501a6d4cd1
     packages:
       - autoconf
       - automake
@@ -45,6 +47,7 @@ pipeline:
       opts: |
         --disable-silent-rules \
         --enable-newgrp \
+        --sbindir=/usr/bin \
         --disable-nls \
         --disable-tls \
         --disable-kill \
@@ -133,6 +136,9 @@ subpackages:
   - range: bins
     name: ${{range.key}}
     description: ${{range.value}}
+    dependencies:
+      runtime:
+        - wolfi-baselayout>=20230201-r17
     pipeline:
       - runs: |
           for i in usr/bin usr/sbin bin sbin; do
@@ -147,6 +153,7 @@ subpackages:
     dependencies:
       runtime:
         - runuser
+        - wolfi-baselayout>=20230201-r17
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/pam.d
@@ -188,6 +195,9 @@ subpackages:
             newgrp --help
 
   - name: util-linux-misc
+    dependencies:
+      runtime:
+        - wolfi-baselayout>=20230201-r17
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 16
+  epoch: 17
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -38,9 +38,19 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin dev etc etc/profile.d etc/secfixes.d home lib proc root var/log usr/bin usr/sbin usr/local/lib sys tmp var/spool/cron opt run usr/lib; do
+      for i in dev etc etc/profile.d etc/secfixes.d home lib proc root var/log usr/bin usr/local/lib sys tmp var/spool/cron opt run usr/lib; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
+
+      # split-usr
+      mkdir -p ${{targets.destdir}}/bin
+      # mkdir -p ${{targets.destdir}}/sbin
+      mkdir -p ${{targets.destdir}}/usr/sbin
+
+      # usr-merge
+      # ln -s usr/bin ${{targets.destdir}}/bin
+      ln -s usr/bin ${{targets.destdir}}/sbin
+      # ln -s bin ${{targets.destdir}}/usr/sbin
 
       for i in lib64 usr/lib64 usr/local/lib64; do
         ln -s lib "${{targets.destdir}}"/${i}
@@ -64,11 +74,6 @@ pipeline:
       chmod 755 "${{targets.destdir}}"/var/empty
 
 test:
-  environment:
-    contents:
-      packages:
-        - bash
-        - coreutils
   pipeline:
     - name: "Files exist"
       runs: |
@@ -76,7 +81,7 @@ test:
         test -f /etc/shadow
         test -f /etc/os-release
         test -f /etc/host.conf
-        test -f /var/empty
+        test -d /var/empty
     - name: "Scanner expectations"
       runs: |
         # This tells scanners which feed to look at.


### PR DESCRIPTION
- **Implement usrmerge for binaries**
  This only converts /sbin directory alone.
  
  This implements usrmerge for binaries. See:
  - https://github.com/orgs/wolfi-dev/discussions/40270
  

- **apk-tools: migrate sbin**
  

- **busybox: do sbin/merge**
  

- **util-linux: do sbin/merge**
  