### PR TITLE
hwloc: ignore -branch tags

### DIFF
--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -67,10 +67,12 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - -branch$
   github:
     identifier: open-mpi/hwloc
     strip-prefix: hwloc-
-    tag-filter: hwloc-
+    tag-filter-prefix: hwloc-
     use-tag: true
 
 test:


### PR DESCRIPTION
These are builds of release branches, we won't ever want them.  (Also update deprecated `tag-filter` while we're here.)