### PR TITLE
gcsfuse: switch to git update backend

### DIFF
--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -30,11 +30,10 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: GoogleCloudPlatform/gcsfuse
+  git:
     strip-prefix: v
     # There are some malformed tags (v@debian_11, etc.)
-    tag-filter: v1
+    tag-filter-prefix: v1
 
 test:
   pipeline:


### PR DESCRIPTION
v1 releases aren't in the `github` backend's query window any longer.