### PR TITLE
symlink java dir instead of copy -r

### DIFF
--- a/jmx-exporter-bitnami.yaml
+++ b/jmx-exporter-bitnami.yaml
@@ -1,7 +1,7 @@
 package:
   name: jmx-exporter-bitnami
   version: "1.1.0"
-  epoch: 0
+  epoch: 1
   description: "Bitnami for Prometheus JMX Exporter"
   copyright:
     - license: Apache-2.0
@@ -54,9 +54,9 @@ pipeline:
     runs: |
       cp -R ./examples ${{targets.destdir}}/opt/bitnami/jmx-exporter/
 
-      # Copy the Java 17 installation into /opt/bitnami/java
+      # Symlink Java 17 into /opt/bitnami/java
       for item in bin conf include jre legal lib release; do
-        cp -R /usr/lib/jvm/java-${{vars.java-version}}-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
+        ln -sf /usr/lib/jvm/java-${{vars.java-version}}-openjdk/$item ${{targets.destdir}}/opt/bitnami/java/
       done
 
       # Copy built JARs for agent and standalone server


### PR DESCRIPTION
Symlink java17 directory instead of copying it over.