### PR TITLE
cargo-auditable: provide automatic wrapper

### DIFF
--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-auditable
   version: 0.6.6
-  epoch: 0
+  epoch: 1
   description: Cargo wrapper for embedding auditing data
   copyright:
     - license: MIT OR Apache-2.0
@@ -36,6 +36,9 @@ pipeline:
       # Install cargo-auditable
       install -Dm755 target/release/cargo-auditable -t "${{targets.destdir}}"/usr/bin/
       install -Dm644 cargo-auditable/cargo-auditable.1 -t "${{targets.destdir}}"/usr/share/man/man1/
+
+      # Install cargo wrapper
+      install -Dm755 cargo -t "${{targets.destdir}}"/usr/local/bin
 
   - uses: strip
 

--- a/cargo-auditable/cargo
+++ b/cargo-auditable/cargo
@@ -1,0 +1,4 @@
+#!/bin/sh
+# https://github.com/rust-secure-code/cargo-auditable/blob/master/REPLACING_CARGO.md
+export CARGO='/usr/bin/cargo'
+cargo-auditable auditable "$@"


### PR DESCRIPTION
Provide cargo-auditable wrapper (similar to openssf-compiler-options
gcc wrappers) such that cargo invocations default to cargo
auditable. This allows to use existing `cargo build` commands via
upstream makefiles, and yet gain audit information by default.

Demo:
- No change rebuild ci-cve-scan empty https://github.com/wolfi-dev/os/pull/42573 the scan result is here https://github.com/wolfi-dev/os/pull/42573/checks?check_run_id=37144021222 no vulnerabilities found 
- Adding the new cargo-auditable package to the environment, without changing vector upstream makefiles that call cargo build, and rust-audit-info is present which lits up ci-cve-scan https://github.com/wolfi-dev/os/pull/42572 see https://github.com/wolfi-dev/os/pull/42572/checks?check_run_id=37143110620

This makes it easier to use auditable
```
└── 📄 /usr/bin/vector
        📦 async-graphql 7.0.7 (rust-crate)
            High CVE-2024-47614 GHSA-5gc2-7c65-8fq8 fixed in 7.0.10
        📦 hickory-proto 0.24.1 (rust-crate)
            Medium CVE-2025-25188 GHSA-37wc-h8xc-5hc4 fixed in 0.24.3
            Medium GHSA-v7pc-74h8-xq2h fixed in 0.24.3
        📦 idna 0.4.0 (rust-crate)
            Medium GHSA-h97m-ww89-6jmq fixed in 1.0.0
        📦 idna 0.2.3 (rust-crate)
            Medium GHSA-h97m-ww89-6jmq fixed in 1.0.0
        📦 openssl 0.10.68 (rust-crate)
            Medium CVE-2025-24898 GHSA-rpmj-rpgj-qmpm fixed in 0.10.70
        📦 rsa 0.9.3 (rust-crate)
            Medium GHSA-4grx-2x9w-596c
            Medium CVE-2023-49092 GHSA-c38w-74pg-36hr
```
And it lits up vector.