### PR TITLE
vector auditable demo

### DIFF
--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-auditable
   version: 0.6.6
-  epoch: 0
+  epoch: 1
   description: Cargo wrapper for embedding auditing data
   copyright:
     - license: MIT OR Apache-2.0
@@ -36,6 +36,9 @@ pipeline:
       # Install cargo-auditable
       install -Dm755 target/release/cargo-auditable -t "${{targets.destdir}}"/usr/bin/
       install -Dm644 cargo-auditable/cargo-auditable.1 -t "${{targets.destdir}}"/usr/share/man/man1/
+
+      # Install cargo wrapper
+      install -Dm755 cargo -t "${{targets.destdir}}"/usr/local/bin
 
   - uses: strip
 

--- a/cargo-auditable/cargo
+++ b/cargo-auditable/cargo
@@ -1,0 +1,4 @@
+#!/bin/sh
+# https://github.com/rust-secure-code/cargo-auditable/blob/master/REPLACING_CARGO.md
+export CARGO='/usr/bin/cargo'
+cargo-auditable auditable "$@"

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.44.0"
-  epoch: 0
+  epoch: 1
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -11,9 +11,12 @@ package:
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/73ec5e07302eaef8723a1646cd815a26242a6540
     packages:
       - bash
       - build-base
+      - cargo-auditable
       - cyrus-sasl-dev
       - librdkafka
       - librdkafka-dev


### PR DESCRIPTION
- **cargo-auditable: provide automatic wrapper**
  Provide cargo-auditable wrapper (similar to openssf-compiler-options
  gcc wrappers) such that cargo invocations default to cargo
  auditable. This allows to use existing `cargo build` commands via
  upstream makefiles, and yet gain audit information by default.
  

- **vector: enable rust-audit-info**
  Demonstrate automatic cargo auditable wrapper usage with rebuild of
  vector image against presubmit repository of:
  - https://github.com/wolfi-dev/os/pull/42571
  