### PR TITLE
vector: rebuild with audit information

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.44.0"
-  epoch: 0
+  epoch: 1
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -14,6 +14,7 @@ environment:
     packages:
       - bash
       - build-base
+      - cargo-auditable
       - cyrus-sasl-dev
       - librdkafka
       - librdkafka-dev


### PR DESCRIPTION
This will lit up vector with CVEs due to presense of the
rust-audit-info.

Thus this needs cargo bumps.
