### PR TITLE
node-problem-detector: update provides and use var-transfroms

### DIFF
--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.20
-  epoch: 5
+  epoch: 6
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,13 @@ package:
       - busybox
       - systemd-dev
     provides:
-      - node-problem-detector=0.8.999
+      - node-problem-detector=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -48,7 +54,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: health-checker-0.8
+  - name: health-checker-${{vars.major-minor-version}}
     description: A health checker for node-problem-detector to check kubelet and container runtime health
     pipeline:
       - runs: |
@@ -56,9 +62,9 @@ subpackages:
           install -m755 -D ./output/$(go env GOOS)_$(go env GOARCH)/bin/health-checker "${{targets.subpkgdir}}"/usr/bin/health-checker
     dependencies:
       provides:
-        - health-checker=0.8.999
+        - health-checker=${{package.full-version}}
 
-  - name: log-counter-0.8
+  - name: log-counter-${{vars.major-minor-version}}
     description: A log couter for journald to count the number of logs in a time window
     pipeline:
       - runs: |
@@ -66,7 +72,7 @@ subpackages:
           install -m755 -D ./output/$(go env GOOS)_$(go env GOARCH)/bin/log-counter "${{targets.subpkgdir}}"/usr/bin/log-counter
     dependencies:
       provides:
-        - log-counter=0.8.999
+        - log-counter=${{package.full-version}}
 
   - name: ${{package.name}}-compat
     pipeline:
@@ -75,7 +81,7 @@ subpackages:
           ln -sf /usr/bin/node-problem-detector ${{targets.subpkgdir}}/node-problem-detector
     dependencies:
       provides:
-        - node-problem-detector-compat=0.8.999
+        - node-problem-detector-compat=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
    node-problem-detector: update provides and use var-transfroms
    
    updates provides to use ${{package.full-version}} and uses
    var-transforms and passes major-minor-version to package names.