### PR TITLE
fluent-plugin-label-router: relax ruby3.2-fluentd version constraint

### DIFF
--- a/fluent-plugin-label-router.yaml
+++ b/fluent-plugin-label-router.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-plugin-label-router
   version: "0.4.0_git20250214"
-  epoch: 0
+  epoch: 1
   description: Label-Router helps routing log messages based on their labels and namespace tag in a Kubernetes environment.
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
     provides:
       - ruby3.2-fluent-plugin-label-router=${{package.full-version}}
     runtime:
-      - ruby3.2-fluentd<1.18
+      - ruby3.2-fluentd
       - ruby3.2-prometheus-client
 
 environment:
@@ -29,6 +29,10 @@ pipeline:
       expected-commit: 9ed269cc6e7eced5d91737ff5cb5e4519f50ba22
       repository: https://github.com/kube-logging/fluent-plugin-label-router
       branch: master
+
+  - uses: patch
+    with:
+      patches: relax-fluent-constraint.patch
 
   - uses: ruby/build
     with:

--- a/fluent-plugin-label-router/relax-fluent-constraint.patch
+++ b/fluent-plugin-label-router/relax-fluent-constraint.patch
@@ -1,0 +1,14 @@
+Enable us to attempt builds of post-1.17 images, until upstream update their
+constraints.
+---
+diff --git a/fluent-plugin-label-router.gemspec b/fluent-plugin-label-router.gemspec
+index 7e29ed1..50b080a 100644
+--- a/fluent-plugin-label-router.gemspec
++++ b/fluent-plugin-label-router.gemspec
+@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
+   spec.add_development_dependency "test-unit", "~> 3.0"
+   spec.add_dependency "prometheus-client", ">= 2.1.0"
+   spec.add_dependency "concurrent-ruby"
+-  spec.add_runtime_dependency "fluentd", [">= 1.17.1", "< 1.18"]
++  spec.add_runtime_dependency "fluentd", ">= 1.17.1"
+ end


### PR DESCRIPTION
This enables us to attempt build of post-1.17 images.