### PR TITLE
fix mime.types issue

### DIFF
--- a/opencost-ui.yaml
+++ b/opencost-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: opencost-ui
   version: 1.114.0
-  epoch: 0
+  epoch: 1
   dependencies:
     runtime:
       - nginx
@@ -14,6 +14,7 @@ environment:
   contents:
     packages:
       - busybox
+      - nginx-package-config
       - nodejs
       - npm
 
@@ -41,12 +42,12 @@ subpackages:
     dependencies:
       provides:
         - nginx-config=0.${{package.full-version}}
-      replaces:
-        - nginx-config
     pipeline:
       - runs: |
+          # Copy nginx config
           mkdir -p ${{targets.subpkgdir}}/etc/nginx
-          mkdir -p ${{targets.contextdir}}/etc/nginx/conf.d
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
+          cp -rf /etc/nginx/* ${{targets.contextdir}}/etc/nginx/
           cp nginx.conf ${{targets.contextdir}}/etc/nginx/nginx.conf
           cp default.nginx.conf.template ${{targets.contextdir}}/etc/nginx/conf.d/default.nginx.conf.template
 


### PR DESCRIPTION
there was an issue while building an image for opencost-ui:

```
2025/02/14 17:53:11 [emerg] 1#1: open() "/etc/nginx/mime.types" failed (2: No such file or directory) in /etc/nginx/nginx.conf:19
```

so this PR aims to fix it.