### PR TITLE
chore(dotnet-9): Update to 9.0.2

### DIFF
--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,8 @@
+#nolint:git-checkout-must-use-github-updates
 package:
   name: dotnet-9
-  version: 9.0.101
-  epoch: 2
+  version: 9.0.200
+  epoch: 0
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -46,12 +47,21 @@ environment:
       - wolfi-base
       - zlib-dev
 
+# FIXME: This is a workaround to fix the version number. The version is 9.0.200 but the tag is 9.0.2
+# It captures the final number segment: if it ends in "00" (like in "9.0.200"), the "00" is removed, leaving just "2".
+# Otherwise (e.g., "9.0.201"), the entire number is kept unchanged.
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(?:(\d+?)00|(\d+))$'
+    replace: ".$1$2"
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/dotnet/dotnet
-      tag: v${{package.version}}
-      expected-commit: f303476b533b0f90901c0a5e07a3bd2fb68777e3
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: c4e5fd73fe5d8c004bf46cb4f1ded77ca8124b1a
       destination: /home/build/src
 
   - working-directory: /home/build/src
@@ -169,13 +179,11 @@ subpackages:
       runtime:
         - dotnet-9-targeting-pack
 
+# FIXME: Used ReleaseMonitor here since they cut 9.0.2 tag instead of 9.0.200 on GitHub so we can't use the GitHub updater
 update:
   enabled: true
-  github:
-    identifier: dotnet/dotnet
-    strip-prefix: v
-    use-tag: true
-    tag-filter: "v9"
+  release-monitor:
+    identifier: 141853
 
 test:
   environment:

--- a/dotnet-bootstrap-9.yaml
+++ b/dotnet-bootstrap-9.yaml
@@ -1,6 +1,7 @@
+#nolint:git-checkout-must-use-github-updates
 package:
   name: dotnet-bootstrap-9
-  version: 9.0.0
+  version: 9.0.200
   epoch: 0
   description: ".NET 9 SDK Bootstrap"
   copyright:
@@ -11,6 +12,12 @@ package:
   dependencies:
     runtime:
       - icu
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(?:(\d+?)00|(\d+))$'
+    replace: ".$1$2"
+    to: mangled-package-version
 
 environment:
   contents:
@@ -34,8 +41,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/dotnet/dotnet
-      tag: v${{package.version}}
-      expected-commit: a2bc464e40415d625118f38fbb0556d1803783ff
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: c4e5fd73fe5d8c004bf46cb4f1ded77ca8124b1a
       destination: /home/build/src
 
   - working-directory: /home/build/src
@@ -53,9 +60,6 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
-  github:
-    identifier: dotnet/dotnet
-    strip-prefix: v
-    use-tag: true
-    tag-filter: "v9"
+  enabled: true
+  release-monitor:
+    identifier: 141853


### PR DESCRIPTION
Update .NET and .NET bootstrap to 9.0.2 (as we were not able to successfully build 9.0.2 with 9.0.101 or 9.0.0 bootstrap)

Microsoft never withdrew the tag for 9.0.101 and never published a tag for 9.0.103. To avoid a withdraw of 9.0.101, mangle the version as 9.0.200