### PR TITLE
expand contour test coverage in melange

### DIFF
--- a/contour-1.30.yaml
+++ b/contour-1.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: contour-1.30
   version: "1.30.2"
-  epoch: 2
+  epoch: 3
   description: Contour is a Kubernetes ingress controller using Envoy proxy.
   copyright:
     - license: Apache-2.0
@@ -75,7 +75,45 @@ update:
     tag-filter: v1.30.
 
 test:
+  environment:
+    contents:
+      packages:
+        - kubectl
   pipeline:
-    - runs: |
+    - name: "Basic checks"
+      runs: |
         contour version
         contour --help
+        contour serve --help
+    - name: "Setup KWOK cluster"
+      uses: test/kwok/cluster
+    - name: "Install CRDs"
+      runs: |
+        kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/v${{package.version}}/examples/contour/01-crds.yaml
+        kubectl wait --for=condition=Established crd --all --timeout=60s
+    - name: "Launch Contour"
+      runs: |
+        # Dump the KWOK cluster config
+        kubectl config view --minify --raw > /tmp/kwok-kubeconfig.yaml
+
+        contour serve \
+          --kubeconfig /tmp/kwok-kubeconfig.yaml \
+          --disable-leader-election \
+          --insecure \
+          > /tmp/contour.log 2>&1 &
+
+        CONTOUR_PID=$!
+        sleep 5
+
+        if ! kill -0 "$CONTOUR_PID" 2>/dev/null; then
+          echo "ERROR: contour serve exited early. Logs:"
+          cat /tmp/contour.log
+          exit 1
+        fi
+
+        # Check contour is running via log validation.
+        if ! grep -qi "started HTTP server" /tmp/contour.log; then
+          echo "ERROR: 'started HTTP server' not found in logs"
+          cat /tmp/contour.log
+          exit 1
+        fi


### PR DESCRIPTION
Expands melange tests to ensure Contour can be launched in a kwok cluster, the process is running, and logging as expected. epoch bump needed, otherwise CI won't run the tests against a binary.