### PR TITLE
python multi-version samba libs

### DIFF
--- a/ldb.yaml
+++ b/ldb.yaml
@@ -170,6 +170,7 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
+        - uses: test/emptypackage
         - uses: python/import
           with:
             python: python3.10

--- a/ldb.yaml
+++ b/ldb.yaml
@@ -1,10 +1,28 @@
 package:
   name: ldb
   version: 2.9.1
-  epoch: 3
+  epoch: 4
   description: schema-less, ldap like, API and database
   copyright:
     - license: LGPL-3.0-or-later
+
+vars:
+  configure-common-opts: |
+    --disable-rpath \
+    --disable-rpath-install \
+    --builtin-libraries=replace \
+    --bundled-libraries=NONE \
+    --with-modulesdir=/usr/lib/ldb/modules \
+  pypi-package: ldb
+  import: ldb
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -20,9 +38,11 @@ environment:
       - lmdb-dev
       - pkgconf-dev
       - popt-dev
-      - py3-tdb
-      - py3-tevent
-      - python3-dev
+      - py3-supported-build-base-dev
+      - py3-supported-talloc-dev
+      - py3-supported-tdb
+      - py3-supported-tevent
+      - python3
       - talloc-dev
       - tdb-dev
       - tevent-dev
@@ -36,15 +56,17 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --disable-rpath \
-        --disable-rpath-install \
-        --builtin-libraries=replace \
-        --bundled-libraries=NONE \
-        --with-modulesdir=/usr/lib/ldb/modules
+        ${{vars.configure-common-opts}}
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - runs: |
+      # These will be provided by the py3.x-ldb subpackages
+      rm -rf "${{targets.contextdir}}"/usr/lib/libpyldb*.so*
+      rm -rf "${{targets.contextdir}}"/usr/lib/python*
+      rm -f  "${{targets.contextdir}}"/usr/lib/pkgconfig/pyldb-util.*.pc
 
   - uses: strip
 
@@ -60,13 +82,110 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
 
-  - name: py3-ldb
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            PYTHON=python${{range.key}} \
+            PYTHON3=python${{range.key}} \
+            ${{vars.configure-common-opts}}
+      - uses: autoconf/make
+      - uses: autoconf/make-install
+      - runs: |
+          ## split out -dev files into holding areas
+          devdir="pyldb-dev.sav"
+          mkdir -p "$devdir"/usr/include
+          mv "${{targets.contextdir}}"/usr/include/pyldb* \
+            "$devdir/usr/include"
+          devdir_versioned="pyldb-dev-${{range.key}}.sav"
+          mkdir -p "$devdir_versioned/usr/lib/pkgconfig"
+          mv "${{targets.contextdir}}"/usr/lib/pkgconfig/pyldb-util.*.pc \
+            "$devdir_versioned/usr/lib/pkgconfig"
+
+          ## Move python bits into a tmpdir, delete everything else, then
+          ## replace the contextdir with our tmpdir.
+          tmpdir="${{targets.contextdir}}.sav"
+          mkdir -p "$tmpdir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/libpyldb*.so* \
+            "$tmpdir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/python${{range.key}} \
+            "$tmpdir/usr/lib"
+          rm -rf "${{targets.contextdir}}"
+          mv "$tmpdir" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: pyldb-dev
+    dependencies:
+      runtime:
+        - py3-ldb
+        - ldb-dev
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libpyldb-util.cpython* "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.contextdir}}"/usr/lib
-    description: Python 3 binding for the ldb library
+          rm -rf "${{targets.contextdir}}"
+          devdir="pyldb-dev.sav"
+          mv "$devdir" "${{targets.contextdir}}"
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-dev
+    description: python${{range.key}} version of ${{vars.pypi-package}} dev files
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}-dev
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          rm -rf "${{targets.contextdir}}"
+          devdir_versioned="pyldb-dev-${{range.key}}.sav"
+          mv "$devdir_versioned" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
   - name: ldb-tools
     pipeline:

--- a/samba.yaml
+++ b/samba.yaml
@@ -41,6 +41,7 @@ environment:
       - popt-dev
       - py3-dnspython
       - py3-markdown
+      - py3-talloc-dev
       - py3-tdb
       - py3-tevent
       - python3-dev

--- a/samba.yaml
+++ b/samba.yaml
@@ -6,6 +6,9 @@ package:
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
 
+vars:
+  py-version: 3.13
+
 environment:
   contents:
     packages:
@@ -39,11 +42,11 @@ environment:
       - perl-parse-yapp
       - pkgconf-dev
       - popt-dev
-      - py3-dnspython
-      - py3-markdown
-      - py3-talloc-dev
-      - py3-tdb
-      - py3-tevent
+      - py${{vars.py-version}}-dnspython
+      - py${{vars.py-version}}-markdown
+      - py${{vars.py-version}}-talloc-dev
+      - py${{vars.py-version}}-tdb
+      - py${{vars.py-version}}-tevent
       - python3-dev
       - rpcgen
       - subunit-dev
@@ -346,7 +349,7 @@ subpackages:
             eventlogadm --help
             nmbd --help
 
-  - name: py3-samba
+  - name: py${{vars.py-version}}-samba
     description: Samba python libraries
     pipeline:
       - runs: |
@@ -354,7 +357,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/python* "${{targets.contextdir}}"/usr/lib
     dependencies:
       runtime:
-        - py3-tdb
+        - py${{vars.py-version}}-tdb
+      provides:
+        - py3-samba
 
   - name: samba-test
     description: Samba server and client testing tools
@@ -373,7 +378,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/samba/libtorture-private-samba.so "${{targets.contextdir}}"/usr/lib
     dependencies:
       runtime:
-        - py3-tdb
+        - py${{vars.py-version}}-tdb
     test:
       pipeline:
         - runs: |

--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: "4.21.4"
-  epoch: 0
+  epoch: 1
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later

--- a/talloc.yaml
+++ b/talloc.yaml
@@ -165,6 +165,7 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
+        - uses: test/emptypackage
         - uses: python/import
           with:
             python: python3.10
@@ -190,6 +191,9 @@ subpackages:
         - py3.11-${{vars.pypi-package}}-dev
         - py3.12-${{vars.pypi-package}}-dev
         - py3.13-${{vars.pypi-package}}-dev
+    test:
+      pipeline:
+        - uses: test/emptypackage
 
 update:
   enabled: true

--- a/talloc.yaml
+++ b/talloc.yaml
@@ -1,10 +1,28 @@
 package:
   name: talloc
   version: "2.4.3"
-  epoch: 0
+  epoch: 1
   description: Memory pool management library
   copyright:
     - license: GPL-3.0-or-later
+
+vars:
+  configure-common-opts: |
+    --bundled-libraries=NONE \
+    --builtin-libraries=replace \
+    --disable-rpath \
+    --disable-rpath-install \
+    --without-gettext \
+  pypi-package: talloc
+  import: talloc
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -15,7 +33,8 @@ environment:
       - busybox
       - docbook-xml
       - libxslt
-      - python3-dev
+      - py3-supported-build-base-dev
+      - python3
 
 pipeline:
   - uses: fetch
@@ -25,16 +44,17 @@ pipeline:
 
   - uses: autoconf/configure
     with:
-      opts: |
-        --bundled-libraries=NONE \
-        --builtin-libraries=replace \
-        --disable-rpath \
-        --disable-rpath-install \
-        --without-gettext
+      opts: ${{vars.configure-common-opts}} --disable-python
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - runs: |
+      # These will be provided by the py3.x-talloc subpackages
+      rm -rf "${{targets.contextdir}}"/usr/lib/libpytalloc*.so*
+      rm -rf "${{targets.contextdir}}"/usr/lib/python*
+      rm -f  "${{targets.contextdir}}"/usr/lib/pkgconfig/pytalloc-util.*.pc
 
   - uses: strip
 
@@ -57,13 +77,119 @@ subpackages:
       pipeline:
         - uses: test/docs
 
-  - name: "py3-talloc"
-    description: "Python 3 binding for libtalloc"
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            PYTHON=python${{range.key}} \
+            PYTHON3=python${{range.key}} \
+            ${{vars.configure-common-opts}}
+      - uses: autoconf/make
+      - uses: autoconf/make-install
+      - runs: |
+          ## split out -dev files into holding areas
+          devdir_common="pytalloc-common-dev.sav"
+          mkdir -p "$devdir_common"/usr/include
+          mv "${{targets.contextdir}}"/usr/include/pytalloc* \
+            "$devdir_common/usr/include"
+          devdir_versioned="pytalloc-dev-${{range.key}}.sav"
+          mkdir -p "$devdir_versioned/usr/lib/pkgconfig"
+          mv "${{targets.contextdir}}"/usr/lib/pkgconfig/pytalloc-util.*.pc \
+            "$devdir_versioned/usr/lib/pkgconfig"
+
+          ## Move python bits into a tmpdir, delete everything else, then
+          ## replace the contextdir with our tmpdir.
+          tmpdir="${{targets.contextdir}}.sav"
+          mkdir -p "$tmpdir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/libpytalloc*.so* \
+            "$tmpdir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/python${{range.key}} \
+            "$tmpdir/usr/lib"
+          rm -rf "${{targets.contextdir}}"
+          mv "$tmpdir" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: pytalloc-dev-common
+    dependencies:
+      runtime:
+        - talloc-dev
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libpy* "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.contextdir}}"/usr/lib
+          rm -rf "${{targets.contextdir}}"
+          devdir_common="pytalloc-common-dev.sav"
+          mv "$devdir_common" "${{targets.contextdir}}"
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-dev
+    description: python${{range.key}} version of ${{vars.pypi-package}} dev files
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}-dev
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - pytalloc-dev-common
+    pipeline:
+      - runs: |
+          rm -rf "${{targets.contextdir}}"
+          devdir_versioned="pytalloc-dev-${{range.key}}.sav"
+          mv "$devdir_versioned" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}-dev
+    description: meta package providing ${{vars.pypi-package}} dev files for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}-dev
+        - py3.11-${{vars.pypi-package}}-dev
+        - py3.12-${{vars.pypi-package}}-dev
+        - py3.13-${{vars.pypi-package}}-dev
 
 update:
   enabled: true

--- a/tdb.yaml
+++ b/tdb.yaml
@@ -91,6 +91,7 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
+        - uses: test/emptypackage
         - uses: python/import
           with:
             python: python3.10

--- a/tdb.yaml
+++ b/tdb.yaml
@@ -1,10 +1,22 @@
 package:
   name: tdb
   version: "1.4.13"
-  epoch: 0
+  epoch: 1
   description: The tdb library
   copyright:
     - license: LGPL-3.0-or-later
+
+vars:
+  pypi-package: tdb
+  import: tdb
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -14,8 +26,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-supported-build-base-dev
       - python3
-      - python3-dev
 
 pipeline:
   - uses: fetch
@@ -40,11 +52,61 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
 
-  - name: py3-tdb
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
     pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            PYTHON=python${{range.key}} \
+            PYTHON3=python${{range.key}}
+      - uses: autoconf/make
+      - uses: autoconf/make-install
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.contextdir}}"/usr/lib/
+          savedir="${{targets.contextdir}}.sav"
+          mkdir -p "$savedir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/python${{range.key}} "$savedir/usr/lib"
+          rm -rf "${{targets.contextdir}}"
+          mv "$savedir" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/tevent.yaml
+++ b/tevent.yaml
@@ -1,10 +1,24 @@
 package:
   name: tevent
   version: "0.16.2"
-  epoch: 1
+  epoch: 2
   description: The tevent library
   copyright:
     - license: LGPL-3.0-or-later
+
+vars:
+  configure-common-opts: |
+    --bundled-libraries=NONE
+  pypi-package: tevent
+  import: tevent
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -16,7 +30,9 @@ environment:
       - ca-certificates-bundle
       - cmocka-dev
       - libtirpc-dev
-      - python3-dev
+      - py3-supported-build-base-dev
+      - py3-supported-talloc-dev
+      - python3
       - talloc-dev
 
 pipeline:
@@ -26,6 +42,10 @@ pipeline:
       uri: https://samba.org/ftp/tevent/tevent-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-python \
+        ${{vars.configure-common-opts}}
 
   - uses: autoconf/make
 
@@ -45,12 +65,60 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
 
-  - name: py3-tevent
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
     pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            PYTHON=python${{range.key}} \
+            PYTHON3=python${{range.key}} \
+            ${{vars.configure-common-opts}}
+      - uses: autoconf/make
+      - uses: autoconf/make-install
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.contextdir}}"/usr/lib
-    description: Python 3 binding for the tevent library
+          savedir="${{targets.contextdir}}.sav"
+          mkdir -p "$savedir/usr/lib"
+          mv "${{targets.contextdir}}"/usr/lib/python${{range.key}} "$savedir/usr/lib"
+          rm -rf "${{targets.contextdir}}"
+          mv "$savedir" "${{targets.contextdir}}"
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/tevent.yaml
+++ b/tevent.yaml
@@ -103,6 +103,7 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
+        - uses: test/emptypackage
         - uses: python/import
           with:
             python: python3.10


### PR DESCRIPTION
Add python multi-version support to talloc, tevent, tdb, and ldb. Pin `samba` to python `3.13`. In theory we should multi-version `py3-samba` as well. But the way we're doing the other libs is by rebuilding the whole package for each python version and scraping out the python-specific bits. I'm hesitant to do that with a package as big as `samba`.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/9056