### PR TITLE
ruby*-rack: convert to git update backend, bump version

### DIFF
--- a/ruby3.2-rack.yaml
+++ b/ruby3.2-rack.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rack
-  version: 3.0.9.1
-  epoch: 4
+  version: 3.1.10
+  epoch: 0
   description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
     - license: MIT
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: a4bc5e0f41c750135969ceece8772ab112dc8f17
+      expected-commit: 03494889c72513eee24a3fc715eb34869a7d4c88
       repository: https://github.com/rack/rack
       tag: v${{package.version}}
 
@@ -39,8 +39,7 @@ vars:
 
 update:
   enabled: true
-  github:
-    identifier: rack/rack
+  git:
     strip-prefix: v
 
 var-transforms:

--- a/ruby3.3-rack.yaml
+++ b/ruby3.3-rack.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.3-rack
-  version: 3.0.9.1
+  version: 3.1.10
   epoch: 0
   description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: a4bc5e0f41c750135969ceece8772ab112dc8f17
+      expected-commit: 03494889c72513eee24a3fc715eb34869a7d4c88
       repository: https://github.com/rack/rack
       tag: v${{package.version}}
 
@@ -39,8 +39,7 @@ vars:
 
 update:
   enabled: true
-  github:
-    identifier: rack/rack
+  git:
     strip-prefix: v
 
 var-transforms:

--- a/ruby3.4-rack.yaml
+++ b/ruby3.4-rack.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rack
-  version: 3.0.9.1
-  epoch: 1
+  version: 3.1.10
+  epoch: 0
   description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
     - license: MIT
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: a4bc5e0f41c750135969ceece8772ab112dc8f17
+      expected-commit: 03494889c72513eee24a3fc715eb34869a7d4c88
       repository: https://github.com/rack/rack
       tag: v${{package.version}}
 
@@ -45,8 +45,7 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: rack/rack
+  git:
     strip-prefix: v
 
 var-transforms:


### PR DESCRIPTION
Upstream have not cut GitHub releases for their most recent releases. Switching to `git` moves to using the tags implicitly.