### PR TITLE
zookeeper-3.9/GHSA-4g8c-wm8x-jfhw netty version update

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.3.2
-  epoch: 1
+  epoch: 2
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -47,7 +47,7 @@ pipeline:
       # -Dnetty.version=4.1.108.Final
       # Patch commons-io version GHSA-78wr-2p64-hpwj/CVE-2024-47554
       # -Dcommons-io.version=2.14.0 moved from 2.11.0 https://github.com/apache/zookeeper/blob/release-3.9.2/pom.xml#L574C5-L574C52
-      mvn install -DskipTests -Dnetty.version=4.1.115.Final -Dcommons-io.version=2.14.0
+      mvn install -DskipTests -Dnetty.version=4.1.118.Final -Dcommons-io.version=2.14.0
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       # Cleanup Windows files


### PR DESCRIPTION
Updating netty version and bumping epoch remediates the CVE as fix version exists in netty 4.1.118.Final