### PR TITLE
ruby*-rails-8.0: use APK to provide net-imap

### DIFF
--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rails-8.0
   version: 8.0.1
-  epoch: 1
+  epoch: 2
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ package:
       - glibc-dev
       - make
       - ruby${{vars.rubyMM}}-bundler
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}-dev
       - tzdata
 
@@ -24,6 +25,7 @@ environment:
       - gcc
       - glibc-dev
       - make
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev
       - yaml-dev

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-rails-8.0
   version: 8.0.1
-  epoch: 1
+  epoch: 2
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ package:
       - glibc-dev
       - make
       - ruby${{vars.rubyMM}}-bundler
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}-dev
       - tzdata
 
@@ -24,6 +25,7 @@ environment:
       - gcc
       - glibc-dev
       - make
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev
       - yaml-dev

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: 8.0.1
-  epoch: 1
+  epoch: 2
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ package:
       - glibc-dev
       - make
       - ruby${{vars.rubyMM}}-bundler
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}-dev
       - tzdata
 
@@ -24,6 +25,7 @@ environment:
       - gcc
       - glibc-dev
       - make
+      - ruby${{vars.rubyMM}}-net-imap
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev
       - yaml-dev


### PR DESCRIPTION
This addresses GHSA-7fc5-f82f-cx69 now, and will pull in future net-imap fixes automatically.