### PR TITLE
dagger: ignore tags containing "llm"

### DIFF
--- a/dagger.yaml
+++ b/dagger.yaml
@@ -30,6 +30,7 @@ update:
   ignore-regex-patterns:
     - 'sdk'
     - 'helm'
+    - 'llm'
   github:
     identifier: dagger/dagger
     strip-prefix: v


### PR DESCRIPTION
Per
https://github.com/dagger/dagger/commit/2273cd29a5283f35a767f18a532a7b7c9ff0f3ff these are pre-release tags.

Fixes: #43063 