### PR TITLE
Fix: add dumb-init-privileged-netbindservice as runtime dep

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -161,7 +161,7 @@ vars:
   NGX_BROTLI_SHA: 63ca02abdcf79c9e788d2eedcc388d2335902e52
   # TODO: ModSecurity-nginx needs a release beyond v1.0.3 to work properly
   # see https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/324
-  MODSECURITY_NGINX_VERSION: "fb678c5b4456c733e011d4bd6ad0888baca8c124"
+  MODSECURITY_NGINX_VERSION: "0b4f0cf38502f34a30c8543039f345cfc075670d"
   # Instrumentation for nginx plugin: https://github.com/open-telemetry/opentelemetry-cpp-contrib
   # NOTE: this is really really critical and the config can break in backwards compatible way!!
   # We should always use the SHA available in release-x.y branch of upstream project (e.g. https://github.com/kubernetes/ingress-nginx/blob/release-1.12/images/nginx/rootfs/build.sh#L532)
@@ -714,4 +714,3 @@ test:
       runs: |
         getcap /usr/bin/nginx-ingress-controller | cut -d ' ' -f2 | grep -q -E '^cap_net_bind_service=ep$'
         getcap /usr/bin/nginx | cut -d ' ' -f2 | grep -q -E '^cap_net_bind_service=ep$'
-        getcap /usr/bin/dumb-init | cut -d ' ' -f2 | grep -q -E '^cap_net_bind_service=ep$'

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 7
+  epoch: 8
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ package:
       - ca-certificates-bundle
       - ca-certificates
       - curl
+      - dumb-init-privileged-netbindservice
       - openssh-client
       - openssl
       - openssl-dev
@@ -494,13 +495,6 @@ pipeline:
 
       setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx \
         && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx
-
-      echo "::::::::::::::::::::::::::::::::::::::::::"
-      echo ":::: SETCAP DUMB INIT                  ::::"
-      echo "::::::::::::::::::::::::::::::::::::::::::"
-
-      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init \
-        && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init
 
 subpackages:
   - name: ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}


### PR DESCRIPTION
addressing issue "ingress-nginx-controller-1.12 setcaps, but doesn't provide, dumb-init"
[#9275](https://github.com/chainguard-dev/internal-dev/issues/9275)