### PR TITLE
Fix: Remove /nginx/owasp-modsecurity-crs/tests to replicate upstream

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
-  # There are manual changes to review between each package update. See 'vars:' section.
+  # There are manual changes to review between each package update. See 'vars:' section
   epoch: 9
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 8
+  epoch: 9
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -478,6 +478,7 @@ pipeline:
       echo "Clean up owasp-modsecurity-crs"
       rm -rf ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/.git
       rm -rf ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/util/regression-tests
+      rm -rf ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/tests
 
   - uses: strip
 


### PR DESCRIPTION
Addressing issue [[BUG]: Azure marketplace scan flagging malware in ingress-nginx-controller-fips](https://github.com/chainguard-dev/customer-issues/issues/2044)
Decision to remove `etc/nginx/owasp-modsecurity-crs/tests`. REF: https://github.com/chainguard-dev/customer-issues/issues/2044#issuecomment-2668339294