### PR TITLE
rpm-sequoia: introduce new package required by rpm

### DIFF
--- a/rpm-sequoia.yaml
+++ b/rpm-sequoia.yaml
@@ -1,0 +1,55 @@
+package:
+  name: rpm-sequoia
+  version: "1.7.0"
+  epoch: 0
+  description: "An OpenPGP backend for rpm using Sequoia PGP"
+  copyright:
+    - license: LGPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - cargo-auditable
+      - clang
+      - nettle-dev
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rpm-software-management/rpm-sequoia
+      expected-commit: 0667e04ae7fb8cf0490919978d69883d16400e41
+      tag: v${{package.version}}
+
+  - runs: |
+      PREFIX=/usr LIBDIR="\${prefix}/lib" \
+        cargo auditable build --target-dir target --release
+
+      # The tests examine OUTPUT_DIR explicitly, so we can't run them after
+      # install
+      cargo test --release
+
+      INSTALL_PATH="${{targets.contextdir}}/usr/lib"
+      mkdir -p "${INSTALL_PATH}/pkgconfig"
+      mv target/release/librpm_sequoia.so* "${INSTALL_PATH}"
+      mv target/release/rpm-sequoia.pc "${INSTALL_PATH}/pkgconfig"
+
+  - uses: strip
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - binutils
+  pipeline:
+    - runs: |
+        # This is a smoke test based on:
+        # https://github.com/rpm-software-management/rpm-sequoia/blob/main/tests/symbols.rs
+        objdump -T /usr/lib/librpm_sequoia.so | grep _rpmInitCrypto


### PR DESCRIPTION
Upstream RPM previously shipped their own GPG implementation, which they no longer consider secure or supported.  They've moved to depending on the separate rpm-sequoia project, so we need to package it up.

Related: https://github.com/wolfi-dev/os/pull/43070

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates