### PR TITLE
docker-selenium/GHSA-4g8c-wm8x-jfhw fix

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.28.1.20250202"
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -107,7 +107,7 @@ subpackages:
               # The netty-codec-http bump is for CVE-2024-29025
               ./coursier fetch --classpath --cache ${{targets.contextdir}}/external_jars \
                 io.opentelemetry:opentelemetry-exporter-otlp:${OPENTELEMETRY_VERSION} \
-                io.netty:netty-codec-http:4.1.108.Final \
+                io.netty:netty-codec-http:4.1.118.Final \
                 io.grpc:grpc-netty:${GRPC_VERSION} > ${{targets.contextdir}}/external_jars/.classpath.txt
               chmod 665 ${{targets.contextdir}}/external_jars/.classpath.txt
               sed -i 's|${{targets.contextdir}}||g' ${{targets.contextdir}}/external_jars/.classpath.txt


### PR DESCRIPTION
Bumping the version of netty being passed to the docker build needed to be updated to 4.1.118.Final, resolves GHSA-4g8c-wm8x-jfhw