### PR TITLE
postgresql-*: reenable automatic updates

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -279,10 +279,6 @@ subpackages:
 update:
   version-separator: _
   enabled: true
-  # Requires manual steps when updating because of usage of ALPINE_VERSION: "3.21" while pulling docker-entrypoint scripts
-  # which gets updated in https://github.com/docker-library/postgres.
-  # This will help us prevent breaking changes in the future.
-  manual: true
   github:
     identifier: postgres/postgres
     strip-prefix: REL_

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -279,10 +279,6 @@ subpackages:
 update:
   version-separator: _
   enabled: true
-  # Requires manual steps when updating because of usage of ALPINE_VERSION: "3.21" while pulling docker-entrypoint scripts
-  # which gets updated in https://github.com/docker-library/postgres.
-  # This will help us prevent breaking changes in the future.
-  manual: true
   github:
     identifier: postgres/postgres
     strip-prefix: REL_


### PR DESCRIPTION
The reason given for requiring manual updates is that package builds might fail if a given value isn't kept up-to-date.  However, it's preferable to only have to manually intervene when that value requires updating, rather than for every new upstream version.