### PR TITLE
Add py3-roman-numerals-py, a missing dep of py3-sphinx

### DIFF
--- a/py3-roman-numerals-py.yaml
+++ b/py3-roman-numerals-py.yaml
@@ -1,0 +1,97 @@
+package:
+  name: py3-roman-numerals-py
+  version: 3.0.0
+  epoch: 0
+  description: A library to convert between integers and Unicode Roman numerals
+  copyright:
+    - license: CC0-1.0 AND 0BSD
+  dependencies:
+    provider-priority: "0"
+
+data:
+  - name: py-versions
+    items:
+      "3.10": "310"
+      "3.11": "311"
+      "3.12": "312"
+      "3.13": "313"
+
+vars:
+  import: roman_numerals
+  pypi-package: roman-numerals-py
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-build-base
+      - py3-supported-flit-core
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/AA-Turner/roman-numerals
+      expected-commit: 6727a2c61cf03026c2ae76f12e01485604a6a8d9
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: cp LICENCE.rst python/
+      - name: Python Build
+        uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+        working-directory: ./python
+    dependencies:
+      provider-priority: ${{range.value}}
+    test:
+      environment: {}
+      pipeline:
+        - name: Import Test
+          uses: python/import
+          with:
+            import: ${{vars.import}}
+            python: python${{range.key}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
+
+test:
+  pipeline:
+    - uses: test/emptypackage
+
+update:
+  enabled: true
+  github:
+    identifier: AA-Turner/roman-numerals
+    strip-prefix: v
+    use-tag: true

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: "8.2.0"
-  epoch: 0
+  epoch: 1
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -48,6 +48,7 @@ subpackages:
         - py${{range.key}}-packaging
         - py${{range.key}}-pygments
         - py${{range.key}}-requests
+        - py${{range.key}}-roman-numerals-py
         - py${{range.key}}-snowballstemmer
         - py${{range.key}}-sphinxcontrib-applehelp
         - py${{range.key}}-sphinxcontrib-devhelp
@@ -72,6 +73,7 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+              from sphinx.writers.latex import LaTeXTranslator, LaTeXWriter
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin


### PR DESCRIPTION
Fixes: #43085

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
