### PR TITLE
py3-netifaces: Use ${{vars.import}} for module name in import test

### DIFF
--- a/py3-netifaces.yaml
+++ b/py3-netifaces.yaml
@@ -57,7 +57,7 @@ subpackages:
         - uses: python/import
           with:
             python: python3.10
-            import: ${{vars.pypi-package}}
+            import: ${{vars.import}}
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
