### PR TITLE
add font-noto-math, font-noto-common and font-noto-symbols to font-noto's runtime deps

### DIFF
--- a/font-noto.yaml
+++ b/font-noto.yaml
@@ -1,10 +1,13 @@
 package:
   name: font-noto
   version: 2025.02.01
-  epoch: 0
+  epoch: 1
   description: Noto fonts
   dependencies:
     runtime:
+      - font-noto-common
+      - font-noto-math
+      - font-noto-symbols
       - fontconfig
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: 

According to the alpine's version of this package **font-noto-math**, **font-noto-common** and **font-noto-symbols** are defined as runtime dependencies of this package so we are doing the same:

- https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/font-noto/APKBUILD#L158-161

```bash
$ docker container run --rm -ti --entrypoint="sh" alpine
# apk update
# apk info font-noto --depends
font-noto-24.7.1-r0 depends on:
fontconfig
font-noto-common=24.7.1-r0
font-noto-math=24.7.1-r0
font-noto-symbols=24.7.1-r0
```

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
