### PR TITLE
Complete 3.13 transition

### DIFF
--- a/py3-dbus-python.yaml
+++ b/py3-dbus-python.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-dbus-python
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   description: Python bindings for libdbus
   copyright:
     - license: MIT
@@ -58,7 +58,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 vars:
   module_name: dbus

--- a/py3-frozendict.yaml
+++ b/py3-frozendict.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-frozendict
   version: 2.4.6
-  epoch: 0
+  epoch: 1
   description: A simple immutable dictionary
   copyright:
     - license: LGPL-3.0-or-later
@@ -19,7 +19,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-notify2.yaml
+++ b/py3-notify2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-notify2
   version: 0.3.1
-  epoch: 0
+  epoch: 1
   description: Python interface to DBus notifications
   copyright:
     - license: BSD-2-Clause
@@ -53,7 +53,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 vars:
   module_name: notify2


### PR DESCRIPTION
Finish bumping priority from 300 to 313 for all remaining py3.13
packages, apart from supported-python.
