### PR TITLE
gcp-compute-persistent-disk-csi-driver-1.15/CVE-2025-22866 fix

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver-1.15.yaml
+++ b/gcp-compute-persistent-disk-csi-driver-1.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcp-compute-persistent-disk-csi-driver-1.15
   version: "1.15.4"
-  epoch: 1
+  epoch: 2
   description: The Google Compute Engine Persistent Disk (GCE PD) Container Storage Interface (CSI) Storage Plugin.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
rebuilding the package and bumping epoch will remediate https://github.com/advisories/GHSA-3whm-j4xm-rv8x as it is a go-version root cause