### PR TITLE
fix(calico-3.29.yaml): Disable the calico-apiserver 3.29.2 when Validating Admission Policy checks until upstream tigrea operator adds the required rules

### DIFF
--- a/calico-3.29.yaml
+++ b/calico-3.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.29
   version: "3.29.2"
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -65,6 +65,15 @@ pipeline:
       repository: https://github.com/projectcalico/calico
       tag: v${{package.version}}
       expected-commit: c29210835f7a2795d0791974602c8e1c625c8ca1
+  # Because we are using tigera-operator during image test we are reliant on tigera-operator setting
+  # up all the required rbac rules that are needed for calico-apiserver to run. Currently it does not and
+  # this is a temporary solution until https://github.com/tigera/operator/issues/3780 is resolved upstream with a new
+  # release of tigera-operator. This issue was highlighed in calico-apiserver 3.29.2 when Validating Admission Policy
+  # became enabled by default. This patch disables the Validating Admission Policy in calico-apiserver until
+  # the issue is resolved.
+  - uses: patch
+    with:
+      patches: calico-apiserver-disable-validating-admission-policy.patch
   - working-directory: felix
     pipeline:
       # Equivalent to target: "build-bpf"

--- a/calico-3.29/calico-apiserver-disable-validating-admission-policy.patch
+++ b/calico-3.29/calico-apiserver-disable-validating-admission-policy.patch
@@ -1,0 +1,13 @@
+diff --git a/apiserver/cmd/apiserver/server/options.go b/apiserver/cmd/apiserver/server/options.go
+index 3701a9659..f8637cff6 100644
+--- a/apiserver/cmd/apiserver/server/options.go
++++ b/apiserver/cmd/apiserver/server/options.go
+@@ -68,7 +68,7 @@ func (o *CalicoServerOptions) addFlags(flags *pflag.FlagSet) {
+ 		"If true, prints swagger to stdout and exits.")
+ 	flags.StringVar(&o.SwaggerFilePath, "swagger-file-path", "./",
+ 		"If print-swagger is set true, then write swagger.json to location specified. Default is current directory.")
+-	flags.BoolVar(&o.EnableValidatingAdmissionPolicy, "enable-validating-admission-policy", true,
++	flags.BoolVar(&o.EnableValidatingAdmissionPolicy, "enable-validating-admission-policy", false,
+ 		"If true, establishes watches for ValidatingAdmissionPolicy at startup.")
+ }
+ 


### PR DESCRIPTION
Because we are using tigera-operator during image test we are reliant on tigera-operator setting
up all the required rbac rules that are needed for calico-apiserver to run. Currently it does not [1] and
this is a temporary solution until https://github.com/tigera/operator/issues/3780 is resolved upstream with a new
release of tigera-operator. This issue was highlighed in calico-apiserver 3.29.2 when Validating Admission Policy
became enabled by default [2]. This patch disables the Validating Admission Policy in calico-apiserver until
the issue is resolved.

[1] https://github.com/tigera/operator/blob/ed26c42e1e232e9cc604a9a010d4ca9111b6f388/pkg/render/apiserver.go#L654C11-L654C28
[2] https://github.com/projectcalico/calico/commit/8eacb02e223edeef01e28d85df794540c6850d0f

Signed-off-by: philroche <phil.roche@chainguard.dev>
