### PR TITLE
postgresql-*: bump to latest versions

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
-  version: "16.6"
-  epoch: 2
+  version: "16.8"
+  epoch: 0
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -52,7 +52,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 1f47e7b59b92c58eee6840325d1aaa6acee84194
+      expected-commit: 71eb35c0b18de96537bd3876ec9bf8075bfd484f
       repository: https://github.com/postgres/postgres
       tag: REL_${{vars.mangled-package-version}}
 

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
-  version: "17.2"
-  epoch: 2
+  version: "17.4"
+  epoch: 0
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -52,7 +52,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 6304632eaa2107bb1763d29e213ff166ff6104c0
+      expected-commit: f8554dee417ffc4540c94cf357f7bf7d4b6e5d80
       repository: https://github.com/postgres/postgres
       tag: REL_${{vars.mangled-package-version}}
 


### PR DESCRIPTION
These were manual until recently, which is why automation hasn't taken care of this (yet).