### PR TITLE
groff - split groff-base package out like debian and avoid perl dep.

### DIFF
--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -3,7 +3,7 @@
 package:
   name: aws-cli-2
   version: "2.24.10"
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ package:
     provides:
       - aws-cli=${{package.full-version}}
     runtime:
-      - groff
+      - groff-base
 
 environment:
   contents:

--- a/groff.yaml
+++ b/groff.yaml
@@ -1,10 +1,13 @@
 package:
   name: groff
   version: 1.23.0
-  epoch: 4
+  epoch: 5
   description: GNU troff text-formatting system
   copyright:
     - license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+      - groff-base
 
 environment:
   contents:
@@ -50,10 +53,75 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: groff-base
+    pipeline:
+      - runs: |
+          # contents of groff-base copied from debian (1.23.0) has these bins
+          # wolfi 1.23 did not have binaries geqn gpic or gtbl, so they are removed from the list.
+          # 'grog' is shipped by debian, but it is a perl script and I want to avoid the perl dep.
+          ver=${{package.version}}
+          moves="
+          usr/bin/eqn
+          usr/bin/groff
+          usr/bin/grops
+          usr/bin/grotty
+          usr/bin/neqn
+          usr/bin/nroff
+          usr/bin/pic
+          usr/bin/preconv
+          usr/bin/soelim
+          usr/bin/tbl
+          usr/bin/troff
+          usr/lib/groff/site-tmac
+          usr/share/groff/$ver/eign
+          usr/share/groff/$ver/font/devascii
+          usr/share/groff/$ver/font/devlatin1
+          usr/share/groff/$ver/font/devps
+          usr/share/groff/$ver/font/devutf8
+          usr/share/groff/current
+          usr/share/groff/site-tmac"
+
+          src=${{targets.destdir}}
+          dest=${{targets.contextdir}}
+          for move in ${moves}; do
+            d=${move%/*}
+            [ -d "$dest/$d" ] || mkdir -p "$dest/$d" || exit 1
+            echo "mv <destdir>/$move -> <contextdir>/$d"
+            mv "$src/$move" "$dest/$d"
+          done
+    test:
+      pipeline:
+        - name: "check --version for groff-base binaries"
+          runs: |
+            set +x
+            bins="eqn groff grops grotty neqn nroff pic preconv soelim tbl troff"
+            ver="${{package.version}}"
+            for bin in ${bins}; do
+              out=$($bin --version) ||
+                { echo "FAIL: $bin --version exited $?"; exit 1; }
+              echo "$out" | grep -q -F "$ver" || {
+                echo "FAIL: $bin --version did not include '$ver'"
+                echo "output: $out"
+                exit 1
+              }
+              echo "PASS: '$bin --version' contained version '$ver'"
+            done
+        - name: "check --help for groff-base binaries"
+          runs: |
+            set +x
+            bins="eqn groff grops grotty neqn nroff pic preconv soelim tbl troff"
+            for bin in ${bins}; do
+              echo "$ $bin --help"
+              $bin --help 2>&1 || { echo "FAIL: '$bin --help' exited $?"; exit 1; }
+            done
+
   - name: groff-doc
     pipeline:
       - uses: split/manpages
-    description: groff manpages
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share
+          mv ${{targets.destdir}}/usr/share/doc ${{targets.contextdir}}/usr/share/
+    description: groff manpages and doc
     test:
       pipeline:
         - uses: test/docs
@@ -75,7 +143,6 @@ test:
         addftinfo --version
         afmtodit --version
         chem --version
-        eqn --version
         eqn2graph --version
         gdiffmk --version
         gperl --version
@@ -83,67 +150,45 @@ test:
         grap2graph --version
         grn --version
         grodvi --version
-        groff --version
-        grog --version
         grolbp --version
         grolj4 --version
         gropdf --version
-        grops --version
-        grotty --version
         hpftodit --version
         indxbib --version
         lkbib --version
         lookbib --version
         mmroff --version
-        neqn --version
-        nroff --version
         pdfmom --version
         pdfroff --version
         pfbtops --version
-        pic --version
         pic2graph --version
         post-grohtml --version
         pre-grohtml --version
-        preconv --version
         refer --version
-        soelim --version
-        tbl --version
         tfmtodit --version
-        troff --version
         addftinfo --help
         afmtodit --help
         chem --help
-        eqn --help
         eqn2graph --help
         gperl --help
         gpinyin --help
         grap2graph --help
         grn --help
         grodvi --help
-        groff --help
         grog --help
         grolbp --help
         grolj4 --help
         gropdf --help
-        grops --help
-        grotty --help
         hpftodit --help
         indxbib --help
         lkbib --help
         lookbib --help
         mmroff --help
-        neqn --help
-        nroff --help
         pdfmom --help
         pdfroff --help
         pfbtops --help
-        pic --help
         pic2graph --help
         post-grohtml --help
         pre-grohtml --help
-        preconv --help
         refer --help
-        soelim --help
-        tbl --help
         tfmtodit --help
-        troff --help


### PR DESCRIPTION
installation of groff pulls in perl.
aws-cli-v2 uses groff to render help, and thus using it requires perl which is less than ideal.

Debian has a 'groff-base' package.  I've taken the list of files in their groff-base package and moved them into a groff-base package here, with a couple exceptions
1. our groff package did not (and do not) ship 3 symlinks (geqn gpic and gtbl). Each points to the non 'g' version (geqn -> eqn). I did not start creating those.
2. grog is a perl script and I wanted to avoid perl dependency, so I left it in the full package (groff).
