### PR TITLE
Remove the Swedish manpage from groff

### DIFF
--- a/groff.yaml
+++ b/groff.yaml
@@ -1,7 +1,7 @@
 package:
   name: groff
   version: 1.23.0
-  epoch: 3
+  epoch: 4
   description: GNU troff text-formatting system
   copyright:
     - license: GPL-3.0-or-later
@@ -43,6 +43,9 @@ pipeline:
       # Prevent conflict with mandoc-doc
       rm -f ${{targets.destdir}}/usr/share/man/man1/soelim.1 \
         ${{targets.destdir}}/usr/share/man/man7/roff.7
+      # Remove the Swedish translation of a man page
+      # https://github.com/wolfi-dev/os/issues/43212
+      rm -f ${{targets.destdir}}/usr/share/man/man7/groff_mmse.7
 
   - uses: strip
 


### PR DESCRIPTION
The Swedish man page is causing the test-doc pipeline to fail, https://github.com/wolfi-dev/os/issues/43212, so let's just not ship it for now.