### PR TITLE
Remove doc tests which actually fail

### DIFF
--- a/kmod.yaml
+++ b/kmod.yaml
@@ -66,9 +66,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: kmod manpages
-    test:
-      pipeline:
-        - uses: test/docs
 
   - name: kmod-libs
     pipeline:

--- a/owfs.yaml
+++ b/owfs.yaml
@@ -63,9 +63,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: owfs manpages
-    test:
-      pipeline:
-        - uses: test/docs
 
 update:
   enabled: true

--- a/perl-common-sense.yaml
+++ b/perl-common-sense.yaml
@@ -39,9 +39,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: perl-common-sense manpages
-    test:
-      pipeline:
-        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION
The test/docs pipeline was added to these packages with the understanding that they passed, however that understanding was incorrect and these actually failed! Let's remove the tests so we don't slow down other teams while we investigate why the tests are failing.