### PR TITLE
fontforge.yaml: Implement Python multiversioning

### DIFF
--- a/fontforge.yaml
+++ b/fontforge.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontforge
   version: "20230101"
-  epoch: 1
+  epoch: 2
   description: Free (libre) font editor
   copyright:
     - license: GPL-3.0-or-later
@@ -11,6 +11,17 @@ package:
       - libspiro
       - py3-setuptools
       - woff2-dev
+
+vars:
+  import: fontforge
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
@@ -29,7 +40,7 @@ environment:
       - libxml2-dev
       - pango-dev
       - potrace
-      - py3-setuptools
+      - py3-supported-build-base-dev
       - python3-dev
       - readline-dev
       - samurai
@@ -87,17 +98,51 @@ subpackages:
       pipeline:
         - uses: test/docs
 
-  - name: py3-fontforge
+  - range: py-versions
+    name: py${{range.key}}-fontforge
+    description: Python ${{range.key}} bindings for fontforge
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-fontforge
     pipeline:
       - runs: |
-          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
+          PYVER="${{range.key}}"
+          # See
+          # https://github.com/wolfi-dev/os/issues/41647#issuecomment-2655627111
+          # for an explanation on why this is done.
+          cd build
+          cmake \
+            -DPython3_EXECUTABLE=/usr/bin/python${PYVER} \
+            -DPYHOOK_INSTALL_DIR=lib/python${PYVER}/site-packages . || true
+          # The first invocation of cmake can fail, but calling it
+          # again works
+          cmake \
+            -DPython3_EXECUTABLE=/usr/bin/python${PYVER} \
+            -DPYHOOK_INSTALL_DIR=lib/python${PYVER}/site-packages .
+          make
+          make DESTDIR="${{targets.destdir}}" install
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/python${PYVER}/site-packages
           mkdir -p "${{targets.subpkgdir}}"/usr/share/fontforge/python
           # use find and exec to move them to the right place
           find ${{targets.destdir}}/usr/lib/python${PYVER}/site-packages -name "fontforge.so" -exec mv {} "${{targets.subpkgdir}}"/usr/lib/python${PYVER}/site-packages \;
           find ${{targets.destdir}}/usr/lib/python${PYVER}/site-packages -name "psMat.so" -exec mv {} "${{targets.subpkgdir}}"/usr/lib/python${PYVER}/site-packages \;
           mv ${{targets.destdir}}/usr/share/fontforge/python "${{targets.subpkgdir}}"/usr/share/fontforge/python
-    description: Python 3 bindings for fontforge
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: py3-supported-fontforge
+    description: meta package providing fontforge bindings for supported Python versions
+    dependencies:
+      runtime:
+        - py3.10-fontforge
+        - py3.11-fontforge
+        - py3.12-fontforge
+        - py3.13-fontforge
 
 update:
   enabled: true


### PR DESCRIPTION
Due to the way fontforge is built, and especially because it doesn't use any Python build system and relies on cmake instead, we have to do some workarounds to get everything properly built and linked against the correct libpython versions.

See https://github.com/wolfi-dev/os/issues/41647#issuecomment-2655627111 for an explanation of the approach taken here.