### PR TITLE
build(wolfictl): bump to v0.29.3

### DIFF
--- a/wolfictl.yaml
+++ b/wolfictl.yaml
@@ -1,6 +1,6 @@
 package:
   name: wolfictl
-  version: "0.29.2"
+  version: "0.29.3"
   epoch: 0
   description: Helper CLI for managing Wolfi
   copyright:
@@ -11,7 +11,7 @@ pipeline:
     with:
       repository: https://github.com/wolfi-dev/wolfictl
       tag: v${{package.version}}
-      expected-commit: e826f8dd819b7a4ea2e791d330df6741ecddaee4
+      expected-commit: a515e4b72325b205075e8caf0b90bd1adac3ff5a
 
   - uses: go/build
     with:


### PR DESCRIPTION
To pick up updates from https://github.com/wolfi-dev/wolfictl/releases/tag/v0.29.3.