### PR TITLE
feat: add polkit and duktape packages to wolfi

### DIFF
--- a/duktape.yaml
+++ b/duktape.yaml
@@ -1,0 +1,36 @@
+package:
+  name: duktape
+  version: "2.7.0"
+  epoch: 0
+  description: "Embeddable Javascript engine with a focus on portability and compact footprint"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 90f8d2fa8b5567c6899830ddef2c03f3c27960b11aca222fa17aa7ac613c2890
+      uri: https://github.com/svaarala/duktape/releases/download/v${{package.version}}/duktape-${{package.version}}.tar.xz
+
+  - runs: |
+      DESTDIR=${{targets.destdir}} INSTALL_PREFIX=/usr make -f Makefile.sharedlibrary install
+
+update:
+  enabled: true
+  github:
+    identifier: svaarala/duktape
+    strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
+    - uses: test/pkgconf

--- a/polkit.yaml
+++ b/polkit.yaml
@@ -1,0 +1,102 @@
+package:
+  name: polkit
+  version: "126"
+  epoch: 0
+  description: "A toolkit for defining and handling authorizations."
+  copyright:
+    - license: LGPL-2.0-or-later
+  dependencies:
+    runtime:
+      - dbus
+      - linux-pam
+      - systemd
+      - wolfi-base
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - dbus-dev
+      - duktape
+      - expat-dev
+      - gettext-dev
+      - glib-dev
+      - glib-gir
+      - gobject-introspection-dev
+      - linux-pam-dev
+      - meson
+      - perl
+      - systemd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d627b0d1e1108563658dabe3fb8d2a065e64df10
+      repository: https://github.com/polkit-org/polkit.git
+      tag: ${{package.version}}
+
+  - uses: meson/configure
+    with:
+      opts: |
+        -Dman=true \
+        -Dpam_prefix=/etc/pam.d \
+        -Dpam_module_dir=/usr/lib/security
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+subpackages:
+  - name: polkit-doc
+    pipeline:
+      - uses: split/manpages
+    dependencies:
+      runtime:
+        - polkit
+    description: polkit manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+  - name: polkit-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - polkit
+    description: polkit dev
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: ${{package.name}}
+        - uses: test/pkgconf
+
+  - name: polkit-lang
+    pipeline:
+      - uses: split/locales
+    dependencies:
+      runtime:
+        - polkit
+    description: polkit locales
+
+update:
+  enabled: true
+  github:
+    identifier: polkit-org/polkit
+
+test:
+  pipeline:
+    - runs: |
+        set -o pipefail
+        pkexec --version | grep "${{package.version}}"
+        pkexec --help
+        pkcheck --version | grep "${{package.version}}"
+        pkcheck --help
+        pkaction --version | grep "${{package.version}}"
+        pkaction --help
+        pkttyagent --version | grep "${{package.version}}"
+        pkttyagent --help


### PR DESCRIPTION
polkit is needed for certain functionality in systemd to correctly function. duktape is a dependency to build polkit. We are not establishing further polkit policies other than the default ones from upstream in this package.
