### PR TITLE
clamav: add clamav-docker subpackage

### DIFF
--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -46,10 +46,11 @@ var-transforms:
     to: major-minor-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 8c92f8ade2a8f2c9d6688d1d63ee57f6caf965d74dce06d0971c6709c8e6c04c
-      uri: https://www.clamav.net/downloads/production/clamav-${{package.version}}.tar.gz
+      repository: https://github.com/Cisco-Talos/clamav
+      tag: clamav-${{package.version}}
+      expected-commit: 98882f5f019ded3b96bacc17a9d1d65fb96dd686
 
   - uses: cmake/configure
     with:

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,10 +1,13 @@
 package:
   name: clamav-1.4
-  version: "1.4.2"
-  epoch: 0
+  version: 1.4.2
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
+  dependencies:
+    provides:
+      - clamav=${{package.full-version}}
 
 environment:
   contents:
@@ -31,6 +34,16 @@ environment:
       - zlib-dev
       # - clamav-scanner
       # - clamav-daemon
+
+vars:
+  CLAMAV_DOCKER_COMMIT: "658ba84dfb16f0a70ea6588c5da208e36962e678"
+  CLAMAV_DOCKER_HASH: "ef2284ba6d984eb249764ebff8d7b2989af668563d4bf8159701ca22121cf063"
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 pipeline:
   - uses: fetch
@@ -153,8 +166,6 @@ subpackages:
         - runs: |
             clamdscan --help
 
-  - name: c
-
   - name: clamav-scanner
     pipeline:
       - runs: |
@@ -235,6 +246,111 @@ subpackages:
         - runs: |
             clamav-milter --version
             clamav-milter --help
+
+  - name: ${{package.name}}-docker
+    description: Scripts needed to run ClamAV in a Docker container
+    dependencies:
+      runtime:
+        - bash
+        - json-c
+        - libbz2-1
+        - libcurl-openssl4
+        - libmilter
+        - libstdc++
+        - libxml2
+        - ncurses
+        - netcat-openbsd
+        - pcre2
+        - tini
+        - tzdata
+        - zlib
+      provides:
+        - clamav-docker=${{package.full-version}}
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://github.com/Cisco-Talos/clamav-docker
+          expected-commit: ${{vars.CLAMAV_DOCKER_COMMIT}}
+          tag: ""
+          branch: main
+      - name: Sanity check to ensure there is corresponding version
+        runs: |
+          if [ ! -d clamav/${{vars.major-minor-version}} ]; then
+            echo "No directory for version ${{vars.major-minor-version}}"
+            exit 1
+          fi
+      - name: Sanity check to ensure folder hash is matching
+        runs: |
+          expected_hash="${{vars.CLAMAV_DOCKER_HASH}}"
+          actual_hash=$(tar -cf - clamav/${{vars.major-minor-version}} | sha256sum | cut -d' ' -f1)
+          if [ "$expected_hash" != "$actual_hash" ]; then
+            echo "Hash mismatch for version ${{vars.major-minor-version}}. Expected $expected_hash, got $actual_hash. Please run 'git clone --depth=1 git@github.com:Cisco-Talos/clamav-docker.git && cd clamav-docker && tar -cf - clamav/1.4 | sha256sum' and update the CLAMAV_DOCKER_HASH variable"
+          fi
+      - name: Create directories
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          mkdir -p "${{targets.contextdir}}"/etc/clamav
+          mkdir -p "${{targets.contextdir}}"/var/lib/clamav
+          mkdir -p "${{targets.contextdir}}"/var/log/clamav
+          mkdir -p "${{targets.contextdir}}"/run/clamav
+          mkdir -p "${{targets.contextdir}}"/tmp
+          touch "${{targets.contextdir}}"/var/log/clamav/freshclam.log
+      - working-directory: clamav/${{vars.major-minor-version}}/alpine/scripts
+        runs: |
+          install -Dm755 docker-entrypoint-unprivileged.sh "${{targets.contextdir}}"/init-unprivileged
+          install -Dm755 docker-entrypoint.sh "${{targets.contextdir}}"/init
+          install -Dm755 clamdcheck.sh "${{targets.contextdir}}"/usr/local/bin/clamdcheck.sh
+      - name: Patch files
+        runs: |
+          sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
+    test:
+      environment:
+        contents:
+          packages:
+            - clamav-daemon
+            - clamav-db
+            - clamav-libunrar
+            - clamav-milter
+            - freshclam
+        accounts:
+          groups:
+            - groupname: clamav
+              gid: 100
+          users:
+            - username: clamav
+              gid: 100
+              uid: 100
+          run-as: 0
+        environment:
+          TINI_SUBREAPER: 1
+      pipeline:
+        - name: "Test clamdcheck"
+          uses: test/daemon-check-output
+          with:
+            start: "/usr/local/bin/clamdcheck.sh"
+            timeout: 60
+            error_strings: |
+              FAIL
+              FATAL
+              Traceback.*most.recent.call
+              Exception in thread
+              java.lang.NullPointerException
+              java.lang.RuntimeException
+              Gem::MissingSpecError
+              command not found
+              No such file or directory
+            expected_output: |
+              Unable to contact server
+        # this test will fail locally with run-as set to 0, but pass pipeline.
+        # switch to run-as: 100 if running locally.
+        - name: "Test init"
+          uses: test/daemon-check-output
+          with:
+            setup: /usr/local/bin/clamdcheck.sh &
+            start: "exec tini -s /init > /proc/1/fd/1 2>&1 & sleep 10 && echo 'ok' && sleep 5"
+            timeout: 60
+            expected_output: |
+              ok
 
 update:
   enabled: true

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -21,6 +21,7 @@ environment:
       - check-dev
       - cmake
       - curl-dev
+      - gnutar
       - json-c-dev
       - libmilter-dev
       - libmspack-dev
@@ -37,7 +38,7 @@ environment:
 
 vars:
   CLAMAV_DOCKER_COMMIT: "658ba84dfb16f0a70ea6588c5da208e36962e678"
-  CLAMAV_DOCKER_HASH: "ef2284ba6d984eb249764ebff8d7b2989af668563d4bf8159701ca22121cf063"
+  CLAMAV_DOCKER_HASH: "5dff45927bd503dfaf71ff8daa541d1bb6fda2c695261e589bf1302fabb03ebe"
 
 var-transforms:
   - from: ${{package.version}}
@@ -283,9 +284,11 @@ subpackages:
       - name: Sanity check to ensure folder hash is matching
         runs: |
           expected_hash="${{vars.CLAMAV_DOCKER_HASH}}"
-          actual_hash=$(tar -cf - clamav/${{vars.major-minor-version}} | sha256sum | cut -d' ' -f1)
+          actual_hash=$(tar --sort=name --mtime='1970-01-01' --owner=0 --group=0 --numeric-owner -cf - clamav/${{vars.major-minor-version}} | sha256sum | cut -d' ' -f1)
           if [ "$expected_hash" != "$actual_hash" ]; then
             echo "Hash mismatch for version ${{vars.major-minor-version}}. Expected $expected_hash, got $actual_hash. Please run 'git clone --depth=1 git@github.com:Cisco-Talos/clamav-docker.git && cd clamav-docker && tar -cf - clamav/1.4 | sha256sum' and update the CLAMAV_DOCKER_HASH variable"
+            echo "Please run 'git clone --depth=1 git@github.com:Cisco-Talos/clamav-docker.git && cd clamav-docker && tar -cf - clamav/1.4 | sha256sum' and update the CLAMAV_DOCKER_HASH variable."
+            exit 1
           fi
       - name: Create directories
         runs: |


### PR DESCRIPTION
Adds `clamav-docker` subpackage: https://github.com/Cisco-Talos/clamav-docker/tree/main