### PR TITLE
kafka-3.9/GHSA-4g8c-wm8x-jfhw-fix

### DIFF
--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-3.9
   version: 3.9.0
-  epoch: 1
+  epoch: 2
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -36,7 +36,9 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 84caaa6e9da06435411510a81fa321d4f99c351f
-
+  - uses: patch
+    with:
+      patches: GHSA-4g8c-wm8x-jfhw-fix.patch
   - runs: |
       gradle clean releaseTarGz
 

--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -36,9 +36,11 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 84caaa6e9da06435411510a81fa321d4f99c351f
+
   - uses: patch
     with:
       patches: GHSA-4g8c-wm8x-jfhw-fix.patch
+
   - runs: |
       gradle clean releaseTarGz
 

--- a/kafka-3.9/GHSA-4g8c-wm8x-jfhw-fix.patch
+++ b/kafka-3.9/GHSA-4g8c-wm8x-jfhw-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index b19822149c..fe67d66315 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -141,7 +141,7 @@ versions += [
+   lz4: "1.8.0",
+   mavenArtifact: "3.9.6",
+   metrics: "2.2.0",
+-  netty: "4.1.111.Final",
++  netty: "4.1.118.Final",
+   opentelemetryProto: "1.0.0-alpha",
+   protobuf: "3.25.5", // a dependency of opentelemetryProto
+   pcollections: "4.0.1",


### PR DESCRIPTION
Found no interdependency conflicts in any of the kafka branches as it is just used for zookeeper, so am patching the gradle dependency. This will change for later releases of 3.9 as they will be restructuring how this dependency is read as seen here: https://github.com/apache/kafka/pull/18450