### PR TITLE
libffi: Install PIC copy of static lib

### DIFF
--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: "3.4.7"
-  epoch: 0
+  epoch: 1
   description: "portable foreign function interface library"
   copyright:
     - license: MIT
@@ -33,6 +33,10 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - runs: |
+      # Lifted from Debian - provide an -fPIC option for linking
+      cp -p .libs/libffi_convenience.a ${{targets.destdir}}/usr/lib64/libffi_pic.a
 
   - uses: strip
 


### PR DESCRIPTION
For bootstrapping PyPy.
