### PR TITLE
logstash-8/GHSA-7fc5-f82f-cx69/GHSA-7g2v-jj9q-g3rg/GHSA-vvfq-8hwr-qm4m/GHSA-5mwf-688x-mr7x fixes

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -312,7 +312,7 @@ subpackages:
                 post: |
                   #!/bin/sh -e
                   url=http://localhost:8080
-                  response=$(curl -fsS --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$url") || {
+                  response=$(curl -fsS --connect-timeout 10 --max-time 20 --retry 5 --retry-delay 1 --retry-max-time 40 "$url") || {
                     echo "curl ${url} failed $?"
                     exit 1
                   }

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.17.2"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -82,10 +82,14 @@ pipeline:
   - name: Patch sources
     runs: |
       echo "gem 'fugit', '1.11.1'" >> Gemfile.template
-      echo "gem 'rexml', '3.3.9'" >> Gemfile.template
-      echo "gem 'puma', '6.4.3'" >> Gemfile.template
-      echo "gem 'sinatra', '4.1.0'" >> Gemfile.template
-      echo "gem 'logstash-integration-kafka', '11.5.3'" >> Gemfile.template
+      echo "gem 'rexml', '3.4.1'" >> Gemfile.template
+      echo "gem 'puma', '6.6.0'" >> Gemfile.template
+      echo "gem 'sinatra', '4.1.1'" >> Gemfile.template
+      echo "gem 'logstash-integration-kafka', '11.6.0'" >> Gemfile.template
+      echo "gem 'rack', '3.1.10'" >> Gemfile.template
+      echo "gem 'net-imap', '0.5.6'" >> Gemfile.template
+      # Fix GHSA-xc9x-jj77-9p9j
+      sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json


### PR DESCRIPTION
The following version bumps have been investigated to cause no dependency conflicts and are required to remediate the following CVEs: GHSA-7fc5-f82f-cx69/GHSA-7g2v-jj9q-g3rg/GHSA-vvfq-8hwr-qm4m/GHSA-5mwf-688x-mr7x