### PR TITLE
fix(rabbitmq-server-4.0): --formatter json broken

### DIFF
--- a/rabbitmq-server-4.0.yaml
+++ b/rabbitmq-server-4.0.yaml
@@ -144,3 +144,14 @@ test:
     - runs: |
         rabbitmq-plugins version
         rabbitmq-plugins --version
+    #- name: Run RabbitMQ server
+    #  runs: |
+    #    mkdir /var/log/rabbitmq
+    #    mkdir /var/lib/rabbitmq
+    #    adduser rabbitmq
+    #    chown rabbitmq:rabbitmq -R /var/log/rabbitmq
+    #    chown rabbitmq:rabbitmq -R /var/lib/rabbitmq
+    #    su rabbitmq -c sh -c "RABBITMQ_ADVANCED_CONFIG_FILE=/etc/rabbitmq/advanced.config RABBITMQ_CONFIG_FILE=/etc/rabbitmq/rabbitmq.conf RABBITMQ_CONF_ENV_FILE=/etc/rabbitmq/rabbitmq-env.conf /usr/sbin/rabbitmq-server"
+    #- name: Test JSON formatter
+    #  runs: |
+    #    su rabbitmq -c sh -c 'ELIXIR_ERL_OPTIONS="+fn" /usr/lib/rabbitmq/bin/rabbitmq-diagnostics environment --formatter json'

--- a/rabbitmq-server-4.0.yaml
+++ b/rabbitmq-server-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-4.0
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -21,7 +21,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - elixir
+      - elixir-1.17
       # pinning to version 26 for now as erlang-27 is causing performance issues according to upstream. https://www.rabbitmq.com/docs/which-erlang#erlang-27-support
       - erlang-26
       - erlang-26-dev


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/rabbitmq-server/+bug/2097790

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
