### PR TITLE
rsyslog - set runstatedir to /run rather than default of /var/run.

### DIFF
--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: 8.2412.0
-  epoch: 2
+  epoch: 3
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0
@@ -55,6 +55,8 @@ environment:
       - util-linux-dev
       - valgrind-dev
       - zlib-dev
+  environment:
+    PID_FILE_PATH: /run/rsyslogd.pid
 
 data:
   - name: plugins
@@ -144,7 +146,8 @@ pipeline:
         --enable-mmsnmptrapd \
         --enable-omrabbitmq \
         --enable-omhiredis \
-        --enable-imdocker
+        --enable-imdocker \
+        --runstatedir=/run
 
   - uses: autoconf/make
 
@@ -152,9 +155,6 @@ pipeline:
 
   - runs: |
       make check
-      # rsyslogd will default to pid files in /var/run
-      mkdir -p ${{targets.destdir}}/var
-      ln -sf ../run ${{targets.destdir}}/var/run # We probably want to move this to wolfi-baselayout
 
   - uses: strip
 
@@ -246,6 +246,20 @@ test:
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}
+    - name: "check rsyslog config"
+      runs: |
+        rsyslogd -N1 >out 2>&1 || {
+          echo "FATAL: rsyslogd -N1 exited $?. output:"
+          sed 's/^/> /' out
+          exit 1
+        }
+
+        grep -q "validation run" out || {
+          echo "FATAL: rsyslogd -N1 output did not contain 'validation run'. output:"
+          sed 's/^/> /' out
+          exit 1
+        }
+        rm -f out
     - name: Test rsyslogd
       uses: test/daemon-check-output
       with:
@@ -253,4 +267,3 @@ test:
         timeout: 5
         expected_output: |
           RSYSLOGD INITIALIZED
-        post: rsyslogd -N1 2>&1 | grep -qi "validation run"


### PR DESCRIPTION
The symlink here was causing issues on installation via apko. Rather just tell rsyslog to use /run for state.
