### PR TITLE
daemon-check-output - do not just exit failure if kill fails.

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -52,7 +52,7 @@ pipeline:
       # then wait up to stime seconds for pid to die.
       # if it is still alive after ktime more seconds, SIGKILL it.
       term_wait_kill() {
-        local pid="$1" ttime="$2" ktime="$3" n=""
+        local pid="$1" ttime="$2" ktime="$3" n="" killrc="0"
         n=0
         [ -d "/proc/$pid" ] || {
           info "twk: pid $pid did not exist"
@@ -69,8 +69,8 @@ pipeline:
             info "twk: pid $pid died on its own within $n seconds"
             return 0
         fi
-        kill -TERM "$pid"
-        info "twk: SIGTERM sent to pid $pid. kill returned $?."
+        kill -TERM "$pid" || killrc=$?
+        info "twk: SIGTERM sent to pid $pid. kill returned $killrc."
         n=0
         while [ $n -lt $ktime ] && n=$((n+1)); do
             if [ ! -d "/proc/$pid" ]; then
@@ -83,8 +83,8 @@ pipeline:
             info "twk: pid $pid exited within $n seconds after SIGTERM"
             return 0
         fi
-        kill -KILL "$pid"
-        info "twk: SIGKILL sent to pid $pid [kill returned $?]"
+        kill -KILL "$pid" || killrc=$?
+        info "twk: SIGKILL sent to pid $pid [kill returned $killrc]"
         return 0
       }
 


### PR DESCRIPTION
We would not expect for 'kill' to fail here, but becauase of 'set -e' execution if it does we don't catch that error.  The logs clearly expected to continue on.

I did actually see this failure path in test of rsyslog in bwrap. The daemon would start and be running, but 'kill' would fail with permission denied.

The change here just makes the script continue as it was obviously expecting to do.
