### PR TITLE
Fix libeconf and enable `test/pkgconf` pipeline

### DIFF
--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -23,7 +23,9 @@ pipeline:
       repository: https://github.com/openSUSE/libeconf
       tag: v${{package.version}}
 
-  - runs: meson build
+  - uses: meson/configure
+    with:
+      output-dir: build
 
   - runs: ninja -C build
 

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libeconf
   version: "0.7.7"
-  epoch: 0
+  epoch: 1
   description: Enhanced Config File Parser
   copyright:
     - license: MIT

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -32,8 +32,7 @@ pipeline:
   - runs: DESTDIR="${{targets.destdir}}" ninja -C build install
 
 subpackages:
-  - range: ""
-    name: libeconf-dev
+  - name: libeconf-dev
     pipeline:
       - uses: split/dev
     dependencies:

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -39,6 +39,9 @@ subpackages:
       runtime:
         - libeconf
     description: libeconf dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true
@@ -48,6 +51,7 @@ update:
 
 test:
   pipeline:
+    - uses: test/pkgconf
     - name: "Verify econftool availability"
       runs: |
         econftool --help


### PR DESCRIPTION
libeconf currently installs its files under `/usr/local` due to the fact that it invokes `meson build` without passing any prefix.  Fix it by relying on the `meson/configure` pipeline.

Moreover, add the `test/pkgconf` pipeline to its tests (both for subpackages and for the main package).

Fixes: #37189 