### PR TITLE
logstash-input-beats: introduce new package

### DIFF
--- a/logstash-input-beats.yaml
+++ b/logstash-input-beats.yaml
@@ -1,0 +1,66 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-input-beats
+  version: 6.9.3
+  epoch: 0
+  description: Logstash Beats Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-input-beats
+      tag: v${{package.version}}
+      expected-commit: 089d663ba9e7f384761dd57679d8624ee7990393
+  - runs: |
+      # `s.platform = java` causes installation failures later
+      sed -i '/s.platform = /d' ${{vars.gem}}.gemspec
+
+      ./gradlew vendor
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-input-beats
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v6


### PR DESCRIPTION
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates