### PR TITLE
logstash-input-{http,tcp}: introduce new plugins

### DIFF
--- a/logstash-input-http.yaml
+++ b/logstash-input-http.yaml
@@ -1,0 +1,66 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-input-http
+  version: 3.10.2
+  epoch: 0
+  description: Logstash http Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-input-http
+      tag: v${{package.version}}
+      expected-commit: e31da10fe36c000859f2feb3145c454948e37a97
+  - runs: |
+      # `s.platform = java` causes installation failures later
+      sed -i '/s.platform = /d' ${{vars.gem}}.gemspec
+
+      ./gradlew vendor
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-input-http
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v3

--- a/logstash-input-tcp.yaml
+++ b/logstash-input-tcp.yaml
@@ -1,0 +1,66 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-input-tcp
+  version: 6.4.6
+  epoch: 0
+  description: Logstash tcp Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-input-tcp
+      tag: v${{package.version}}
+      expected-commit: 5a458bc98e0ddc6b391003830886849a7fa5a4be
+  - runs: |
+      # `s.platform = java` causes installation failures later
+      sed -i '/s.platform /d' ${{vars.gem}}.gemspec
+
+      ./gradlew vendor
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-input-tcp
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v6


### PR DESCRIPTION
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates