### PR TITLE
kube-fluentd-operator/GHSA-7fc5-f82f-cx69 fix

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 22
+  epoch: 23
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -78,6 +78,8 @@ pipeline:
       echo "gem 'google-protobuf', '3.25.5'" >> Gemfile
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'webrick', '1.8.2'" >> Gemfile
+      # bump net-imap to mitigate GHSA-7fc5-f82f-cx69
+      sed -i 's/net-imap (0\.3\.7)/net-imap (0.3.8)/' Gemfile.lock
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       bundle update rack
       bundle install


### PR DESCRIPTION
The remediation for this CVE is a version bump from 0.3.7 to 0.3.8 which required modification of the gemfile.