### PR TITLE
Allow tests to pass extra library paths to `ldd-check` & fix neon

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "7930"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0
@@ -65,6 +65,9 @@ pipeline:
       # neon where to find the postgres binaries.
       # POSTGRES_DISTRIB_DIR=/usr/libexec
       mkdir -p "${{targets.destdir}}"/usr/libexec/neon
+
+      # When updating these paths, don't forget to update the
+      # "extra_library_paths" parameter of the ldd-check test.
       mv pg_install/v14 "${{targets.destdir}}"/usr/libexec/neon/v14
       mv pg_install/v15 "${{targets.destdir}}"/usr/libexec/neon/v15
       mv pg_install/v16 "${{targets.destdir}}"/usr/libexec/neon/v16
@@ -110,3 +113,7 @@ test:
       runs: |
         storage_broker --version
         storage_broker --help
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
+        extra_library_paths: "/usr/libexec/neon/v14/lib:/usr/libexec/neon/v15/lib:/usr/libexec/neon/v16/lib"

--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -20,6 +20,10 @@ inputs:
       Should the full ldd output be shown
     required: false
     default: false
+  extra_library_paths:
+    description: |
+      Extra paths that should be added to LD_LIBRARY_PATH
+    required: false
 
 pipeline:
   - name: "check for missing library dependencies using ldd"
@@ -40,6 +44,7 @@ pipeline:
       files="${{inputs.files}}"
       packages="${{inputs.packages}}"
       VERBOSE="${{inputs.verbose}}"
+      extra_library_paths="${{inputs.extra_library_paths}}"
       case "$VERBOSE" in
         true|false) :;;
         *) error "VERBOSE must be 'true' or 'false'. found '$VERBOSE'";;
@@ -51,6 +56,10 @@ pipeline:
       vmsg() {
         [ "$VERBOSE" = "false" ] || echo "$@"
       }
+
+      if [ -n "$extra_library_paths" ]; then
+        vmsg "Testing with extra library paths: $extra_library_paths"
+      fi
 
       failormsg() {
         local cond="$1" msg="$2"
@@ -82,7 +91,7 @@ pipeline:
       check_file() {
         local f="$1" insist_dyn="$2" rc="0"
         local outf="$tmpd/ldd.stdout" errf="$tmpd/ldd.sterr"
-        local ld_library_path=$LD_LIBRARY_PATH
+        local ld_library_path="$extra_library_paths:"
 
         if [ ! -e "$f" ]; then
           failormsg "$insist_dyn" "$f: did not exist"
@@ -95,12 +104,11 @@ pipeline:
 
         case "$f" in
           *python*site-packages*)
-            [ -n "$ld_library_path" ] && ld_library_path=$ld_library_path:
-            ld_library_path=$(dirname "$f")
+            ld_library_path="$(dirname "$f"):$ld_library_path"
             vmsg "Added python site package directory to ld_library_path, result is $ld_library_path"
         esac
 
-        LD_LIBRARY_PATH=$ld_library_path ldd "$f" >$outf 2>$errf || rc=$?
+        LD_LIBRARY_PATH="$ld_library_path:$LD_LIBRARY_PATH" ldd "$f" >$outf 2>$errf || rc=$?
 
         if [ $rc -eq 1 ]; then
           if grep -q 'not a dynamic executable' "$errf"; then


### PR DESCRIPTION
neon is currently failing `ldd-check` because it installs libraries under non standard locations (`/usr/libexec`).  We'll need to pass these paths to `LD_LIBRARY_PATH` in order to properly check these libs.

I decided to implement a new parameter to `ldd-check` called `extra_library_paths`, which takes a colon-separated list of paths that will be added to `LD_LIBRARY_PATH` before running tests.

This PR also includes a commit to enable `ldd-check` on neon and make sure that it passes the correct paths via `extra_library_paths`.

Fixes: #40839 
Relates: #40629 