### PR TITLE
Make Foundations squad code owners of CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Require review by repo owners of changes to CODEOWNERS
-CODEOWNERS @wolfi-dev/wolfi-owners
+CODEOWNERS @wolfi-dev/foundations-squad
 
 # Makefile and pipeline changes require approval of the Guarded OS squad.
 Makefile   @wolfi-dev/foundations-squad


### PR DESCRIPTION
Given that the Foundations team is the Guardians of the OS we should be the code owners of the CODEOWNERS.