### PR TITLE
add more separated logstash plugins

### DIFF
--- a/logstash-input-elastic_serverless_forwarder.yaml
+++ b/logstash-input-elastic_serverless_forwarder.yaml
@@ -1,0 +1,64 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-input-elastic_serverless_forwarder
+  version: 1.0.0
+  epoch: 0
+  description: Logstash elastic_serverless_forwarder Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder
+      tag: v${{package.version}}
+      expected-commit: 88e6cd2bd293531f8e499ca84c7d8557efeb1f78
+  - runs: |
+      # `s.platform = java` causes installation failures later
+      sed -i '/s.platform /d' ${{vars.gem}}.gemspec
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-input-elastic_serverless_forwarder
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v1

--- a/logstash-input-graphite.yaml
+++ b/logstash-input-graphite.yaml
@@ -1,0 +1,61 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-input-graphite
+  version: 3.0.6
+  epoch: 0
+  description: Logstash graphite Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-input-graphite
+      tag: v${{package.version}}
+      expected-commit: 5f832c01ab149160a3afb45a8e63781f08990344
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-input-graphite
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v3

--- a/logstash-integration-logstash.yaml
+++ b/logstash-integration-logstash.yaml
@@ -1,0 +1,63 @@
+#
+# WARNING: Due to the way logstash loads plugins we have to load this package
+#          at build time. That means the logstash package must be rebuilt to
+#          pick up changes from this package. Simply building and publishing
+#          a new version of this package is not enough to land changes.
+#
+# tl;dr: If you're touching this package please also rebuild logstash!!
+#
+package:
+  name: logstash-integration-logstash
+  version: 1.0.4
+  epoch: 0
+  description: Logstash logstash Plugin
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - jruby-9.4-default-ruby
+      - openjdk-17-default-jdk
+
+# Do not run ruby/clean as logstash needs the cached gem file to install
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-integration-logstash
+      tag: v${{package.version}}
+      expected-commit: d2e35f4d39a4c78c737934d21884abb05d6cd99b
+  - runs: |
+      # `s.platform = java` causes installation failures later
+      sed -i '/s.platform /d' ${{vars.gem}}.gemspec
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+vars:
+  gem: logstash-integration-logstash
+
+test:
+  environment:
+    contents:
+      packages:
+        - logstash
+        - openjdk-17-default-jvm
+        - jruby-9.4
+  pipeline:
+    - runs: |
+        logstash-plugin install $(find / -type f -name "${{package.name}}-*.gem")
+        logstash-plugin list | grep ${{package.name}}
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v


### PR DESCRIPTION
These are required to avoid pulling in vulnerable plugins transitively.