### PR TITLE
Add the pkgconf test to percona-server-9.0-dev

### DIFF
--- a/percona-server-9.0.yaml
+++ b/percona-server-9.0.yaml
@@ -136,6 +136,9 @@ subpackages:
     description: "headers for percona-server"
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: ${{package.name}}-oci-entrypoint
     description: Entrypoint for using Percona Server in OCI containers


### PR DESCRIPTION
The linter told me to add the test:

`2025-02-21T22:56:27Z WARN 🔗 linter "pkgconf" failed on package "percona-server-9.0-dev": pkgconfig directory found: usr/lib/pkgconfig/perconaserverclient.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline`

So I did and it passed:

```

2025/02/21 16:01:09 INFO running step "pkgconf build dependency check"
2025/02/21 16:01:09 WARN + '[' -d /home/build ]
2025/02/21 16:01:09 WARN + cd /home/build
2025/02/21 16:01:09 WARN + basename /home/build/melange-out/percona-server-9.0-dev
2025/02/21 16:01:09 WARN + dev_pkg=percona-server-9.0-dev
2025/02/21 16:01:09 WARN + cd /
2025/02/21 16:01:09 WARN + pc_files=false
2025/02/21 16:01:09 WARN + apk info -L percona-server-9.0-dev
2025/02/21 16:01:09 WARN + grep '\.pc$'
2025/02/21 16:01:09 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory
2025/02/21 16:01:09 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory
2025/02/21 16:01:09 WARN + pc_files=true
2025/02/21 16:01:09 WARN + grep -q ^Name: usr/lib/pkgconfig/perconaserverclient.pc
2025/02/21 16:01:09 WARN + basename usr/lib/pkgconfig/perconaserverclient.pc .pc
2025/02/21 16:01:09 WARN + lib_name=perconaserverclient
2025/02/21 16:01:09 WARN + echo usr/lib/pkgconfig/perconaserverclient.pc
2025/02/21 16:01:09 WARN + grep -q '^usr/lib/pkgconfig/perconaserverclient.pc$\|^usr/share/pkgconfig/perconaserverclient.pc$'
2025/02/21 16:01:09 WARN + pkgconf --exists perconaserverclient
2025/02/21 16:01:09 WARN + grep -q ^Version: usr/lib/pkgconfig/perconaserverclient.pc
2025/02/21 16:01:09 WARN + pkgconf --modversion perconaserverclient
2025/02/21 16:01:09 INFO 24.1.1
2025/02/21 16:01:09 WARN + grep -q ^Libs: usr/lib/pkgconfig/perconaserverclient.pc
2025/02/21 16:01:09 WARN + pkgconf --libs perconaserverclient
2025/02/21 16:01:09 INFO -lperconaserverclient
2025/02/21 16:01:09 WARN + grep -q ^Cflags: usr/lib/pkgconfig/perconaserverclient.pc
2025/02/21 16:01:09 WARN + pkgconf --cflags perconaserverclient
2025/02/21 16:01:09 INFO -I/usr/include/mysql
2025/02/21 16:01:09 WARN + '[' true '=' false ]
2025/02/21 16:01:09 WARN + exit 0
```