### PR TITLE
oauth2-proxy/CVE-2025-22866 fix

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: "7.8.1"
-  epoch: 1
+  epoch: 2
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT


### PR DESCRIPTION
A rebuild fixes the above CVE for the affected packages