### PR TITLE
fix(ffmpeg-dev): Always pull in ffmpeg

### DIFF
--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -2,11 +2,12 @@
 package:
   name: ffmpeg
   version: 7.1
-  epoch: 4
+  epoch: 5
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
   dependencies:
+    provider-priority: 5
     runtime:
       - libavcodec61=${{package.full-version}}
       - libavdevice61=${{package.full-version}}
@@ -121,6 +122,8 @@ subpackages:
   - range: libraries
     name: ${{range.key}}
     description: "${{range.value}} library"
+    dependencies:
+      provider-priority: 5
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -132,6 +135,10 @@ subpackages:
     description: ffmpeg static libraries
 
   - name: ffmpeg-dev
+    dependencies:
+      runtime:
+        - ffmpeg
+        - ffmpeg-static
     pipeline:
       - uses: split/dev
     description: ffmpeg development headers


### PR DESCRIPTION
Its possible to resolve to ffmpeg-cuda instead of ffmpeg when library versions align so explicitly depend on ffmpeg

Also set provider priority going forward