### PR TITLE
vitess-21.0/GHSA-67mh-4wv8-2f99 fix

### DIFF
--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.3"
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -76,6 +76,7 @@ pipeline:
       npm pkg set overrides.nanoid=3.3.8
       npm pkg set overrides.ip=2.0.1
       npm pkg set overrides.tar=6.2.1
+      npm pkg set overrides.esbuild=0.25.0
 
   - name: Build web UI
     working-directory: web/vtadmin

--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -71,8 +71,8 @@ pipeline:
   - name: Add dependency overrides
     working-directory: web/vtadmin
     runs: |
-      npm pkg set overrides.cookie=0.7.0
-      npm pkg set overrides['get-func-name']=2.0.1
+      npm pkg set overrides.cookie=0.7.2
+      npm pkg set overrides['get-func-name']=2.0.2
       npm pkg set overrides.nanoid=3.3.8
       npm pkg set overrides.ip=2.0.1
       npm pkg set overrides.tar=6.2.1


### PR DESCRIPTION
Adding esbuild=0.25.0 to npm overrides allows the fix version of esbuild to be used, remediating this CVE. Also updated versions where applicable for pinned dependencies.