### PR TITLE
add sts policy for the cve-patch-forge service

### DIFF
--- a/.github/chainguard/lifecycle-cve-patch-forge.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-patch-forge.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://accounts.google.com
+
+# cve-patch-forge-u2rgji37hclon9@staging-enforce-cd1e.iam.gserviceaccount.com
+subject_pattern: "(116008995223794447520)"
+
+permissions:
+  contents: read 


### PR DESCRIPTION
This service just needs to clone the repository for the moment.