### PR TITLE
fix(linux-pam): cleanup /var/run, avoid conflicting packages

### DIFF
--- a/linux-pam.yaml
+++ b/linux-pam.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-pam
   version: 1.7.0
-  epoch: 3
+  epoch: 4
   description: Linux PAM (Pluggable Authentication Modules for Linux)
   copyright:
     - license: BSD-3-Clause
@@ -50,8 +50,8 @@ pipeline:
       chgrp shadow ${{targets.destdir}}/sbin/unix_chkpwd \
         && chmod g+s ${{targets.destdir}}/sbin/unix_chkpwd
 
-      # we don't ship systemd
-      rm -r ${{targets.destdir}}/usr/lib/systemd
+      # Don't ship /var/run
+      rm -r ${{targets.destdir}}/var/run
 
 subpackages:
   - name: linux-pam-dev


### PR DESCRIPTION
Some other packages may conflict if we find var/run already there
clean this up, it has empty files only anyway