### PR TITLE
fix(rabbitmq-server-4.0): Pin to elixir 1.17 and bump to erlang 27

### DIFF
--- a/rabbitmq-server-4.0.yaml
+++ b/rabbitmq-server-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-4.0
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -11,7 +11,7 @@ package:
     runtime:
       # rabbitmq-server is a wrapper shell script.
       - busybox
-      - erlang-26
+      - erlang-27
 
 environment:
   contents:
@@ -21,10 +21,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - elixir
-      # pinning to version 26 for now as erlang-27 is causing performance issues according to upstream. https://www.rabbitmq.com/docs/which-erlang#erlang-27-support
-      - erlang-26
-      - erlang-26-dev
+      - elixir-1.17
+      - erlang-27-dev
       - libxslt
       - python3
       - rsync


### PR DESCRIPTION
Upstream hasn't moved to 1.18 yet, and erlang 27 is currently supported. Performance regressions don't appear to be documented anymore so assuming those have been addressed