### PR TITLE
Add the pkgconf test to libffi

### DIFF
--- a/libffi.yaml
+++ b/libffi.yaml
@@ -52,6 +52,7 @@ subpackages:
           packages:
             - build-base
       pipeline:
+        - uses: test/pkgconf
         - name: Basic closure test
           runs: |
             echo '#include <stdio.h>' > test_closure.c
@@ -64,6 +65,7 @@ subpackages:
 
   - name: "libffi-pic-dev"
     pipeline:
+      - uses: test/pkgconf
       - runs: |
           rm -rf "${{targets.contextdir}}"
           cp -a save-for-pic-dev "${{targets.contextdir}}"

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: "3.4.7"
-  epoch: 2
+  epoch: 3
   description: "portable foreign function interface library"
   copyright:
     - license: MIT


### PR DESCRIPTION
This was discovered to be missing by the pkgconf linter.

```
2025-02-24T15:55:26Z WARN 🔗 linter "pkgconf" failed on package "libffi-dev": pkgconfig directory found: usr/lib/pkgconfig/libffi.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline
2025-02-24T15:55:26Z WARN 🔗 linter "pkgconf" failed on package "libffi-pic-dev": pkgconfig directory found: usr/lib/pkgconfig/libffi.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline
```