### PR TITLE
Add the pkgconf test to percona-server-9.1

### DIFF
--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -136,6 +136,9 @@ subpackages:
     description: "headers for percona-server"
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: ${{package.name}}-oci-entrypoint
     description: Entrypoint for using Percona Server in OCI containers

--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.1
   version: "9.1.0.1"
-  epoch: 0
+  epoch: 1
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
The build logs said I should add the pkgconf test to this package:

```
2025-02-24T15:10:00Z WARN 🔗 linter "pkgconf" failed on package "percona-server-9.1-dev": pkgconfig directory found: usr/lib/pkgconfig/perconaserverclient.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline
```