### PR TITLE
Add the pkgconf test to qemu

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: "9.2.2"
-  epoch: 0
+  epoch: 1
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -172,6 +172,7 @@ subpackages:
 
 test:
   pipeline:
+    - uses: test/pkgconf
     - runs: |
         for i in /usr/bin/qemu-system-*; do
           $i --help 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"


### PR DESCRIPTION
The build logs told me to add this so I did:

```
2025-02-24T12:10:23Z WARN 🔗 linter "pkgconf" failed on package "qemu": pkgconfig directory found: usr/lib/pkgconfig/libfdt.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline
```