### PR TITLE
feat: rsass 0.29.0: new package

### DIFF
--- a/rsass.yaml
+++ b/rsass.yaml
@@ -1,0 +1,46 @@
+package:
+  name: rsass
+  version: 0.29.0
+  epoch: 0
+  description: "A Rust-based Sass compiler"
+  copyright:
+    - license: MIT
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kaj/rsass.git
+      tag: v${{package.version}}
+      expected-commit: a84c34aa4246d324d8adbeff10d8964aedd7c78c
+
+  - name: Build
+    uses: cargo/build
+    with:
+      modroot: .
+      output: rsass
+
+test:
+  pipeline:
+    - runs: |
+        rsass --version | grep -E "rsass-cli ${{package.version}}$"
+    - name: Render test SASS file
+      runs: |
+        # Create a test SASS file
+        mkdir -p /tmp/scss
+        cat > /tmp/scss/test.scss <<EOF
+        \$primary-color: blue;
+        body {
+        background-color: \$primary-color;
+        }
+        EOF
+        # Render the test SASS file to CSS
+        rsass /tmp/scss/test.scss > /tmp/scss/test.css
+        # Check the rendered CSS file
+        grep 'background-color: blue;' /tmp/scss/test.css
+
+update:
+  enabled: true
+  github:
+    identifier: kaj/rsass
+    use-tag: true
+    strip-prefix: v


### PR DESCRIPTION
Add new package rsass:  a Sass compiler reimplemented in Rust with nom. 

Upstream: https://github.com/kaj/rsass


### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

