### PR TITLE
Add the pkgconf test to spdlog

### DIFF
--- a/spdlog.yaml
+++ b/spdlog.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdlog
   version: "1.15.1"
-  epoch: 0
+  epoch: 1
   description: Fast C++ logging library.
   copyright:
     - license: MIT
@@ -47,6 +47,9 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 test:
   environment:


### PR DESCRIPTION
The build logs told me to add the test so I did:

```
2025-02-24T09:15:50Z WARN 🔗 linter "pkgconf" failed on package "spdlog-dev": pkgconfig directory found: usr/lib/pkgconfig/spdlog.pc; suggest: This package provides files in a pkgconfig directory, please add the pkgconf test pipeline
```