### PR TITLE
kube-downscaler: Bump epoch to rebuild

### DIFF
--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-downscaler
   version: 23.2.0
-  epoch: 8
+  epoch: 9
   description: Scale down Kubernetes deployments after work hours
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
Needs to be rebuilt with python 3.13.