### PR TITLE
fix(py3-cassandra-medusa): Vendor poetry in virtual environment

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.23.0"
-  epoch: 2
+  epoch: 3
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - py${{vars.py-version}}-poetry-bin
+      - python-${{vars.py-version}}
 
 vars:
   py-version: 3.11
@@ -19,10 +19,7 @@ vars:
 environment:
   contents:
     packages:
-      - build-base
-      - ca-certificates-bundle
       - py${{vars.py-version}}-build-base-dev
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -48,35 +45,34 @@ pipeline:
       POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
       poetry build
 
-  - runs: |
       # Setup the virtualenv
-      python${{vars.py-version}} -m venv .venv --system-site-packages
+      python${{vars.py-version}} -m venv .venv
 
-  - runs: |
       .venv/bin/pip${{vars.py-version}} install -I -r requirements.txt --no-compile
       .venv/bin/pip${{vars.py-version}} install -I --no-compile dist/*.whl
 
-  - runs: |
       # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
       .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile
 
-  - runs: |
+      # Install poetry
+      .venv/bin/pip${{vars.py-version}} install 'poetry>=1.0.0,<2.0.0'
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -s /home/cassandra/.venv/bin/poetry ${{targets.destdir}}/usr/bin/poetry
+
       mkdir -p ${{targets.destdir}}/home/cassandra
       mv .venv ${{targets.destdir}}/home/cassandra/
 
       # edit the venv paths
       find '${{targets.destdir}}/home/cassandra/.venv/bin/' -type f | \
-        xargs sed -i "s|/home/build|${{targets.destdir}}/home/cassandra|g"
+        xargs sed -i "s|/home/build|/home/cassandra|g"
 
       # allow site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/home/cassandra/.venv/pyvenv.cfg
 
-  - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       cp k8s/medusa.sh ${{targets.destdir}}/usr/bin/medusa
       chmod +x ${{targets.destdir}}/usr/bin/medusa
 
-  - runs: |
       cp pyproject.toml ${{targets.destdir}}/home/cassandra
       cp k8s/docker-entrypoint.sh ${{targets.destdir}}/home/cassandra
       chmod +x ${{targets.destdir}}/home/cassandra/docker-entrypoint.sh


### PR DESCRIPTION
Medusa depends on Poetry 1.x, and our Poetry has moved on to 2.x. Vendor 1.x in the virtual environment

https://github.com/thelastpickle/cassandra-medusa/pull/844