### PR TITLE
expand tests for descheduler package

### DIFF
--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -1,7 +1,7 @@
 package:
   name: descheduler
   version: "0.32.2"
-  epoch: 0
+  epoch: 1
   description: Descheduler for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -49,10 +49,24 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - runs: |
+    - name: "Binary checks"
+      runs: |
         descheduler version
         descheduler --help
+    - name: "Functional test"
+      runs: |
         # Scale the cluster further
         kwokctl scale node --replicas 3
-        curl -fL -o policy.yaml https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/examples/policy.yaml
+
+        # Upstream repo contains examples, so lets use one of the example policies here to test with.
+        curl -fL -o policy.yaml https://raw.githubusercontent.com/kubernetes-sigs/descheduler/v${{package.version}}/examples/policy.yaml
         descheduler --kubeconfig ~/.kube/config --policy-config-file policy.yaml
+
+        # Deploy the policy.
+        descheduler --kubeconfig ~/.kube/config --policy-config-file policy.yaml --v=4 2>&1 | tee /tmp/descheduler-output.log
+
+        # Verify that the anti-affinity plugin is processing nodes (functional check)
+        grep "Processing node" /tmp/descheduler-output.log || { echo "No node processing found, plugin may not be running"; exit 1; }
+
+        # Verify successful run metrics
+        grep "Number of evictions/requests" /tmp/descheduler-output.log || { echo "Eviction metrics not found"; exit 1; }


### PR DESCRIPTION
Small improvement to package tests. Previously always downloaded an example policy file from the 'master' branch, now pulls in the example policy from the GitHub release we're building.

Tests now attempt to create a descheduler policy. 