### PR TITLE
fix(rabbitmq-server-4.0): Add posix-libc-utils

### DIFF
--- a/rabbitmq-server-4.0.yaml
+++ b/rabbitmq-server-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-4.0
   version: "4.0.6"
-  epoch: 1
+  epoch: 2
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -12,6 +12,7 @@ package:
       # rabbitmq-server is a wrapper shell script.
       - busybox
       - erlang-27
+      - posix-libc-utils
 
 environment:
   contents:


### PR DESCRIPTION
rabbitmq relies on getconf for retrieving system info such as the page size

```
2025-02-25 02:03:51.323692+00:00 [warning] <0.3943.0> Failed to get memory page size, using 4096. Reason: getconf not found in PATH
```
