### PR TITLE
Improve neon by adjusting `rpath` while installing PostgreSQL libs/bins

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "8005"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/neon.yaml
+++ b/neon.yaml
@@ -29,6 +29,7 @@ environment:
       - libseccomp-dev
       - libtool
       - openssl-dev
+      - patchelf
       - perl
       - pkgconf
       - poetry
@@ -65,9 +66,29 @@ pipeline:
       # neon where to find the postgres binaries.
       # POSTGRES_DISTRIB_DIR=/usr/libexec
       mkdir -p "${{targets.destdir}}"/usr/libexec/neon
-      mv pg_install/v14 "${{targets.destdir}}"/usr/libexec/neon/v14
-      mv pg_install/v15 "${{targets.destdir}}"/usr/libexec/neon/v15
-      mv pg_install/v16 "${{targets.destdir}}"/usr/libexec/neon/v16
+
+      # The postgresql libraries/binaries need RPATH adjustment
+      # because they're installed under non-standard paths.
+      #
+      # Unfortunately we cannot use /etc/ld.so.conf.d/ snippets here
+      # because each psql binary should load their corresponding
+      # versioned libpq.so.  If we rely on the /etc/ld.so.conf.d/
+      # mechanism, ld will always load the first libpq.so it finds,
+      # which e.g. ends up being v14.
+      find pg_install/ -mindepth 1 -maxdepth 1 -type d -name "v*" | while read -r dir; do
+        verdir=$(basename "${dir}")
+        mv "${dir}" "${{targets.destdir}}"/usr/libexec/neon/"${verdir}"
+        find "${{targets.destdir}}"/usr/libexec/neon/"${verdir}" -type f | while read -r obj; do
+          # Are we looking at an ELF file?
+          if head -c 4 "${obj}" | grep -qF $'\x7FELF'; then
+            # Unfortunately we need to use the full path here (instead
+            # of '$ORIGIN/../lib', for example) because the
+            # libraries/binaries are installed under several nested
+            # directories.
+            patchelf --set-rpath /usr/libexec/neon/"${verdir}"/lib "${obj}"
+          fi
+        done
+      done
 
   - uses: strip
 


### PR DESCRIPTION
This PR improves the neon package and make its PostgreSQL binaries and libraries to be usable out-of-the-box by adjust their `rpath`.

Unfortunately I had to use the full path while adjust `rpath` because of the many files being installed under nested directories.  In order to be able to use `$ORIGIN` I'd have to take note of the subdir level and adjust `rpath` accordingly, which is too much work for too little gain.

Fixes: #43607 
Relates: #43370 