### PR TITLE
include tzdata as runtime dep for k3s package

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.32.1.1"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ package:
       - mount
       - runc
       - umount
+      - tzdata # this is required for cronjobs with timezones to work.
       # Do not include runtime dependencies already included in the multicall k3s
       # - ctr
       # - crictl

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -20,13 +20,13 @@ package:
       - libseccomp
       - mount
       - runc
-      - umount
       - tzdata # this is required for cronjobs with timezones to work.
       # Do not include runtime dependencies already included in the multicall k3s
       # - ctr
       # - crictl
       # - containerd
       # - kubectl
+      - umount
 
 environment:
   contents:


### PR DESCRIPTION
this is required for cronjobs with timezones to work.

cross refs: https://github.com/k3s-io/k3s/issues/8832 and https://github.com/k3d-io/k3d/issues/1083 

required for: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones