### PR TITLE
update package pipeline and add bitnami-compat

### DIFF
--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -24,13 +24,14 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/opt/jsonnet/grafonnet
       cd gen/grafonnet-$GRAFONNET_VERSION
+
       install -m755 *.libsonnet "${{targets.destdir}}"/opt/jsonnet/grafonnet/
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 
       for i in clean custom raw; do
-          if [ -d "$i" ]; then
-            install -Dm644 -Dm644 "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
-          fi
+        if [ -d "$i" ]; then
+          cp -r "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+        fi
       done
 
   - uses: strip

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -39,9 +39,6 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-bitnami-compat
     description: "compat package for bitnami/grafonnet library"
-    dependencies:
-      runtime:
-        - grafana-grafonnet
     pipeline:
       - uses: bitnami/compat
         with:

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -24,7 +24,6 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/opt/jsonnet/grafonnet
       cd gen/grafonnet-$GRAFONNET_VERSION
-
       install -m755 *.libsonnet "${{targets.destdir}}"/opt/jsonnet/grafonnet/
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -29,9 +29,7 @@ pipeline:
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 
       for i in clean custom raw; do
-        if [ -d "$i" ]; then
-          cp -r "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
-        fi
+          install -Dm644 "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
       done
 
   - uses: strip

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -56,6 +56,16 @@ subpackages:
         - runs: |
             ls -l /opt/bitnami/grafonnet-lib/grafonnet
 
+test:
+  pipeline:
+    - runs: |
+        test -f /opt/jsonnet/grafonnet/alerting.libsonnet || (echo "Missing alerting.libsonnet" && exit 1)
+        test -f /opt/jsonnet/grafonnet/jsonnetfile.json || (echo "Missing jsonnetfile.json" && exit 1)
+        for dir in clean custom raw; do
+          test -d /opt/jsonnet/grafonnet/$dir || (echo "Missing $dir directory" && exit 1)
+        done
+        test -f /opt/jsonnet/grafonnet/clean/dashboard.libsonnet || (echo "Missing clean/dashboard.libsonnet" && exit 1)
+
 update:
   enabled: false
   exclude-reason: no releases or tags available

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-grafonnet
   version: 0.0_git20231114
-  epoch: 2
+  epoch: 3
   description: Jsonnet library for generating Grafana dashboards
   copyright:
     - license: Apache-2.0
@@ -29,11 +29,32 @@ pipeline:
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 
       for i in clean custom raw; do
-        mkdir -p ${{targets.destdir}}/opt/jsonnet/grafonnet/$i
-        mv $i "${{targets.destdir}}"/opt/jsonnet/grafonnet/$i/
+        if [ -d "$i" ]; then
+          cp -r "$i"/* "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+        fi
       done
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-bitnami-compat
+    description: "compat package for bitnami/grafonnet library"
+    dependencies:
+      runtime:
+        - grafana-grafonnet
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: grafana-operator
+          version-path: 5/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/grafonnet-lib/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /opt/jsonnet/grafonnet ${{targets.subpkgdir}}/opt/bitnami/grafonnet-lib/grafonnet
+    test:
+      pipeline:
+        - runs: |
+            ls -l /opt/bitnami/grafonnet-lib/grafonnet
 
 update:
   enabled: false

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -30,7 +30,7 @@ pipeline:
 
       for i in clean custom raw; do
         if [ -d "$i" ]; then
-          cp -r "$i"/* "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+          cp -r "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
         fi
       done
 

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -29,7 +29,7 @@ pipeline:
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 
       for i in clean custom raw; do
-          install -Dm644 "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+          install -Dm644 -t "${{targets.destdir}}/opt/jsonnet/grafonnet/" "$i"
       done
 
   - uses: strip

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -29,7 +29,9 @@ pipeline:
       install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
 
       for i in clean custom raw; do
-          install -Dm644 -t "${{targets.destdir}}/opt/jsonnet/grafonnet/" "$i"
+          if [ -d "$i" ]; then
+            install -Dm644 -Dm644 "$i" "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+          fi
       done
 
   - uses: strip


### PR DESCRIPTION
This PR resolves the issue with nested directories within `/opt/jsonnet/grafonnet/` and improve alignment with the source structure.

Earlier the pipeline use to create an nested directories like `/opt/jsonnet/grafonnet/clean/clean/`, `/opt/jsonnet/grafonnet/custom/custom/,` and `/opt/jsonnet/grafonnet/raw/raw/` due to `mv` placing each source directory inside a pre-created subdirectory.

The PR replaces  `mv` with a conditional `cp -r`which copy each directory (clean/, custom/, raw/) directly into `/opt/jsonnet/grafonnet/` preserving their structure without nesting.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Also add bitnami compat package for grafonnet as per the [Dockerfile](https://github.com/bitnami/containers/blob/main/bitnami/grafana-operator/5/debian-12/Dockerfile#L49)

<!--
Please include references to any related issues or delete this section otherwise.
 -->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
