### PR TITLE
Add /etc/ld.so.conf.d support

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 9
+  epoch: 10
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -123,7 +123,10 @@ pipeline:
 
   - name: "Set up ldconfig"
     runs: |
-      cp vendor/ld.so.conf "${{targets.destdir}}"/etc/ld.so.conf
+      mkdir -p "${{targets.destdir}}"/etc
+      cp vendor/ld.so.conf "${{targets.destdir}}"/etc
+      mkdir -p "${{targets.destdir}}"/etc/ld.so.conf.d
+      cp vendor/ld.so.conf.d/*.conf "${{targets.destdir}}"/etc/ld.so.conf.d
 
   - name: 'Clean up documentation'
     runs: |

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -386,6 +386,44 @@ subpackages:
       provider-priority: 10
       runtime:
         - wolfi-baselayout
+    test:
+      environment:
+        contents:
+          packages:
+            - gcc
+            - glibc-dev
+      pipeline:
+        - name: Test usage of /etc/ld.so.conf.d/ snippets
+          runs: |
+            tmpdir="$(mktemp -d)"
+            tmplibdir="$(mktemp -d)"
+            ldcfg="/etc/ld.so.conf.d/test-snippet.conf"
+            cleanup() {
+              rm -f "$ldcfg"
+              rm -rf "$tmpdir" "$tmplibdir"
+            }
+            trap cleanup EXIT
+            cat > "$tmpdir/ldsoconfdotd.c" << EOF
+            #include <stdio.h>
+
+            void ldsoconfdotd_test(void) {
+              printf("Calling %s\n", __func__);
+            }
+            EOF
+            cat > "$tmpdir/test.c" << EOF
+            void ldsoconfdotd_test(void);
+            int main(void) {
+              ldsoconfdotd_test();
+            }
+            EOF
+            gcc -c -fpic "$tmpdir/ldsoconfdotd.c" -o "$tmpdir/ldsoconfdotd.o"
+            gcc -shared -o "$tmplibdir/libldsoconfdotd.so" \
+              "$tmpdir/ldsoconfdotd.o"
+            echo "$tmplibdir" > "$ldcfg"
+            ldconfig
+            LIBRARY_PATH="$tmplibdir" \
+              gcc "$tmpdir/test.c" -o "$tmpdir/test" -lldsoconfdotd
+            "$tmpdir"/test
 
   - name: "glibc-dev"
     description: "GLIBC development headers"

--- a/glibc/vendor/ld.so.conf
+++ b/glibc/vendor/ld.so.conf
@@ -1,6 +1,1 @@
-/usr/local/lib
-/usr/local/lib64
-/lib
-/lib64
-/usr/lib
-/usr/lib64
+include /etc/ld.so.conf.d/*.conf

--- a/glibc/vendor/ld.so.conf.d/libc.conf
+++ b/glibc/vendor/ld.so.conf.d/libc.conf
@@ -1,0 +1,6 @@
+/usr/local/lib
+/usr/local/lib64
+/lib
+/lib64
+/usr/lib
+/usr/lib64


### PR DESCRIPTION
We have several packaged libraries that install in non-standard paths. The CUDA libs are the primary example. Today, we have to propagate these paths up through various levels of packaging, in both build and test sections, and ultimately into images by way of `LD_LIBRARY_PATH` settings. This is error-prone.

Packages that rely on non-standard library paths can drop `.conf` snippets into this directory. This relies on the existing support in `apk` for running `ldconfig` after package installation, and similar support in `apko` when preparing an image filesystem.
