### PR TITLE
Add the pkgconf test to libsass

### DIFF
--- a/libsass.yaml
+++ b/libsass.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsass
   version: "3.6.6"
-  epoch: 0
+  epoch: 1
   description: C/C++ implementation of a Sass compiler
   copyright:
     - license: MIT
@@ -43,6 +43,9 @@ subpackages:
         - libsass
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
I added the pkgconf test because the linter told me and it passed.