### PR TITLE
Fix `boost` FTBFS

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: 1.87.0
-  epoch: 0
+  epoch: 1
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"

--- a/boost.yaml
+++ b/boost.yaml
@@ -57,7 +57,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://boostorg.jfrog.io/artifactory/main/release/${{package.version}}/source/boost_${{vars.mangled-package-version}}.tar.gz
+      uri: https://archives.boost.io/release/${{package.version}}/source/boost_${{vars.mangled-package-version}}.tar.gz
       expected-sha256: f55c340aa49763b1925ccf02b2e83f35fdcf634c9d5164a2acb87540173c741d
 
   - runs: |


### PR DESCRIPTION
It isn't clear why we were using a third-party fetch URL to grab the tarball here (archaeology didn't help), but the FTBFS is happening because of some expired subscription thing on their side.

The fix is obvious: we should use the official upstream URL to fetch the tarball.

Fixes: #43586 