### PR TITLE
rancher-kontainer-driver-metadata-2.10: Bump expected-commit

### DIFF
--- a/rancher-kontainer-driver-metadata-2.10.yaml
+++ b/rancher-kontainer-driver-metadata-2.10.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: rancher-kontainer-driver-metadata-2.10
-  version: 0_git20241126
+  version: 0_git20250225
   epoch: 0
   description: Complete container management platform - kontainer driver metadata
   copyright:
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/rancher/kontainer-driver-metadata/
       branch: release-v2.10
-      expected-commit: ff8d9bff7cdde065395f6bb67d4677d883b68bec
+      expected-commit: f0aade6d997db927613f7dc74cac62b047fb960e
 
   - runs: |
       mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata


### PR DESCRIPTION
Upstream has bumped the HEAD of the release-v2.10 branch.  We need to reflect this bump here otherwise the build fails due to the unexpected commit hash.

Fixes: #43087 