### PR TITLE
Adds compat package to provide compatibility with Bitnami helm chart

### DIFF
--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: 0.7.2
-  epoch: 5
+  epoch: 6
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,28 @@ pipeline:
       mv metrics-server ${{targets.destdir}}/usr/bin/
 
   - uses: strip
+
+# Note, we don't need to fetch any upstream files, as there aren't any custom
+# entrypoints or scripts required for compatibility with the metrics-server
+# Bitnami helm chart.
+subpackages:
+  - name: ${{package.name}}-bitnami-compat
+    description: "Compatibility package for usage with the Bitnami helm chart."
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/metrics-server ${{targets.subpkgdir}}/opt/bitnami/metrics-server
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - bash
+      pipeline:
+        - runs: |
+            /opt/bitnami/metrics-server --version
+            /opt/bitnami/metrics-server --help
 
 update:
   enabled: true


### PR DESCRIPTION
Adds a new subpackage to provide compatability with the Bitnami helm chart for metrics-server. Note at present time, there aren't any custom scripts or entrypoints required for this compatibility, other than the binary being symlinked in the directory that the helm chart expects, and some configuration at the image level.

Thus this is a pretty straight forward subpackage.