### PR TITLE
Add the pkgconf test to grpc-1.69

### DIFF
--- a/grpc-1.69.yaml
+++ b/grpc-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.69
   version: 1.69.0
-  epoch: 2
+  epoch: 3
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -151,9 +151,13 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
+        - opentelemetry-cpp-dev
       provides:
         - grpc-dev=${{package.full-version}}
     description: grpc dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
The linter told me to add the pkgconf test to grpc-1.69 and it should pass with the new runtime dep.