### PR TITLE
New package: liquibase-package-manager

### DIFF
--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -13,6 +13,12 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1cd39ecef00dee2b6cb800acd2d2410f06179231
 
+  - name: Prebuild setup
+    runs: |
+      # The version in file: liquibase-package-manager/internal/app/VERSION is statically set to 0.2.3
+      # Need to run 'make updateVersion' before performing go build to set proper lmp release version
+      make updateVersion
+
   - uses: go/build
     with:
       packages: ./cmd/lpm/darwin.go
@@ -30,21 +36,40 @@ update:
 
 test:
   environment:
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+      REPO: liquibase/liquibase
+      LIQUIBASE_HOME: /liquibase
     contents:
       packages:
         - go
         - curl
         - git
+        - openjdk-17
   pipeline:
-    - name: Run test suite
+    - name: Setup
       runs: |
         # Clone lpm repo for test suite access
         git clone -b v${{package.version}} https://github.com/liquibase/liquibase-package-manager
+
+        # Setup liquibase home dir
+        mkdir -p /liquibase
+
+        # Get liquibase upstream source
+        export VERSION=$(curl -s https://api.github.com/repos/$REPO/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+        export LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/$REPO/releases/latest | grep "browser_download_url" | grep ".tar.gz" | cut -d '"' -f 4)
+        curl -Ls $LATEST_RELEASE_URL -o liquibase-$VERSION.tar.gz
+
+        # Extract liquibase
+        tar -xzvf liquibase-$VERSION.tar.gz -C /liquibase
+    - name: Run test suite
+      runs: |
+        # Navigate to lpm dir
         cd ${{package.name}}
 
         # Install prereqs
-        go install honnef.co/go/tools/cmd/staticcheck@latest
+        make test-setup
 
         # Run test suite
-        export PATH=$PATH:$(go env GOPATH)/bin
-        make test
+        export PATH=$PATH:$JAVA_HOME/bin
+        make e2e

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -6,11 +6,6 @@ package:
   copyright:
     - license: Apache-2.0 AND MPL-2.0
 
-environment:
-  contents:
-    packages:
-      - go
-
 pipeline:
   - uses: git-checkout
     with:

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -24,14 +24,6 @@ pipeline:
       packages: ./cmd/lpm/darwin.go
       output: lpm
 
-subpackages:
-  - name: ${{package.name}}-compat
-    description: "Compatibility package to place binaries in the location expected by lpm"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}/bin"
-          ln -sf /usr/bin/lpm ${{targets.contextdir}}/bin/lpm
-
 update:
   enabled: true
   github:

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -34,3 +34,23 @@ update:
   github:
     identifier: liquibase/liquibase-package-manager
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - go
+        - curl
+  pipeline:
+    - uses: git-checkout
+      with:
+        repository: https://github.com/liquibase/liquibase-package-manager
+        tag: v${{package.version}}
+        expected-commit: 1cd39ecef00dee2b6cb800acd2d2410f06179231
+    - name: Install prereqs
+      runs: |
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+    - name: Run test suite
+      runs: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        make test

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -22,8 +22,6 @@ pipeline:
       mkdir -p "${{targets.contextdir}}/bin"
       ln -sf /usr/bin/lpm ${{targets.contextdir}}/bin/lpm
 
-  - uses: strip
-
 update:
   enabled: true
   github:
@@ -36,16 +34,17 @@ test:
       packages:
         - go
         - curl
+        - git
   pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/liquibase/liquibase-package-manager
-        tag: v${{package.version}}
-        expected-commit: 1cd39ecef00dee2b6cb800acd2d2410f06179231
-    - name: Install prereqs
-      runs: |
-        go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run test suite
       runs: |
+        # Clone lpm repo for test suite access
+        git clone -b v${{package.version}} https://github.com/liquibase/liquibase-package-manager
+        cd ${{package.name}}
+
+        # Install prereqs
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+
+        # Run test suite
         export PATH=$PATH:$(go env GOPATH)/bin
         make test

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -27,9 +27,6 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by lpm"
-    dependencies:
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}/bin"
@@ -80,3 +77,6 @@ test:
         # Run test suite
         export PATH=$PATH:$JAVA_HOME/bin
         make e2e
+    - name: Run lpm check
+      runs: |
+        /usr/bin/lpm 2>&1 | grep -i liquibase

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -1,0 +1,36 @@
+package:
+  name: liquibase-package-manager
+  version: "0.2.9"
+  epoch: 0
+  description: "Easily manage external dependencies for Database Development. Search for, install, and uninstall liquibase drivers, extensions, and utilities."
+  copyright:
+    - license: Apache-2.0 AND MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/liquibase/liquibase-package-manager
+      tag: v${{package.version}}
+      expected-commit: 1cd39ecef00dee2b6cb800acd2d2410f06179231
+
+  - uses: go/build
+    with:
+      packages: ./cmd/lpm/darwin.go
+      output: lpm
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/bin"
+      ln -sf /usr/bin/lpm ${{targets.contextdir}}/bin/lpm
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: liquibase/liquibase-package-manager
+    strip-prefix: v

--- a/liquibase-package-manager.yaml
+++ b/liquibase-package-manager.yaml
@@ -24,9 +24,16 @@ pipeline:
       packages: ./cmd/lpm/darwin.go
       output: lpm
 
-  - runs: |
-      mkdir -p "${{targets.contextdir}}/bin"
-      ln -sf /usr/bin/lpm ${{targets.contextdir}}/bin/lpm
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by lpm"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/bin"
+          ln -sf /usr/bin/lpm ${{targets.contextdir}}/bin/lpm
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding Liquibase-package-manager tool. Additional package needed to match upstream liquibase.
Related:
- https://github.com/chainguard-dev/image-requests/issues/5181

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
