### PR TITLE
Add the pkgconf test to libtermkey

### DIFF
--- a/libtermkey.yaml
+++ b/libtermkey.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtermkey
   version: "0.22"
-  epoch: 2
+  epoch: 3
   description: "Library for easy processing of keyboard entry from terminal-based programs"
   copyright:
     - license: MIT
@@ -39,6 +39,9 @@ subpackages:
       runtime:
         - libtermkey
     description: ${{package.name}} dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
The linter told me to add the pkgconf tests to libtermkey and I did and it passed.