### PR TITLE
fix(datadog-agent): Don't remove object files

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.60.1
-  epoch: 5
+  epoch: 6
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -161,8 +161,6 @@ pipeline:
       # up using will be part of the multicall below.
       unshare --user --map-root-user \
         invoke -e system-probe.build \
-        --strip-object-files \
-        --no-bundle \
         --bundle-ebpf
 
   - runs: |


### PR DESCRIPTION
Leveraged by the OOM killer and other features