### PR TITLE
Package update and Refactor the pipeline into chunks

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 package:
   name: chromium
   version: "133.0.6943.126"
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -6,7 +6,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: "133.0.6943.126"
+  version: "133.0.6943.141"
   epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
@@ -144,7 +144,7 @@ pipeline:
       repository: https://chromium.googlesource.com/chromium/src.git
       tag: ${{package.version}}
       depth: 1
-      expected-commit: cffa127ce7b6be72885391527c15b452056a2e81
+      expected-commit: 2a5d6da0d6165d7b107502095a937fe7704fcef6
       destination: /home/src
 
   - name: clone depot-tools and setup .gclient

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 package:
   name: chromium
   version: "133.0.6943.141"
-  epoch: 1
+  epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -147,11 +147,18 @@ pipeline:
       expected-commit: cffa127ce7b6be72885391527c15b452056a2e81
       destination: /home/src
 
-  - runs: |
+  - name: clone depot-tools and setup .gclient
+    runs: |
       cd /home
+      # depot_tools contains essential Chromium build tools
+      # in consists of gclient, gn, autoninja, etc. that are used to build Chromium
+      # We are cloning it to /home/depot_tools and have to add it to PATH
       time git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
-      export PATH="$PATH:/home/depot_tools"
-      # .gclient must be in one directory above chromium's src
+
+      # Create .gclient configuration file
+      # Important: File must be in /home (parent of src/)
+      # Because: gclient searches for .gclient in parent directories
+      # Reference: https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/README.gclient.md
       cat <<EOF >/home/.gclient
       # Setup a .gclient config (handled by 'fetch' in upstream instructions)
       solutions = [
@@ -164,17 +171,25 @@ pipeline:
       ]
       EOF
       cat /home/.gclient
+
+  - working-directory: /home/src
+    name: sync-dependencies
+    runs: |
+      # Add depot_tools to PATH to use gclient
+      export PATH="$PATH:/home/depot_tools"
+
       # === INFO === Sync dependencies: takes about 11 minutes, requires 30 GB of disk
-      # go back into our chromium src directory
-      cd /home/src
       time gclient sync --no-history
-      # === INFO === Use system dependencies
+
+  - working-directory: /home/src
+    name: configure-system-libraries
+    runs: |
       # Use USB IDs already provided by hwdata-usb
       sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
         -i services/device/public/cpp/usb/BUILD.gn
 
-      # System libraries
-      # Chromium doesn't like our ffmpeg so remove for now
+      # Define system libraries to use
+      # Chromium doesn't like our ffmpeg so removing it for now
       system_libs="
         brotli
         crc32c
@@ -195,7 +210,7 @@ pipeline:
         zstd
       "
 
-      # Remove system provided library buildscripts
+      # Remove bundled libraries
       for _lib in $system_libs libjpeg_turbo unrar; do
         echo "Removing buildscripts for system provided $_lib"
         _lib="${_lib/swiftshader-/swiftshader/third_party/}"
@@ -211,7 +226,7 @@ pipeline:
           -delete
       done
 
-      # Update gn configuration to use system libraries
+      # Update GN configuration to use system libraries
       python3 build/linux/unbundle/replace_gn_files.py --system-libraries $system_libs
       python3 third_party/libaddressinput/chromium/tools/update-strings.py
 
@@ -220,10 +235,15 @@ pipeline:
         tools/generate_shim_headers/generate_shim_headers.py
 
       # === INFO === Make node executable: works around permission denial
-      cd /home/src
-      chmod +x third_party/node/linux/node-linux-x64/bin/node
-      # === INFO === Generate config: takes about 30 minutes /
-      cd /home/src
+      chmod +x /home/src/third_party/node/linux/node-linux-x64/bin/node
+
+  - working-directory: /home/src
+    name: prepare-build
+    runs: |
+      # Add depot_tools to PATH to use gn
+      export PATH="$PATH:/home/depot_tools"
+
+      # === INFO === Generate config: takes about 30 minutes
       time gn gen /home/src/out/Default --args="
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
@@ -252,31 +272,39 @@ pipeline:
         use_system_libjpeg=true
         use_system_zlib=true
       "
+
+  - working-directory: /home/src
+    name: build
+    runs: |
+      # Add depot_tools to PATH to use autoninja
+      export PATH="$PATH:/home/depot_tools"
+
       # === INFO === Compile: takes about 3 hours, 60 GB of disk (on a 32xXeon, 128GBxRAM, 2TBxNVME system)
-      cd /home/src
-      time autoninja -C /home/src/out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
-      # === INFO === Install the binaries and libraries
-      cd /home/src/out/Default
+      time autoninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
+
+  - working-directory: /home/src/out/Default
+    name: install the binaries and libraries
+    runs: |
       mkdir -p ${{targets.destdir}}/usr/bin ${{targets.destdir}}/usr/lib/${{package.name}}
+      mkdir -p ${{targets.destdir}}/etc/chromium
+
+      # Install binaries
       mv *.so* ${{targets.destdir}}/usr/lib/${{package.name}}
       mv chrome ${{targets.destdir}}/usr/lib/${{package.name}}
       mv chrome_crashpad_handler ${{targets.destdir}}/usr/lib/${{package.name}}
       mv chrome_sandbox ${{targets.destdir}}/usr/lib/${{package.name}}
-      # resources
-      mv snapshot_blob.bin ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv v8_context_snapshot.bin ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv xdg-mime ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv xdg-settings ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv vk_swiftshader_icd.json ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv *.pak ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv locales ${{targets.destdir}}/usr/lib/${{package.name}}
-      # wrapper
+
+      # Install resources
+      mv snapshot_blob.bin v8_context_snapshot.bin \
+         xdg-mime xdg-settings vk_swiftshader_icd.json \
+         *.pak locales \
+         ${{targets.destdir}}/usr/lib/${{package.name}}/
+
+      # Setup wrapper and symlinks
       cd /home/build
       mv chromium-launcher.sh ${{targets.destdir}}/usr/bin/chromium-browser
-      # links
       ln -sf /usr/lib/${{package.name}}/chrome ${{targets.destdir}}/usr/bin/chromium
       ln -sf /usr/lib/${{package.name}}/chromedriver ${{targets.destdir}}/usr/bin/chromedriver
-      mkdir -p ${{targets.destdir}}/etc/chromium
 
   - uses: strip
     with:


### PR DESCRIPTION
- Package Version Update to chromium/133.0.6943.141
- Refactor: divide the main pipeline into chunks, so that it can get easier to understand and debug
- Add more code comments to explain the Why.

I've worked on fixing Chromium build issues multiple times, and the single monolithic pipeline made it difficult to debug failures. This refactor improves clarity, making it easier to identify issues and hopefully helps others working on it in the future.