### PR TITLE
Symlink replaces are not working with apko, but do with apk-tools

### DIFF
--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-base
   version: 1
-  epoch: 7
+  epoch: 8
   description: "Wolfi base metapackage"
   copyright:
     - license: MIT
@@ -21,7 +21,29 @@ pipeline:
     runs: |
       mkdir -p "${{targets.destdir}}"
 
+subpackages:
+  - name: package-with-symlink
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/etc/
+          ln -s ../run/target1.conf ${{targets.contextdir}}/etc/some.conf
+
+  - name: package-with-symlink-replaces
+    dependencies:
+      runtime:
+        - package-with-symlink
+      replaces:
+        - package-with-symlink
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/etc/
+          ln -s ../run/target2.conf ${{targets.contextdir}}/etc/some.conf
+
 test:
+  environment:
+    contents:
+      packages:
+        - package-with-symlink-replaces
   pipeline:
     - name: "Commands exist"
       runs: |


### PR DESCRIPTION
with the modified wolfi-base, which has two subpackages, that ship the same symlink, with different target destination and replaces of one another, it works with apk tools, but not with apko:

```
$ make package/wolfi-base
$ make local-wolfi
# apk add package-with-symlink
(1/1) Installing package-with-symlink (1-r8)
OK: 14 MiB in 16 packages
# readlink /etc/some.conf 
../run/target1.conf
# apk add package-with-symlink-replaces
(1/1) Installing package-with-symlink-replaces (1-r8)
OK: 14 MiB in 17 packages
# readlink /etc/some.conf 
../run/target2.conf
# exit
$ make test/wolfi-base
Testing package wolfi-base with version wolfi-base-1-r8 from file wolfi-base.yaml
/home/xnox/go/bin/melange test wolfi-base.yaml --repository-append /home/xnox/wolfi-dev/os/packages --keyring-append local-melange.rsa.pub --arch x86_64 --pipeline-dirs ./pipelines/ --repository-append https://packages.wolfi.dev/os --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub --test-package-append wolfi-base --debug  --source-dir ./wolfi-base/
2025/02/26 11:31:22 INFO building test workspace in: '/tmp/melange-guest-815115064-main' with apko
2025/02/26 11:31:22 [DEBUG] GET https://packages.wolfi.dev/os/apk-configuration
2025/02/26 11:31:22 INFO setting apk repositories: [/home/xnox/wolfi-dev/os/packages https://packages.wolfi.dev/os]
2025/02/26 11:31:22 INFO image configuration:
2025/02/26 11:31:22 INFO   contents:
2025/02/26 11:31:22 INFO     build repositories: []
2025/02/26 11:31:22 INFO     runtime repositories: []
2025/02/26 11:31:22 INFO     keyring:      []
2025/02/26 11:31:22 INFO     packages:     [package-with-symlink-replaces wolfi-base]
2025/02/26 11:31:22 INFO installing package-with-symlink (1-r8)
2025/02/26 11:31:22 INFO installing package-with-symlink-replaces (1-r8)
2025/02/26 11:31:22 INFO ERROR: failed to test package. the test environment has been preserved:
2025/02/26 11:31:22 INFO   workspace dir: /tmp/melange-workspace-2334097068
2025/02/26 11:31:22 INFO   guest dir: /tmp/melange-guest-815115064
2025/02/26 11:31:22 ERRO failed to test package: unable to build guest: unable to generate image: installing apk packages: installing packages: installing package-with-symlink-replaces (ver:1-r8 arch:x86_64): unable to install files for pkg package-with-symlink-replaces: unable to install symlink from etc/some.conf -> ../run/target2.conf: symlink ../run/target2.conf /tmp/melange-guest-815115064-main/etc/some.conf: file exists
make: *** [Makefile:115: test/wolfi-base] Error 1
```

