### PR TITLE
otel-cli: New package

### DIFF
--- a/otel-cli.yaml
+++ b/otel-cli.yaml
@@ -19,6 +19,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 0d4b8a9c49f60a6fc25ed22863259ff573332060
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.33.0
+
   - uses: go/build
     with:
       packages: .
@@ -27,11 +32,6 @@ pipeline:
         -X main.commit=$(git rev-parse HEAD)
         -X main.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       output: otel-cli
-
-  - uses: go/bump
-    with:
-      deps: |-
-        golang.org/x/net@v0.33.0
 
 update:
   enabled: true

--- a/otel-cli.yaml
+++ b/otel-cli.yaml
@@ -28,6 +28,11 @@ pipeline:
         -X main.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       output: otel-cli
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.33.0
+
 update:
   enabled: true
   github:

--- a/otel-cli.yaml
+++ b/otel-cli.yaml
@@ -28,7 +28,6 @@ pipeline:
         -X main.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       output: otel-cli
 
-
 update:
   enabled: true
   github:

--- a/otel-cli.yaml
+++ b/otel-cli.yaml
@@ -1,0 +1,43 @@
+package:
+  name: otel-cli
+  version: "0.4.5"
+  epoch: 0
+  description: OpenTelemetry CLI Application
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/equinix-labs/otel-cli
+      tag: v${{package.version}}
+      expected-commit: 0d4b8a9c49f60a6fc25ed22863259ff573332060
+
+  - uses: go/build
+    with:
+      packages: .
+      ldflags: |
+        -X main.version=v${{package.version}}
+        -X main.commit=$(git rev-parse HEAD)
+        -X main.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      output: otel-cli
+
+
+update:
+  enabled: true
+  github:
+    identifier: equinix-labs/otel-cli
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v
+
+test:
+  pipeline:
+    - runs: |
+        otel-cli --help


### PR DESCRIPTION
Add otel-cli package useful for both test and cli driven trace generation


### Pre-review Checklist

#### For new package PRs only

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates