### PR TITLE
sonar-scanner-cli-entrypoint: Automate package upgrade & upgrade to 1.2.1.1844_7.0.2

### DIFF
--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -4,8 +4,8 @@
 # code, we need to fetch it and be able to auto-update.
 package:
   name: sonar-scanner-cli-entrypoint
-  version: "10.0.3.1430.5.0.1"
-  epoch: 1
+  version: "11.2.1.1844.7.0.2"
+  epoch: 0
   description: Fetches the sonar-scanner-cli entrypoint script from upstream docker repository.
   copyright:
     - license: LGPL-3.0-or-later
@@ -15,18 +15,27 @@ environment:
     packages:
       - busybox
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+\.\d+)\.(\d+.\d+.\d+)
+    replace: "${1}_${2}"
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/SonarSource/sonar-scanner-cli-docker
-      branch: master
-      expected-commit: 1bb96ade36663d531bfc3814e118225649e2a614
+      tag: ${{vars.mangled-package-version}}
+      expected-commit: 31871f7162a21c71da20a10efbed55016d9300a2
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/
       install -m755 bin/entrypoint.sh ${{targets.destdir}}/usr/bin/
 
 update:
-  manual: true
+  enabled: true
+  version-transform:
+    - match: '_'
+      replace: '.'
   github:
     identifier: SonarSource/sonar-scanner-cli-docker


### PR DESCRIPTION
For some obscure reason we've decided to manually upgrade sonar-scanner-cli-entrypoint.  Upstream has been publishing proper release tags for a while now, so we can just default to automatic updates.

Fixes: #43074