### PR TITLE
tclap: Update commit hash & fix FTBFS

### DIFF
--- a/tclap.yaml
+++ b/tclap.yaml
@@ -2,7 +2,7 @@
 package:
   name: tclap
   version: 1.4
-  epoch: 2
+  epoch: 3
   description: "Templatized command-line argument parser for C++"
   copyright:
     - license: LicenseRef-tclap
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://git.code.sf.net/p/tclap/code
       branch: ${{package.version}}
-      expected-commit: 61cfae16ceba4cadc3d74439fa1e9fd4fce16bc9
+      expected-commit: 4430e9d25c6e3b78f82914a466b767490f760c53
 
   - uses: patch
     with:


### PR DESCRIPTION
Upstream recently made some new commits to tclap's 1.4 branch.  Update the expected commit hash.

Fixes: #43071