### PR TITLE
go-1.24: fix go main version not semver compatible

### DIFF
--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.0"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -41,6 +41,7 @@ pipeline:
       patches: |
         cmd-go-always-emit-ldflags-version-information.patch
         change-default-telemetry-from-local-to-off.patch
+        go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
 
   - runs: |
       cd src

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -68,21 +68,40 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/go_bootstrap
       rm -rf "${{targets.destdir}}"/usr/lib/go/src/cmd/dist/dist
 
-      # Remove tests from /usr/lib/go/src, not needed at runtime
-      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
-        -exec rm -rf \{\} \+
-      find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
-        -exec rm -rf \{\} \+
-      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.rc" \) \
-        -exec rm -rf \{\} \+
-      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
-        -exec rm -rf \{\} \+
-      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.pem" \) \
-        -exec rm -rf \{\} \+
-
   - uses: strip
 
 subpackages:
+  - name: "${{package.name}}-src"
+    description: "go source code and tests"
+    dependencies:
+      runtime:
+        - ${{package.name}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          cd ${{targets.destdir}}/
+          mkdir -p ${{targets.subpkgdir}}
+          find . -name '*_test.go' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name 'testdata' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*.rc' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*.bat' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*.pem' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+
+          find . -name '*_test.go' -exec rm -f '{}' \;
+          find . -name 'testdata' -exec rm -f '{}' \;
+          find . -name '*.rc' -exec rm -f '{}' \;
+          find . -name '*.bat' -exec rm -f '{}' \;
+          find . -name '*.pem' -exec rm -f '{}' \;
+    test:
+      environment:
+        contents:
+          packages:
+            - git
+      pipeline:
+        - name: Test Semver fix
+          runs: |
+            go telemetry local
+            go test -a -v cmd/go -run=Script/build_version_stamping_git
+
   - name: "${{package.name}}-doc"
     description: "go documentation"
     pipeline:

--- a/go-1.24/go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
+++ b/go-1.24/go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
@@ -1,0 +1,70 @@
+From ee66f3c8fd27506c789810fff86f09880d0354ad Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 19 Jul 2022 11:07:00 -0400
+Subject: [PATCH] go: fix +incompatible+dirty build metadata to be SemVer
+ compatible
+
+Change "+incompatible+dirty" version to be "+incompatible.dirty" such
+that it is SemVer spec compatible.
+
+Struggling to add test case for a locally generated module that will
+create +incompatible version.
+
+See:
+- https://github.com/golang/go/issues/71971
+- https://github.com/golang/go/issues/71969
+- https://github.com/golang/go/issues/71970
+- https://github.com/anchore/grype/issues/2482
+- https://semver.org/#spec-item-10
+
+Change-Id: I714ffb3f1ad88c793656c3652367db34739a2144
+---
+ src/cmd/go/internal/load/pkg.go                     |  7 ++++++-
+ .../testdata/script/build_version_stamping_git.txt  | 13 +++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
+index 0c4639ce82..13add8ad5b 100644
+--- a/src/cmd/go/internal/load/pkg.go
++++ b/src/cmd/go/internal/load/pkg.go
+@@ -2563,7 +2563,12 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+ 		vers := revInfo.Version
+ 		if vers != "" {
+ 			if st.Uncommitted {
+-				vers += "+dirty"
++				// SemVer build metadata is dot-separated https://semver.org/#spec-item-10
++				if strings.HasSuffix(vers, "+incompatible") {
++					vers += ".dirty"
++				} else {
++					vers += "+dirty"
++				}
+ 			}
+ 			info.Main.Version = vers
+ 		}
+diff --git a/src/cmd/go/testdata/script/build_version_stamping_git.txt b/src/cmd/go/testdata/script/build_version_stamping_git.txt
+index db804b3847..e7ca8d25df 100644
+--- a/src/cmd/go/testdata/script/build_version_stamping_git.txt
++++ b/src/cmd/go/testdata/script/build_version_stamping_git.txt
+@@ -108,6 +108,19 @@ go version -m example$GOEXE
+ stdout '\s+mod\s+example\s+v1.0.3-0.20220719150703-2e239bf29c13\s+'
+ rm example$GOEXE
+ 
++# Create +incompatible module
++exec git checkout v1.0.4
++exec git rm go.mod
++exec git commit -m 'commit 6'
++exec git tag v2.0.0
++exec git checkout HEAD^ go.mod
++# And make the tree +dirty
++mv README4 README5
++go build
++go version -m example$GOEXE
++stdout '\s+mod\s+example\s+v2.0.0+incompatible.dirty\s+'
++rm example$GOEXE
++
+ -- $WORK/repo/go.mod --
+ module example
+ 
+-- 
+2.43.0
+

--- a/pipelines/strip.yaml
+++ b/pipelines/strip.yaml
@@ -1,0 +1,35 @@
+name: Strip binaries
+
+needs:
+  packages:
+    - binutils
+    - scanelf
+
+inputs:
+  opts:
+    description: |
+      The option flags to pass to the strip command.
+    default: -g
+
+pipeline:
+  - working-directory: ${{targets.contextdir}}
+    runs: |
+      check() { "$@" || { echo "[strip] FATAL: '$*' failed $?"; exit 1; }; }
+
+      scanout=$(mktemp)
+      check scanelf --recursive --nobanner --etype "ET_DYN,ET_EXEC" --format "%I %a" -o "$scanout" .
+
+      count=0
+      while read osabi arch filename; do
+        # Skip foreign binaries
+        case "${{build.arch}}" in
+          x86_64) [ "$arch" = "EM_X86_64" ] || continue;;
+          aarch64) [ "$arch" = "EM_AARCH64" ] || continue;;
+        esac
+        [ "$osabi" != "STANDALONE" ] || continue
+        check strip ${{inputs.opts}} "$filename"
+        count=$((count+1))
+      done < "$scanout"
+
+      echo "[strip] stripped $count ${{build.arch}} binaries in $PWD"
+      rm -f "$scanout"


### PR DESCRIPTION
Fix +incompatible+dirty build metadata to be semver compatible.

With this change, rebuilding pulumi in https://github.com/wolfi-dev/os/pull/43877 makes it all work as expected

Also enable running the testsuite during build.

See: https://github.com/golang/go/issues/71971

Submitted upstream at https://go-review.googlesource.com/c/go/+/652955/3

```
# apk add --allow-untrusted -X https://apk.cgr.dev/wolfi-presubmit/944c657b461f89a52b356d1e3ccae1c4aed980fc  go pulumi grype

# go version -m /usr/bin/pulumi  | grep -e pulumi
/usr/bin/pulumi: go1.24.0
	path	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi
	mod	github.com/pulumi/pulumi/pkg/v3	v3.152.0+incompatible.dirty	
	dep	github.com/pulumi/appdash	v0.0.0-20231130102222-75f619a67231	h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
	dep	github.com/pulumi/esc	v0.10.0	h1:jzBKzkLVW0mePeanDRfqSQoCJ5yrkux0jIwAkUxpRKE=
	dep	github.com/pulumi/inflector	v0.1.1	h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+SobA=
	dep	github.com/pulumi/pulumi/sdk/v3	v3.151.0
	=>	github.com/pulumi/ssh-agent	v0.5.1	h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
	build	-ldflags="-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=v3.152.0"

# grype /usr/bin/pulumi 
 ✔ Vulnerability DB                [updated]  
 ✔ Indexed file system                                                                                                                     /usr/bin/pulumi
 ✔ Cataloged contents                                                                     c1947d89c427ea46f21cf1963a8c446d6e668ec5d8d45bf85f912ff932abcb1e
   ├── ✔ Packages                        [212 packages]  
   ├── ✔ File digests                    [1 files]  
   ├── ✔ File metadata                   [1 locations]  
   └── ✔ Executables                     [1 executables]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
No vulnerabilities found
```