### PR TITLE
test pulumi

### DIFF
--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.0"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -41,6 +41,7 @@ pipeline:
       patches: |
         cmd-go-always-emit-ldflags-version-information.patch
         change-default-telemetry-from-local-to-off.patch
+        go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
 
   - runs: |
       cd src

--- a/go-1.24/go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
+++ b/go-1.24/go-fix-incompatible-dirty-build-metadata-to-be-SemVe.patch
@@ -1,0 +1,60 @@
+From ebfa4120a231ff12942ef77e8bea7fc07726152d Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 19 Jul 2022 11:07:00 -0400
+Subject: [PATCH] go: fix +incompatible+dirty build metadata to be SemVer
+ compatible
+
+Change "+incompatible+dirty" version to be "+incompatible.dirty" such
+that it is SemVer spec compatible.
+
+Struggling to add test case for a locally generated module that will
+create +incompatible version.
+
+See:
+- https://github.com/golang/go/issues/71971
+- https://github.com/golang/go/issues/71969
+- https://github.com/golang/go/issues/71970
+- https://github.com/anchore/grype/issues/2482
+- https://semver.org/#spec-item-10
+
+Change-Id: I714ffb3f1ad88c793656c3652367db34739a2144
+---
+ src/cmd/go/internal/load/pkg.go                           | 7 ++++++-
+ src/cmd/go/testdata/script/build_version_stamping_git.txt | 3 +++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
+index 0c4639ce82..13add8ad5b 100644
+--- a/src/cmd/go/internal/load/pkg.go
++++ b/src/cmd/go/internal/load/pkg.go
+@@ -2563,7 +2563,12 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+ 		vers := revInfo.Version
+ 		if vers != "" {
+ 			if st.Uncommitted {
+-				vers += "+dirty"
++				// SemVer build metadata is dot-separated https://semver.org/#spec-item-10
++				if strings.HasSuffix(vers, "+incompatible") {
++					vers += ".dirty"
++				} else {
++					vers += "+dirty"
++				}
+ 			}
+ 			info.Main.Version = vers
+ 		}
+diff --git a/src/cmd/go/testdata/script/build_version_stamping_git.txt b/src/cmd/go/testdata/script/build_version_stamping_git.txt
+index db804b3847..ba0576e55b 100644
+--- a/src/cmd/go/testdata/script/build_version_stamping_git.txt
++++ b/src/cmd/go/testdata/script/build_version_stamping_git.txt
+@@ -108,6 +108,9 @@ go version -m example$GOEXE
+ stdout '\s+mod\s+example\s+v1.0.3-0.20220719150703-2e239bf29c13\s+'
+ rm example$GOEXE
+ 
++# TODO simulate +incompatible version here, as well as +incompatible.dirty
++# how can one locally create +incompatible version?
++
+ -- $WORK/repo/go.mod --
+ module example
+ 
+-- 
+2.43.0
+

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,13 +1,16 @@
 package:
   name: pulumi
   version: "3.152.0"
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0
 
 environment:
   contents:
+    build_repositories:
+      # Fixed up go-1.24 semver
+      - https://apk.cgr.dev/wolfi-presubmit/4eb3aab51db30cf5555e838ba2b61bf92abb621d
     packages:
       - build-base
       - busybox


### PR DESCRIPTION
- **go-1.24: fix go main version not semver compatible**
  Fix +incompatible+dirty build metadata to be semver compatible.
  

- **rebuild pulumi**
  