### PR TITLE
unwedge debezium again

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.7"
-  epoch: 2
+  epoch: 3
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/43846 updated debezium-connect-entrypoint-3.0 to r3 and our images stupidly require these to have the same epochs.