### PR TITLE
ingress-nginx-controller-1.12: Drop ld.so.conf modification

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 10
+  epoch: 11
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -302,9 +302,6 @@ pipeline:
       ARCH=$(uname -m)
 
       ls -lah ${BUILD_PATH}/lua-nginx-module-${{vars.LUA_NGX_VERSION}}
-      echo /usr/local/lib >> /etc/ld.so.conf
-      ldconfig
-      cat /etc/ld.so.conf
 
       mkdir -p ${{targets.destdir}}/etc/nginx/
 


### PR DESCRIPTION
We already cover /usr/local/lib in our /etc/ld.so.conf, so there's no need to replicate it there.