### PR TITLE
Add the pkgconf test to libvorbis

### DIFF
--- a/libvorbis.yaml
+++ b/libvorbis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvorbis
   version: 1.3.7
-  epoch: 3
+  epoch: 4
   description: Vorbis codec library
   copyright:
     - license: BSD-3-Clause
@@ -47,7 +47,13 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
     description: ${{package.name}} dev
+    dependencies:
+      runtime:
+        - libogg-dev
 
 update:
   enabled: true


### PR DESCRIPTION
Add ogg-dev because:

```
2025/02/26 10:50:20 WARN + grep -q ^Cflags: usr/lib/pkgconfig/vorbis.pc
2025/02/26 10:50:20 WARN + pkgconf --cflags vorbis
2025/02/26 10:50:20 WARN Package ogg was not found in the pkg-config search path.
2025/02/26 10:50:20 WARN Perhaps you should add the directory containing `ogg.pc'
2025/02/26 10:50:20 WARN to the PKG_CONFIG_PATH environment variable
2025/02/26 10:50:20 WARN Package 'ogg', required by 'vorbis', not found
2025/02/26 10:50:20 ERRO ERROR: failed to test package. the test environment has been preserved:
```