### PR TITLE
Add the pkgconf test to grpc-1.66

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 5
+  epoch: 6
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -123,9 +123,13 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
     dependencies:
       runtime:
         - ${{package.name}}
+        - opentelemetry-cpp-dev
       provides:
         - grpc-dev=${{package.full-version}}
     description: grpc dev


### PR DESCRIPTION
Add a runtime dep because of:

```
2025/02/26 11:13:35 WARN + echo usr/lib/pkgconfig/grpcpp_otel_plugin.pc
2025/02/26 11:13:35 WARN + grep -q '^usr/lib/pkgconfig/grpcpp_otel_plugin.pc$\|^usr/share/pkgconfig/grpcpp_otel_plugin.pc$'
2025/02/26 11:13:35 WARN + pkgconf --exists grpcpp_otel_plugin
2025/02/26 11:13:35 WARN + pkgconf --print-errors --exists grpcpp_otel_plugin
2025/02/26 11:13:35 WARN Package opentelemetry_api was not found in the pkg-config search path.
2025/02/26 11:13:35 WARN Perhaps you should add the directory containing `opentelemetry_api.pc'
2025/02/26 11:13:35 WARN to the PKG_CONFIG_PATH environment variable
2025/02/26 11:13:35 WARN Package 'opentelemetry_api', required by 'grpcpp_otel_plugin', not found
2025/02/26 11:13:35 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/02/26 11:13:35 ERRO failed to test package: unable to run pipeline: unable to run pipeline: unable to run pipeline: exit status 1
```