### PR TITLE
grafana-image-renderer-3.12.1/fix GHSA-rhx6-c78j-4q9w

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: "3.12.1"
-  epoch: 0
+  epoch: 1
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,8 @@ pipeline:
       repository: https://github.com/grafana/grafana-image-renderer
       tag: v${{package.version}}
       expected-commit: 13845a35ef6814bf2cf6727343b5b305dcb9bfaf
+      cherry-picks: |
+        pull/605/head/7aa89d1ab559c03a8295c39515b1ccca16051c2c: Update dompurify to 3.2.4 - fixes CVE-2025-26791
 
   - uses: patch
     with:

--- a/grafana-image-renderer/GHSA-rhx6-c78j-4q9w.patch
+++ b/grafana-image-renderer/GHSA-rhx6-c78j-4q9w.patch
@@ -1,5 +1,14 @@
+From ca4d0e9b36aecfecb88c436663d53656f9197d8a Mon Sep 17 00:00:00 2001
+From: Kyle Steere <kyle.steere@chainguard.dev>
+Date: Wed, 26 Feb 2025 15:37:48 -0600
+Subject: [PATCH] fixes: GHSA-rhx6-c78j-4q9w
+
+---
+ package.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/package.json b/package.json
-index b25b17d..7486348 100644
+index 9a52c75..f4b6dab 100644
 --- a/package.json
 +++ b/package.json
 @@ -76,7 +76,8 @@
@@ -12,3 +21,5 @@ index b25b17d..7486348 100644
    },
    "lint-staged": {
      "*.ts": [
+--
+2.43.0


### PR DESCRIPTION
fix: GHSA-rhx6-c78j-4q9w

#### For security-related PRs
- [X] The security fix is recorded in the [advisory](https://github.com/chainguard-dev/CVE-Dashboard/issues/19549) repo

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
