### PR TITLE
Run golang testsuite during build

### DIFF
--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.0"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -20,6 +20,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - git-daemon
       - go-1.22 # https://go.dev/doc/go1.24#bootstrap
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
@@ -44,7 +45,10 @@ pipeline:
 
   - runs: |
       cd src
-      ./make.bash -v
+      # Tests need at least local telemtry on, which we patch out
+      mkdir -p ~/.config/go/telemetry
+      echo "local" > ~/.config/go/telemetry/mode
+      ./all.bash -v
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin "${{targets.destdir}}"/usr/lib/go/bin "${{targets.destdir}}"/usr/share/doc/go


### PR DESCRIPTION
Add additional runtime dependencies needed to execute the full
upstream testsuite.
