### PR TITLE
opensearch-dashboards-2/CVE-2025-26791 fix

### DIFF
--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-2
   version: "2.19.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 0
+  epoch: 1
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -130,14 +130,11 @@ subpackages:
           tag: ${{package.version}}.0
           destination: ./plugins/${{range.value}}
       - runs: |
-          # fix cve CVE-2024-45801
           cd ./plugins/${{range.value}}
+          # fixes CVE-2025-26791 by bumping dompurify dependency definitions
           if [ ${{range.value}} = "reportsDashboards" ]
           then
-            # Define the dependencies
-            dependencies='{"dompurify": "^3.1.3"}'
-            # Apply the dependencies
-            jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
+            git fetch origin 2.19 && git cherry-pick 3ad10434bd83591588476a057b8eacc5739f7882
           fi
 
           # Downgrade cypress version to 12.17.4 if this is securityDashboard due to upstream problem:

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -125,18 +125,18 @@ subpackages:
       - runs: |
           rm -r plugins/* || true
       - uses: git-checkout
-        if: "'${{range.value}}' == 'reportsDashboards'"
+        with:
+          repository: https://github.com/opensearch-project/${{range.key}}.git
+          tag: ${{package.version}}.0
+          destination: ./plugins/${{range.value}}
+      - if: "'${{range.value}}' == 'reportsDashboards'"
+        uses: git-checkout
         with:
           repository: https://github.com/opensearch-project/${{range.key}}.git
           tag: ${{package.version}}.0
           destination: ./plugins/${{range.value}}
           cherry-picks: |
             2.19/3ad10434bd83591588476a057b8eacc5739f7882: required to bump jspdf to 3.0, fixes CVE-2025-26791
-      - uses: git-checkout
-        with:
-          repository: https://github.com/opensearch-project/${{range.key}}.git
-          tag: ${{package.version}}.0
-          destination: ./plugins/${{range.value}}
       - runs: |
           cd ./plugins/${{range.value}}
 

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -128,7 +128,7 @@ subpackages:
         if: "'${{range.value}}' == 'reportsDashboards'"
         with:
           repository: https://github.com/opensearch-project/${{range.key}}.git
-          branch: 2.19
+          tag: ${{package.version}}.0
           destination: ./plugins/${{range.value}}
           cherry-picks: |
             2.19/3ad10434bd83591588476a057b8eacc5739f7882: required to bump jspdf to 3.0, fixes CVE-2025-26791

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -125,17 +125,20 @@ subpackages:
       - runs: |
           rm -r plugins/* || true
       - uses: git-checkout
+        if: "'${{range.value}}' == 'reportsDashboards'"
+        with:
+          repository: https://github.com/opensearch-project/${{range.key}}.git
+          branch: 2.19
+          destination: ./plugins/${{range.value}}
+          cherry-picks: |
+            2.19/3ad10434bd83591588476a057b8eacc5739f7882: required to bump jspdf to 3.0, fixes CVE-2025-26791
+      - uses: git-checkout
         with:
           repository: https://github.com/opensearch-project/${{range.key}}.git
           tag: ${{package.version}}.0
           destination: ./plugins/${{range.value}}
       - runs: |
           cd ./plugins/${{range.value}}
-          # fixes CVE-2025-26791 by bumping dompurify dependency definitions
-          if [ ${{range.value}} = "reportsDashboards" ]
-          then
-            git fetch origin 2.19 && git cherry-pick 3ad10434bd83591588476a057b8eacc5739f7882
-          fi
 
           # Downgrade cypress version to 12.17.4 if this is securityDashboard due to upstream problem:
           # ERROR [single_version_dependencies] Multiple version ranges for the same dependency were found declared across different package.json files.


### PR DESCRIPTION
opensearch-project[ merged a manual backport](https://github.com/opensearch-project/dashboards-reporting/commit/3ad10434bd83591588476a057b8eacc5739f7882) of [this commit](https://github.com/opensearch-project/dashboards-reporting/commit/c25ad293626c3964037a142b3bf3cc797eda2d3f) to the 2.19 branch of [dashboards-reporting](https://github.com/opensearch-project/dashboards-reporting). Which bumps jspdf to 3.0, this alllows us to remove the now inaccurate logic in our build and fixes https://github.com/advisories/GHSA-vhxf-7vqr-mrjg.