### PR TITLE
Do not print warnings when running apk info

### DIFF
--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -12,7 +12,7 @@ pipeline:
       # Find all pc files installed by this dev_pkg
       cd /
       pc_files=false
-      for pc_file in $(apk info -L "$dev_pkg" | grep "\.pc$"); do
+      for pc_file in $(apk info -L "$dev_pkg" 2>/dev/null | grep "\.pc$"); do
         pc_files=true
         # Ensure this is a pkgconf .pc file
         if grep -q "^Name:" $pc_file; then


### PR DESCRIPTION
Before this change the pkgconf test pipeline would always print the following warnings, which are entirely innocuous.

```
2025/02/26 16:35:32 WARN + apk info -L libsdl2-dev
2025/02/26 16:35:32 WARN + grep '\.pc$'
2025/02/26 16:35:32 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory
2025/02/26 16:35:32 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory
```

So let's suppress them.