### PR TITLE
ingress-nginx-controller-1.12: add bitnami compat package

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -511,11 +511,15 @@ subpackages:
         - ingress-nginx-controller-bitnami-compat=${{package.full-version}}
       runtime:
         - bash # https://github.com/bitnami/charts/blob/db53e622ecf1be5a78d1ce683cec8baa41110fa3/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml#L89
+        - coreutils
+        - curl
+        - findutils
         - gmp
         - gnutls
+        - grep
         - ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
         - libffi
-        #- libhogweed6 missing pkg/so
+        #- libhogweed6 missing pkg/so # https://github.com/bitnami/containers/blob/942861e0cea74a6a07bceafb299180a2733c0bfe/bitnami/nginx-ingress-controller/1/debian-12/Dockerfile#L29
         - libmaxminddb-dev
         - librtmp
         - libssh
@@ -523,6 +527,7 @@ subpackages:
         - nettle
         - p11-kit
         - procps
+        - sed
     pipeline:
       - uses: bitnami/compat
         with:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -517,7 +517,7 @@ subpackages:
         - gmp
         - gnutls
         - grep
-        - ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
+        - ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}} # We depend on generic compat because it ships some symlinks that also Bitnami needs, like symlinks to /nginx-ingress-controller, /dev/stdout and /dev/stderr.
         - libffi
         #- libhogweed6 missing pkg/so # https://github.com/bitnami/containers/blob/942861e0cea74a6a07bceafb299180a2733c0bfe/bitnami/nginx-ingress-controller/1/debian-12/Dockerfile#L29
         - libmaxminddb-dev

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -560,6 +560,9 @@ subpackages:
               /nginx-ingress-controller --kubeconfig ~/.kube/config
             timeout: 30
             expected_output: |
+              NGINX Ingress controller
+              Release:       controller-v${{package.version}}
+              nginx version: nginx/${{vars.NGINX_VERSION}}
               Running in Kubernetes cluster
 
   - name: ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
@@ -788,4 +791,7 @@ test:
           nginx-ingress-controller --kubeconfig ~/.kube/config
         timeout: 30
         expected_output: |
+          NGINX Ingress controller
+          Release:       controller-v${{package.version}}
+          nginx version: nginx/${{vars.NGINX_VERSION}}
           Running in Kubernetes cluster

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 12
+  epoch: 13
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -505,10 +505,10 @@ pipeline:
 
 subpackages:
   - name: ingress-nginx-controller-bitnami-compat-${{vars.nginx-ingress-major-minor}}
-    description: Compatibility package wit Bitnami bitnami/nginx-ingress-controller image
+    description: Compatibility package with bitnami/nginx-ingress-controller image
     dependencies:
       provides:
-        - ingress-nginx-controller-bitnami-compat-${{package.full-version}}
+        - ingress-nginx-controller-bitnami-compat=${{package.full-version}}
       runtime:
         - bash # https://github.com/bitnami/charts/blob/db53e622ecf1be5a78d1ce683cec8baa41110fa3/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml#L89
         - gmp
@@ -518,11 +518,11 @@ subpackages:
         #- libhogweed6 missing pkg/so
         - libmaxminddb-dev
         - librtmp
-        - libssh # sus
+        - libssh
         - libtasn1
         - nettle
         - p11-kit
-        - procps # sus
+        - procps
     pipeline:
       - uses: bitnami/compat
         with:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -539,6 +539,9 @@ subpackages:
         contents:
           packages:
             - libmaxminddb
+            - ${{package.name}}
+        environment:
+          BITNAMI_APP_NAME: nginx-ingress-controller
       pipeline:
         - uses: test/ldd-check
           with:
@@ -546,8 +549,18 @@ subpackages:
         - name: Test symlinks
           runs: |
             test -f $(readlink -f /opt/bitnami/common/bin/mmdblookup)
-            test -f $(readlink -f /opt/bitnami/common/lib)
-            test -f $(readlink -f /opt/bitnami/common/include)
+            test -d $(readlink -f /opt/bitnami/common/lib)
+            test -d $(readlink -f /opt/bitnami/common/include)
+        - name: Run KwoK
+          uses: test/kwok/cluster
+        - name: Test entrypoint and controller logs
+          uses: test/daemon-check-output
+          with:
+            start: |
+              /nginx-ingress-controller --kubeconfig ~/.kube/config
+            timeout: 30
+            expected_output: |
+              Running in Kubernetes cluster
 
   - name: ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
     description: Compatibility package for ingress-nginx-controller
@@ -766,3 +779,13 @@ test:
       runs: |
         getcap /usr/bin/nginx-ingress-controller | cut -d ' ' -f2 | grep -q -E '^cap_net_bind_service=ep$'
         getcap /usr/bin/nginx | cut -d ' ' -f2 | grep -q -E '^cap_net_bind_service=ep$'
+    - name: Run KwoK
+      uses: test/kwok/cluster
+    - name: Check controller logs
+      uses: test/daemon-check-output
+      with:
+        start: |
+          nginx-ingress-controller --kubeconfig ~/.kube/config
+        timeout: 30
+        expected_output: |
+          Running in Kubernetes cluster

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -548,6 +548,7 @@ subpackages:
             packages: ${{subpkg.name}}
         - name: Test symlinks
           runs: |
+            set -e
             test -f $(readlink -f /opt/bitnami/common/bin/mmdblookup)
             test -d $(readlink -f /opt/bitnami/common/lib)
             test -d $(readlink -f /opt/bitnami/common/include)

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -54,6 +54,10 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: nginx-ingress-major-minor
+  - from: ${{package.version}}
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: nginx-ingress-major
 
 environment:
   contents:
@@ -500,6 +504,51 @@ pipeline:
         && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx
 
 subpackages:
+  - name: ingress-nginx-controller-bitnami-compat-${{vars.nginx-ingress-major-minor}}
+    description: Compatibility package wit Bitnami bitnami/nginx-ingress-controller image
+    dependencies:
+      provides:
+        - ingress-nginx-controller-bitnami-compat-${{package.full-version}}
+      runtime:
+        - bash # https://github.com/bitnami/charts/blob/db53e622ecf1be5a78d1ce683cec8baa41110fa3/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml#L89
+        - gmp
+        - gnutls
+        - ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
+        - libffi
+        #- libhogweed6 missing pkg/so
+        - libmaxminddb-dev
+        - librtmp
+        - libssh # sus
+        - libtasn1
+        - nettle
+        - p11-kit
+        - procps # sus
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: nginx-ingress-controller
+          version-path: ${{vars.nginx-ingress-major}}/debian-12
+      - name: Ensure symlinks
+        runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/common/bin
+          ln -s /usr/bin/mmdblookup ${{targets.subpkgdir}}/opt/bitnami/common/bin/mmdblookup
+          ln -s /usr/lib ${{targets.subpkgdir}}/opt/bitnami/common/lib
+          ln -s /usr/include ${{targets.subpkgdir}}/opt/bitnami/common/include
+    test:
+      environment:
+        contents:
+          packages:
+            - libmaxminddb
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: $(basename ${{targets.contextdir}})
+        - name: Test symlinks
+          runs: |
+            test -f $(readlink -f /opt/bitnami/common/bin/mmdblookup)
+            test -f $(readlink -f /opt/bitnami/common/lib)
+            test -f $(readlink -f /opt/bitnami/common/include)
+
   - name: ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
     description: Compatibility package for ingress-nginx-controller
     dependencies:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -543,9 +543,9 @@ subpackages:
         environment:
           BITNAMI_APP_NAME: nginx-ingress-controller
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            packages: ${{subpkg.name}}
         - name: Test symlinks
           runs: |
             test -f $(readlink -f /opt/bitnami/common/bin/mmdblookup)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

Notes:
The name aligns the compat one being: `ingress-nginx-controller-compat-{MAJOR_MINOR_VERSION}`.

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
