### PR TITLE
update runtime deps for k8s-csi-driver-nfs

### DIFF
--- a/kubernetes-csi-driver-nfs.yaml
+++ b/kubernetes-csi-driver-nfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-driver-nfs
   version: 4.10.0
-  epoch: 0
+  epoch: 1
   description: This driver allows Kubernetes to access NFS server on Linux node
   copyright:
     - license: Apache-2.0
@@ -9,11 +9,10 @@ package:
     runtime:
       - coreutils
       - efs-utils
-      - libcap-dev
+      - libcap
       # https://github.com/kubernetes-csi/csi-driver-nfs/blob/b68ee7181160b12717c80c53667e2d33bf1edc7b/Dockerfile#L21
       - mount
       - umount
-      - util-linux
       - util-linux-misc
 
 pipeline:

--- a/kubernetes-csi-driver-nfs.yaml
+++ b/kubernetes-csi-driver-nfs.yaml
@@ -40,6 +40,10 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/
           ln -sf /usr/bin/nfsplugin "${{targets.contextdir}}"/nfsplugin
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - runs: |
             test "$(readlink /nfsplugin)" = "/usr/bin/nfsplugin"

--- a/kubernetes-csi-driver-nfs.yaml
+++ b/kubernetes-csi-driver-nfs.yaml
@@ -39,6 +39,11 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/
           ln -sf /usr/bin/nfsplugin "${{targets.contextdir}}"/nfsplugin
+    test:
+      pipeline:
+        - runs: |
+            test "$(readlink /nfsplugin)" = "/usr/bin/nfsplugin"
+            /nfsplugin --help
 
 update:
   enabled: true


### PR DESCRIPTION
only libcap is required and util-linux-misc will pull util-linux as
well. 

ref: https://github.com/wolfi-dev/os/pull/43879#discussion_r1973434877