### PR TITLE
add nginx-bitnami

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -319,8 +319,8 @@ subpackages:
       - name: Copy HTML to /app
         runs: |
           mkdir -p ${{targets.contextdir}}/app
-          ln -sf /home/build/melange-out/${{package.name}}/var/lib/nginx/html/50x.html ${{targets.contextdir}}/app
-          ln -sf /home/build/melange-out/${{package.name}}/var/lib/nginx/html/index.html ${{targets.contextdir}}/app
+          cp ${{targets.destdir}}/var/lib/nginx/html/50x.html ${{targets.contextdir}}/app
+          cp ${{targets.destdir}}/var/lib/nginx/html/index.html ${{targets.contextdir}}/app
     test:
       environment:
         contents:
@@ -328,13 +328,13 @@ subpackages:
             - ${{package.name}}-config
             - ${{package.name}}-config-compat
             - curl
-            - crane
             - shadow
             - sudo-rs
             - wait-for-it
       pipeline:
         - working-directory: /app
           pipeline:
+            # using accounts to create user fails in CI
             - name: Create Nginx user and directories
               runs: |
                 adduser -D -g 'Nginx User' nginx

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: "1.27.4"
-  epoch: 2
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -319,8 +319,8 @@ subpackages:
       - name: Copy HTML to /app
         runs: |
           mkdir -p ${{targets.contextdir}}/app
-          cp -R /home/build/melange-out/${{package.name}}/var/lib/nginx/html/50x.html ${{targets.contextdir}}/app
-          cp -R /home/build/melange-out/${{package.name}}/var/lib/nginx/html/index.html ${{targets.contextdir}}/app
+          ln -sf /home/build/melange-out/${{package.name}}/var/lib/nginx/html/50x.html ${{targets.contextdir}}/app
+          ln -sf /home/build/melange-out/${{package.name}}/var/lib/nginx/html/index.html ${{targets.contextdir}}/app
     test:
       environment:
         contents:

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -268,7 +268,7 @@ subpackages:
         - grep
         - openssl
         - glibc-locales
-        - nginx-mainline-package-config
+        - nginx-package-config
         - nginx-mod-http_geoip
         - nginx-mod-stream_geoip
     pipeline:
@@ -283,6 +283,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/conf.d
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/conf.d
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/logs
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/bitnami/certs
@@ -297,7 +298,8 @@ subpackages:
           ln -sf /usr/lib/nginx/modules ${{targets.contextdir}}/opt/bitnami/nginx/modules
           ln -sf /var/lib/nginx/html ${{targets.contextdir}}/opt/bitnami/nginx/html
           ln -sf /opt/bitnami/nginx/html ${{targets.contextdir}}/app
-          ln -sf /var/log/nginx ${{targets.contextdir}}/opt/bitnami/nginx/logs
+          ln -sf /dev/stdout ${{targets.contextdir}}/opt/bitnami/nginx/logs/access.log
+          ln -sf /dev/stderr ${{targets.contextdir}}/opt/bitnami/nginx/logs/error.log
           ln -sf /opt/bitnami/nginx/conf/bitnami/certs ${{targets.contextdir}}/certs
       - name: Set symlinks (configs)
         runs: |

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: "1.27.4"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -35,6 +35,12 @@ environment:
       - pkgconf
       - zeromq-dev
       - zlib-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 data:
   - name: modules
@@ -246,6 +252,27 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/
           ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+
+  - name: nginx-bitnami-compat
+    description: "compat package with bitnami/keycloak image"
+    dependencies:
+      runtime:
+        - coreutils
+        - glibc-locale-en
+        - net-tools
+        - posix-libc-utils
+        - su-exec
+        - busybox
+        - curl
+        - bash
+        - sed
+        - grep
+        - glibc-locales
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: nginx
+          version-path: ${{vars.major-version}}/debian-12
 
 test:
   environment:

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -255,7 +255,7 @@ subpackages:
           ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
 
   - name: nginx-bitnami-compat
-    description: "compat package with bitnami/keycloak image"
+    description: "compat package with bitnami/NGINX image"
     dependencies:
       runtime:
         - coreutils

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: "1.27.4"
-  epoch: 1
+  epoch: 2
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -38,9 +38,9 @@ environment:
 
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+).*
-    replace: $1
-    to: major-version
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 data:
   - name: modules
@@ -263,16 +263,96 @@ subpackages:
         - posix-libc-utils
         - su-exec
         - busybox
-        - curl
         - bash
         - sed
         - grep
+        - openssl
         - glibc-locales
+        - nginx-mainline-package-config
+        - nginx-mod-http_geoip
+        - nginx-mod-stream_geoip
     pipeline:
       - uses: bitnami/compat
         with:
           image: nginx
-          version-path: ${{vars.major-version}}/debian-12
+          version-path: ${{vars.major-minor-version}}/debian-12
+      - name: Create dirs
+        runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/sbin
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/conf.d
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/conf.d
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/bitnami/certs
+          mkdir -p ${{targets.contextdir}}/bitnami/nginx/conf/vhosts
+          mkdir -p ${{targets.contextdir}}/docker-entrypoint-initdb.d
+          mkdir -p ${{targets.contextdir}}/bitnami/nginx
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/client_body ${{targets.contextdir}}/var/lib/nginx/tmp/proxy ${{targets.contextdir}}/var/lib/nginx/tmp/fastcgi ${{targets.contextdir}}/var/lib/nginx/tmp/uwsgi ${{targets.contextdir}}/var/lib/nginx/tmp/scgi ${{targets.contextdir}}/run/nginx ${{targets.contextdir}}/var/run
+          touch ${{targets.contextdir}}/.rnd
+      - name: Set symlinks
+        runs: |
+          ln -sf /usr/sbin/nginx ${{targets.contextdir}}/opt/bitnami/nginx/sbin/nginx
+          ln -sf /usr/lib/nginx/modules ${{targets.contextdir}}/opt/bitnami/nginx/modules
+          ln -sf /var/lib/nginx/html ${{targets.contextdir}}/opt/bitnami/nginx/html
+          ln -sf /opt/bitnami/nginx/html ${{targets.contextdir}}/app
+          ln -sf /var/log/nginx ${{targets.contextdir}}/opt/bitnami/nginx/logs
+          ln -sf /opt/bitnami/nginx/conf/bitnami/certs ${{targets.contextdir}}/certs
+      - name: Set symlinks (configs)
+        runs: |
+          ln -sf /etc/nginx/nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf
+          ln -sf /etc/nginx/conf.d/nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf.default
+          ln -sf /etc/nginx/nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf
+          ln -sf /etc/nginx/conf.d/nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.default.conf
+          for file in $(find ${{targets.contextdir}}/etc/nginx/ -type f); do
+            ln -sf $file ${{targets.contextdir}}/opt/bitnami/nginx/conf/$(basename $file)
+          done
+          for file in $(find ${{targets.contextdir}}/etc/nginx/ -type f); do
+            ln -sf $file ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/$(basename $file)
+          done
+      - name: Set permissions
+        runs: |
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/opt/bitnami/
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/bitnami/nginx
+          find ${{targets.contextdir}}/ -perm /6000 -type f -exec chmod a-s {} \; || true
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}-config
+            - ${{package.name}}-config-compat
+            - curl
+            - crane
+            - shadow
+            - sudo-rs
+            - wait-for-it
+      pipeline:
+        - working-directory: /app
+          pipeline:
+            - name: Create Nginx user and directories
+              runs: |
+                adduser -D -g 'Nginx User' nginx
+                chown -R nginx:nginx /var/lib/nginx /run/nginx
+            - name: "Launch the nginx"
+              uses: test/daemon-check-output
+              with:
+                start: |
+                  env BITNAMI_APP_NAME=nginx \
+                      NGINX_HTTPS_PORT_NUMBER="" \
+                      NGINX_HTTP_PORT_NUMBER="" \
+                      PATH="/opt/bitnami/common/bin:/opt/bitnami/nginx/sbin:$PATH" \
+                      BITNAMI_DEBUG=true \
+                      /opt/bitnami/scripts/nginx/entrypoint.sh /opt/bitnami/scripts/nginx/run.sh
+                timeout: 60
+                expected_output: |
+                  Welcome to the Bitnami nginx container
+                  Starting NGINX setup
+                  NGINX setup finished!
+                  Starting NGINX
+                post: |
+                  wait-for-it -t 10 localhost:8080
+                  curl -I http://localhost:8080 || exit 1
 
 test:
   environment:

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -287,7 +287,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/bitnami/certs
           mkdir -p ${{targets.contextdir}}/docker-entrypoint-initdb.d
-          mkdir -p ${{targets.contextdir}}/bitnami/nginx
+          mkdir -p ${{targets.contextdir}}/bitnami/nginx/conf/vhosts
           mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/client_body
           mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/proxy
           mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/fastcgi
@@ -296,12 +296,15 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/run/nginx
           mkdir -p ${{targets.contextdir}}/var/run
           touch ${{targets.contextdir}}/.rnd
-      - name: Copy contents (app) | Set symlinks (configs)
+      - name: Copy contents | Set symlinks
         runs: |
           install -m644 -D nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf
           install -m644 -D nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf.default
           install -m644 -D nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf
           install -m644 -D nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf.default
+
+          ln -sf /usr/sbin/nginx ${{targets.contextdir}}/opt/bitnami/nginx/sbin/nginx
+          ln -sf /usr/lib/nginx/modules ${{targets.contextdir}}/opt/bitnami/nginx/
       - name: Run postunpack.sh
         runs: |
           find ${{targets.contextdir}}/opt/bitnami -iname "*.sh" -exec sh -c '
@@ -311,6 +314,8 @@ subpackages:
               sed -i "s#/bitnami/nginx/data#${{targets.contextdir}}/bitnami/nginx/data#g" "$1"
           ' sh {} \;
           bash -x ${{targets.contextdir}}/opt/bitnami/scripts/nginx/postunpack.sh
+          # Restore original paths
+          find ${{targets.contextdir}}/opt/bitnami -type f -exec sed -i "s#${{targets.contextdir}}##g" {} \;
       - name: Copy HTML to /app
         runs: |
           mkdir -p ${{targets.contextdir}}/app

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -19,6 +19,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - brotli-dev
       - build-base
       - busybox
@@ -280,44 +281,41 @@ subpackages:
         runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/sbin
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf
-          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/conf.d
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default
-          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/conf.d
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/html
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/logs
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
-          mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx/conf/bitnami/certs
-          mkdir -p ${{targets.contextdir}}/bitnami/nginx/conf/vhosts
           mkdir -p ${{targets.contextdir}}/docker-entrypoint-initdb.d
           mkdir -p ${{targets.contextdir}}/bitnami/nginx
-          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/client_body ${{targets.contextdir}}/var/lib/nginx/tmp/proxy ${{targets.contextdir}}/var/lib/nginx/tmp/fastcgi ${{targets.contextdir}}/var/lib/nginx/tmp/uwsgi ${{targets.contextdir}}/var/lib/nginx/tmp/scgi ${{targets.contextdir}}/run/nginx ${{targets.contextdir}}/var/run
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/client_body
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/proxy
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/fastcgi
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/uwsgi
+          mkdir -p ${{targets.contextdir}}/var/lib/nginx/tmp/scgi
+          mkdir -p ${{targets.contextdir}}/run/nginx
+          mkdir -p ${{targets.contextdir}}/var/run
           touch ${{targets.contextdir}}/.rnd
-      - name: Set symlinks
+      - name: Copy contents (app) | Set symlinks (configs)
         runs: |
-          ln -sf /usr/sbin/nginx ${{targets.contextdir}}/opt/bitnami/nginx/sbin/nginx
-          ln -sf /usr/lib/nginx/modules ${{targets.contextdir}}/opt/bitnami/nginx/modules
-          ln -sf /var/lib/nginx/html ${{targets.contextdir}}/opt/bitnami/nginx/html
-          ln -sf /opt/bitnami/nginx/html ${{targets.contextdir}}/app
-          ln -sf /dev/stdout ${{targets.contextdir}}/opt/bitnami/nginx/logs/access.log
-          ln -sf /dev/stderr ${{targets.contextdir}}/opt/bitnami/nginx/logs/error.log
-          ln -sf /opt/bitnami/nginx/conf/bitnami/certs ${{targets.contextdir}}/certs
-      - name: Set symlinks (configs)
+          install -m644 -D nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf
+          install -m644 -D nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf.default
+          install -m644 -D nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf
+          install -m644 -D nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf.default
+      - name: Run postunpack.sh
         runs: |
-          ln -sf /etc/nginx/nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf
-          ln -sf /etc/nginx/conf.d/nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf/nginx.conf.default
-          ln -sf /etc/nginx/nginx.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.conf
-          ln -sf /etc/nginx/conf.d/nginx.default.conf ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/nginx.default.conf
-          for file in $(find ${{targets.contextdir}}/etc/nginx/ -type f); do
-            ln -sf $file ${{targets.contextdir}}/opt/bitnami/nginx/conf/$(basename $file)
-          done
-          for file in $(find ${{targets.contextdir}}/etc/nginx/ -type f); do
-            ln -sf $file ${{targets.contextdir}}/opt/bitnami/nginx/conf.default/$(basename $file)
-          done
-      - name: Set permissions
+          find ${{targets.contextdir}}/opt/bitnami -iname "*.sh" -exec sh -c '
+              sed -i "s#/opt/bitnami#${{targets.contextdir}}/opt/bitnami#g" "$1"
+              sed -i "s#\"/bitnami\"#\"${{targets.contextdir}}/bitnami\"#g" "$1"
+              sed -i "s#\"/certs\"#\"${{targets.contextdir}}/certs\"#g" "$1"
+              sed -i "s#/bitnami/nginx/data#${{targets.contextdir}}/bitnami/nginx/data#g" "$1"
+          ' sh {} \;
+          bash -x ${{targets.contextdir}}/opt/bitnami/scripts/nginx/postunpack.sh
+      - name: Copy HTML to /app
         runs: |
-          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/opt/bitnami/
-          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/bitnami/nginx
-          find ${{targets.contextdir}}/ -perm /6000 -type f -exec chmod a-s {} \; || true
+          mkdir -p ${{targets.contextdir}}/app
+          cp -R /home/build/melange-out/${{package.name}}/var/lib/nginx/html/50x.html ${{targets.contextdir}}/app
+          cp -R /home/build/melange-out/${{package.name}}/var/lib/nginx/html/index.html ${{targets.contextdir}}/app
     test:
       environment:
         contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
