### PR TITLE
fix(aws-cli-2.yaml): re introduced required runtime dependency of zlib

### DIFF
--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -3,7 +3,7 @@
 package:
   name: aws-cli-2
   version: "2.24.13"
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ package:
       - aws-cli=${{package.full-version}}
     runtime:
       - groff-base
+      - zlib
 
 environment:
   contents:


### PR DESCRIPTION
A change introduced in https://github.com/wolfi-dev/os/pull/43209 dropped a transitive dependency of perl from aws-cli-2.

Perl depends on zlib and as such resolved the aws-cli-2 undeclared yet required dependency on zlib.

Expliciltly adding zlib as a dependency resolves the issue.

This was highlighted in aws-cli-2 image tests which is a different test environment to the package test env.
The package test env already has zlib present so did not exhibit the error below

```
libz.so.1: cannot open shared object file: No such file or directory
│       exit status 127
```

Signed-off-by: philroche <phil.roche@chainguard.dev>
