### PR TITLE
remove yq from kubectl-bitnami-compat

### DIFF
--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.32
   version: "1.32.2"
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -101,7 +101,6 @@ subpackages:
         - bash
         - busybox
         - coreutils
-        - yq
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/opt/bitnami/kubectl/bin"


### PR DESCRIPTION
Removes `yq` from the `kubectl-bitnami-compat` sub package.
`yq` is being removed from the package level and being added to the image level.