### PR TITLE
oauth2-proxy/cve remediation - Fix: GHSA-c6gw-w398-hv78

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: "7.8.1"
-  epoch: 2
+  epoch: 3
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -24,7 +24,12 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.3 golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0
+      deps: |-
+        github.com/go-jose/go-jose/v3@v3.0.4
+        golang.org/x/crypto@v0.31.0
+        golang.org/x/net@v0.33.0
+      replaces: |
+        github.com/go-jose/go-jose/v4=github.com/go-jose/go-jose/v4@v4.0.5
 
   - uses: go/build
     with:


### PR DESCRIPTION
updating both go-jose versions to latest to address GHSA-c6gw-w398-hv78