### PR TITLE
linkerd-network-validator: convert to git update backend

### DIFF
--- a/linkerd-network-validator.yaml
+++ b/linkerd-network-validator.yaml
@@ -37,10 +37,9 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: linkerd/linkerd2-proxy-init
+  git:
     strip-prefix: validator/v
-    tag-filter: validator/v
+    tag-filter-prefix: validator/v
 
 test:
   pipeline:


### PR DESCRIPTION
To fix updatebot failures.