### PR TITLE
openmp-17: Enable test/ldd-check

### DIFF
--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-17
   version: 17.0.6
-  epoch: 2
+  epoch: 3
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
@@ -60,7 +60,13 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - llvm17-dev
         - openmp-17
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
Also, add llvm17-dev as a runtime dependency of openmp-17-dev.

Fixes: #40841 