### PR TITLE
openmp-16: Enable test/ldd-check

### DIFF
--- a/openmp-16.yaml
+++ b/openmp-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-16
   version: 16.0.6
-  epoch: 1
+  epoch: 2
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
@@ -60,7 +60,13 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - llvm16-dev
         - openmp-16
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
Also, add llvm16-dev as a runtime dependency of openmp-16-dev.

Fixes: #40840