### PR TITLE
chore(clang): Run ldd check

### DIFF
--- a/llvm.yaml
+++ b/llvm.yaml
@@ -412,6 +412,9 @@ subpackages:
           ln -sf ../../$sonamefull ${{targets.contextdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
     test:
       pipeline:
+        - uses: test/ldd-check
+          with:
+            packages: ${{subpkg.name}}
         - uses: test/compiler-hardening-check
           with:
             cc: clang-${{vars.major-version}}


### PR DESCRIPTION
Don't bump the epoch as package composition has not changed (tests were ran locally and pass)