### PR TITLE
feat(chromium): Add support for arm64

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -103,9 +103,7 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
-      - mesa
       - mesa-dev
-      - mesa-gbm
       - minizip
       - nghttp2-dev
       - openh264-dev
@@ -124,6 +122,7 @@ environment:
       - rust
       - rust-bindgen
       - samurai
+      - scanelf
       - speex-dev
       - sqlite-dev
       - systemd-dev
@@ -137,50 +136,27 @@ environment:
     RUSTC_BOOTSTRAP: 1
 
 pipeline:
-  - uses: git-checkout
+  - name: Fetch Chromium tarball
+    uses: fetch
     with:
-      # Initial git clone: takes ~3 minutes, needs 6GB disk
-      repository: https://chromium.googlesource.com/chromium/src.git
-      tag: ${{package.version}}
-      depth: 1
-      expected-commit: 2a5d6da0d6165d7b107502095a937fe7704fcef6
-      destination: /home/src
+      # Fetch source and dependencies: takes about 11 minutes, requires 30 GB of disk
+      # Gentoo provides tarballs where they've already performed a client sync (which isn't possible on arm64)
+      uri: https://chromium-tarballs.distfiles.gentoo.org/chromium-${{package.version}}-linux.tar.xz
+      expected-sha512: 04ca888078ab3ce4775d0dff9c9d46b342be5bda2fe41493dcf8695fa9b52ed749455275cfc4bba234a10fbe6df0eeac3d8bb2f8d73ca1250a142c58944ff6d9
 
-  - working-directory: /home
-    name: Clone depot-tools and setup .gclient
+  - name: Remove binaries from source tree
     runs: |
-      # depot_tools contains essential Chromium build tools
-      # in consists of gclient, gn, autoninja, etc. that are used to build Chromium
-      # We are cloning it to /home/depot_tools and have to add it to PATH
-      time git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      # These binaries are tools transient from the client sync Gentoo performs for us
+      # All we need is the Chromium source tree and its dependencies
+      #
+      # Tarballs are built using the instructions here:
+      # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
+      scanelf -RA -F "%F" "$HOME" 2>/dev/null | while read -r elf; do
+        echo "Removing $elf"
+        rm -f "$elf"
+      done
 
-      # Create .gclient configuration file
-      # Important: File must be in /home (parent of src/)
-      # Because: gclient searches for .gclient in parent directories
-      # Reference: https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/README.gclient.md
-      cat <<EOF > /home/.gclient
-      # Setup a .gclient config (handled by 'fetch' in upstream instructions)
-      solutions = [
-        { "name"        : "src",
-          "url"         : "https://chromium.googlesource.com/chromium/src.git",
-          "managed": False,
-          "custom_deps": {},
-          "custom_vars": {},
-        },
-      ]
-      EOF
-
-  - working-directory: /home/src
-    name: sync-dependencies
-    runs: |
-      # Add depot_tools to PATH to use gclient
-      export PATH="$PATH:/home/depot_tools"
-
-      # Sync dependencies: takes about 11 minutes, requires 30 GB of disk
-      time gclient sync --no-history
-
-  - working-directory: /home/src
-    name: Use system libraries
+  - name: Use system libraries
     runs: |
       # Use USB IDs already provided by hwdata-usb
       sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
@@ -232,17 +208,15 @@ pipeline:
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
         tools/generate_shim_headers/generate_shim_headers.py
 
-      # Make node executable: works around permission denial
-      chmod +x /home/src/third_party/node/linux/node-linux-x64/bin/node
+      # Use host node
+      mkdir -p third_party/node/linux/node-linux-x64/bin
+      ln -sv /usr/bin/node third_party/node/linux/node-linux-x64/bin/node
 
   - working-directory: /home/src
     name: prepare-build
     runs: |
-      # Add depot_tools to PATH to use gn
-      export PATH="$PATH:/home/depot_tools"
-
       # Generate config: takes about 30 minutes
-      time gn gen /home/src/out/Default --args="
+      time gn gen $HOME/out/Default --args="
         blink_symbol_level=0
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
@@ -276,12 +250,8 @@ pipeline:
         use_system_zlib=true
       "
 
-  - working-directory: /home/src
-    name: Build
+  - name: Build
     runs: |
-      # Add depot_tools to PATH to use autoninja
-      export PATH="$PATH:/home/depot_tools"
-
       # Disable compiler warnings encountered when using system provided libraries
       export CFLAGS="$CFLAGS -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
       export CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
@@ -290,7 +260,7 @@ pipeline:
       # Compile: takes about 3 hours, 60 GB of disk (on a 32xXeon, 128GBxRAM, 2TBxNVME system)
       time autoninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
 
-  - working-directory: /home/src/out/Default
+  - working-directory: /home/build/out/Default
     name: Install the binaries and libraries
     runs: |
       mkdir -p \
@@ -312,7 +282,7 @@ pipeline:
          ${{targets.contextdir}}/usr/lib/${{package.name}}/
 
       # Setup wrapper and symlinks
-      cd /home/build
+      cd $HOME
       mv chromium-launcher.sh ${{targets.destdir}}/usr/bin/chromium-browser
       ln -s /usr/lib/${{package.name}}/chrome ${{targets.contextdir}}/usr/bin/chromium
       ln -s /usr/lib/${{package.name}}/chromedriver ${{targets.contextdir}}/usr/bin/chromedriver
@@ -322,7 +292,7 @@ pipeline:
       opts: -s
 
   # Do not strip ChromeDriver
-  - working-directory: /home/src/out/Default
+  - working-directory: /home/build/out/Default
     runs: |
       mv chromedriver.unstripped ${{targets.destdir}}/usr/lib/${{package.name}}/chromedriver
 
@@ -340,9 +310,9 @@ subpackages:
   - name: chromium-docker-selenium-compat
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/selenium
+          mkdir -p ${{targets.contextdir}}/opt/selenium
 
-          ln -s /usr/lib/chromium/chromedriver ${{targets.subpkgdir}}/opt/selenium/chromedriver-${{package.version}}
+          ln -s /usr/lib/chromium/chromedriver ${{targets.contextdir}}/opt/selenium/chromedriver-${{package.version}}
 
           echo "chrome" > ${{targets.contextdir}}/opt/selenium/browser_name
           echo ${{package.version}} > ${{targets.contextdir}}/opt/selenium/browser_version

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -1,5 +1,6 @@
 #nolint:git-checkout-must-use-github-updates
 # Note: To produce a debug build of Chromium, pass these options to gn:
+#  blink_symbol_level=2
 #  is_debug=true
 #  is_official_build=false
 #  symbol_level=2
@@ -238,6 +239,7 @@ pipeline:
 
       # Generate config: takes about 30 minutes
       time gn gen /home/src/out/Default --args="
+        blink_symbol_level=0
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
         enable_nacl=false

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -361,6 +361,8 @@ test:
         - grep
         - py3-pip
         - python3
+    environment:
+      LD_LIBRARY_PATH: "/usr/lib/chromium"
   pipeline:
     - name: Check for lang pack
       runs: |

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -48,6 +48,7 @@ environment:
       - dav1d-dev
       - dbus-dev
       - dbus-glib-dev
+      - default-jdk
       - double-conversion-dev
       - elfutils
       - elfutils-dev
@@ -200,7 +201,7 @@ pipeline:
           -delete
       done
 
-      # Update GN configuration to use system libraries
+      # Update gn configuration to use system libraries
       python3 build/linux/unbundle/replace_gn_files.py --system-libraries $system_libs
       python3 third_party/libaddressinput/chromium/tools/update-strings.py
 
@@ -210,10 +211,13 @@ pipeline:
 
       # Use host node
       mkdir -p third_party/node/linux/node-linux-x64/bin
-      ln -sv /usr/bin/node third_party/node/linux/node-linux-x64/bin/node
+      ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/node
 
-  - working-directory: /home/src
-    name: prepare-build
+      # Use host java
+      mkdir -p third_party/jdk/current/bin
+      ln -s /usr/bin/java third_party/jdk/current/bin/java
+
+  - name: Generate gn config
     runs: |
       # Generate config: takes about 30 minutes
       time gn gen $HOME/out/Default --args="
@@ -261,7 +265,7 @@ pipeline:
       time autoninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
 
   - working-directory: /home/build/out/Default
-    name: Install the binaries and libraries
+    name: Install binaries & libraries
     runs: |
       mkdir -p \
         ${{targets.contextdir}}/usr/bin \

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -122,6 +122,7 @@ environment:
       - qt5-qtbase-dev
       - qt6-qtbase-dev
       - rust
+      - rust-bindgen
       - samurai
       - speex-dev
       - sqlite-dev
@@ -131,6 +132,9 @@ environment:
       - xz
       - zlib-dev
       - zstd-dev
+  environment:
+    # Allow unstable rust features with stable rust
+    RUSTC_BOOTSTRAP: 1
 
 pipeline:
   - uses: git-checkout
@@ -242,10 +246,11 @@ pipeline:
         blink_symbol_level=0
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
+        enable_freetype=true
         enable_nacl=false
         enable_nocompile_tests_new=false
+        enable_rust=true
         enable_widevine=true
-        enable_freetype=true
         ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
         is_debug=false
@@ -253,6 +258,9 @@ pipeline:
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
+        rustc_version=\"$(rustc --version)\"
+        rust_bindgen_root=\"/usr\"
+        rust_sysroot_absolute=\"/usr\"
         safe_browsing_use_unrar=false
         symbol_level=0
         treat_warnings_as_errors=false

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -129,25 +129,20 @@ environment:
       - xz
       - zlib-dev
       - zstd-dev
-  environment:
-    # Disable compiler warnings encountered when using system provided libraries
-    CFLAGS: "$(echo ${CFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
-    CXXFLAGS: "$(echo ${CXXFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
-    CPPFLAGS: "$(echo ${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS/}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
 
 pipeline:
   - uses: git-checkout
     with:
-      # === INFO === Initial git clone: takes ~3 minutes, needs 6GB disk
+      # Initial git clone: takes ~3 minutes, needs 6GB disk
       repository: https://chromium.googlesource.com/chromium/src.git
       tag: ${{package.version}}
       depth: 1
       expected-commit: 2a5d6da0d6165d7b107502095a937fe7704fcef6
       destination: /home/src
 
-  - name: clone depot-tools and setup .gclient
+  - working-directory: /home
+    name: Clone depot-tools and setup .gclient
     runs: |
-      cd /home
       # depot_tools contains essential Chromium build tools
       # in consists of gclient, gn, autoninja, etc. that are used to build Chromium
       # We are cloning it to /home/depot_tools and have to add it to PATH
@@ -157,7 +152,7 @@ pipeline:
       # Important: File must be in /home (parent of src/)
       # Because: gclient searches for .gclient in parent directories
       # Reference: https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/README.gclient.md
-      cat <<EOF >/home/.gclient
+      cat <<EOF > /home/.gclient
       # Setup a .gclient config (handled by 'fetch' in upstream instructions)
       solutions = [
         { "name"        : "src",
@@ -168,7 +163,6 @@ pipeline:
         },
       ]
       EOF
-      cat /home/.gclient
 
   - working-directory: /home/src
     name: sync-dependencies
@@ -176,11 +170,11 @@ pipeline:
       # Add depot_tools to PATH to use gclient
       export PATH="$PATH:/home/depot_tools"
 
-      # === INFO === Sync dependencies: takes about 11 minutes, requires 30 GB of disk
+      # Sync dependencies: takes about 11 minutes, requires 30 GB of disk
       time gclient sync --no-history
 
   - working-directory: /home/src
-    name: configure-system-libraries
+    name: Use system libraries
     runs: |
       # Use USB IDs already provided by hwdata-usb
       sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
@@ -232,7 +226,7 @@ pipeline:
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
         tools/generate_shim_headers/generate_shim_headers.py
 
-      # === INFO === Make node executable: works around permission denial
+      # Make node executable: works around permission denial
       chmod +x /home/src/third_party/node/linux/node-linux-x64/bin/node
 
   - working-directory: /home/src
@@ -241,7 +235,7 @@ pipeline:
       # Add depot_tools to PATH to use gn
       export PATH="$PATH:/home/depot_tools"
 
-      # === INFO === Generate config: takes about 30 minutes
+      # Generate config: takes about 30 minutes
       time gn gen /home/src/out/Default --args="
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
@@ -272,37 +266,45 @@ pipeline:
       "
 
   - working-directory: /home/src
-    name: build
+    name: Build
     runs: |
       # Add depot_tools to PATH to use autoninja
       export PATH="$PATH:/home/depot_tools"
 
-      # === INFO === Compile: takes about 3 hours, 60 GB of disk (on a 32xXeon, 128GBxRAM, 2TBxNVME system)
+      # Disable compiler warnings encountered when using system provided libraries
+      export CFLAGS="$CFLAGS -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
+      export CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
+      export CPPFLAGS="${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS/} -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
+
+      # Compile: takes about 3 hours, 60 GB of disk (on a 32xXeon, 128GBxRAM, 2TBxNVME system)
       time autoninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
 
   - working-directory: /home/src/out/Default
-    name: install the binaries and libraries
+    name: Install the binaries and libraries
     runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin ${{targets.destdir}}/usr/lib/${{package.name}}
-      mkdir -p ${{targets.destdir}}/etc/chromium
+      mkdir -p \
+        ${{targets.contextdir}}/usr/bin \
+        ${{targets.contextdir}}/usr/lib/${{package.name}} \
+        ${{targets.contextdir}}/etc/chromium
+
+      # Install libraries
+      mv *.so* ${{targets.contextdir}}/usr/lib/${{package.name}}
 
       # Install binaries
-      mv *.so* ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv chrome ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv chrome_crashpad_handler ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv chrome_sandbox ${{targets.destdir}}/usr/lib/${{package.name}}
+      mv chrome chrome_crashpad_handler chrome_sandbox \
+        ${{targets.contextdir}}/usr/lib/${{package.name}}
 
       # Install resources
       mv snapshot_blob.bin v8_context_snapshot.bin \
          xdg-mime xdg-settings vk_swiftshader_icd.json \
          *.pak locales \
-         ${{targets.destdir}}/usr/lib/${{package.name}}/
+         ${{targets.contextdir}}/usr/lib/${{package.name}}/
 
       # Setup wrapper and symlinks
       cd /home/build
       mv chromium-launcher.sh ${{targets.destdir}}/usr/bin/chromium-browser
-      ln -sf /usr/lib/${{package.name}}/chrome ${{targets.destdir}}/usr/bin/chromium
-      ln -sf /usr/lib/${{package.name}}/chromedriver ${{targets.destdir}}/usr/bin/chromedriver
+      ln -s /usr/lib/${{package.name}}/chrome ${{targets.contextdir}}/usr/bin/chromium
+      ln -s /usr/lib/${{package.name}}/chromedriver ${{targets.contextdir}}/usr/bin/chromedriver
 
   - uses: strip
     with:
@@ -317,8 +319,8 @@ subpackages:
   - name: ${{package.name}}-lang
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales
-          mv ${{targets.destdir}}/usr/lib/${{package.name}}/locales/* ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales/
+          mkdir -p ${{targets.contextdir}}/usr/lib/${{package.name}}/locales
+          mv ${{targets.destdir}}/usr/lib/${{package.name}}/locales/* ${{targets.contextdir}}/usr/lib/${{package.name}}/locales/
 
           # Ensure we provide one locale in the base package
           mv ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales/en-US.pak ${{targets.destdir}}/usr/lib/${{package.name}}/locales/en-US.pak
@@ -329,11 +331,11 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/selenium
 
-          ln -sf /usr/lib/chromium/chromedriver ${{targets.subpkgdir}}/opt/selenium/chromedriver-${{package.version}}
+          ln -s /usr/lib/chromium/chromedriver ${{targets.subpkgdir}}/opt/selenium/chromedriver-${{package.version}}
 
-          echo "chrome" > ${{targets.subpkgdir}}/opt/selenium/browser_name
-          echo ${{package.version}} > ${{targets.subpkgdir}}/opt/selenium/browser_version
-          echo "\"goog:chromeOptions\": {\"binary\": \"/usr/bin/chromium-browser\"}" > ${{targets.subpkgdir}}/opt/selenium/browser_binary_location
+          echo "chrome" > ${{targets.contextdir}}/opt/selenium/browser_name
+          echo ${{package.version}} > ${{targets.contextdir}}/opt/selenium/browser_version
+          echo "\"goog:chromeOptions\": {\"binary\": \"/usr/bin/chromium-browser\"}" > ${{targets.contextdir}}/opt/selenium/browser_binary_location
 
 update:
   enabled: true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -350,27 +350,27 @@ test:
     contents:
       packages:
         - grep
-        - posix-libc-utils
-        - libnss
-        #- py3-pip
-        #- python3
+        - py3-pip
+        - python3
   pipeline:
-    - runs: |
-        # Make sure Chrome and ChromeDriver are at the correct path
-        test -x /usr/lib/chromium/chrome
-        test -x /usr/lib/chromium/chromedriver
+    - name: Check for lang pack
+      runs: |
         test -f /usr/lib/chromium/locales/en-US.pak
-
+    - name: Check status page
+      runs: |
         # Check status with new headless mode
         chromium --no-sandbox --headless --disable-gpu --dump-dom https://www.chromestatus.com
 
         # Test wrapper
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com
-
+    - name: Test ChromeDriver with Selenium
+      runs:
         # Test ChromeDriver functionality
         # Disable ChromeDriver test until py3-selenium has been packaged
-        #pip3 install selenium
-        #python3 ./test-chromedriver.py
+        pip3 install selenium
+        python3 ./test-chromedriver.py
+    - name: Version/help check
+      runs: |
         chromedriver --version
         chromedriver --help
         chromium --version

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -106,6 +106,7 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
+      - lld
       - llvm-dev
       - mesa-dev
       - minizip

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -110,6 +110,7 @@ environment:
       - mesa-dev
       - minizip
       - nghttp2-dev
+      - nodejs
       - openh264-dev
       - opus-dev
       - pango

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -41,6 +41,8 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - cairo-dev
+      - clang
+      - compiler-rt
       - crc32c-dev
       - cups-dev
       - curl
@@ -104,6 +106,7 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
+      - llvm-dev
       - mesa-dev
       - minizip
       - nghttp2-dev
@@ -133,7 +136,12 @@ environment:
       - zlib-dev
       - zstd-dev
   environment:
-    # Allow unstable rust features with stable rust
+    # Use host clang
+    AR: "llvm-ar"
+    CC: "clang"
+    CXX: "clang++"
+    NM: "llvm-nm"
+    # Allow unstable features with stable rust
     RUSTC_BOOTSTRAP: 1
 
 pipeline:
@@ -142,6 +150,9 @@ pipeline:
     with:
       # Fetch source and dependencies: takes about 11 minutes, requires 30 GB of disk
       # Gentoo provides tarballs where they've already performed a client sync (which isn't possible on arm64)
+      #
+      # Tarballs are built using the instructions here:
+      # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       uri: https://chromium-tarballs.distfiles.gentoo.org/chromium-${{package.version}}-linux.tar.xz
       expected-sha512: 04ca888078ab3ce4775d0dff9c9d46b342be5bda2fe41493dcf8695fa9b52ed749455275cfc4bba234a10fbe6df0eeac3d8bb2f8d73ca1250a142c58944ff6d9
 
@@ -149,13 +160,16 @@ pipeline:
     runs: |
       # These binaries are tools transient from the client sync Gentoo performs for us
       # All we need is the Chromium source tree and its dependencies
-      #
-      # Tarballs are built using the instructions here:
-      # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       scanelf -RA -F "%F" "$HOME" 2>/dev/null | while read -r elf; do
         echo "Removing $elf"
         rm -f "$elf"
       done
+
+  - uses: patch
+    with:
+      patches: |
+        bindgen.patch \
+        fortify_level.patch
 
   - name: Use system libraries
     runs: |
@@ -219,18 +233,28 @@ pipeline:
 
   - name: Generate gn config
     runs: |
+      # Fetch clang version
+      # We could parse clang --version with awk, but this is cleaner
+      clang_version=$(basename $(clang --print-resource-dir))
+
       # Generate config: takes about 30 minutes
       time gn gen $HOME/out/Default --args="
         blink_symbol_level=0
+        clang_base_path=\"/usr/lib/llvm-$clang_version\"
         clang_use_chrome_plugins=false
+        clang_version=\"$clang_version\"
         chrome_pgo_phase=0
+        custom_toolchain=\"//build/toolchain/linux/unbundle:default\"
         enable_freetype=true
         enable_nacl=false
-        enable_nocompile_tests_new=false
         enable_rust=true
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
+        is_cfi=false
+        is_clang=true
+        is_component_build=false
+        is_component_ffmpeg=true
         is_debug=false
         is_official_build=true
         link_pulseaudio=true
@@ -245,6 +269,7 @@ pipeline:
         use_lld=true
         use_pulseaudio=true
         use_qt6=true
+        use_safe_libstdcxx=false
         use_sysroot=false
         use_system_freetype=true
         use_system_harfbuzz=true
@@ -262,7 +287,7 @@ pipeline:
       export CPPFLAGS="${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS/} -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
 
       # Compile: takes about 3 hours, 60 GB of disk (on a 32xXeon, 128GBxRAM, 2TBxNVME system)
-      time autoninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
+      time ninja -C ./out/Default chrome chromedriver.unstripped chrome_crashpad_handler chrome_sandbox
 
   - working-directory: /home/build/out/Default
     name: Install binaries & libraries

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -372,10 +372,10 @@ test:
 
         # Test wrapper
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com
-    - name: Test ChromeDriver with Selenium
-      runs: |
-        pip3 install selenium
-        python3 ./test-chromedriver.py
+    #- name: Test ChromeDriver with Selenium
+    #  runs: |
+    #    pip3 install selenium
+    #    python3 ./test-chromedriver.py
     - name: Version/help check
       runs: |
         chromedriver --version

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -371,9 +371,7 @@ test:
         # Test wrapper
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com
     - name: Test ChromeDriver with Selenium
-      runs:
-        # Test ChromeDriver functionality
-        # Disable ChromeDriver test until py3-selenium has been packaged
+      runs: |
         pip3 install selenium
         python3 ./test-chromedriver.py
     - name: Version/help check

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,15 +7,13 @@
 package:
   name: chromium
   version: "133.0.6943.141"
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
   resources:
     cpu: 65
     memory: 128Gi
-  target-architecture:
-    - x86_64
   dependencies:
     runtime:
       - font-opensans

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -22,6 +22,7 @@ package:
       - icu-data-full
       - libnss
       - mesa
+      - mesa-glx
       - nss
       - systemd
       - xdg-utils

--- a/chromium/bindgen.patch
+++ b/chromium/bindgen.patch
@@ -1,0 +1,27 @@
+Look for libclang at the installed path for clang rather than the prefix for rust-bindgen
+diff --git a/build/rust/rust_bindgen.gni b/build/rust/rust_bindgen.gni
+index 5c809c6..782c198 100644
+--- a/build/rust/rust_bindgen.gni
++++ b/build/rust/rust_bindgen.gni
+@@ -19,7 +19,7 @@ if (host_os == "win") {
+ 
+ # On Windows, the libclang.dll is beside the bindgen.exe, otherwise it is in
+ # ../lib.
+-_libclang_path = rust_bindgen_root
++_libclang_path = clang_base_path
+ if (host_os == "win") {
+   _libclang_path += "/bin"
+ } else {
+diff --git a/build/rust/rust_bindgen_generator.gni b/build/rust/rust_bindgen_generator.gni
+index c91916b..e504824 100644
+--- a/build/rust/rust_bindgen_generator.gni
++++ b/build/rust/rust_bindgen_generator.gni
+@@ -18,7 +18,7 @@ if (host_os == "win") {
+ 
+ # On Windows, the libclang.dll is beside the bindgen.exe, otherwise it is in
+ # ../lib.
+-_libclang_path = rust_bindgen_root
++_libclang_path = clang_base_path
+ if (host_os == "win") {
+   _libclang_path += "/bin"
+ } else {

--- a/chromium/fortify_level.patch
+++ b/chromium/fortify_level.patch
@@ -1,0 +1,14 @@
+Align the fortify level with our default
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index eb329bc88fec..7c98dfddcf8a 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -2054,7 +2054,7 @@ config("chromium_code") {
+       # Non-chromium code is not guaranteed to compile cleanly with
+       # _FORTIFY_SOURCE. Also, fortified build may fail when optimizations are
+       # disabled, so only do that for Release build.
+-      fortify_level = "2"
++      fortify_level = "3"
+
+       # ChromeOS's toolchain supports a high-quality _FORTIFY_SOURCE=3
+       # implementation with a few custom glibc patches. Use that if it's


### PR DESCRIPTION
These changes implement support for arm64 in our builds of Chromium. Here are the changes at a high level:
* Build Chromium with our toolchain. Use our Clang, our Rust, our Java, etc to produce builds of Chromium independent of Chromium's toolchain. Chromium's toolchain only supports x64 systems. Ours supports x64 and arm64
* Use Gentoo's Chromium tarballs. Google's depot tools do not work on arm64. Dependencies must be synced before we start building Chromium, and Gentoo actively maintains tarballs containing Chromium's source and dependencies after they've been synced with gclient. In the future, we should be able to perform syncs using qemu