### PR TITLE
fix postunpack.sh to generate postgresql.conf file

### DIFF
--- a/postgresql-17-bitnami-compat.yaml
+++ b/postgresql-17-bitnami-compat.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17-bitnami-compat
   version: "17.0"
-  epoch: 1
+  epoch: 2
   description: "compat package with postgresql image"
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,9 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - busybox
+      - net-tools
       - postgresql-17-base
 
 pipeline:
@@ -46,7 +48,7 @@ pipeline:
 
       # Use package path while unpacking
       find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.contextdir}}/opt/bitnami#g' -i {} \;
-        ${{targets.contextdir}}/opt/bitnami/scripts/postgresql/postunpack.sh || true
+        ${{targets.contextdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
       # Restore path
       find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
 


### PR DESCRIPTION
`"postunpack.sh"` script is basically a script where the most of the bitnami container images run in their Dockerfile at build stage. For the postgresql, they executed this script at line [#L56](https://github.com/bitnami/containers/blob/6fe32028355a4e03447a9d905e5208d3aea8824c/bitnami/postgresql/17/debian-12/Dockerfile#L56) so we do the same in our builds too if you have a look at the following [link](https://github.com/search?q=repo%3Achainguard-dev%2Fenterprise-packages%20%22opt%2Fbitnami%2Fscripts%2Fpostgresql%2Fpostunpack.sh%22&type=code). But what we've missed is that we add || true right after we executed the postunpack.sh and even if it throws an error like `2025/02/28 11:35:37 WARN /bin/sh: /home/build/melange-out/postgresql-17-bitnami-compat/opt/bitnami/scripts/postgresql/postunpack.sh: not found`, and we ignored it, but this is not the actual problem over here because file is exists but it uses `#!/bin/bash` interpreter on top of it so we don't have it in our build environment so I've added it and the script ran `2025/02/28 11:40:53 WARN postgresql 08:40:53.%2N INFO  ==> postgresql.conf file not detected. Generating it...`

so what I can see now is:

```
(っ◔◡◔)っ  tar tvf packages/aarch64/postgresql-17-bitnami-compat-17.0-r2.apk | grep "postgresql.conf"
drwxrwxrwx  0 batuhanapaydin dialout     0 Dec  3 12:35 opt/bitnami/postgresql/conf
drwxrwxrwx  0 batuhanapaydin dialout     0 Dec  3 12:35 opt/bitnami/postgresql/conf/conf.d
-rw-rw-r--  0 batuhanapaydin dialout   213 Dec  3 12:35 opt/bitnami/postgresql/conf/pg_hba.conf
-rw-rw-r--  0 batuhanapaydin dialout 30639 Dec  3 12:35 opt/bitnami/postgresql/conf/postgresql.conf
drwxrwxrwx  0 batuhanapaydin dialout     0 Dec  3 12:35 opt/bitnami/postgresql/conf.default
drwxrwxrwx  0 batuhanapaydin dialout     0 Dec  3 12:35 opt/bitnami/postgresql/conf.default/conf.d
-rw-r--r--  0 batuhanapaydin dialout   213 Dec  3 12:35 opt/bitnami/postgresql/conf.default/pg_hba.conf
-rw-r--r--  0 batuhanapaydin dialout 30639 Dec  3 12:35 opt/bitnami/postgresql/conf.default/
```