### PR TITLE
daemon-check-output: expand error cases

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -38,10 +38,15 @@ inputs:
       FATAL
       Traceback.*most.recent.call
       Exception in thread
-      java.lang.NullPointerException
-      java.lang.RuntimeException
+      java.lang.*Exception
       Gem::MissingSpecError
       command not found
+      connection refused
+      unable to load
+      does not exist
+      ModuleNotFoundError
+      unrecognized option
+      invalid option
 
 pipeline:
   - name: "start daemon on localhost"


### PR DESCRIPTION
Expands test cases of `daemon-check-output` pipeline.