### PR TITLE
Correct symlink path in subpackage, and add additional link

### DIFF
--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: 0.7.2
-  epoch: 6
+  epoch: 7
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   copyright:
     - license: Apache-2.0
@@ -42,9 +42,10 @@ subpackages:
     description: "Compatibility package for usage with the Bitnami helm chart."
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/metrics-server/bin/
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/metrics-server/certificates/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
-          ln -sf /usr/bin/metrics-server ${{targets.subpkgdir}}/opt/bitnami/metrics-server
+          ln -sf /usr/bin/metrics-server ${{targets.subpkgdir}}/opt/bitnami/metrics-server/bin/metrics-server
     test:
       environment:
         contents:
@@ -53,8 +54,8 @@ subpackages:
             - bash
       pipeline:
         - runs: |
-            /opt/bitnami/metrics-server --version
-            /opt/bitnami/metrics-server --help
+            /opt/bitnami/metrics-server/bin/metrics-server --version
+            /opt/bitnami/metrics-server/bin/metrics-server --help
 
 update:
   enabled: true


### PR DESCRIPTION
Earlier commit: https://github.com/wolfi-dev/os/commit/962bc3d52d764bb882e9e27c6ae34f8b27e9bf0e, didn't set the correct path for the metrics-server symlink in the -compat package. This is now corrected.

Also adding additional directory expected for compatibility with an upstream helm chart.