### PR TITLE
pypy hotfix

### DIFF
--- a/pypy-3.10.yaml
+++ b/pypy-3.10.yaml
@@ -18,6 +18,7 @@ package:
       - ncurses
       - openssl
       - zlib
+      - gcc
 
 environment:
   contents:

--- a/pypy-3.10.yaml
+++ b/pypy-3.10.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.10
   description: PyPy is a very fast and compliant implementation of the Python language v 3.10
-  epoch: 0
+  epoch: 1
   version: 7.3.19
   copyright:
     - license: Apache-2.0

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.11
   description: PyPy is a very fast and compliant implementation of the Python language v 3.11
-  epoch: 0
+  epoch: 1
   version: 7.3.19
   copyright:
     - license: Apache-2.0

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -18,6 +18,7 @@ package:
       - ncurses
       - openssl
       - zlib
+      - gcc
 
 environment:
   contents:


### PR DESCRIPTION
Add gcc to runtime dependencies for pypy-3.10 and pypy-3.11