### PR TITLE
couchdb-3.3: Enable test/ldd-check

### DIFF
--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,13 +1,15 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 7
+  epoch: 8
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - couchdb=${{package.full-version}}
+    runtime:
+      - mozjs91
 
 environment:
   contents:
@@ -99,6 +101,9 @@ test:
         - curl
         - jq
   pipeline:
+    - uses: test/ldd-check
+      with:
+        packages: ${{package.name}}
     - name: CouchDB Start Server
       uses: test/daemon-check-output
       with:


### PR DESCRIPTION
Add missing runtime dependency on mozjs91.

Closes: #40836