### PR TITLE
py3-pydantic: pin pydantic-core at version expected by upstream

### DIFF
--- a/py3-pydantic.yaml
+++ b/py3-pydantic.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic
   version: "2.10.6"
-  epoch: 0
+  epoch: 1
   description: Data validation using Python type hints
   copyright:
     - license: MIT
@@ -55,7 +55,7 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-annotated-types
-        - py${{range.key}}-pydantic-core
+        - py${{range.key}}-pydantic-core~2.27.2
         - py${{range.key}}-typing-extensions
       provides:
         - py3-${{vars.pypi-package}}
@@ -66,11 +66,29 @@ subpackages:
           python: python${{range.key}}
       - uses: strip
     test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-jsonschema
+            - py${{range.key}}-pytest-bin
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+        - uses: git-checkout
+          with:
+            expected-commit: df05e69a8a3fb37628a0e3a33518ca0425334bc9
+            repository: https://github.com/pydantic/pydantic
+            tag: v${{package.version}}
+        - runs: |
+            # test_version includes a test that the correct version of
+            # pydantic-core is in the environment; we touch pytest.ini to avoid
+            # using the project-wide pytest settings (which require pytest
+            # plugins we don't have packaged)
+            cd tests
+            touch pytest.ini
+            pytest test_version.py
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
Using the most recent pydantic-core results in exceptions in downstream packages like `py3-fromager` as the API expected by pydantic has changed since.

This also adds execution of `tests/test_version.py`: upstream have introduced a test that the version of `pydantic-core` installed is the one expected by `pydantic` itself: this will force us to update the version pin when upstream changes require it.