### PR TITLE
docker-selenium: Add missing dep on gettext

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.29.0.20250222"
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ package:
       - bash
       - busybox
       - coreutils
+      - gettext
 
 environment:
   contents:


### PR DESCRIPTION
/opt/bin/start-selenium-node.sh: line 146: envsubst: command not found
