### PR TITLE
selenium, docker-selenium: bump openjdk to 21

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.29.0.20250222"
-  epoch: 1
+  epoch: 2
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -33,12 +33,12 @@ environment:
       - git
       - gnupg
       - jq
-      - openjdk-17-default-jdk
+      - openjdk-${{vars.openjdk-version}}-default-jdk
       - openssl
       - x11vnc
       - yq
   environment:
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-${{vars.openjdk-version}}-openjdk
     TC: UTC
     SEL_USER: seluser
     SEL_PASSWD: secret
@@ -49,6 +49,9 @@ var-transforms:
     match: ^(.+)\.(\d+)$
     replace: $1-$2
     to: mangled-package-version
+
+vars:
+  openjdk-version: 21
 
 pipeline:
   - uses: git-checkout

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,13 +1,16 @@
 package:
   name: selenium
   version: "4.28.0"
-  epoch: 1
+  epoch: 2
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - openjdk-17-default-jvm
+      - openjdk-${{vars.openjdk-version}}-default-jvm
+
+vars:
+  openjdk-version: 21
 
 environment:
   contents:
@@ -26,13 +29,13 @@ environment:
       - libbz2-1
       - liblz4-1
       - libzstd1
-      - openjdk-17-default-jdk
+      - openjdk-${{vars.openjdk-version}}-default-jdk
       - python3
       - ruby-3.3
       - tzdata
       - wolfi-baselayout
   environment:
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-${{vars.openjdk-version}}-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -61,7 +64,7 @@ subpackages:
     description: The Selenium Server is needed in order to run Remote Selenium WebDriver (Grid).
     dependencies:
       runtime:
-        - openjdk-17-default-jvm
+        - openjdk-${{vars.openjdk-version}}-default-jvm
     pipeline:
       - runs: |
           bazel build //java/src/org/openqa/selenium/grid:executable-grid
@@ -75,7 +78,7 @@ subpackages:
         contents:
           packages:
             - wolfi-base
-            - openjdk-17-default-jvm
+            - openjdk-${{vars.openjdk-version}}-default-jvm
       pipeline:
         - runs: |
             selenium-server-standalone info
@@ -86,7 +89,7 @@ subpackages:
     description: The Selenium Server is needed in order to run Remote Selenium WebDriver (Grid).
     dependencies:
       runtime:
-        - openjdk-17-default-jvm
+        - openjdk-${{vars.openjdk-version}}-default-jvm
     pipeline:
       - runs: |
           bazel build //java/src/org/openqa/selenium/grid:selenium_server_deploy.jar
@@ -100,7 +103,7 @@ subpackages:
         contents:
           packages:
             - wolfi-base
-            - openjdk-17-default-jvm
+            - openjdk-${{vars.openjdk-version}}-default-jvm
       pipeline:
         - runs: |
             java -jar /usr/bin/selenium-server
@@ -120,7 +123,7 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17-default-jvm
+        - openjdk-${{vars.openjdk-version}}-default-jvm
   pipeline:
     - runs: |
         selenium info


### PR DESCRIPTION
Observed in latest upstream images:

```
 130 % docker run --rm -it --entrypoint java selenium/standalone-firefox:latest --version
 openjdk 21.0.6 2025-01-21
 OpenJDK Runtime Environment (build 21.0.6+7-Ubuntu-124.04.1)
 OpenJDK 64-Bit Server VM (build 21.0.6+7-Ubuntu-124.04.1, mixed mode, sharing)
