### PR TITLE
remove incorrect dependencies from spark

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -2,7 +2,7 @@
 package:
   name: spark-3.5
   version: "3.5.5"
-  epoch: 0
+  epoch: 1
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5/pombump-deps.yaml
+++ b/spark-3.5/pombump-deps.yaml
@@ -12,12 +12,6 @@ patches:
     - groupId: org.codehaus.jettison
       artifactId: jettison
       version: 1.5.4
-    - groupId: org.apache.hive
-      artifactId: hive-llap-common
-      version: 4.0.0
-    - groupId: org.apache.hive
-      artifactId: hive-exec
-      version: 4.0.1
     - groupId: org.apache.derby.osgi.EmbeddedActivator
       artifactId: derby
       version: 10.14.3

--- a/spark-3.5/pombump-deps.yaml
+++ b/spark-3.5/pombump-deps.yaml
@@ -1,17 +1,17 @@
 patches:
-    - groupId: com.squareup.okio
-      artifactId: okio
-      version: 1.17.6
-      scope: import
-      type: jar
-    - groupId: com.google.code.gson
-      artifactId: gson
-      version: 2.10.1
-      scope: import
-      type: jar
-    - groupId: org.codehaus.jettison
-      artifactId: jettison
-      version: 1.5.4
-    - groupId: org.apache.derby.osgi.EmbeddedActivator
-      artifactId: derby
-      version: 10.14.3
+  - groupId: com.squareup.okio
+    artifactId: okio
+    version: 1.17.6
+    scope: import
+    type: jar
+  - groupId: com.google.code.gson
+    artifactId: gson
+    version: 2.10.1
+    scope: import
+    type: jar
+  - groupId: org.codehaus.jettison
+    artifactId: jettison
+    version: 1.5.4
+  - groupId: org.apache.derby.osgi.EmbeddedActivator
+    artifactId: derby
+    version: 10.14.3


### PR DESCRIPTION
Due to [reconsolidating spark-3.5-scala-2.12/13 into subpackages ](https://github.com/wolfi-dev/os/commit/d1ebe79463c285bb37158837d4da965158a4c825)under a parent package spark-3.5, we need to change the name definition here. Automation is [incorrectly attempting](https://github.com/wolfi-dev/os/pull/43127/files#diff-7b0e3934c478ef777b85f5cc2723f6bda0905c5a37d94dc18f4a20ca853c9cd5R18-R20) to update the relevant maven/pombump. 

This commit will remove incompatible hive versions that will compile but are not functional. Work to bump hive beyond 2.3.9 is still ongoing as can be seen here: https://issues.apache.org/jira/browse/SPARK-44114

[This commit must land first so automation does not pick this up and revert](https://github.com/chainguard-dev/infra-images/pull/2129)