### PR TITLE
add bitnami compats to cert-manager

### DIFF
--- a/cert-manager-1.17.yaml
+++ b/cert-manager-1.17.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.17
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: "1.17.1"
-  epoch: 1
+  epoch: 2
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -69,6 +69,22 @@ subpackages:
       provides:
         - cert-manager-controller=${{package.full-version}}
 
+  - name: cert-manager-controller-bitnami-compat${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - cert-manager-controller-bitnami-compat=${{package.full-version}}
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: cert-manager
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/cert-manager/bin/
+          ln -sf /usr/bin/controller ${{targets.contextdir}}/opt/bitnami/cert-manager/bin/cert-manager
+    test:
+      pipeline:
+        - runs: stat /opt/bitnami/cert-manager/bin/cert-manager
+
   - name: cert-manager-webhook-${{vars.major-minor-version}}
     pipeline:
       - runs: |
@@ -76,6 +92,22 @@ subpackages:
     dependencies:
       provides:
         - cert-manager-webhook=${{package.full-version}}
+
+  - name: cert-manager-webhook-bitnami-compat${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - cert-manager-webhook-bitnami-compat=${{package.full-version}}
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: cert-manager-webhook
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/cert-manager-webhook/bin/
+          ln -sf /usr/bin/webhook ${{targets.contextdir}}/opt/bitnami/cert-manager-webhook/bin/cert-manager-webhook
+    test:
+      pipeline:
+        - runs: stat /opt/bitnami/cert-manager-webhook/bin/cert-manager-webhook
 
   - name: cert-manager-cainjector-${{vars.major-minor-version}}
     pipeline:
@@ -85,6 +117,22 @@ subpackages:
       provides:
         - cert-manager-cainjector=${{package.full-version}}
 
+  - name: cert-manager-cainjector-bitnami-compat${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - cert-manager-cainjector-bitnami-compat=${{package.full-version}}
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: cainjector
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/cainjector/bin/
+          ln -sf /usr/bin/cainjector ${{targets.contextdir}}/opt/bitnami/cainjector/bin/cainjector
+    test:
+      pipeline:
+        - runs: stat /opt/bitnami/cainjector/bin/cainjector
+
   - name: cert-manager-acmesolver-${{vars.major-minor-version}}
     pipeline:
       - runs: |
@@ -92,6 +140,22 @@ subpackages:
     dependencies:
       provides:
         - cert-manager-acmesolver=${{package.full-version}}
+
+  - name: cert-manager-acmesolver-bitnami-compat${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - cert-manager-acmesolver-bitnami-compat=${{package.full-version}}
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: acmesolver
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/acmesolver/bin/
+          ln -sf /usr/bin/acmesolver ${{targets.contextdir}}/opt/bitnami/acmesolver/bin/acmesolver
+    test:
+      pipeline:
+        - runs: stat /opt/bitnami/acmesolver/bin/acmesolver
 
   - name: cert-manager-startupapicheck-${{vars.major-minor-version}}
     pipeline:

--- a/cert-manager-1.17.yaml
+++ b/cert-manager-1.17.yaml
@@ -69,7 +69,7 @@ subpackages:
       provides:
         - cert-manager-controller=${{package.full-version}}
 
-  - name: cert-manager-controller-bitnami-compat${{vars.major-minor-version}}
+  - name: cert-manager-controller-bitnami-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
         - cert-manager-controller-bitnami-compat=${{package.full-version}}
@@ -93,7 +93,7 @@ subpackages:
       provides:
         - cert-manager-webhook=${{package.full-version}}
 
-  - name: cert-manager-webhook-bitnami-compat${{vars.major-minor-version}}
+  - name: cert-manager-webhook-bitnami-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
         - cert-manager-webhook-bitnami-compat=${{package.full-version}}
@@ -117,7 +117,7 @@ subpackages:
       provides:
         - cert-manager-cainjector=${{package.full-version}}
 
-  - name: cert-manager-cainjector-bitnami-compat${{vars.major-minor-version}}
+  - name: cert-manager-cainjector-bitnami-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
         - cert-manager-cainjector-bitnami-compat=${{package.full-version}}
@@ -141,7 +141,7 @@ subpackages:
       provides:
         - cert-manager-acmesolver=${{package.full-version}}
 
-  - name: cert-manager-acmesolver-bitnami-compat${{vars.major-minor-version}}
+  - name: cert-manager-acmesolver-bitnami-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
         - cert-manager-acmesolver-bitnami-compat=${{package.full-version}}

--- a/cert-manager-1.17.yaml
+++ b/cert-manager-1.17.yaml
@@ -74,10 +74,6 @@ subpackages:
       provides:
         - cert-manager-controller-bitnami-compat=${{package.full-version}}
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: cert-manager
-          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/cert-manager/bin/
           ln -sf /usr/bin/controller ${{targets.contextdir}}/opt/bitnami/cert-manager/bin/cert-manager
@@ -98,10 +94,6 @@ subpackages:
       provides:
         - cert-manager-webhook-bitnami-compat=${{package.full-version}}
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: cert-manager-webhook
-          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/cert-manager-webhook/bin/
           ln -sf /usr/bin/webhook ${{targets.contextdir}}/opt/bitnami/cert-manager-webhook/bin/cert-manager-webhook
@@ -122,10 +114,6 @@ subpackages:
       provides:
         - cert-manager-cainjector-bitnami-compat=${{package.full-version}}
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: cainjector
-          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/cainjector/bin/
           ln -sf /usr/bin/cainjector ${{targets.contextdir}}/opt/bitnami/cainjector/bin/cainjector
@@ -146,10 +134,6 @@ subpackages:
       provides:
         - cert-manager-acmesolver-bitnami-compat=${{package.full-version}}
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: acmesolver
-          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/acmesolver/bin/
           ln -sf /usr/bin/acmesolver ${{targets.contextdir}}/opt/bitnami/acmesolver/bin/acmesolver

--- a/cert-manager-1.17.yaml
+++ b/cert-manager-1.17.yaml
@@ -69,7 +69,7 @@ subpackages:
       provides:
         - cert-manager-controller=${{package.full-version}}
 
-  - name: cert-manager-controller-bitnami-compat-${{vars.major-minor-version}}
+  - name: cert-manager-controller-${{vars.major-minor-version}}-bitnami-compat
     dependencies:
       provides:
         - cert-manager-controller-bitnami-compat=${{package.full-version}}
@@ -93,7 +93,7 @@ subpackages:
       provides:
         - cert-manager-webhook=${{package.full-version}}
 
-  - name: cert-manager-webhook-bitnami-compat-${{vars.major-minor-version}}
+  - name: cert-manager-webhook-${{vars.major-minor-version}}-bitnami-compat
     dependencies:
       provides:
         - cert-manager-webhook-bitnami-compat=${{package.full-version}}
@@ -117,7 +117,7 @@ subpackages:
       provides:
         - cert-manager-cainjector=${{package.full-version}}
 
-  - name: cert-manager-cainjector-bitnami-compat-${{vars.major-minor-version}}
+  - name: cert-manager-cainjector-${{vars.major-minor-version}}-bitnami-compat
     dependencies:
       provides:
         - cert-manager-cainjector-bitnami-compat=${{package.full-version}}
@@ -141,7 +141,7 @@ subpackages:
       provides:
         - cert-manager-acmesolver=${{package.full-version}}
 
-  - name: cert-manager-acmesolver-bitnami-compat-${{vars.major-minor-version}}
+  - name: cert-manager-acmesolver-${{vars.major-minor-version}}-bitnami-compat
     dependencies:
       provides:
         - cert-manager-acmesolver-bitnami-compat=${{package.full-version}}


### PR DESCRIPTION
adds compat and a simple stat test to verify the symlink, testing is minimal in here given there's no scripts and entrypoint is the binary itself which we're already testing. 