### PR TITLE
font-ubuntu: switch to the SPDX identifier

### DIFF
--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -2,11 +2,10 @@
 package:
   name: font-ubuntu
   version: 0.869
-  epoch: 2
+  epoch: 3
   description: Ubuntu font family
   copyright:
-    - license: LicenseRef-ubuntu-font
-      license-path: LICENCE.txt
+    - license: Ubuntu-font-1.0
 
 environment:
   contents:


### PR DESCRIPTION
The Ubuntu Font SPDX license is now out, and propagated to all the
tooling, hence can switch to it, instead of a custom license tag.

References:
- https://spdx.org/licenses/Ubuntu-font-1.0.html
