### PR TITLE
git: enable ELF package notes canary

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: "2.48.1"
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
@@ -20,6 +20,8 @@ environment:
       - pcre2-dev
       - wolfi-base
       - zlib-dev
+  environment:
+    GCC_SPEC_FILE: openssf-melange.spec
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
git is present in all -dev tags, thus as a single package this can
affect roughly half of our image tags. Many users do use and scan -dev
tags. A single package in -dev tags with ELF notes is a very good
canary, that will give us a good signal if this is being tolerated by
our user base and scanners. And also, it is very easy to revert, as it
is a single package withdrawal & rebuild.
