### PR TITLE
add bitnami compat package for flux-kustomize-controller

### DIFF
--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -47,6 +47,25 @@ pipeline:
       output: kustomize-controller
       packages: .
 
+subpackages:
+  - name: fluxcd-kustomize-controller-bitnami-compat
+    description: "compat package with bitnami/flux image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: fluxcd-kustomize-controller
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/kustomize-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
+          cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
+    test:
+      pipeline:
+        - runs: |
+            run-script --version
+            run-script --help
+
 update:
   ignore-regex-patterns:
     - api/

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: "1.5.1"
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Added bitnami compat package for flux-kustomize-controller, following the [Dockerfile](https://github.com/bitnami/containers/blob/main/bitnami/fluxcd-kustomize-controller/1/debian-12/Dockerfile)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
