### PR TITLE
add bitnami compat package for flux-helm-controller

### DIFF
--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -36,13 +36,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/
           ln -sf /usr/bin/helm-controller ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/helm-controller
     test:
-      accounts:
-        groups:
-          - gid: 1001
-        users:
-          - gid: 1001
-            uid: 1001
-        run-as: 1001
       environment:
         contents:
           packages:

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: "1.2.0"
-  epoch: 4
+  epoch: 5
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -36,6 +36,13 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/
           ln -sf /usr/bin/helm-controller ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/helm-controller
     test:
+      accounts:
+        groups:
+          - gid: 1001
+        users:
+          - gid: 1001
+            uid: 1001
+        run-as: 1001
       environment:
         contents:
           packages:

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -37,6 +37,25 @@ pipeline:
       output: helm-controller
       packages: .
 
+subpackages:
+  - name: fluxcd-helm-controller-bitnami-compat
+    description: "compat package with bitnami/flux image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: fluxcd-helm-controller
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/fluxcd-helm-controller/bin/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/helm-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-helm-controller/bin/helm-controller
+          cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
+    test:
+      pipeline:
+        - runs: |
+            run-script --version
+            run-script --help
+
 update:
   enabled: true
   ignore-regex-patterns:

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -6,15 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-  environment:
-    CGO_ENABLED: "0"
-
 pipeline:
   - uses: git-checkout
     with:
@@ -39,22 +30,20 @@ pipeline:
 
 subpackages:
   - name: fluxcd-helm-controller-bitnami-compat
-    description: "compat package with bitnami/flux image"
+    description: "compat package for bitnami fluxcd-helm-controller image"
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: fluxcd-helm-controller
-          version-path: 1/debian-12
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/fluxcd-helm-controller/bin/
-          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
-          ln -sf /usr/bin/helm-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-helm-controller/bin/helm-controller
-          cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/
+          ln -sf /usr/bin/helm-controller ${{targets.contextdir}}/opt/bitnami/fluxcd-helm-controller/bin/helm-controller
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
+        # the test is extensive in the main package and this is the same binary invoked via a symlink.
         - runs: |
-            run-script --version
-            run-script --help
+            /opt/bitnami/fluxcd-helm-controller/bin/helm-controller --help 2>&1 | grep -i "Usage of /opt/bitnami/fluxcd-helm-controller/bin/helm-controller"
 
 update:
   enabled: true
@@ -73,9 +62,22 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - name: Verify helm-controller installation
-      runs: |
-        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
-        kubectl wait --for=condition=Ready nodes --all
-        helm-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
-        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total
+    - name: "start ${{package.name}} and test"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+          kubectl wait --for=condition=Ready nodes --all
+        start: helm-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
+        timeout: 30
+        expected_output: |
+          starting manager
+          Serving metrics server
+          helm.toolkit.fluxcd.io
+          Starting Controller
+          Starting workers
+        post: |
+          #!/bin/sh -e
+          set -o pipefail
+          curl -s localhost:8081/metrics  | grep rest_client_requests_total
+          curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -29,7 +29,7 @@ pipeline:
       packages: .
 
 subpackages:
-  - name: fluxcd-helm-controller-bitnami-compat
+  - name: ${{package.name}}-bitnami-compat
     description: "compat package for bitnami fluxcd-helm-controller image"
     pipeline:
       - runs: |


### PR DESCRIPTION
Added bitnami compat package for flux-helm-controller, following the [Dockerfile](https://github.com/bitnami/containers/blob/main/bitnami/fluxcd-helm-controller/1/debian-12/Dockerfile)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
