### PR TITLE
add bitnami compat package for flux-kustomize-controller 

### DIFF
--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -51,7 +51,7 @@ pipeline:
       packages: .
 
 subpackages:
-  - name: fluxcd-kustomize-controller-bitnami-compat
+  - name: ${{package.name}}-bitnami-compat
     description: "compat package with bitnami/flux image"
     pipeline:
       - runs: |

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -54,78 +54,36 @@ subpackages:
   - name: fluxcd-kustomize-controller-bitnami-compat
     description: "compat package with bitnami/flux image"
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: fluxcd-kustomize-controller
-          version-path: 1/debian-12
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/
-          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
-          ln -sf /usr/bin/kustomize-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
-          cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/
+          ln -sf /usr/bin/kustomize-controller ${{targets.contextdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
     test:
       environment:
         contents:
           packages:
             - curl
-            - flux-kustomize-controller
-            - kubectl
+            - ${{package.name}}
       pipeline:
         - uses: test/kwok/cluster
-        - runs: |
-            run-script --version
-            run-script --help
-        - name: "Test kustomize-controller startup"
+        - name: "start ${{package.name}} and test"
           uses: test/daemon-check-output
           with:
             setup: |
-              # Create required directories
-              mkdir -p /opt/bitnami/fluxcd-kustomize-controller/bin/
-              # Create symlink to the installed binary
-              ln -sf /usr/bin/kustomize-controller /opt/bitnami/fluxcd-kustomize-controller/bin/
-              # Set up Kubernetes configuration
               kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
               kubectl wait --for=condition=Ready nodes --all
-            start: |
-              env PATH=/opt/bitnami/fluxcd-kustomize-controller/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-                  BITNAMI_APP_NAME=fluxcd-kustomize-controller \
-                  /opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
+            start: /opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
             timeout: 30
             expected_output: |
-              Starting workers
+              starting manager
+              kustomize.toolkit.fluxcd.io
+              Serving metrics server
               Starting Controller
-            error_strings: |
-              "msg":"error"
-              "level":"error"
-              "panic"
-              "fatal"
-              failed
-              Error:
-              error:
-              denied
+              Starting workers
             post: |
-              # Verify metrics endpoint is accessible
-              n=0
-              max=30
-              url=http://localhost:8080/metrics
-              while ! out=$(curl --fail "$url" 2>err) &&
-                  n=$((n+1)) && [ $n -lt $max ]; do
-                echo  "=== curl rc=$? for $n/$max on $url ==="
-                sleep 1
-              done
-              [ $n -eq $max ] && {
-                echo "FATAL - gave up after $max tries";
-                echo "out=$out";
-                echo "err: $(cat err))";
-                exit 1;
-              }
-              echo "== vv $url content after $n seconds vv =="
-              echo "$out" | sed "s,^,> ,"
-              echo "== ^^ $url content after $n seconds ^^ =="
-              echo "$out" | grep kustomize_controller || {
-                echo "FATAL: expected kustomize_controller not found in output"
-                exit 1
-              }
+              #!/bin/sh -e
+              set -o pipefail
+              curl -s localhost:8081/metrics  | grep rest_client_requests_total
+              curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"
 
 update:
   ignore-regex-patterns:
@@ -136,17 +94,3 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
-
-#test:
-#  environment:
-#    contents:
-#      packages:
-#        - curl
-#  pipeline:
-#    - uses: test/kwok/cluster
-#    - name: Verify kustomize-controller installation
-#      runs: |
-#        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
-#        kubectl wait --for=condition=Ready nodes --all
-#        kustomize-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
-#        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -64,10 +64,48 @@ subpackages:
           ln -sf /usr/bin/kustomize-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
           cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
     test:
+      environment:
+        contents:
+          packages:
+            - curl
+            - flux-kustomize-controller
+            - kubectl
       pipeline:
+        - uses: test/kwok/cluster
         - runs: |
             run-script --version
             run-script --help
+        - name: "Test kustomize-controller startup"
+          uses: test/daemon-check-output
+          with:
+            setup: |
+              # Create required directories
+              mkdir -p /opt/bitnami/fluxcd-kustomize-controller/bin/
+              # Create symlink to the installed binary
+              ln -sf /usr/bin/kustomize-controller /opt/bitnami/fluxcd-kustomize-controller/bin/
+              # Set up Kubernetes configuration
+              kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+              kubectl wait --for=condition=Ready nodes --all
+            start: |
+              env PATH=/opt/bitnami/fluxcd-kustomize-controller/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+                  BITNAMI_APP_NAME=fluxcd-kustomize-controller \
+                  bash -x /opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
+            timeout: 30
+            expected_output: |
+              starting kustomize-controller
+              Kustomize Controller started
+            error_strings: |
+              "msg":"error"
+              "level":"error"
+              "panic"
+              "fatal"
+              failed
+              Error:
+              error:
+              denied
+            post: |
+              # Verify metrics endpoint is accessible
+              curl -s http://localhost:8080/metrics | grep kustomize_controller
 
 update:
   ignore-regex-patterns:

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -89,11 +89,11 @@ subpackages:
             start: |
               env PATH=/opt/bitnami/fluxcd-kustomize-controller/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
                   BITNAMI_APP_NAME=fluxcd-kustomize-controller \
-                  bash -x /opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
+                  /opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
             timeout: 30
             expected_output: |
-              starting kustomize-controller
-              Kustomize Controller started
+              Starting workers
+              Starting Controller
             error_strings: |
               "msg":"error"
               "level":"error"
@@ -105,7 +105,27 @@ subpackages:
               denied
             post: |
               # Verify metrics endpoint is accessible
-              curl -s http://localhost:8080/metrics | grep kustomize_controller
+              n=0
+              max=30
+              url=http://localhost:8080/metrics
+              while ! out=$(curl --fail "$url" 2>err) &&
+                  n=$((n+1)) && [ $n -lt $max ]; do
+                echo  "=== curl rc=$? for $n/$max on $url ==="
+                sleep 1
+              done
+              [ $n -eq $max ] && {
+                echo "FATAL - gave up after $max tries";
+                echo "out=$out";
+                echo "err: $(cat err))";
+                exit 1;
+              }
+              echo "== vv $url content after $n seconds vv =="
+              echo "$out" | sed "s,^,> ,"
+              echo "== ^^ $url content after $n seconds ^^ =="
+              echo "$out" | grep kustomize_controller || {
+                echo "FATAL: expected kustomize_controller not found in output"
+                exit 1
+              }
 
 update:
   ignore-regex-patterns:
@@ -117,16 +137,16 @@ update:
     tag-filter: v
     use-tag: true
 
-test:
-  environment:
-    contents:
-      packages:
-        - curl
-  pipeline:
-    - uses: test/kwok/cluster
-    - name: Verify kustomize-controller installation
-      runs: |
-        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
-        kubectl wait --for=condition=Ready nodes --all
-        kustomize-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
-        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total
+#test:
+#  environment:
+#    contents:
+#      packages:
+#        - curl
+#  pipeline:
+#    - uses: test/kwok/cluster
+#    - name: Verify kustomize-controller installation
+#      runs: |
+#        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+#        kubectl wait --for=condition=Ready nodes --all
+#        kustomize-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
+#        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -50,6 +50,25 @@ pipeline:
       output: kustomize-controller
       packages: .
 
+subpackages:
+  - name: fluxcd-kustomize-controller-bitnami-compat
+    description: "compat package with bitnami/flux image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: fluxcd-kustomize-controller
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/kustomize-controller ${{targets.subpkgdir}}/opt/bitnami/fluxcd-kustomize-controller/bin/kustomize-controller
+          cp LICENSE ${{targets.subpkgdir}}/opt/bitnami/licenses/LICENSE
+    test:
+      pipeline:
+        - runs: |
+            run-script --version
+            run-script --help
+
 update:
   ignore-regex-patterns:
     - api/


### PR DESCRIPTION
Added bitnami compat package for flux-kustomize-controller, following the [Dockerfile](https://github.com/bitnami/containers/blob/main/bitnami/fluxcd-kustomize-controller/1/debian-12/Dockerfile)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
