### PR TITLE
keycloak-config-cli: fix bitnami symlink

### DIFF
--- a/keycloak-config-cli.yaml
+++ b/keycloak-config-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-config-cli
   version: 6.4.0
-  epoch: 1
+  epoch: 2
   description: Import YAML/JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
   copyright:
     - license: Apache-2.0
@@ -122,13 +122,13 @@ subpackages:
 
           ln -sf ${JAVA_HOME} ${{targets.contextdir}}/opt/bitnami/java
           ln -sf /usr/share/java/${{package.name}}/${{package.name}}.jar ${{targets.contextdir}}/opt/bitnami/${{package.name}}/${{package.name}}-${KEYCLOAK_VERSION}.jar
-          ln -sf ./${{package.name}}-${KEYCLOAK_VERSION}.jar ${{targets.contextdir}}/opt/bitnami/${{package.name}}/${{package.name}}.jar
+          ln -sf /opt/bitnami/${{package.name}}/${{package.name}}-${KEYCLOAK_VERSION}.jar ${{targets.contextdir}}/opt/bitnami/${{package.name}}/${{package.name}}.jar
     test:
       environment:
         accounts:
           users:
             - username: bitnami
-              gid: 0
+              gid: 1001
               uid: 1001
           run-as: 0
         contents:


### PR DESCRIPTION
The Bitnami keycloak-config-cli image defaults to the `bitnami - 1000:0` user, however the defaults in their helm chart runs the container as `bitnami - 1001:1001` which throws an error about not being able to access the jarfile referenced by the current symlink.

This fix changes the symlink to the full filepath and adjusts the subpackage test to confirm that this runs with the default Bitnami helm chart uid:gid.