### PR TITLE
remove pinning containerd to 1.x from k3s

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.32.2.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -9,12 +9,7 @@ package:
     runtime:
       - busybox
       - conntrack-tools
-      # containerd-shim-runc-v2 is now pulling in versions > 2.0.0 by default. (https://github.com/containerd/containerd/issues/10984)
-      # pinning is required because any version >2.0.0 is not compatible with daemon < 2.0.0
-      # daemon in this case is coming from k3s itself and they've not migrated yet to version > 2.0.0
-      # there's is an issue tracking k3s update to containerd > 2.0.0 (https://github.com/k3s-io/k3s/issues/11375)
-      # remove pin once upstream migrates to containerd > 2.0.0
-      - containerd-shim-runc-v2=~1
+      - containerd-shim-runc-v2
       - ip6tables # this pulls in iptables as well
       - kmod
       - libseccomp


### PR DESCRIPTION
we can remove this given https://github.com/k3s-io/k3s/issues/11375 is merged now. 

putting this to draft first and will test it out first with images. 