### PR TITLE
add py3-prettytable package with multi-version support and testing

### DIFF
--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -41,7 +41,6 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - python-${{range.key}}
         - py${{range.key}}-wcwidth
     pipeline:
       - uses: py/pip-build-install

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -5,8 +5,10 @@ package:
   epoch: 0
   copyright:
     - license: BSD-3-Clause
+
 vars:
   pypi-package: prettytable
+
 environment:
   contents:
     packages:
@@ -16,11 +18,10 @@ environment:
       - py3-supported-build-base
       - py3-supported-hatch
       - py3-supported-hatch-vcs
-      - python3
       - py3-wcwidth
+      - python3
   environment:
     SOURCE_DATE_EPOCH: 315532800
-
 
 data:
   - name: py-versions
@@ -36,6 +37,7 @@ pipeline:
       repository: https://github.com/prettytable/prettytable.git
       tag: ${{package.version}}
       expected-commit: be8d6f2510b8151ee9b0579e21eb3ceef681fcb0
+
 subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
@@ -52,7 +54,6 @@ subpackages:
           prevent-inclusion: melange-out
       - uses: strip
     test:
-
       pipeline:
         - name: Check if the package is installed
           runs: |
@@ -91,6 +92,7 @@ subpackages:
 
             print('Table data retrieval matches expected values.')
             "
+
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
@@ -99,6 +101,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
 update:
   enabled: true
   github:

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -58,10 +58,10 @@ subpackages:
             python3 -c "import prettytable; print(prettytable.__version__)" | grep -q "${{package.version}}"
         - name: Test adding and retrieving table data
           runs: |
-            python3 -c "
+            cat <<"EOF" >test.py
+            #!/usr/bin/env python
             from prettytable import PrettyTable
 
-            # Expected structured data
             expected_data = [
                 {'Name': 'Alice', 'Age': 30, 'City': 'New York'},
                 {'Name': 'Bob', 'Age': 25, 'City': 'Los Angeles'},
@@ -75,21 +75,26 @@ subpackages:
             for row in expected_data:
                 table.add_row([row['Name'], row['Age'], row['City']])
 
-            # Retrieve data from table
-            actual_data = [
-                {'Name': row[0], 'Age': int(row[1]), 'City': row[2]}
-                for row in table._rows  # Access raw data stored in the table
-            ]
+            print(table)
+            EOF
+            got="$(python test.py)"
+            if [ -z "${got}" ]; then
+              echo "PrettyTable output is empty"
+              exit 1
+            fi
 
-            # Compare retrieved data with expected values
-            if actual_data != expected_data:
-                print('Mismatch in table data!')
-                print('Expected:', expected_data)
-                print('Actual:', actual_data)
-                exit(1)
-
-            print('Table data retrieval matches expected values.')
-            "
+              # Compare retrieved data with expected values
+            expected="+---------+-----+-------------+
+            |   Name  | Age |     City    |
+            +---------+-----+-------------+
+            |  Alice  |  30 |   New York  |
+            |   Bob   |  25 | Los Angeles |
+            | Charlie |  35 |   Chicago   |
+            +---------+-----+-------------+"
+            if [[ "${got}" != "${expected}" ]]; then
+              echo "PrettyTable output is not as expected"
+              exit 1
+            fi
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -12,14 +12,10 @@ vars:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
       - ca-certificates-bundle
       - py3-supported-build-base
       - py3-supported-hatch
       - py3-supported-hatch-vcs
-      - py3-wcwidth
-      - python3
   environment:
     SOURCE_DATE_EPOCH: 315532800
 

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -1,0 +1,106 @@
+package:
+  name: py3-prettytable
+  version: "3.15.1"
+  description: "Display tabular data in a visually appealing ASCII table format"
+  epoch: 0
+  copyright:
+    - license: BSD-3-Clause
+vars:
+  pypi-package: prettytable
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-build-base
+      - py3-supported-hatch
+      - py3-supported-hatch-vcs
+      - python3
+      - py3-wcwidth
+  environment:
+    SOURCE_DATE_EPOCH: 315532800
+
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prettytable/prettytable.git
+      tag: ${{package.version}}
+      expected-commit: be8d6f2510b8151ee9b0579e21eb3ceef681fcb0
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - python-${{range.key}}
+        - py${{range.key}}-wcwidth
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+          prevent-inclusion: melange-out
+      - uses: strip
+    test:
+
+      pipeline:
+        - name: Check if the package is installed
+          runs: |
+            python3 -c "import prettytable; print(prettytable.__version__)" | grep -q "${{package.version}}"
+        - name: Test adding and retrieving table data
+          runs: |
+            python3 -c "
+            from prettytable import PrettyTable
+
+            # Expected structured data
+            expected_data = [
+                {'Name': 'Alice', 'Age': 30, 'City': 'New York'},
+                {'Name': 'Bob', 'Age': 25, 'City': 'Los Angeles'},
+                {'Name': 'Charlie', 'Age': 35, 'City': 'Chicago'}
+            ]
+
+            # Create PrettyTable instance
+            table = PrettyTable(['Name', 'Age', 'City'])
+
+            # Add rows dynamically
+            for row in expected_data:
+                table.add_row([row['Name'], row['Age'], row['City']])
+
+            # Retrieve data from table
+            actual_data = [
+                {'Name': row[0], 'Age': int(row[1]), 'City': row[2]}
+                for row in table._rows  # Access raw data stored in the table
+            ]
+
+            # Compare retrieved data with expected values
+            if actual_data != expected_data:
+                print('Mismatch in table data!')
+                print('Expected:', expected_data)
+                print('Actual:', actual_data)
+                exit(1)
+
+            print('Table data retrieval matches expected values.')
+            "
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+update:
+  enabled: true
+  github:
+    identifier: prymitive/karma
+    strip-prefix: v

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -105,5 +105,4 @@ subpackages:
 update:
   enabled: true
   github:
-    identifier: prymitive/karma
-    strip-prefix: v
+    identifier: prettytable/prettytable

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -47,12 +47,11 @@ subpackages:
         with:
           python: python${{range.key}}
           prevent-inclusion: melange-out
-      - uses: strip
     test:
       environment:
         contents:
           packages:
-            - python-3.11
+            - python-${{range.key}}
       pipeline:
         - name: Check if the package is installed
           runs: |

--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -49,6 +49,10 @@ subpackages:
           prevent-inclusion: melange-out
       - uses: strip
     test:
+      environment:
+        contents:
+          packages:
+            - python-3.11
       pipeline:
         - name: Check if the package is installed
           runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
prettytable: new package
Prettytable is tabular display package written in python that is required by the ceph package as a runtime dependency
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates