### PR TITLE
Supress 'apk info' noise when testing docs

### DIFF
--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -13,9 +13,9 @@ pipeline:
       # Get our doc package name, which is usually a sub package
       doc_pkg=$(basename ${{targets.contextdir}})
       # We seem to have a lot of "empty" doc packages...
-      if [ $(apk info -L "$doc_pkg" | wc -l) -le 3 ]; then
+      if [ $(apk info -L "$doc_pkg" 2>/dev/null | wc -l) -le 3 ]; then
         echo "See:"
-        apk info -L "$doc_pkg"
+        apk info -L "$doc_pkg" 2>/dev/null
         echo "This package [$doc_pkg] is completely empty (i.e. installs no files)."
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or"
@@ -27,7 +27,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/man/"); do
+      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -37,14 +37,14 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/info/"); do
+      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/"); do
+      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/"); do
         if [ -f /"$doc_file" ]; then
           # Check that we have readable files installed in /usr/share
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
@@ -54,7 +54,7 @@ pipeline:
       done
       if [ $doc_files = "false" ]; then
         echo "See:"
-        apk info -L "$doc_pkg"
+        apk info -L "$doc_pkg" 2>/dev/null
         echo "This package [$doc_pkg] installs files, but no usable documentation"
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include docs (check the split/manpages and split/infodir pipelines), or"

--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -13,9 +13,9 @@ pipeline:
       # Get our doc package name, which is usually a sub package
       doc_pkg=$(basename ${{targets.contextdir}})
       # We seem to have a lot of "empty" doc packages...
-      if [ $(apk info -L "$doc_pkg" 2>/dev/null | wc -l) -le 3 ]; then
+      if [ $(apk info -qL "$doc_pkg" | wc -l) -le 3 ]; then
         echo "See:"
-        apk info -L "$doc_pkg" 2>/dev/null
+        apk info -qL "$doc_pkg"
         echo "This package [$doc_pkg] is completely empty (i.e. installs no files)."
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or"
@@ -27,7 +27,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/man/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -37,14 +37,14 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/info/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -L "$doc_pkg" 2>/dev/null | grep "^usr/share/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/"); do
         if [ -f /"$doc_file" ]; then
           # Check that we have readable files installed in /usr/share
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
@@ -54,7 +54,7 @@ pipeline:
       done
       if [ $doc_files = "false" ]; then
         echo "See:"
-        apk info -L "$doc_pkg" 2>/dev/null
+        apk info -qL "$doc_pkg"
         echo "This package [$doc_pkg] installs files, but no usable documentation"
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include docs (check the split/manpages and split/infodir pipelines), or"

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -12,7 +12,7 @@ pipeline:
       # Find all pc files installed by this dev_pkg
       cd /
       pc_files=false
-      for pc_file in $(apk info -L "$dev_pkg" 2>/dev/null | grep "\.pc$"); do
+      for pc_file in $(apk info -qL "$dev_pkg" | grep "\.pc$"); do
         pc_files=true
         # Ensure this is a pkgconf .pc file
         if grep -q "^Name:" $pc_file; then


### PR DESCRIPTION
`apk info` will produce some WARNING messages when being run and this supresses those.  Here's an example:

```
2025/03/03 13:44:21 WARN + apk info -L gdbm-doc
2025/03/03 13:44:21 WARN + grep ^usr/share/info/
2025/03/03 13:44:21 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory
2025/03/03 13:44:21 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory
2025/03/03 13:44:21 WARN + '[' -f /usr/share/info/gdbm.info ]
2025/03/03 13:44:21 WARN + info -f /usr/share/info/gdbm.info -o -
2025/03/03 13:44:21 WARN + wc -l
2025/03/03 13:44:21 WARN + '[' 74 -gt 0 ]
2025/03/03 13:44:21 WARN + doc_files=true
2025/03/03 13:44:21 WARN + apk info -L gdbm-doc
2025/03/03 13:44:21 WARN + grep ^usr/share/
2025/03/03 13:44:21 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory
2025/03/03 13:44:21 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory
```