### PR TITLE
pipelines: test/tw/ldd-check: Default to packages: ${{context.name}}

### DIFF
--- a/pipelines/test/tw/ldd-check.yaml
+++ b/pipelines/test/tw/ldd-check.yaml
@@ -22,7 +22,12 @@ inputs:
 pipeline:
   - name: "check for missing library dependencies using ldd"
     runs: |
+      if [ -z "${{inputs.files}}" ] && [ -z "${{inputs.packages}}" ]; then
+          packages="${{context.name}}"
+      else
+          packages="${{inputs.packages}}"
+      fi
       ldd-check \
           --files="${{inputs.files}}" \
-          --packages="${{inputs.packages}}" \
+          --packages="$packages" \
           --verbose="${{inputs.verbose}}"


### PR DESCRIPTION
If no inputs are provided default to behaving as if `packages: ${{context.name}}` was provided, as that's by far the most common mode in-use.
