### PR TITLE
Fix druid pombump and improve test

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: "32.0.0"
-  epoch: 5
+  epoch: 6
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0

--- a/druid.yaml
+++ b/druid.yaml
@@ -96,12 +96,37 @@ test:
       packages:
         - python3
         - perl
+        - curl
   pipeline:
     - uses: test/daemon-check-output
       with:
-        start: /usr/share/java/druid/bin/start-nano-quickstart
+        start: env DRUID_LOG_DIR=/tmp/druid-logs /usr/share/java/druid/bin/start-nano-quickstart
         expected_output: |
           Starting Apache Druid
+        post: |
+          if grep -q -r java.lang.NoClassDefFoundError /tmp/druid-logs; then
+            echo "FATAL: found java.lang.NoClassDefFoundError in logs"
+            exit 1
+          fi
+          set -- curl -L --fail http://localhost:8888/
+          n=0
+          rc=1
+          max=60
+          while [ $n -lt $max ] && n=$((n+1)); do
+            sleep 1
+            "$@" > stdout.log 2>stderr.log && rc=0 && break
+            echo "[$n/$max] curl http://localhost:8888/ returned $?"
+          done
+          [ $n -eq $max ] && {
+            echo "FATAL: gave up on http://localhost:8888/ after $max tries"
+            exit 1
+          }
+          echo "$* returned success after $n/$max tries"
+          grep -q "Apache Druid" stdout.log &&
+            echo "PASS: found Apache Druid in curl output" || {
+            echo "FATAL: output of '$*' did not contain \"Apache Druid\"";
+            exit 1;
+          }
 
 update:
   enabled: true

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -2,9 +2,6 @@ patches:
     - groupId: org.apache.kafka
       artifactId: kafka-clients
       version: 3.7.1
-    - groupId: io.netty
-      artifactId: netty-handler
-      version: 4.1.118.Final
     - groupId: org.apache.derby.osgi.EmbeddedActivator
       artifactId: derby
       version: 10.14.3

--- a/druid/pombump-properties.yaml
+++ b/druid/pombump-properties.yaml
@@ -4,4 +4,4 @@ properties:
   - property: apache.kafka.version
     value: "3.7.1"
   - property: netty4.version
-    value: 4.1.115.Final
+    value: 4.1.118.Final


### PR DESCRIPTION
 *  Move bump of netty
    
    PR #37343 (da1effa048283f) explains why this change is made.
    
    The druid service was showing stacktrace like:
    
     > Exception in thread "main" java.lang.NoClassDefFoundError: io/netty/handler/ssl/SslContext
     >  at org.apache.druid.server.emitter.EmitterModule.configure(EmitterModule.java:78)
     >  at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:409)
     >  at com.google.inject.spi.Elements.getElements(Elements.java:108)
     >  at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:213)
     >  at com.google.inject.AbstractModule.configure(AbstractModule.java:66)
     >  at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:409)
    
    Such can be seen in the log dir in the *.stdout files such as 'router.log.stdout'.

 *  improve druid test
    
    This more carefully looks at the druid output and looks for
    successfull http service running.

