### PR TITLE
add missing py3-cryptography for dask-gateway-server

### DIFF
--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2024.1.0
-  epoch: 15
+  epoch: 16
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause
@@ -79,6 +79,7 @@ subpackages:
         - py${{vars.py-version}}-colorlog
         - py${{vars.py-version}}-sqlalchemy
         - py${{vars.py-version}}-traitlets
+        - py${{vars.py-version}}-cryptography
     pipeline:
       - name: Python Build
         runs: |


### PR DESCRIPTION
There was an issue reported related to the following error:

```bash
[C 2025-02-25 02:46:22.807 DaskGateway] Bad config encountered during initialization: Failed to import 'dask_gateway_server.backends.local.UnsafeLocalBackend' for trait 'DaskGateway.backend_class':

No module named 'cryptography'
```

so we added that module into the runtime dependencies of the dask-gateway-server to fix the problem.