### PR TITLE
fix(docker-selenium): add gettext as runtime which fails to start script

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.29.0.20250222"
-  epoch: 1
+  epoch: 2
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -255,6 +255,7 @@ subpackages:
         - freetype
         - glib
         - glibc-locale-en
+        - gettext
         - libfontconfig1
         - libgcc
         - libnss


### PR DESCRIPTION
Adds a runtime dep that was missing causing error in startup scripts