### PR TITLE
ruby3.4-rails-8.0: bump epoch to pull in new gem versions

### DIFF
--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: 8.0.1
-  epoch: 2
+  epoch: 3
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT


### PR DESCRIPTION
This will include the latest uri gem, addressing GHSA-22h5-pq3x-2gf2.