### PR TITLE
Make dotnet provides a virtual

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.136
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT
@@ -11,6 +11,8 @@ package:
   dependencies:
     runtime:
       - icu
+    provides:
+      - dotnet=${{package.version}}
 
 environment:
   contents:

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.120
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -12,6 +12,8 @@ package:
   dependencies:
     runtime:
       - icu
+    provides:
+      - dotnet=${{package.version}}
 
 environment:
   contents:

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.13"
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -11,6 +11,8 @@ package:
   dependencies:
     runtime:
       - icu
+    provides:
+      - dotnet=${{package.version}}
 
 environment:
   contents:

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: 9.0.2
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -11,6 +11,8 @@ package:
   dependencies:
     runtime:
       - icu
+    provides:
+      - dotnet=${{package.version}}
 
 environment:
   environment:


### PR DESCRIPTION
These all conflict on `usr/share/dotnet/ThirdPartyNotices.txt` so they aren't co-installable and should provide something that conflicts at solve time instead of at build time.