### PR TITLE
add bitnami compat package for influxd

### DIFF
--- a/influxd.yaml
+++ b/influxd.yaml
@@ -60,6 +60,7 @@ subpackages:
         - busybox
         - bash
         - yq
+
   - name: ${{package.name}}-${{package.version}}-bitnami-compat
     description: "compat package with bitnami/influxdb image"
     pipeline:

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -96,6 +96,8 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/bitnami/influxdb
           chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/bitnami/influxdb
+
+          mkdir -p ${{targets.subpkgdir}}/docker-entrypoint-initdb.d/
     test:
       environment:
         environment:
@@ -105,7 +107,6 @@ subpackages:
             - username: influxdb
               gid: 1000
               uid: 1000
-          run-as: 1000
       pipeline:
         - name: version tests
           runs: |

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -89,6 +89,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/bin
           ln -sf /usr/bin/influxd ${{targets.subpkgdir}}/opt/bitnami/influxdb/bin/influxd
+          ln -sf /usr/bin/influx ${{targets.subpkgdir}}/opt/bitnami/influxdb/bin/influx
 
           # copy etc to influxdb/etc.default
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -92,12 +92,20 @@ subpackages:
           # copy etc to influxdb/etc.default
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default
           cp -pr ${{targets.destdir}}/etc/* ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default/
-
           chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/opt/bitnami/
+
+          mkdir -p ${{targets.subpkgdir}}/bitnami/influxdb
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/bitnami/influxdb
     test:
       environment:
         environment:
           BITNAMI_APP_NAME: "influxd"
+        accounts:
+          users:
+            - username: influxdb
+              gid: 1000
+              uid: 1000
+          run-as: 1000
       pipeline:
         - name: version tests
           runs: |

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -94,7 +94,7 @@ subpackages:
 
           # copy etc to influxdb/etc.default
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default
-          cp -pr ${{targets.destdir}}/etc/* ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default/
+          install -m755 -Dt ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default/defaults/influxdb2 ${{targets.destdir}}/etc/defaults/influxdb2/config.yml
           chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/opt/bitnami/
 
           mkdir -p ${{targets.subpkgdir}}/bitnami/influxdb
@@ -104,7 +104,7 @@ subpackages:
 
           # Use package path while unpacking
           find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.subpkgdir}}/opt/bitnami#g' -i {} \;
-            ${{targets.subpkgdir}}/opt/bitnami/scripts/influxdb/postunpack.sh || true
+            ${{targets.subpkgdir}}/opt/bitnami/scripts/influxdb/postunpack.sh
           # Restore path
           find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
     test:

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -75,6 +75,7 @@ subpackages:
         - coreutils
         - curl
         - influxd
+        - influx
         - grep
         - libgcc
         - procps
@@ -105,8 +106,8 @@ subpackages:
         accounts:
           users:
             - username: influxdb
-              gid: 1000
-              uid: 1000
+              gid: 0
+              uid: 1001
       pipeline:
         - name: version tests
           runs: |

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -5,7 +5,7 @@ package:
   # a commit which will fix it but it is not released yet.
   # So, for the next bump, please remove the `rust=1.82.0` pinning.
   version: 2.7.11
-  epoch: 4
+  epoch: 5
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT
@@ -60,6 +60,53 @@ subpackages:
         - busybox
         - bash
         - yq
+  - name: ${{package.name}}-${{package.version}}-bitnami-compat
+    description: "compat package with bitnami/influxdb image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: influxdb
+          version-path: 2/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxd/bin
+          cp ${{targets.destdir}}/usr/bin/influxd ${{targets.subpkgdir}}/opt/bitnami/influxd/bin/influxd
+    test:
+      environment:
+        contents:
+          packages:
+            - curl
+      pipeline:
+        - name: version tests
+          runs: |
+            /opt/bitnami/influxd/bin/influxd version | grep ${{package.version}}
+        - name: Start the influxd server
+          uses: test/daemon-check-output
+          with:
+            start: |
+              /opt/bitnami/influxd/bin/influxd run
+            timeout: 60
+            expected_output: |
+              Welcome to InfluxDB
+              Starting
+              Listening
+            post: |
+              #!/bin/sh -e
+              url=http://localhost:8086
+              response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+              if [ "$response" -ne 200 ]; then
+                echo "Error: InfluxDB did not start correctly."
+                exit 1
+              fi
+              html=$(curl -s "$url")
+              if [ -z "$html" ]; then
+                echo "Got empty HTML content from $url"
+                exit 1
+              fi
+              echo "$html" | grep -q "InfluxDB is a time series platform" || {
+                echo "response from $url did not contain \"InfluxDB is a time series platform\""
+                exit 1
+              }
+              echo "InfluxDB instance is up"
 
 update:
   enabled: true

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -21,6 +21,12 @@ environment:
       - go
       - rust=1.82.0
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: major-version
+
 pipeline:
   - uses: git-checkout
     with:
@@ -61,13 +67,13 @@ subpackages:
         - bash
         - yq
 
-  - name: ${{package.name}}-${{package.version}}-bitnami-compat
+  - name: ${{package.name}}-bitnami-compat
     description: "compat package with bitnami/influxdb image"
     pipeline:
       - uses: bitnami/compat
         with:
           image: influxdb
-          version-path: 2/debian-12
+          version-path: ${{vars.major-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxd/bin
           cp ${{targets.destdir}}/usr/bin/influxd ${{targets.subpkgdir}}/opt/bitnami/influxd/bin/influxd

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -69,51 +69,55 @@ subpackages:
 
   - name: ${{package.name}}-bitnami-compat
     description: "compat package with bitnami/influxdb image"
+    dependencies:
+      runtime:
+        - bash
+        - coreutils
+        - curl
+        - influxd
+        - grep
+        - libgcc
+        - procps
+        - sed
+        - wait-for-port # used in /opt/bitnami/scripts/libinfluxdb.sh
     pipeline:
       - uses: bitnami/compat
         with:
           image: influxdb
           version-path: ${{vars.major-version}}/debian-12
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxd/bin
-          cp ${{targets.destdir}}/usr/bin/influxd ${{targets.subpkgdir}}/opt/bitnami/influxd/bin/influxd
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/bin
+          ln -sf /usr/bin/influxd ${{targets.subpkgdir}}/opt/bitnami/influxdb/bin/influxd
+
+          # copy etc to influxdb/etc.default
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default
+          cp -pr ${{targets.destdir}}/etc/* ${{targets.subpkgdir}}/opt/bitnami/influxdb/etc.default/
+
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/opt/bitnami/
     test:
       environment:
-        contents:
-          packages:
-            - curl
+        environment:
+          BITNAMI_APP_NAME: "influxd"
       pipeline:
         - name: version tests
           runs: |
-            /opt/bitnami/influxd/bin/influxd version | grep ${{package.version}}
+            /opt/bitnami/influxdb/bin/influxd version | grep ${{package.version}}
         - name: Start the influxd server
           uses: test/daemon-check-output
           with:
             start: |
-              /opt/bitnami/influxd/bin/influxd run
+              env INFLUXDB_ADMIN_USER=marty \
+                  INFLUXDB_ADMIN_USER_PASSWORD=F1uxKapacit0r85 \
+                  INFLUXDB_ADMIN_ORG=InfluxData \
+                  INFLUXDB_ADMIN_BUCKET=telegraf \
+                  INFLUXDB_ADMIN_RETENTION=168 \
+                  INFLUXDB_ADMIN_USER_TOKEN=where-were-going-we-dont-need-roads \
+                  /opt/bitnami/scripts/influxdb/entrypoint.sh /opt/bitnami/scripts/influxdb/run.sh
             timeout: 60
             expected_output: |
-              Welcome to InfluxDB
-              Starting
-              Listening
-            post: |
-              #!/bin/sh -e
-              url=http://localhost:8086
-              response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
-              if [ "$response" -ne 200 ]; then
-                echo "Error: InfluxDB did not start correctly."
-                exit 1
-              fi
-              html=$(curl -s "$url")
-              if [ -z "$html" ]; then
-                echo "Got empty HTML content from $url"
-                exit 1
-              fi
-              echo "$html" | grep -q "InfluxDB is a time series platform" || {
-                echo "response from $url did not contain \"InfluxDB is a time series platform\""
-                exit 1
-              }
-              echo "InfluxDB instance is up"
+              Welcome to the Bitnami influxd container
+              Starting InfluxDB in background...
+              Deploying InfluxDB from scratch
 
 update:
   enabled: true

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -99,6 +99,12 @@ subpackages:
           chmod -R u+rwX,g+rwX,o+rw ${{targets.subpkgdir}}/bitnami/influxdb
 
           mkdir -p ${{targets.subpkgdir}}/docker-entrypoint-initdb.d/
+
+          # Use package path while unpacking
+          find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.subpkgdir}}/opt/bitnami#g' -i {} \;
+            ${{targets.subpkgdir}}/opt/bitnami/scripts/influxdb/postunpack.sh || true
+          # Restore path
+          find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
     test:
       environment:
         environment:

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -74,6 +74,7 @@ subpackages:
         - bash
         - coreutils
         - curl
+        - findutils
         - influxd
         - influx
         - grep


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
