### PR TITLE
libsdl2-ttf: only find 2.x versions in `update`

### DIFF
--- a/libsdl2-ttf.yaml
+++ b/libsdl2-ttf.yaml
@@ -44,6 +44,7 @@ update:
   github:
     identifier: libsdl-org/SDL_ttf
     strip-prefix: release-
+    tag-filter: release-2
 
 test:
   environment:


### PR DESCRIPTION
Closes: #44234