### PR TITLE
add support for eth interfances named end*

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.3"
-  epoch: 20
+  epoch: 21
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -453,6 +453,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/systemd/network/
           cp 20-eth.network  ${{targets.subpkgdir}}/etc/systemd/network/
           cp 21-enp.network  ${{targets.subpkgdir}}/etc/systemd/network/
+          cp 22-end.network  ${{targets.subpkgdir}}/etc/systemd/network/
 
   - name: "systemd-logind-service"
     description: "Logind service"

--- a/systemd/22-end.network
+++ b/systemd/22-end.network
@@ -1,0 +1,4 @@
+[Match]
+Name=end*
+[Network]
+DHCP=yes


### PR DESCRIPTION
There are some ethernet interfaces that are named end*.  We could perhaps update the 21-enp* rule to be 21-en* if you prefer...  Otherwise, this works too...