### PR TITLE
feat(crane): add crane-cov for coverage profiling

### DIFF
--- a/crane.yaml
+++ b/crane.yaml
@@ -60,3 +60,38 @@ test:
       runs: |
         crane pull chainguard/static:latest static_latest.tar || exit 1
         [ -f static_latest.tar ] || exit 1
+
+subpackages:
+  - name: crane-cov
+    description: "Crane compiled for collecting coverage profiles"
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/crane
+          extra-args: -cover
+          ldflags: -buildid= -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=${{package.version}} -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version=${{package.version}}
+          modroot: /home/build
+          output: crane
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+            - go
+            - jq
+        environment:
+          GOCOVERDIR: /home/build
+      pipeline:
+        - name: Run a command with the instrumented binary
+          runs: |
+            crane manifest chainguard/static
+        - name: Check file paths are as expected.
+          runs: |
+            go tool covdata func -i=. 2>/dev/null | head -2 | awk {'print $1'} | grep -q -E "^github.com/google/go-containerregistry/"
+        - name: Check that coverage data is generated for the main function.
+          runs: |
+            go tool covdata func -i=. 2>/dev/null | head -2 | awk {'print $2'} | grep -q -E "^main$" -q
+        - name: Check that a coverage global summary by function is generated.
+          runs: |
+            go tool covdata func -i=. 2>/dev/null | tail -1 | awk {'print $2'} | grep -q -E "^\(statements\)$" -q
+            go tool covdata func -i=. 2>/dev/null | tail -1 | awk {'print $3'} | grep -q -E '^[0-9]+\.[0-9]+%$' -q


### PR DESCRIPTION
The crane-cov package can be used to improve observability in our tests at both package and image levels.
In example it uses the go feature for profiling integration tests [1].

Coverage data can be analysed by the Go tool `covdata`, which can be used also via the `go/covdata` Melange pipeline to print the summary coverage percentage.

1. https://go.dev/doc/build-cover
