### PR TITLE
add nats-server-config-reloader package

### DIFF
--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -23,8 +23,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/local/bin
       cp -r ${{targets.destdir}}/usr/bin/nats-server-config-reloader ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
       chmod 755 ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
-      mkdir -p ${{targets.destdir}}/etc/ssl/certs
-      cp /etc/ssl/certs/ca-certificates.crt ${{targets.destdir}}/etc/ssl/certs/
       cp cicd/assets/entrypoint.sh ${{targets.destdir}}/entrypoint.sh
       chmod +x ${{targets.destdir}}/entrypoint.sh
 
@@ -32,10 +30,11 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-compat
+    description: "Compat package for ${{package.name}}"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/usr/local/bin
           ln -sf /usr/local/bin/nats-server-config-reloader ${{targets.contextdir}}/nats-server-config-reloader
+          ln -sf /usr/local/bin/nats-server-config-reloader /usr/bin/nats-server-config-reloader
     test:
       environment:
         contents:
@@ -44,7 +43,7 @@ subpackages:
       pipeline:
         - runs: |
             stat /nats-server-config-reloader
-            /nats-server-config-reloader --version
+            /usr/bin/nats-server-config-reloader --help
             /usr/local/bin/nats-server-config-reloader --help
 
 update:

--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -72,43 +72,29 @@ test:
         nats-server-config-reloader --version 2>&1 | grep "${{package.version}}"
         nats-server-config-reloader --help
     - name: "Test nats-server-config-reloader with nats-server"
-      runs: |
-        echo "Starting NATS server with a configuration file..."
-        cat <<EOF > /tmp/nats-server.conf
-        pid_file: "/tmp/nats-server.pid"
-        http: 8222
-        EOF
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          cat <<EOF > /tmp/nats-server.conf
+          pid_file: "/tmp/nats-server.pid"
+          http: 8222
+          EOF
+          nats-server -c /tmp/nats-server.conf -l /tmp/nats-server.log &
+          sleep 10
+        start: nats-server-config-reloader -config /tmp/nats-server.conf -pid /tmp/nats-server.pid
+        timeout: 30
+        expected_output: |
+          Watching file: /tmp/nats-server.conf
+        post: |
+          #!/bin/sh -e
+          echo "Modifying config to reload..."
+          cat <<EOF > /tmp/nats-server.conf
+          pid_file: "/tmp/nats-server.pid"
+          http: 8222
+          debug: true
+          EOF
 
-        nats-server -c /tmp/nats-server.conf -l /tmp/nats-server.log &
-        sleep 2
+          sleep 5
 
-        echo "Verifying NATS server process..."
-        if ! pgrep -f "nats-server -c /tmp/nats-server.conf"; then
-          echo "NATS server did not start properly!"
-          exit 1
-        fi
-
-        # Start the config reloader in the background
-        nats-server-config-reloader -config /tmp/nats-server.conf -pid /tmp/nats-server.pid &
-        RELOADER_PID=$!
-        sleep 2
-
-        echo "Modifying config to reload..."
-        cat <<EOF > /tmp/nats-server.conf
-        pid_file: "/tmp/nats-server.pid"
-        http: 8222
-        debug: true
-        EOF
-
-        sleep 5
-
-        echo "Checking NATS server logs for reload confirmation..."
-        cat /tmp/nats-server.log
-
-        # Validate that the reload occurred by checking logs
-        if ! grep -q "Reloaded: debug = true" /tmp/nats-server.log; then
-          echo "Error: Config reload for debug=true not detected in logs!"
-          exit 1
-        fi
-
-        echo "Config reload test passed successfully!"
+          echo "Checking NATS server logs for reload confirmation..."
+          cat /tmp/nats-server.log

--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -17,12 +17,7 @@ pipeline:
     with:
       packages: ./cmd/nats-server-config-reloader
       output: nats-server-config-reloader
-      ldflags: -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%S%z) -X main.GitInfo=$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)$(git diff --quiet || echo "-dirty") -X main.Version=${{package.version}}
-
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp -r ${{targets.destdir}}/usr/bin/nats-server-config-reloader ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
-      chmod 755 ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
+      ldflags: -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%S%z) -X main.GitInfo=$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)$(git diff --quiet || echo "-dirty") -X main.Version=v${{package.version}}
 
   - uses: strip
 
@@ -31,6 +26,8 @@ subpackages:
     description: "Compat package for ${{package.name}}"
     pipeline:
       - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          ln -sf /usr/bin/nats-server-config-reloader ${{targets.contextdir}}/usr/local/bin/nats-server-config-reloader
           ln -sf /usr/local/bin/nats-server-config-reloader ${{targets.contextdir}}/nats-server-config-reloader
     test:
       environment:
@@ -41,13 +38,13 @@ subpackages:
         - runs: |
             /usr/bin/nats-server-config-reloader --help
             /usr/local/bin/nats-server-config-reloader --help
+            /nats-server-config-reloader --help
 
   - name: ${{package.name}}-oci-entrypoint
     description: Entrypoint for ${{package.name}}
     pipeline:
       - runs: |
-          cp cicd/assets/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
-          chmod +x ${{targets.contextdir}}/entrypoint.sh
+          install -m755 cicd/assets/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
       - uses: strip
     test:
       pipeline:
@@ -72,7 +69,7 @@ test:
   pipeline:
     - name: "Verify basic installation"
       runs: |
-        nats-server-config-reloader --version
+        nats-server-config-reloader --version 2>&1 | grep "${{package.version}}"
         nats-server-config-reloader --help
     - name: "Test nats-server-config-reloader with nats-server"
       runs: |

--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -23,8 +23,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/local/bin
       cp -r ${{targets.destdir}}/usr/bin/nats-server-config-reloader ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
       chmod 755 ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
-      cp cicd/assets/entrypoint.sh ${{targets.destdir}}/entrypoint.sh
-      chmod +x ${{targets.destdir}}/entrypoint.sh
 
   - uses: strip
 
@@ -34,7 +32,6 @@ subpackages:
     pipeline:
       - runs: |
           ln -sf /usr/local/bin/nats-server-config-reloader ${{targets.contextdir}}/nats-server-config-reloader
-          ln -sf /usr/local/bin/nats-server-config-reloader /usr/bin/nats-server-config-reloader
     test:
       environment:
         contents:
@@ -42,9 +39,21 @@ subpackages:
             - ${{package.name}}
       pipeline:
         - runs: |
-            stat /nats-server-config-reloader
             /usr/bin/nats-server-config-reloader --help
             /usr/local/bin/nats-server-config-reloader --help
+
+  - name: ${{package.name}}-oci-entrypoint
+    description: Entrypoint for ${{package.name}}
+    pipeline:
+      - runs: |
+          cp cicd/assets/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
+          chmod +x ${{targets.contextdir}}/entrypoint.sh
+      - uses: strip
+    test:
+      pipeline:
+        - name: "Check expected scripts exist"
+          runs: |
+            stat /entrypoint.sh
 
 update:
   enabled: true

--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -98,3 +98,9 @@ test:
 
           echo "Checking NATS server logs for reload confirmation..."
           cat /tmp/nats-server.log
+
+          if ! grep -q "Reloaded: debug = true" /tmp/nats-server.log; then
+            echo "Error: Config reload for debug=true not detected in logs!"
+            exit 1
+          fi
+          echo "Config reload test passed successfully!"

--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -1,0 +1,109 @@
+package:
+  name: nats-server-config-reloader
+  version: "0.17.1"
+  epoch: 0
+  description: "NATS server configuration reloader utility"
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nats-io/nack.git
+      tag: v${{package.version}}
+      expected-commit: 03e5e930036a5baacc12ef604cd57ad6ff6ada96
+
+  - uses: go/build
+    with:
+      packages: ./cmd/nats-server-config-reloader
+      output: nats-server-config-reloader
+      ldflags: -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%S%z) -X main.GitInfo=$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)$(git diff --quiet || echo "-dirty") -X main.Version=${{package.version}}
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp -r ${{targets.destdir}}/usr/bin/nats-server-config-reloader ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
+      chmod 755 ${{targets.destdir}}/usr/local/bin/nats-server-config-reloader
+      mkdir -p ${{targets.destdir}}/etc/ssl/certs
+      cp /etc/ssl/certs/ca-certificates.crt ${{targets.destdir}}/etc/ssl/certs/
+      cp cicd/assets/entrypoint.sh ${{targets.destdir}}/entrypoint.sh
+      chmod +x ${{targets.destdir}}/entrypoint.sh
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          ln -sf /usr/local/bin/nats-server-config-reloader ${{targets.contextdir}}/nats-server-config-reloader
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - runs: |
+            stat /nats-server-config-reloader
+            /nats-server-config-reloader --version
+            /usr/local/bin/nats-server-config-reloader --help
+
+update:
+  enabled: true
+  github:
+    identifier: nats-io/nack
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - bash
+        - nats-server
+        - curl
+        - jq
+  pipeline:
+    - name: "Verify basic installation"
+      runs: |
+        nats-server-config-reloader --version
+        nats-server-config-reloader --help
+    - name: "Test nats-server-config-reloader with nats-server"
+      runs: |
+        echo "Starting NATS server with a configuration file..."
+        cat <<EOF > /tmp/nats-server.conf
+        pid_file: "/tmp/nats-server.pid"
+        http: 8222
+        EOF
+
+        nats-server -c /tmp/nats-server.conf -l /tmp/nats-server.log &
+        sleep 2
+
+        echo "Verifying NATS server process..."
+        if ! pgrep -f "nats-server -c /tmp/nats-server.conf"; then
+          echo "NATS server did not start properly!"
+          exit 1
+        fi
+
+        # Start the config reloader in the background
+        nats-server-config-reloader -config /tmp/nats-server.conf -pid /tmp/nats-server.pid &
+        RELOADER_PID=$!
+        sleep 2
+
+        echo "Modifying config to reload..."
+        cat <<EOF > /tmp/nats-server.conf
+        pid_file: "/tmp/nats-server.pid"
+        http: 8222
+        debug: true
+        EOF
+
+        sleep 5
+
+        echo "Checking NATS server logs for reload confirmation..."
+        cat /tmp/nats-server.log
+
+        # Validate that the reload occurred by checking logs
+        if ! grep -q "Reloaded: debug = true" /tmp/nats-server.log; then
+          echo "Error: Config reload for debug=true not detected in logs!"
+          exit 1
+        fi
+
+        echo "Config reload test passed successfully!"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/4444

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [X] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
