### PR TITLE
remove patch since it breaks the app

### DIFF
--- a/apache-tika-3.1.yaml
+++ b/apache-tika-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-tika-3.1
   version: "3.1.0"
-  epoch: 1
+  epoch: 2
   description: The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).
   copyright:
     - license: Apache-2.0
@@ -37,7 +37,6 @@ pipeline:
   - uses: maven/pombump
     with:
       properties-file: pombump-properties.yaml
-      pom: tika-parent/pom.xml
 
   - runs: |
       mvn clean install -am -DskipTests -Dossindex.skip


### PR DESCRIPTION
We were assuming that this patch could work but the app is failing with the following error:

```bash
INFO: Setting the server's publish address to be http://0.0.0.0:9998/
Exception in thread "main" java.lang.NoSuchMethodError: 'int org.eclipse.jetty.util.URIUtil.getDefaultPortForScheme(java.lang.String)'
        at org.eclipse.jetty.http.HttpScheme.<init>(HttpScheme.java:45)
```

so this PR aims to fix this issue but there will be CVEs reported but we are going to fill an advisory for the given CVE for the package.