### PR TITLE
git: add signing and verification tools as runtime dependencies.

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -1,12 +1,17 @@
 package:
   name: git
   version: "2.48.1"
-  epoch: 1
+  epoch: 2
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
     provider-priority: 10
+    runtime:
+      # Signing and verification tools. See https://github.com/git/git/blob/6a64ac7b014fa2cfa7a69af3c253bcd53a94b428/gpg-interface.c#L93-L124
+      - gpg
+      - gpgsm
+      - openssh-keygen
 
 environment:
   contents:


### PR DESCRIPTION
These tools are exec-ed out to by git at run time to perform signing and verification for git commit signatures.

This is a bit of a grey area w.r.t. packaging - technically git can function without these, but since these are configured by default these feel like they're worth including? The alternative is we can bundle these at the image layer.
Open to suggestions here!

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
