### PR TITLE
spark-3.5/GHSA-4g8c-wm8x-jfhw custom image subpackage name fix and other dependency updates

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -2,7 +2,7 @@
 package:
   name: spark-3.5
   version: "3.5.5"
-  epoch: 1
+  epoch: 2
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -205,7 +205,7 @@ subpackages:
       - uses: strip
 
   - range: openjdk-versions
-    name: ${{package.name}}-minimal-openjdk-${{range.key}}
+    name: ${{package.name}}-scala-2.12-minimal-openjdk-${{range.key}}
     dependencies:
       runtime:
         - openjdk-${{range.key}}-default-jvm

--- a/spark-3.5/pombump-deps.yaml
+++ b/spark-3.5/pombump-deps.yaml
@@ -12,6 +12,3 @@ patches:
   - groupId: org.codehaus.jettison
     artifactId: jettison
     version: 1.5.4
-  - groupId: org.apache.derby.osgi.EmbeddedActivator
-    artifactId: derby
-    version: 10.14.3

--- a/spark-3.5/pombump-properties.yaml
+++ b/spark-3.5/pombump-properties.yaml
@@ -1,10 +1,8 @@
 properties:
   - property: hadoop.version
     value: "3.3.6"
-  - property: zookeeper.version
-    value: "3.7.2"
   - property: ivy.version
-    value: "2.5.2"
+    value: "2.5.3"
   - property: avro.version
     value: "1.11.4"
   - property: snappy.version
@@ -14,8 +12,10 @@ properties:
   - property: guava.version
     value: "33.2.1-jre"
   - property: netty.version
-    value: "4.1.108.Final"
+    value: "4.1.119.Final"
+  - property: netty-tcnative.version
+    value: "2.0.70.Final"
   - property: zookeeper.version
-    value: "3.8.4"
+    value: "3.9.1"
   - property: jetty.version
     value: "9.4.56.v20240826"


### PR DESCRIPTION
I updated dependencies that I was able to, able to remediate netty and zookeeper CVEs that were previously advisories. This will be the first step in a two step PR for bumping dependencies, next will attempt to correctly integrate derby version. automation that added the derby dependency bump included only part of the dependency so more work will need to be done to fully pull that in. Served name correctly for use in custom request-471's spark