### PR TITLE
Build gcc w/ iconv support to fix 93 glibc test case failures

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 9
+  epoch: 10
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -26,6 +26,7 @@ environment:
       - file
       - flex-dev
       - gawk
+      - glibc-iconv
       - gmp-dev
       - isl-dev
       - make


### PR DESCRIPTION
gcc was building w/o iconv support, which causes the `check-installed-headers-*` tests from glibc's testsuite to fail with errors like:

```
cc1: error: no iconv implementation, cannot convert from ascii to UTF-8
:::: -std=gnu11 -D_XOPEN_SOURCE=700 #define _FORTIFY_SOURCE 1
cc1: error: no iconv implementation, cannot convert from ascii to UTF-8
:::: -std=gnu11 -D_XOPEN_SOURCE=700 #define _FORTIFY_SOURCE 2
cc1: error: no iconv implementation, cannot convert from ascii to UTF-8
:::: -std=gnu11 -D_XOPEN_SOURCE=700 #define _FORTIFY_SOURCE 3
cc1: error: no iconv implementation, cannot convert from ascii to UTF-8
```

This takes our FAIL count down from 104 to 11.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/9485
