### PR TITLE
Revert "Supress 'apk info' noise when testing docs"

### DIFF
--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -13,9 +13,9 @@ pipeline:
       # Get our doc package name, which is usually a sub package
       doc_pkg=$(basename ${{targets.contextdir}})
       # We seem to have a lot of "empty" doc packages...
-      if [ $(apk info -qL "$doc_pkg" | wc -l) -le 3 ]; then
+      if [ $(apk info -L "$doc_pkg" | wc -l) -le 3 ]; then
         echo "See:"
-        apk info -qL "$doc_pkg"
+        apk info -L "$doc_pkg"
         echo "This package [$doc_pkg] is completely empty (i.e. installs no files)."
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or"
@@ -27,7 +27,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/man/"); do
+      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -37,14 +37,14 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/info/"); do
+      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/"); do
+      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/"); do
         if [ -f /"$doc_file" ]; then
           # Check that we have readable files installed in /usr/share
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
@@ -54,7 +54,7 @@ pipeline:
       done
       if [ $doc_files = "false" ]; then
         echo "See:"
-        apk info -qL "$doc_pkg"
+        apk info -L "$doc_pkg"
         echo "This package [$doc_pkg] installs files, but no usable documentation"
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include docs (check the split/manpages and split/infodir pipelines), or"

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -12,7 +12,7 @@ pipeline:
       # Find all pc files installed by this dev_pkg
       cd /
       pc_files=false
-      for pc_file in $(apk info -qL "$dev_pkg" | grep "\.pc$"); do
+      for pc_file in $(apk info -L "$dev_pkg" 2>/dev/null | grep "\.pc$"); do
         pc_files=true
         # Ensure this is a pkgconf .pc file
         if grep -q "^Name:" $pc_file; then


### PR DESCRIPTION
Reverts wolfi-dev/os#44369

Breaks some doc test cases.