### PR TITLE
envoy-ratelimit: ensure full history is checked out.

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -3,7 +3,7 @@ package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
   version: "0.0.0_git20250303"
-  epoch: 0
+  epoch: 1
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ pipeline:
     with:
       expected-commit: 80b15778548f5f66fe7246cc2c982bbec0f5bd45
       repository: https://github.com/envoyproxy/ratelimit
+      depth: -1
       branch: main
 
   - uses: go/build


### PR DESCRIPTION
Note, that current pipeline expects full history, when branch tip is moves, and one ones to use older commit from a branch.

We should really adopt the approach OddBloke demonstrated of fetching
explicit commits instead. But we need envoy-ratelimit to be buildable
for usrmerge transtions in the current form.

Otherwise currently failing with [git checkout] FAIL expected commit 80b15778548f5f66fe7246cc2c982bbec0f5bd45 on main, got ae4cee115cbbcbe34ceefb7188dbfcd53756f029, set depth to -1 to attempt a reset
