### PR TITLE
feat: add kots-compat subpackage to kots

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -85,6 +85,29 @@ subpackages:
 
           ln -s /usr/bin/kubectl ${{targets.subpkgdir}}/usr/local/bin/kubectl
     description: Compatability package for kots
+  - name: kots-compat # adding kots-compat here since we removed the older one and want to avoid breaking anything
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/local/bin
+
+          # TODO: this is a manual intervention whenever helm releases a new major version
+          ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm
+          ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm3
+
+          # TODO: this is a manual intervention whenever kustomize releases a new major version
+          ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize
+          ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize5
+          
+          # TODO: this is a manual intervention whenever kubectl releases a new major version
+          ln -s /usr/bin/kubectl-1.20 ${{targets.destdir}}/usr/local/bin/kubectl-v1.20
+          ln -s /usr/bin/kubectl-1.21 ${{targets.destdir}}/usr/local/bin/kubectl-v1.21
+          ln -s /usr/bin/kubectl-1.22 ${{targets.destdir}}/usr/local/bin/kubectl-v1.22
+          ln -s /usr/bin/kubectl-1.23 ${{targets.destdir}}/usr/local/bin/kubectl-v1.23
+          ln -s /usr/bin/kubectl-1.24 ${{targets.destdir}}/usr/local/bin/kubectl-v1.24
+          ln -s /usr/bin/kubectl-1.25 ${{targets.destdir}}/usr/local/bin/kubectl-v1.25
+          ln -s /usr/bin/kubectl-1.26 ${{targets.destdir}}/usr/local/bin/kubectl-v1.26
+          ln -s /usr/bin/kubectl ${{targets.destdir}}/usr/local/bin/kubectl
+    description: Compatability package for kots
 
 update:
   enabled: true

--- a/kots.yaml
+++ b/kots.yaml
@@ -85,6 +85,7 @@ subpackages:
 
           ln -s /usr/bin/kubectl ${{targets.subpkgdir}}/usr/local/bin/kubectl
     description: Compatability package for kots
+
   - name: kots-compat # adding kots-compat here since we removed the older one and want to avoid breaking anything
     pipeline:
       - runs: |
@@ -97,7 +98,7 @@ subpackages:
           # TODO: this is a manual intervention whenever kustomize releases a new major version
           ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize
           ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize5
-          
+
           # TODO: this is a manual intervention whenever kubectl releases a new major version
           ln -s /usr/bin/kubectl-1.20 ${{targets.destdir}}/usr/local/bin/kubectl-v1.20
           ln -s /usr/bin/kubectl-1.21 ${{targets.destdir}}/usr/local/bin/kubectl-v1.21

--- a/kots.yaml
+++ b/kots.yaml
@@ -89,17 +89,17 @@ subpackages:
   - name: kots-compat # adding kots-compat here since we removed the older one and want to avoid breaking anything
     pipeline:
       - runs: |
-          mkdir -p ${{targets.destdir}}/usr/local/bin
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
 
-          # TODO: this is a manual intervention whenever helm releases a new major version
-          ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm
-          ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm3
+          # NOTE: this is a manual intervention whenever helm releases a new major version
+          ln -s /usr/bin/helm ${{targets.contextdir}}/usr/local/bin/helm
+          ln -s /usr/bin/helm ${{targets.contextdir}}/usr/local/bin/helm3
 
-          # TODO: this is a manual intervention whenever kustomize releases a new major version
-          ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize
-          ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize5
+          # NOTE: this is a manual intervention whenever kustomize releases a new major version
+          ln -s /usr/bin/kustomize ${{targets.contextdir}}/usr/local/bin/kustomize
+          ln -s /usr/bin/kustomize ${{targets.contextdir}}/usr/local/bin/kustomize5
 
-          ln -s /usr/bin/kubectl ${{targets.destdir}}/usr/local/bin/kubectl
+          ln -s /usr/bin/kubectl ${{targets.contextdir}}/usr/local/bin/kubectl
     description: Compatability package for kots
 
 update:

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: "1.124.4"
-  epoch: 1
+  epoch: 2
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -99,14 +99,6 @@ subpackages:
           ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize
           ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize5
 
-          # TODO: this is a manual intervention whenever kubectl releases a new major version
-          ln -s /usr/bin/kubectl-1.20 ${{targets.destdir}}/usr/local/bin/kubectl-v1.20
-          ln -s /usr/bin/kubectl-1.21 ${{targets.destdir}}/usr/local/bin/kubectl-v1.21
-          ln -s /usr/bin/kubectl-1.22 ${{targets.destdir}}/usr/local/bin/kubectl-v1.22
-          ln -s /usr/bin/kubectl-1.23 ${{targets.destdir}}/usr/local/bin/kubectl-v1.23
-          ln -s /usr/bin/kubectl-1.24 ${{targets.destdir}}/usr/local/bin/kubectl-v1.24
-          ln -s /usr/bin/kubectl-1.25 ${{targets.destdir}}/usr/local/bin/kubectl-v1.25
-          ln -s /usr/bin/kubectl-1.26 ${{targets.destdir}}/usr/local/bin/kubectl-v1.26
           ln -s /usr/bin/kubectl ${{targets.destdir}}/usr/local/bin/kubectl
     description: Compatability package for kots
 


### PR DESCRIPTION
This PR adds `kots-compat` to the kots subpackages.
We removed the already existing `kots-compat` package which existed and want to add it here to prevent breaking anything.