### PR TITLE
gn: bump to latest git snapshot

### DIFF
--- a/gn.yaml
+++ b/gn.yaml
@@ -1,7 +1,7 @@
 package:
   name: gn
-  version: 0.0_git20240725
-  epoch: 1
+  version: 0.0_git20250305
+  epoch: 0
   description: "Meta-build system that generates build files for Ninja"
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ pipeline:
       cd gn
 
       # Bump this commit when updating
-      git checkout b2afae122eeb6ce09c52d63f67dc53fc517dbdc8
+      git checkout dae6a4496ecbe141b76c67ce5f1996711a3f87cd
 
       python3 build/gen.py
       ninja -C out


### PR DESCRIPTION
The chromium build now relies on functionality introduced since the last snapshot (specifically
https://gn.googlesource.com/gn/+/ed1abc107815210dc66ec439542bee2f6cbabc00).