### PR TITLE
use 9.0.103 to correct scanners prevents false positives

### DIFF
--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,6 +1,6 @@
 package:
   name: dotnet-9
-  version: 9.0.2
+  version: 9.0.103
   epoch: 0
   description: ".NET SDK"
   copyright:
@@ -11,6 +11,9 @@ package:
   dependencies:
     runtime:
       - icu
+
+vars:
+  tag: v9.0.2
 
 environment:
   environment:
@@ -50,7 +53,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/dotnet/dotnet
-      tag: v${{package.version}}
+      tag: ${{vars.tag}}
       expected-commit: c4e5fd73fe5d8c004bf46cb4f1ded77ca8124b1a
       destination: /home/build/src
 
@@ -172,7 +175,7 @@ subpackages:
 update:
   enabled: true
   github:
-    identifier: dotnet/core
+    identifier: dotnet/dotnet
     strip-prefix: v
     use-tag: true
     tag-filter: "v9"


### PR DESCRIPTION
There is an issue reported related to the vuln scanners that scanner reports false positive vulnerabilities addressed in 9.0.101 to be flagged as vulnerable in 9.0.2.

```bash
dotnet-9          9.0.2-r0   9.0.101-r0  apk   CVE-2024-43498       Critical  
```

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

