### PR TITLE
Use apk info -q in doc test pipeline

### DIFF
--- a/ldb.yaml
+++ b/ldb.yaml
@@ -214,9 +214,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: ldb manpages
-    test:
-      pipeline:
-        - uses: test/docs
 
 update:
   enabled: true

--- a/ldb.yaml
+++ b/ldb.yaml
@@ -214,6 +214,9 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: ldb manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -13,9 +13,9 @@ pipeline:
       # Get our doc package name, which is usually a sub package
       doc_pkg=$(basename ${{targets.contextdir}})
       # We seem to have a lot of "empty" doc packages...
-      if [ $(apk info -L "$doc_pkg" | wc -l) -le 3 ]; then
+      if [ $(apk info -qL "$doc_pkg" | grep -v "^var/lib/db/sbom" | grep -v "^$" | wc -l) -eq 0 ]; then
         echo "See:"
-        apk info -L "$doc_pkg"
+        apk info -qL "$doc_pkg"
         echo "This package [$doc_pkg] is completely empty (i.e. installs no files)."
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or"
@@ -27,7 +27,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/man/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -37,14 +37,14 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/info/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -L "$doc_pkg" | grep "^usr/share/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/"); do
         if [ -f /"$doc_file" ]; then
           # Check that we have readable files installed in /usr/share
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
@@ -54,7 +54,7 @@ pipeline:
       done
       if [ $doc_files = "false" ]; then
         echo "See:"
-        apk info -L "$doc_pkg"
+        apk info -qL "$doc_pkg"
         echo "This package [$doc_pkg] installs files, but no usable documentation"
         echo "Please check the package build for proper docs installation, and either:"
         echo "  (a) fix the docs subpackage build to actually include docs (check the split/manpages and split/infodir pipelines), or"


### PR DESCRIPTION
This modifies the calls to apk info to use the -q switch to quiet some output and additionally clarifies what an empty doc package is by showing, in the code, the files we are ignoring.

A failure looks like:
```
2025/03/05 11:49:16 WARN + basename /home/build/melange-out/ldb-doc
2025/03/05 11:49:16 WARN + doc_pkg=ldb-doc
2025/03/05 11:49:16 WARN + apk info -qL ldb-doc
2025/03/05 11:49:16 WARN + grep -v ^var/lib/db/sbom
2025/03/05 11:49:16 WARN + grep -v '^$'
2025/03/05 11:49:16 WARN + wc -l
2025/03/05 11:49:16 WARN + '[' 0 -eq 0 ]
2025/03/05 11:49:16 WARN + echo See:
2025/03/05 11:49:16 WARN + apk info -qL ldb-doc
2025/03/05 11:49:16 INFO See:
2025/03/05 11:49:16 INFO var/lib/db/sbom/ldb-doc-2.9.1-r4.spdx.json
2025/03/05 11:49:16 INFO
2025/03/05 11:49:16 INFO This package [ldb-doc] is completely empty (i.e. installs no files).
2025/03/05 11:49:16 INFO Please check the package build for proper docs installation, and either:
2025/03/05 11:49:16 INFO   (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or
2025/03/05 11:49:16 INFO   (b) remove the test/docs pipeline (if for some reason we want an empty docs package), or
2025/03/05 11:49:16 INFO   (c) remove the docs subpackage entirely
2025/03/05 11:49:16 WARN + echo 'This package [ldb-doc] is completely empty (i.e. installs no files).'
2025/03/05 11:49:16 WARN + echo 'Please check the package build for proper docs installation, and either:'
2025/03/05 11:49:16 WARN + echo '  (a) fix the docs subpackage build to actually include documentation (check the split/manpages and split/infodir pipelines), or'
2025/03/05 11:49:16 WARN + echo '  (b) remove the test/docs pipeline (if for some reason we want an empty docs package), or'
2025/03/05 11:49:16 WARN + echo '  (c) remove the docs subpackage entirely'
2025/03/05 11:49:16 WARN + exit 1
2025/03/05 11:49:16 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/03/05 11:49:16 ERRO failed to test package: unable to run pipeline: unable to run pipeline: unable to run pipeline: exit status 1
make: *** [Makefile:115: test/ldb] Error 1
```

And we can see that dash, which had failed during a previous attempt at this, still passes.
```
2025/03/05 11:54:07 INFO running step "test/docs"
2025/03/05 11:54:07 WARN + '[' -d /home/build ]
2025/03/05 11:54:07 WARN + cd /home/build
2025/03/05 11:54:07 WARN + exit 0
2025/03/05 11:54:07 INFO running step "docs readability check"
2025/03/05 11:54:07 WARN + '[' -d /home/build ]
2025/03/05 11:54:07 WARN + cd /home/build
2025/03/05 11:54:07 WARN + basename /home/build/melange-out/dash-doc
2025/03/05 11:54:07 WARN + doc_pkg=dash-doc
2025/03/05 11:54:07 WARN + apk info -qL dash-doc
2025/03/05 11:54:07 WARN + grep -v ^var/lib/db/sbom
2025/03/05 11:54:07 WARN + grep -v '^$'
2025/03/05 11:54:07 WARN + wc -l
2025/03/05 11:54:07 WARN + '[' 1 -eq 0 ]
2025/03/05 11:54:07 WARN + cd /
2025/03/05 11:54:07 WARN + doc_files=false
2025/03/05 11:54:07 WARN + apk info -qL dash-doc
2025/03/05 11:54:07 WARN + grep ^usr/share/man/
2025/03/05 11:54:07 WARN + '[' -f /usr/share/man/man1/dash.1 ]
2025/03/05 11:54:07 WARN + man -l /usr/share/man/man1/dash.1
2025/03/05 11:54:07 WARN + doc_files=true
2025/03/05 11:54:07 WARN + apk info -qL dash-doc
2025/03/05 11:54:07 WARN + grep ^usr/share/info/
2025/03/05 11:54:07 WARN + apk info -qL dash-doc
2025/03/05 11:54:07 WARN + grep ^usr/share/
2025/03/05 11:54:07 WARN + '[' -f /usr/share/man/man1/dash.1 ]
2025/03/05 11:54:07 WARN + cat /usr/share/man/man1/dash.1
2025/03/05 11:54:07 WARN + doc_files=true
2025/03/05 11:54:07 WARN + '[' true '=' false ]
2025/03/05 11:54:07 WARN + exit 0
```