### PR TITLE
fix rrdtool FTBFS after /sbin usrmerge

### DIFF
--- a/rrdtool.yaml
+++ b/rrdtool.yaml
@@ -1,7 +1,7 @@
 package:
   name: rrdtool
   version: 1.9.0
-  epoch: 2
+  epoch: 3
   description: Data logging and graphing application
   copyright:
     - license: GPL-2.0-or-later
@@ -60,20 +60,25 @@ pipeline:
       ln -sf python${{vars.py-version}} /usr/bin/python3
       ln -sf python${{vars.py-version}} /usr/bin/python
 
-  - uses: autoconf/configure
-    with:
-      opts: |
-        --prefix=/usr \
-        --disable-nls \
-        --disable-tcl \
-        --disable-ruby \
-        --enable-rrdcgi \
-        --enable-perl-site-install \
-        --enable-lua-site-install \
-        --with-perl-options="INSTALLDIRS=vendor"
+  - runs: |
+      autoreconf -fiv
+
+  - runs: |
+      # we want lua to be seen from /usr/bin not /usr/sbin
+      PATH=/usr/bin:/usr/local/bin \
+        ./configure \
+          --prefix=/usr \
+          --disable-nls \
+          --disable-tcl \
+          --disable-ruby \
+          --enable-rrdcgi \
+          --enable-perl-site-install \
+          --enable-lua-site-install \
+          --with-perl-options="INSTALLDIRS=vendor"
 
   - runs: |
       export INSTALLDIRS=vendor
+      make DESTDIR="${{targets.destdir}}" CFLAGS=-I/usr/include/lua${{vars.lua-version}}
       make DESTDIR="${{targets.destdir}}" install
       find "${{targets.destdir}}" -name '.packlist' -delete
       find "${{targets.destdir}}" -name 'perllocal.pod' -delete


### PR DESCRIPTION
This build started to fail after /sbin was usrmerged. True story.

If configure finds /usr/sbin/lua before /usr/bin/lua then it will state:

    checking for lua... /usr/sbin/lua
    checking for lua >= 5.0... 5.4 found
    checking for lua54/lua.h... no
    checking for lua5.4/lua.h... yes
    ...
    Build Lua Bindings: yes
    Lua Binary: /usr/sbin/lua
    Lua Version: 5.4.7
    Lua C-modules dir: /usr/local/lib/lua/5.4

And will then fail to build with :

    rrdlua.c:24:10: fatal error: lua.h: No such file or directory

Changing the PATH to have /usr/bin first then we get:

     checking for lua... /usr/bin/lua
     checking for lua >= 5.0... 5.4 found
     checking for lua54/lua.h... no
     checking for lua5.4/lua.h... yes
     ...
     Build Lua Bindings: yes
     Lua Binary: /usr/bin/lua
     Lua Version: 5.4.7
     Lua C-modules dir: /usr/lib/lua/5.4

So... whatever. Make it happy.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
