### PR TITLE
repmgr-17 - usrmerge /usr/sbin

### DIFF
--- a/repmgr-17.yaml
+++ b/repmgr-17.yaml
@@ -52,6 +52,8 @@ pipeline:
       expected-commit: c0d9dc6dac34c4cb60c3d8805842eed18cca4e85
 
   - uses: autoconf/configure
+    with:
+      opts: --sbindir=/usr/bin
 
   - uses: autoconf/make
 

--- a/repmgr-17.yaml
+++ b/repmgr-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: repmgr-17
   version: 5.5.0
-  epoch: 2
+  epoch: 40
   description: "A lightweight replication manager for PostgreSQL"
   copyright:
     - license: GPL-3.0-only
@@ -10,9 +10,11 @@ package:
       - repmgr=${{package.full-version}}
     runtime:
       - libpq-17
+      - merged-usrsbin
       - pgaudit-17
       - postgresql-17
       - postgresql-17-client
+      - wolfi-baselayout
 
 environment:
   contents:
@@ -119,6 +121,7 @@ subpackages:
         - krb5-libs
         - cyrus-sasl
         - gmp
+        - merged-usrsbin
     pipeline:
       - uses: bitnami/compat
         with:


### PR DESCRIPTION
repmgr-17 has coreutils in its runtime deps. So pull it out so that it can get that.