### PR TITLE
Update Spark package configuration for OpenJDK and enhance PySpark di…

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -2,7 +2,7 @@
 package:
   name: spark-3.5
   version: "3.5.5"
-  epoch: 2
+  epoch: 3
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -205,7 +205,7 @@ subpackages:
       - uses: strip
 
   - range: openjdk-versions
-    name: ${{package.name}}-minimal-openjdk-${{range.key}}
+    name: ${{package.name}}-scala-2.12-minimal-openjdk-${{range.key}}
     dependencies:
       runtime:
         - openjdk-${{range.key}}-default-jvm
@@ -274,7 +274,7 @@ subpackages:
           properties-file: pombump-properties-2.13.yaml
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/lib/spark/
-          ./dev/make-distribution.sh --name pyspark-2.13 --pip --tgz -Pscala-2.13 -Phive -Phive-thriftserver -Pyarn
+          ./dev/make-distribution.sh --name pyspark-2.13 --pip --tgz -Pscala-2.13 -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes
           mv dist/* ${{targets.contextdir}}/usr/lib/spark/
           cp resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh ${{targets.contextdir}}/usr/lib/spark/
     test:

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -2,7 +2,7 @@
 package:
   name: spark-3.5
   version: "3.5.5"
-  epoch: 1
+  epoch: 2
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Coming from this [escalation](https://github.com/orgs/chainguard-dev/projects/45/views/62?pane=issue&itemId=100254391&issue=chainguard-dev%7Ccustomer-issues%7C2097) customer was unable to use kubernetes libraries in the `spark-3.5-scala-2.13` package.
This change adds the `-PKubernetes` build parameter for building a spark distribution.

Also used this change to rename the `spark-3.5-minimal-openjdk-` package to `spark-3.5-scala-2.12-minimal-openjdk-` to match what is expected in the custom package [here](https://github.com/chainguard-images/images-private/blob/main/images/request-471/main.tf#L5) 

Update Spark package configuration for OpenJDK and enhance PySpark distribution script
