### PR TITLE
Several prism CVE fixes

### DIFF
--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: 5.12.1
-  epoch: 2
+  epoch: 3
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:

--- a/prism/CVE-2025-1302.patch
+++ b/prism/CVE-2025-1302.patch
@@ -2,13 +2,17 @@ diff --git a/package.json b/package.json
 index 7bea0421..4ec7464b 100644
 --- a/package.json
 +++ b/package.json
-@@ -22,7 +22,8 @@
+@@ -22,7 +22,12 @@
      "test.harness": "jest -c ./jest.harness.config.js"
    },
    "resolutions": {
 -    "sanitize-html": "2.12.1"
 +    "sanitize-html": "2.12.1",
-+    "jsonpath-plus": "10.3.0"
++    "jsonpath-plus": "10.3.0",
++    "braces": "3.0.3",
++    "micromatch": "4.0.8",
++    "axios": "1.7.9",
++    "cross-spawn": "7.0.6"
    },
    "devDependencies": {
      "@stoplight/types": "^14.1.0",


### PR DESCRIPTION
braces CVE: GHSA-grv7-fg5c-xmjg, micromatch GHSA-952p-6rrq-rcjv, axios GHSA-8hc4-vh64-cxmj, cross-spawn GHSA-3xgq-45jj-v275 all remediated by bumping versions