### PR TITLE
glibc: make scriplet not depend on any shell

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 21
+  epoch: 22
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -29,8 +29,7 @@ package:
         - /usr/lib
         - /usr/lib64
       script: |
-        #!/bin/busybox sh
-        /usr/bin/ldconfig
+        #!/usr/bin/ldconfig
 
 environment:
   contents:


### PR DESCRIPTION
Note it means no arguments can be passed to ldconfig

```
# apk add yaml
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/1) Installing yaml (0.2.5-r5)
Executing glibc-2.40-r22.trigger
/usr/bin/ldconfig: relative path `lib/apk/exec/glibc-2.40-r22.trigger' used to build cache
ERROR: glibc-2.40-r22.trigger: script exited with error 1
1 error; 14 MiB in 16 packages
```

hm, confused what this warning means and if it is real or not.