### PR TITLE
WIP: temporarily bump epochs to trigger tests

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: "0.33.0"
-  epoch: 1
+  epoch: 2
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.12.0
-  epoch: 6
+  epoch: 7
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0

--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: 3.9.1
-  epoch: 10
+  epoch: 11
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0

--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: "5.3"
-  epoch: 0
+  epoch: 1
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only

--- a/haproxy-3.1.yaml
+++ b/haproxy-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.1
   version: "3.1.5"
-  epoch: 0
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 11
+  epoch: 12
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.32
   version: "1.32.2"
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.9"
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.2"
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: "1.11.2"
-  epoch: 2
+  epoch: 3
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We've seen the tests in 8ed1122fd74dda0a4fa12aad71c720a725fe00a8 fail (because they were never run in CI), so let's find all those failures now.