### PR TITLE
Use apk info -q in test/emptypackage

### DIFF
--- a/pipelines/test/emptypackage.yaml
+++ b/pipelines/test/emptypackage.yaml
@@ -6,11 +6,11 @@ pipeline:
       # Get our empty package name
       pkg=$(basename ${{targets.contextdir}})
       # Make sure this is an empty package
-      # Skip the "contains:" line and any empty lines
+      # Skip any empty lines
       # We're only really expecting a single spdx.json file in an empty package
-      if [ $(apk info -L "$pkg" | grep -v " contains:$" | grep -v "^$" | wc -l) -le 1 ] && (apk info -L "$pkg" | grep -q ".spdx.json$"); then
+      if [ $(apk info -qL "$pkg" | grep -v "^$" | wc -l) -le 1 ] && (apk info -qL "$pkg" | grep -q ".spdx.json$"); then
         echo "Package [$pkg] seems to be empty, as expected"
       else
         echo "Expected this package [$pkg] to be empty, but it isn't:"
-        apk info -L "$pkg"
-      fi 
+        apk info -qL "$pkg"
+      fi


### PR DESCRIPTION
By switching to the use of `apk info -q` we can suppress some warning messages from apk and additionally remove filter for `contains:` which no longer appears in the output e.g.

```
635befa6f2b6:/work/packages# apk info -L rekor
rekor-1.3.9-r4 contains:
var/lib/db/sbom/rekor-1.3.9-r4.spdx.json

635befa6f2b6:/work/packages# apk info -qL rekor
var/lib/db/sbom/rekor-1.3.9-r4.spdx.json
```