### PR TITLE
emissary: bump jinja2 to 3.1.6

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: 3.9.1
-  epoch: 10
+  epoch: 11
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -88,7 +88,7 @@ subpackages:
 
           # Bump the dependencies in the targetdir.
           python${{range.key}} -m pip install --no-cache-dir --prefix=/usr --root=${{targets.contextdir}} --upgrade \
-            Jinja2==3.1.5 \
+            Jinja2==3.1.6 \
             certifi==2024.07.04 \
             gunicorn==22.0.0 \
             idna==3.7 \


### PR DESCRIPTION
CVE-2025-27516