### PR TITLE
kserve: bump jinja2 to 3.1.6

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: 0.14.1
-  epoch: 3
+  epoch: 4
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -101,7 +101,7 @@ subpackages:
             "google.cloud" \
             "typing-extensions" \
             "starlette=^0.40.0" \
-            "jinja2=3.1.5" \
+            "jinja2=3.1.6" \
             "cryptography@^44.0.1"
 
           poetry run pip freeze | grep -v kserve > requirements.txt


### PR DESCRIPTION
CVE-2025-27516