### PR TITLE
feat: openssh with pam support

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "9.9_p2"
-  epoch: 1
+  epoch: 2
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -57,6 +57,7 @@ pipeline:
          --with-privsep-user=sshd \
          --with-ssl-engine \
          --with-pam \
+         --with-pam-service=sshd \
          --with-libedit
 
   - uses: autoconf/make
@@ -196,8 +197,8 @@ subpackages:
             ssh-keygen -A -q -N ""
             sshd -T | grep -i 'Banner /does-not-exist'
 
-  - name: "openssh-pam-config"
-    description: "OpenSSH server pam configuration"
+  - name: "openssh-pam-configuration"
+    description: "OpenSSH server pam config"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc/pam.d


### PR DESCRIPTION
We forgot to include sshd_session pam support so pam modules like mkhomedir did not work when the user session was created.