### PR TITLE
superset-4.1.1/cve remediation

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: 4.1.1
-  epoch: 5
+  epoch: 6
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -72,7 +72,7 @@ pipeline:
       pip install pillow pyarrow
 
       # For running translations
-      pip install flask flask-appbuilder==4.5.1
+      pip install flask flask-appbuilder==4.5.3
 
       sed -i 's/"cryptography>=42.0.4.*"/"cryptography>=44.0.1"/' pyproject.toml
 


### PR DESCRIPTION
fixes CVE-2025-24023 by bumping flask-appbuilder to 4.5.3