### PR TITLE
llvm: fix /usr/bin/llvm-config symlink

### DIFF
--- a/llvm.yaml
+++ b/llvm.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm
   version: "19.1.7"
-  epoch: 1
+  epoch: 2
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -642,7 +642,7 @@ subpackages:
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/bin/llvm-config ${{targets.contextdir}}/${{vars.llvm-prefix}}/bin/
 
           mkdir -p ${{targets.contextdir}}/usr/bin
-          ln -s ../lib/${{package.name}}/bin/llvm-config ${{targets.contextdir}}/usr/bin/llvm-config
+          ln -s ../lib/llvm-${{vars.major-version}}/bin/llvm-config ${{targets.contextdir}}/usr/bin/llvm-config
 
           # Symlink binaries to /usr/bin in main LLVM package
           # Must come last after we've split away everything else
@@ -656,6 +656,9 @@ subpackages:
         - uses: test/ldd-check
           with:
             packages: $(basename ${{targets.contextdir}})
+        - runs: |
+            llvm-config --version
+            llvm-config --help
 
 update:
   enabled: true


### PR DESCRIPTION
And add it to testing to avoid future regressions.

Previously this package was named `llvm-19`, which would have produced the correct path, so this was a minor miss in the package rename.