### PR TITLE
Revert "python: Use more generic march for rosetta compatibiity (#44644)"

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.16
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,22 +61,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Use more generic -march for rosetta2 compatibility
-      # Add additional flag overrides here
-      case "${{build.arch}}" in
-      "aarch64")
-         common_flags=""
-         ;;
-      "x86_64")
-         common_flags="-march=x86-64"
-         ;;
-      esac
-
-      export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
-      export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
-      export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.11
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,21 +61,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Use more generic -march for rosetta2 compatibility
-      # Add additional flag overrides here
-      case "${{build.arch}}" in
-      "aarch64")
-         common_flags=""
-         ;;
-      "x86_64")
-         common_flags="-march=x86-64"
-         ;;
-      esac
-
-      export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
-      export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
-      export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.9"
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,21 +68,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Use more generic -march for rosetta2 compatibility
-      # Add additional flag overrides here
-      case "${{build.arch}}" in
-      "aarch64")
-         common_flags=""
-         ;;
-      "x86_64")
-         common_flags="-march=x86-64"
-         ;;
-      esac
-
-      export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
-      export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
-      export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.2"
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,21 +68,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Use more generic -march for rosetta2 compatibility
-      # Add additional flag overrides here
-      case "${{build.arch}}" in
-      "aarch64")
-         common_flags=""
-         ;;
-      "x86_64")
-         common_flags="-march=x86-64"
-         ;;
-      esac
-
-      export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
-      export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
-      export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \


### PR DESCRIPTION
pyperformance on a gcloud VM noticed some seemingly significant regressions due to this. Let's roll it back until we can properly assess how to proceed.

This reverts commit 0d66ee5bf0c07f6ad26ce8c4244fb7c6ca6cb83c.
