### PR TITLE
Add in some pkgconf tests which are disabled

### DIFF
--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -329,6 +329,8 @@ test:
         gcov-6.5 --help
         gcov-dump-6.5 --help
         gcov-tool-6.5 --help
+    # Will fail https://github.com/wolfi-dev/os/issues/34009
+    # - uses: test/pkgconf
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -282,6 +282,8 @@ subpackages:
 
 test:
   pipeline:
+    # Will fail see https://github.com/wolfi-dev/os/issues/34320
+    # - uses: test/pkgconf
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -73,6 +73,8 @@ test:
         [ -d "/opt/metrics-collector/lib/collectd/lib/" ] || exit 1
         [ -d "/opt/metrics-collector/lib/collectd/etc/" ] || exit 1
         [ -d "/opt/metrics-collector/lib/collectd/usr/" ] || exit 1
+    # Will fail see https://github.com/wolfi-dev/os/issues/34356
+    # - uses: test/pkgconf
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -143,6 +143,8 @@ test:
         export PATH="/usr/share/mlflow/bin:${PATH}"
         python3 ./test-mlflow.py
         mlflow ui & sleep 5; curl -vsL localhost:5000
+    # Will fail see https://github.com/wolfi-dev/os/issues/34358
+    # - uses: test/pkgconf
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}

--- a/neon.yaml
+++ b/neon.yaml
@@ -103,6 +103,8 @@ update:
 
 test:
   pipeline:
+    # Will fail see https://github.com/wolfi-dev/os/issues/34360
+    # - uses: test/pkgconf
     - name: Test neon_local command
       runs: |
         neon_local --version


### PR DESCRIPTION
There a few packages which should have the pkgconf test pipeline added to them but have not had it added because it fails. Let's add the disabled test with a link to the issue so that the failures are more discoverable.