### PR TITLE
Withdraw incorrect instio-install-cni-1.21-compat subpackage that is causing CVEs

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,2 @@
 pypy-bootstrap-7.3.19-r1.apk
+istio-install-cni-1.21-compat-1.22.0-r1.apk


### PR DESCRIPTION
We need to withdraw an [incorrectly published](https://github.com/wolfi-dev/os/blob/b57a623030cd09488fa5a99970963ffccff59ef2/istio-cni-1.22.yaml#L61) istio-install-cni-1.21-compat-1.22.0-r1 subpackage so the correct 1.21 subpackage (from enterprise packages) is used going forward. The mismatch occurred when a 1.22 build file mistakenly served a subpackage labeled as 1.21, causing automation to pick up the flawed release instead of the actual 1.21 version (1.21.6-r5). Multiple CVEs (including CVE-2024-24789, CVE-2024-24790, and CVE-2024-24791) were identified in the bad package and are addressed in later versions, so removing the faulty package ensures the next correctly built image will contain the fixes.