### PR TITLE
mariadb-11.7 - Include a configuration file with appropriate defaults

### DIFF
--- a/mariadb-11.7.yaml
+++ b/mariadb-11.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.7
   version: "11.7.2"
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -10,6 +10,7 @@ package:
     memory: 32Gi
   dependencies:
     runtime:
+      - mariadb-config
       - pwgen
     provides:
       - mariadb=${{package.full-version}}
@@ -152,6 +153,17 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/var/lib/mysql
 
 subpackages:
+  - name: "${{package.name}}-config"
+    description: Mariadb configuration file with appropriate defaults
+    dependencies:
+      provides:
+        - mariadb-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/
+          echo "[mariadbd]" >> "${{targets.subpkgdir}}"/etc/my.cnf
+          echo "basedir = /usr" >> "${{targets.subpkgdir}}"/etc/my.cnf
+
   - name: "${{package.name}}-dev"
     description: "headers for mariadb"
     dependencies:
@@ -201,7 +213,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/mariadb "${{targets.subpkgdir}}"/usr/bin/
 
   - name: "${{package.name}}-oci-entrypoint"
-    description: Entrypoint for using HAProxy in OCI containers
+    description: Entrypoint for using MariaDB in OCI containers
     dependencies:
       provides:
         - mariadb-oci-entrypoint=${{package.full-version}}


### PR DESCRIPTION
Post `/bin` usrmerge, `/bin/mariadbd` now exists because of the `/bin` symlink to `/usr/bin`, where `mariadbd` actually resides. The mariadb docker entrypoint startup scripts check for the existence of `/bin/mariadbd`, and guess that the installation root is `/` when it is actually `/usr`, causing a failure to find some startup SQL scripts.