### PR TITLE
scriplet more fixes

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 22
+  epoch: 23
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -21,16 +21,6 @@ package:
       - merged-sbin
       - wolfi-baselayout
       - wolfi-baselayout
-  scriptlets:
-    trigger:
-      paths:
-        - /lib
-        - /lib64
-        - /usr/lib
-        - /usr/lib64
-      script: |
-        #!/usr/bin/sh
-        /usr/bin/ldconfig
 
 environment:
   contents:
@@ -130,6 +120,8 @@ pipeline:
       cp vendor/ld.so.conf "${{targets.destdir}}"/etc
       mkdir -p "${{targets.destdir}}"/etc/ld.so.conf.d
       cp vendor/ld.so.conf.d/*.conf "${{targets.destdir}}"/etc/ld.so.conf.d
+      mkdir -p ${{targets.destdir}}/etc/apk/commit_hooks.d
+      cp ldconfig-commit.sh -p ${{targets.destdir}}/etc/apk/commit_hooks.d/
 
   - name: "Clean up documentation"
     runs: |
@@ -744,6 +736,7 @@ test:
   environment:
     contents:
       packages:
+        - apk-tools
         - gcc
         - glibc-dev
   pipeline:
@@ -778,6 +771,12 @@ test:
         }
         EOF
         g++ -o test_build gcc_test.cc
+    - name: Verify apk bootstrap works
+      runs: |
+        # Verify that glibc + bash-binsh bootstrap works
+        apk add --allow-untrusted -X https://packages.wolfi.dev/os --initdb --root /tmp/glibc-bash glibc bash-binsh
+        # Verify that glibc + busybox bootstrap works
+        apk add --allow-untrusted -X https://packages.wolfi.dev/os --initdb --root /tmp/glibc-busybox glibc busybox
 
 update:
   enabled: true

--- a/glibc/ldconfig-commit.sh
+++ b/glibc/ldconfig-commit.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Post-commit apk-tools hook, which is executed after busybox trigger
+# has completed installing /bin/sh symlink.
+if [ "$1" = "post-commit" ]; then
+    /usr/bin/ldconfig
+fi


### PR DESCRIPTION
- **Use merged-bin location for any shell**
  

- **glibc: better support ldconfig trigger with different shells**
  apk-tools orders triggers in runtime dependency order, meaning glibc
  trigger is guaranteed to execute before busybox trigger sets up "sh"
  symlink.
  
  Move glibc trigger to apk-tools post-commit hook, such that it is
  executed after all triggers have been fired, to ensure shell is
  accessible.
  
  Separately, will submit glibc upstream feature change to make it
  possible to use "#!/usr/bin/ldconfig.trigger" as a trigger which
  ignores all arguments.
  
  Add test cases to verify that bootstraps work with various shells.
  