### PR TITLE
withdrawn-packages: withdraw remaining incorrectly versioning istio package

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,4 @@
 pypy-bootstrap-7.3.19-r1.apk
 nginx-bitnami-compat-1.27.4-r1.apk
 istio-install-cni-1.21-compat-1.22.0-r1.apk
+istio-install-cni-1.21-compat-1.22.0-r0.apk


### PR DESCRIPTION
This is for the same reason that
https://github.com/wolfi-dev/os/commit/799fe5eb273998fa1fa577435f332562efdb6fa3 was landed: we crossed the version streams and produced a 1.21 package containing 1.22 code.