### PR TITLE
Revert "openmp-17: Enable test/ldd-check"

### DIFF
--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-17
   version: 17.0.6
-  epoch: 3
+  epoch: 4
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
@@ -60,13 +60,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - llvm17-dev
         - openmp-17
-    test:
-      pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
This causes an FTBFS with other packages that B-D on openmp-17 and llvm15.  We need to solve that problem (we shouldn't be depending on two different versions of LLVM-related packages), but for now let's revert the addition of the runtime dependency to solve the FTBFSes.

Relates: #40841