### PR TITLE
mariadb-11.7: Add basedir arg to entrypoint

### DIFF
--- a/mariadb-11.7.yaml
+++ b/mariadb-11.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.7
   version: "11.7.2"
-  epoch: 2
+  epoch: 3
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later

--- a/mariadb-11.7/docker-entrypoint.sh
+++ b/mariadb-11.7/docker-entrypoint.sh
@@ -233,7 +233,7 @@ _mariadb_version() {
 # initializes the database directory
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
-	installArgs=( --datadir="$DATADIR" --rpm --auth-root-authentication-method=normal )
+	installArgs=( --datadir="$DATADIR" --rpm --auth-root-authentication-method=normal --basedir=/usr )
 	# "Other options are passed to mariadbd." (so we pass all "mariadbd" arguments directly here)
 
 	local mariadbdArgs=()


### PR DESCRIPTION
The basedir path is being set to "." without this addition. This is causing a failure in the mariadb image.
