### PR TITLE
logstash-8/GHSA-8cgq-6mh2-7j6v fix

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.17.3"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -96,7 +96,7 @@ pipeline:
       echo "gem 'puma', '6.6.0'" >> Gemfile.template
       echo "gem 'sinatra', '4.1.1'" >> Gemfile.template
       echo "gem 'logstash-integration-kafka', '11.6.0'" >> Gemfile.template
-      echo "gem 'rack', '3.1.10'" >> Gemfile.template
+      echo "gem 'rack', '3.1.11'" >> Gemfile.template
       echo "gem 'net-imap', '0.5.6'" >> Gemfile.template
       # Fix GHSA-xc9x-jj77-9p9j
       sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"


### PR DESCRIPTION
bump to rack gem version, remaining CVEs will have an advisory submitted shortly.