### PR TITLE
spark-3.5/GHSA-vmq6-5m68-f53m fix

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -2,7 +2,7 @@
 package:
   name: spark-3.5
   version: "3.5.5"
-  epoch: 3
+  epoch: 5
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5/pombump-properties-2.13.yaml
+++ b/spark-3.5/pombump-properties-2.13.yaml
@@ -23,8 +23,12 @@ properties:
     value: "3.25.5"
   - property: woodstox-core.version
     value: "5.4.0"
+  - property: netty.version
+    value: "4.1.119.Final"
+  - property: netty-tcnative.version
+    value: "2.0.70.Final"
   - property: zookeeper.version
-    value: "3.7.2" # Changed from 3.7.3 to an existing version
+    value: "3.9.3"
   - property: derby.version
     value: "10.14.2.0"
   - property: ivy.version

--- a/spark-3.5/pombump-properties.yaml
+++ b/spark-3.5/pombump-properties.yaml
@@ -16,6 +16,6 @@ properties:
   - property: netty-tcnative.version
     value: "2.0.70.Final"
   - property: zookeeper.version
-    value: "3.9.1"
+    value: "3.9.3"
   - property: jetty.version
     value: "9.4.56.v20240826"


### PR DESCRIPTION
bumping zookeeper from 3.9.1 and 3.7.2 to 3.9.3 remediates GHSA-vmq6-5m68-f53m as the zookeeper dependency logback-classic is bumped to the fix version. 