### PR TITLE
fix error where tar was operating on an *

### DIFF
--- a/chainguard-keys.yaml
+++ b/chainguard-keys.yaml
@@ -57,4 +57,3 @@ test:
           # This must fail, due to the signature tampering
           (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
         done
-

--- a/chainguard-keys.yaml
+++ b/chainguard-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: chainguard-keys
   version: 2
-  epoch: 6
+  epoch: 7
   description: "Chainguard public keys"
   copyright:
     - license: MIT
@@ -43,3 +43,18 @@ test:
           # Mess it up, and make sure it can't be processed
           sed -e "s/\-/x/g" $i | openssl pkey -pubin 2>&1 | grep -q "Could not find private key of Public Key from"
         done
+        apk update
+        # Verify what should be a good signature
+        ls -halF /var/cache/apk/APKINDEX.*.tar.gz
+        apk verify /var/cache/apk/APKINDEX.*.tar.gz
+        # Now, tamper with a signature, and ensure the signature does not verify
+        for f in /var/cache/apk/APKINDEX.*.tar.gz; do
+          d=$(mktemp -d)
+          cd "$d"
+          tar xf "$f"
+          sed -i -e "1 s/^C:......../C:abcdefgh/" APKINDEX
+          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.wolfi-signing.rsa.pub APKINDEX DESCRIPTION
+          # This must fail, due to the signature tampering
+          (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
+        done
+

--- a/chainguard-keys.yaml
+++ b/chainguard-keys.yaml
@@ -53,7 +53,7 @@ test:
           cd "$d"
           tar xf "$f"
           sed -i -e "1 s/^C:......../C:abcdefgh/" APKINDEX
-          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.wolfi-signing.rsa.pub APKINDEX DESCRIPTION
+          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.*.pub APKINDEX DESCRIPTION
           # This must fail, due to the signature tampering
           (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
         done

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-keys
   version: 1
-  epoch: 9
+  epoch: 10
   description: "Wolfi signing keyring"
   copyright:
     - license: MIT
@@ -44,12 +44,15 @@ test:
         done
         apk update
         # Verify what should be a good signature
+        ls -halF /var/cache/apk/APKINDEX.*.tar.gz
         apk verify /var/cache/apk/APKINDEX.*.tar.gz
         # Now, tamper with a signature, and ensure the signature does not verify
-        d=$(mktemp -d)
-        cd "$d"
-        tar xf /var/cache/apk/APKINDEX.*.tar.gz
-        sed -i -e "1 s/^C:......../C:abcdefgh/" APKINDEX
-        tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.wolfi-signing.rsa.pub APKINDEX DESCRIPTION
-        # This must fail, due to the signature tampering
-        (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
+        for f in /var/cache/apk/APKINDEX.*.tar.gz; do
+          d=$(mktemp -d)
+          cd "$d"
+          tar xf "$f"
+          sed -i -e "1 s/^C:......../C:abcdefgh/" APKINDEX
+          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.wolfi-signing.rsa.pub APKINDEX DESCRIPTION
+          # This must fail, due to the signature tampering
+          (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
+        done

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -52,7 +52,7 @@ test:
           cd "$d"
           tar xf "$f"
           sed -i -e "1 s/^C:......../C:abcdefgh/" APKINDEX
-          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.wolfi-signing.rsa.pub APKINDEX DESCRIPTION
+          tar zcf APKINDEX.bad.tar.gz .SIGN.RSA256.*.pub APKINDEX DESCRIPTION
           # This must fail, due to the signature tampering
           (apk verify APKINDEX.bad.tar.gz || true) | grep -i "BAD signature"
         done


### PR DESCRIPTION
There was a bug in the wolfi-keys test where tar was extracting a file path with an * wildcard.  That made tar try to do something that it wasn't supposed to do.  Fix this by looping over all of the apk index files in the directory.  And match the same test / logic in chainguard-keys
