### PR TITLE
freetds: enable extra options

### DIFF
--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetds
   version: "1.4.26"
-  epoch: 2
+  epoch: 3
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
     - license: GPL-2.0-or-later
@@ -14,8 +14,10 @@ environment:
       - build-base
       - busybox
       - gettext-dev
+      - glibc-dev
       - gnutls-dev
       - gperf
+      - krb5-dev
       - libgcrypt-dev
       - libtool
       - pkgconf-dev
@@ -31,9 +33,14 @@ pipeline:
 
   - working-directory: ${{package.name}}
     pipeline:
-      - name: Configure
-        runs: |
-          ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
+      - uses: autoconf/configure
+        with:
+          opts: |
+            --enable-krb5 \
+            --enable-msdblib \
+            --enable-sybase-compat \
+            --with-gnutls \
+            --with-unixodbc=/usr
       - uses: autoconf/make
       - uses: autoconf/make-install
       - uses: strip
@@ -74,3 +81,8 @@ test:
       uses: test/tw/ldd-check
       with:
         packages: freetds
+    - name: Verify tsql config
+      runs: |
+        tsql -C | grep -q -E "iconv library:\s+yes"
+        tsql -C | grep -q -E "GnuTLS:\s+yes"
+        tsql -C | grep -q -E "Kerberos:\s+yes"


### PR DESCRIPTION
Switch to use autoconf/configure to fix sysconfdir

Enable libiconv (glibc), krb5, msdblib, sybas-compat

Fixes enabling gnutls

Adds test to ensure config present in tsql

Related: [chainguard-dev/customer-issues#2108
](https://github.com/chainguard-dev/customer-issues/issues/2108)

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
