### PR TITLE
add new package zipkin

### DIFF
--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -25,6 +25,7 @@ environment:
       - ca-certificates-bundle
       - maven
       - openjdk-21
+      - unzip
 
 pipeline:
   - uses: git-checkout
@@ -32,14 +33,14 @@ pipeline:
       repository: https://github.com/openzipkin/zipkin
       tag: ${{package.version}}
       expected-commit: 0f8fc88d33131dc938532322e19126def8cad8e8
-  - uses: maven/pombump
-  - runs: |
-      export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
-      ./build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${{package.version}} exec
-      mv zipkin-server zipkin
-      mkdir -p ${{targets.destdir}}/usr/share/zipkin
-      cp -av zipkin/* ${{targets.destdir}}/usr/share/zipkin/
 
+  - runs: |
+      export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+      ./mvnw -X -q --batch-mode -DskipTests --also-make -pl zipkin-server clean install
+      mkdir -p ${{targets.destdir}}/zipkin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      unzip zipkin-server/target/zipkin-server-*-exec.jar -d ${{targets.destdir}}/zipkin
+      cp -av docker/start-zipkin ${{targets.destdir}}/usr/local/bin/
 
 subpackages:
   - name: zipkin-slim
@@ -52,11 +53,33 @@ subpackages:
     pipeline:
       - runs: |
           export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
-          ./build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${{package.version}} slim
-          mv zipkin-server zipkin-slim
-          mkdir -p ${{targets.subpkgdir}}/usr/share/zipkin-slim
-          cp -av zipkin-slim/* ${{targets.subpkgdir}}/usr/share/zipkin-slim/
-    
+          mkdir -p ${{targets.subpkgdir}}/zipkin
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          unzip zipkin-server/target/zipkin-server-*-slim.jar -d ${{targets.subpkgdir}}/zipkin
+          cp -av docker/start-zipkin ${{targets.subpkgdir}}/usr/local/bin/
+    test:
+      pipeline:
+        - name: Running the server
+          uses: test/daemon-check-output
+          working-directory: /zipkin
+          with:
+            start: |
+              start-zipkin
+            timeout: 60
+            expected_output: |
+              Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
+
+test:
+  pipeline:
+    - name: Running the server
+      uses: test/daemon-check-output
+      working-directory: /zipkin
+      with:
+        start: |
+          start-zipkin
+        timeout: 60
+        expected_output: |
+          Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
 
 update:
   enabled: true

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -1,0 +1,65 @@
+package:
+  name: zipkin
+  version: 3.5.0
+  epoch: 0
+  description: Zipkin distributed tracing system
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - busybox
+      - ca-certificates
+      - openjdk-21-default-jvm
+
+data:
+  - name: openjdk-versions
+    items:
+      21: "/usr/lib/jvm/java-21-openjdk"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-21
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openzipkin/zipkin
+      tag: ${{package.version}}
+      expected-commit: 0f8fc88d33131dc938532322e19126def8cad8e8
+  - uses: maven/pombump
+  - runs: |
+      export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
+      ./build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${{package.version}} exec
+      mv zipkin-server zipkin
+      mkdir -p ${{targets.destdir}}/usr/share/zipkin
+      cp -av zipkin/* ${{targets.destdir}}/usr/share/zipkin/
+
+
+subpackages:
+  - name: zipkin-slim
+    dependencies:
+      runtime:
+        - bash
+        - busybox
+        - ca-certificates
+        - openjdk-21-default-jvm
+    pipeline:
+      - runs: |
+          export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
+          ./build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${{package.version}} slim
+          mv zipkin-server zipkin-slim
+          mkdir -p ${{targets.subpkgdir}}/usr/share/zipkin-slim
+          cp -av zipkin-slim/* ${{targets.subpkgdir}}/usr/share/zipkin-slim/
+    
+
+update:
+  enabled: true
+  github:
+    identifier: openzipkin/zipkin
+    use-tag: true

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -67,7 +67,8 @@ subpackages:
               start-zipkin
             timeout: 60
             expected_output: |
-              Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
+              Serving HTTP
+              http://127.0.0.1:9411/
 
 test:
   pipeline:
@@ -79,7 +80,8 @@ test:
           start-zipkin
         timeout: 60
         expected_output: |
-          Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
+          Serving HTTP
+          http://127.0.0.1:9411/
 
 update:
   enabled: true

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -11,6 +11,7 @@ package:
       - busybox
       - ca-certificates
       - openjdk-21-default-jvm
+      - wget
 
 data:
   - name: openjdk-versions

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -27,6 +27,8 @@ environment:
       - maven
       - openjdk-21
       - unzip
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -36,7 +38,6 @@ pipeline:
       expected-commit: 0f8fc88d33131dc938532322e19126def8cad8e8
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
       ./mvnw -X -q --batch-mode -DskipTests --also-make -pl zipkin-server clean install
       mkdir -p ${{targets.destdir}}/zipkin
       mkdir -p ${{targets.destdir}}/usr/local/bin

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -61,6 +61,10 @@ subpackages:
           unzip zipkin-server/target/zipkin-server-*-slim.jar -d ${{targets.subpkgdir}}/zipkin
           cp -av docker/start-zipkin ${{targets.subpkgdir}}/usr/local/bin/
     test:
+      environment:
+        contents:
+          packages:
+            - curl
       pipeline:
         - name: Running the server
           uses: test/daemon-check-output
@@ -72,6 +76,24 @@ subpackages:
             expected_output: |
               Serving HTTP
               http://127.0.0.1:9411/
+            post: |
+              echo "Checking Zipkin instance"
+              url=http://localhost:9411/zipkin/
+              response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+              if [ "$response" -ne 200 ]; then
+                echo "Zipkin instance is not responding correctly"
+                exit 1
+              fi
+              html=$(curl -s "$url")
+              if [ -z "$html" ]; then
+                echo "Got empty HTML content from $url"
+                exit 1
+              fi
+              echo "$html" | grep -q "<title>Zipkin</title>" || {
+                echo "response from $url did not contain \"Zipkin\""
+                exit 1
+              }
+              echo "Zipkin instance is up"
 
 test:
   environment:

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -74,6 +74,10 @@ subpackages:
               http://127.0.0.1:9411/
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
   pipeline:
     - name: Running the server
       uses: test/daemon-check-output
@@ -85,6 +89,24 @@ test:
         expected_output: |
           Serving HTTP
           http://127.0.0.1:9411/
+        post: |
+          echo "Checking Zipkin instance"
+          url=http://localhost:9411/zipkin/
+          response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+          if [ "$response" -ne 200 ]; then
+            echo "Zipkin instance is not responding correctly"
+            exit 1
+          fi
+          html=$(curl -s "$url")
+          if [ -z "$html" ]; then
+            echo "Got empty HTML content from $url"
+            exit 1
+          fi
+          echo "$html" | grep -q "<title>Zipkin</title>" || {
+            echo "response from $url did not contain \"Zipkin\""
+            exit 1
+          }
+          echo "Zipkin instance is up"
 
 update:
   enabled: true

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -93,7 +93,7 @@ subpackages:
               }
               echo "Zipkin instance is up"
 
-  - name: zipkin-compat
+  - name: zipkin-oci-entrypoint
     description: "Compatibility package providing start-zipkin entrypoint"
     pipeline:
       - runs: |

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -41,8 +41,7 @@ pipeline:
       ./mvnw -X -q --batch-mode -DskipTests --also-make -pl zipkin-server clean install
       mkdir -p ${{targets.destdir}}/zipkin
       mkdir -p ${{targets.destdir}}/usr/local/bin
-      unzip zipkin-server/target/zipkin-server-*-exec.jar -d ${{targets.destdir}}/zipkin
-      cp -av docker/start-zipkin ${{targets.destdir}}/usr/local/bin/
+      unzip -o zipkin-server/target/zipkin-server-*-exec.jar -d ${{targets.destdir}}/zipkin
 
 subpackages:
   - name: zipkin-slim
@@ -58,8 +57,7 @@ subpackages:
           export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
           mkdir -p ${{targets.subpkgdir}}/zipkin
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          unzip zipkin-server/target/zipkin-server-*-slim.jar -d ${{targets.subpkgdir}}/zipkin
-          cp -av docker/start-zipkin ${{targets.subpkgdir}}/usr/local/bin/
+          unzip -o zipkin-server/target/zipkin-server-*-slim.jar -d ${{targets.subpkgdir}}/zipkin
     test:
       environment:
         contents:
@@ -71,7 +69,7 @@ subpackages:
           working-directory: /zipkin
           with:
             start: |
-              start-zipkin
+              java -cp '.:BOOT-INF/lib/*:BOOT-INF/classes' zipkin.server.ZipkinServer
             timeout: 60
             expected_output: |
               Serving HTTP
@@ -95,6 +93,17 @@ subpackages:
               }
               echo "Zipkin instance is up"
 
+  - name: zipkin-compat
+    description: "Compatibility package providing start-zipkin entrypoint"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          cp -av docker/start-zipkin ${{targets.subpkgdir}}/usr/local/bin/
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/local/bin/start-zipkin
+
 test:
   environment:
     contents:
@@ -106,7 +115,7 @@ test:
       working-directory: /zipkin
       with:
         start: |
-          start-zipkin
+          java -cp '.:BOOT-INF/lib/*:BOOT-INF/classes' zipkin.server.ZipkinServer
         timeout: 60
         expected_output: |
           Serving HTTP

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - bash-binsh
-      - coreutils
       - ca-certificates
+      - coreutils
       - openjdk-21-default-jvm
       - wget
 
@@ -48,8 +48,8 @@ subpackages:
     dependencies:
       runtime:
         - bash-binsh
-        - coreutils
         - ca-certificates
+        - coreutils
         - openjdk-21-default-jvm
         - wget
     pipeline:

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -7,8 +7,8 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - bash
-      - busybox
+      - bash-binsh
+      - coreutils
       - ca-certificates
       - openjdk-21-default-jvm
       - wget
@@ -47,10 +47,11 @@ subpackages:
   - name: zipkin-slim
     dependencies:
       runtime:
-        - bash
-        - busybox
+        - bash-binsh
+        - coreutils
         - ca-certificates
         - openjdk-21-default-jvm
+        - wget
     pipeline:
       - runs: |
           export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
