### PR TITLE
feat(pypy): Temporarily disable automated updates to allow to update fix without PR conflcits

### DIFF
--- a/pypy-3.10.yaml
+++ b/pypy-3.10.yaml
@@ -217,7 +217,7 @@ test:
         pip cache dir | xargs ls -al
 
 update:
-  enabled: true
+  enabled: false
   github:
     identifier: pypy/pypy
     strip-prefix: release-pypy3.10-v

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -218,7 +218,7 @@ test:
         pip cache dir | xargs ls -al
 
 update:
-  enabled: true
+  enabled: false
   github:
     identifier: pypy/pypy
     strip-prefix: release-pypy3.11-v


### PR DESCRIPTION
To fix the repeated automated updated with only epoch bump [1] to need to update the `update` stanza but
the automated updates are so frequent we get conflicts.

Force mergeing this PR will allow us to land out changes.

[1] https://github.com/wolfi-dev/os/commits/main/pypy-3.11.yaml

Signed-off-by: philroche <phil.roche@chainguard.dev>
