### PR TITLE
jupyter-base-notebook: rebuild to pull new jinja2 version

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: 7.3.2
-  epoch: 1
+  epoch: 2
   description: Jupyter Notebook
   dependencies:
     runtime:


### PR DESCRIPTION
CVE-2025-27516