### PR TITLE
promitor: bump OpenTelemetry.Api dependencies to 1.11.2

### DIFF
--- a/promitor.yaml
+++ b/promitor.yaml
@@ -1,7 +1,7 @@
 package:
   name: promitor
   version: "2.13.0"
-  epoch: 0
+  epoch: 1
   description: Bringing Azure Monitor metrics where you need them.
   copyright:
     - license: MIT
@@ -22,6 +22,10 @@ pipeline:
       repository: https://github.com/tomkerkhove/promitor
       tag: Scraper-v${{package.version}}
       expected-commit: 2778e8409e3cc3990ed5d1b57a0cfa04e541c025
+
+  - uses: patch
+    with:
+      patches: CVE-2025-27513.patch
 
   - working-directory: src
     pipeline:

--- a/promitor/CVE-2025-27513.patch
+++ b/promitor/CVE-2025-27513.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTe
+lemetry.csproj
+index 45844e6..a2455b5 100644
+--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
++++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+@@ -14,8 +14,8 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
++    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
++    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+   </ItemGroup>
+ 
+   <ItemGroup>


### PR DESCRIPTION
GHSA-8785-wc3w-h8q6