### PR TITLE
tw - bump to v0.0.4, add header-check and utilize in uthash

### DIFF
--- a/pipelines/test/tw/header-check.yaml
+++ b/pipelines/test/tw/header-check.yaml
@@ -1,0 +1,15 @@
+name: header-check
+needs:
+  packages:
+    - header-check
+
+inputs:
+  packages:
+    description: check the header files in provided packages
+    required: false
+    default: "${{context.name}}"
+
+pipeline:
+  - name: check header files using header-check
+    runs: |
+      header-check "--packages=${{context.name}}"

--- a/tw.yaml
+++ b/tw.yaml
@@ -1,14 +1,16 @@
 package:
   name: tw
-  version: 0.0.3
+  version: 0.0.4
   epoch: 0
-  description:
+  description: Testing tools
   options:
     no-provides: true
   copyright:
     - license: Apache-2.0
 
 environment:
+  environment:
+    GOMODCACHE: /var/cache/melange
   contents:
     packages:
       - build-base
@@ -21,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/tw
       tag: v${{package.version}}
-      expected-commit: ff5dd2febb74a5fab995f08478a1a8ea22f329f3
+      expected-commit: 035aca6f5a6fca28f6bece9624d79d638d58226d
 
   # Make the tw binary in the main package so we don't end up with `tw-tw`
   - runs: |
@@ -30,6 +32,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: twt
+    options:
+      no-provides: true
+    pipeline:
+      - runs: |
+          install -Dm755 tw/bin/twt ${{targets.contextdir}}/usr/bin/twt
+      - uses: strip
+
   - name: ldd-check
     options:
       no-provides: true
@@ -46,6 +56,43 @@ subpackages:
         - runs: |
             [ -f /usr/bin/ldd-check ]
             [ -x /usr/bin/ldd-check ]
+
+  - name: header-check
+    options:
+      no-provides: true
+    dependencies:
+      runtime:
+        - apk-tools
+        - autoconf
+        - build-base
+        - busybox
+    pipeline:
+      - runs: |
+          make -C header-check MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
+    test:
+      pipeline:
+        - runs: |
+            [ -f /usr/bin/header-check ]
+            [ -x /usr/bin/header-check ]
+
+  - name: syspeek
+    options:
+      no-provides: true
+    dependencies:
+      runtime:
+        - apk-tools
+        - binutils
+        - busybox
+        - linux-headers
+        - posix-libc-utils
+    pipeline:
+      - runs: |
+          make -C syspeek-tool MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
+    test:
+      pipeline:
+        - runs: |
+            [ -f /usr/bin/syspeek ]
+            [ -x /usr/bin/syspeek ]
 
   - name: usrmerge-tool
     options:

--- a/uthash.yaml
+++ b/uthash.yaml
@@ -1,7 +1,7 @@
 package:
   name: uthash
   version: "2.3.0"
-  epoch: 0
+  epoch: 1
   description: "Header file for providing hash table for C structures"
   copyright:
     - license: "BSD-2-Clause"
@@ -25,6 +25,10 @@ pipeline:
   - runs: cp src/uthash.h ${{targets.destdir}}/usr/include/
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/tw/header-check
 
 update:
   enabled: true


### PR DESCRIPTION
tw 0.0.4 contains 'header-check' which can be run to do a autoconf like test on header files.

This:
1. bumps tw to v0.0.4
2. adds pipelines/test/tw/header-check.yaml
3. uses `uses: test/tw/header-check` from uthash.yaml