### PR TITLE
Add the ldd-check test to some packages

### DIFF
--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent-nvml
   version: 1.0.9
-  epoch: 4
+  epoch: 5
   description: "Checks NVIDIA Management Library (NVML) exposed metrics through the Datadog Agent and can correlate them with the exposed Kubernetes devices"
   copyright:
     - license: Apache-2.0
@@ -106,6 +106,9 @@ test:
     environment:
       PYTHONPATH: ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages
   pipeline:
+    - uses: test/tw/ldd-check
+      with:
+        packages: ${{package.name}}
     - runs: |
         stat /etc/datadog-agent/conf.d/nvml.d/conf.yaml.example
         stat ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages/datadog_checks/nvml/__init__.py

--- a/openmp-16.yaml
+++ b/openmp-16.yaml
@@ -1,10 +1,13 @@
 package:
   name: openmp-16
   version: 16.0.6
-  epoch: 2
+  epoch: 3
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libLLVM-16
 
 environment:
   contents:
@@ -67,6 +70,12 @@ subpackages:
         - uses: test/ldd-check
           with:
             packages: ${{package.name}}
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -1,10 +1,13 @@
 package:
   name: openmp-17
   version: 17.0.6
-  epoch: 4
+  epoch: 5
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libLLVM-17
 
 environment:
   contents:
@@ -61,6 +64,12 @@ subpackages:
     dependencies:
       runtime:
         - openmp-17
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+      with:
+        packages: ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
A couple of these packages failed initial testing with the ldd-check pipeline until runtime dependencies were added.