### PR TITLE
add tests for bazelisk, fix runtime dependency problem

### DIFF
--- a/bazelisk.yaml
+++ b/bazelisk.yaml
@@ -1,13 +1,14 @@
 package:
   name: bazelisk
   version: 1.25.0
-  epoch: 2
+  epoch: 3
   description: A user-friendly launcher for Bazel.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - libstdc++
 
 environment:
   contents:
@@ -47,3 +48,10 @@ update:
   github:
     identifier: bazelbuild/bazelisk
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        bazelisk help
+        bazelisk version
+        bazelisk license >/dev/null


### PR DESCRIPTION
Add a couple of tests for bazelisk, which actually identified a missing runtime dependency on libstdc++.

Why didn't SCA catch this?  Perhaps because the first thing this binary does is reach out to the internet and fetch a newer copy of itself?  Is that what we want?  Not sure...  If we want this to work out of the box in this manner, then we need to add the runtime dependency on libstdc++.  On the other hand, a binary that reaches out to the internet and downloads a different thing to run doesn't really feel like the secure source for open source....

Definitely need a review on this one....