### PR TITLE
feat(new-package):pg_timetable

### DIFF
--- a/pg_timetable.yaml
+++ b/pg_timetable.yaml
@@ -1,0 +1,173 @@
+package:
+  name: pg_timetable
+  version: "5.11.0"
+  epoch: 0
+  description: Advanced scheduling for PostgreSQL
+  copyright:
+    - license: PostgreSQL
+  dependencies:
+    runtime:
+      - curl
+      - postgresql-client
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5046c1ad93f6588c330dcbf6b85d738a107caf42
+      repository: https://github.com/cybertec-postgresql/pg_timetable.git
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+
+  - uses: go/build
+    with:
+      packages: .
+      ldflags: |
+        -X main.version=$(git describe --tags --abbrev=0)
+        -X main.commit=$(git show -s --format=%H HEAD)
+        -X main.date=$(git show -s --format=%cI HEAD)
+      output: pg_timetable
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by pg_timetable"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}
+          ln -sf /usr/bin/pg_timetable ${{targets.contextdir}}/pg_timetable
+    test:
+      pipeline:
+        - runs: "[ \"$(stat -c '%N' /pg_timetable 2>/dev/null)\" = \"'/pg_timetable' -> '/usr/bin/pg_timetable'\" ]"
+
+update:
+  enabled: true
+  github:
+    identifier: cybertec-postgresql/pg_timetable
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql
+        - build-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+      PGHOST: /tmp
+  pipeline:
+    - name: "Initialize and Start PostgreSQL"
+      runs: |
+        echo "Creating PostgreSQL user..."
+        useradd wolfi
+        echo "Initializing PostgreSQL..."
+        sudo -u wolfi initdb -D /tmp/test_db
+        echo "Starting PostgreSQL..."
+        sudo -u wolfi pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        sleep 5  # Ensure PostgreSQL has time to start
+    - name: "Ensure PostgreSQL is running"
+      runs: |
+        echo "Checking PostgreSQL status..."
+        until pg_isready -h /tmp -U wolfi; do
+          echo "Waiting for PostgreSQL..."
+          sleep 2
+        done
+        echo "PostgreSQL is ready."
+    - name: "Create test database and scheduler user"
+      runs: |
+        echo "Creating test database as user wolfi..."
+        createdb -U wolfi testdb
+
+        echo "Creating timetable database..."
+        createdb -U wolfi timetable
+
+        echo "Creating scheduler user..."
+        psql -U wolfi -d testdb -c "CREATE ROLE scheduler WITH LOGIN SUPERUSER PASSWORD 'scheduler';"
+
+        echo "Granting privileges to scheduler..."
+        psql -U wolfi -d timetable -c "GRANT ALL PRIVILEGES ON DATABASE timetable TO scheduler;"
+        psql -U wolfi -d testdb -c "GRANT ALL PRIVILEGES ON DATABASE testdb TO scheduler;"
+    - name: "Initialize pg_timetable Schema"
+      runs: |
+        echo "Initializing pg_timetable schema in timetable database..."
+        pg_timetable --init -c "dbname=timetable user=scheduler password=scheduler host=/tmp sslmode=disable"
+
+        echo "Ensuring timetable schema exists..."
+        SCHEMA_EXISTS=$(psql -U scheduler -d timetable -t -A -c \
+          "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'timetable';")
+
+        if [ -z "$SCHEMA_EXISTS" ]; then
+          echo "ERROR: timetable schema is missing in timetable database!"
+          exit 1
+        fi
+    - name: "Create a Simple SQL Task"
+      runs: |
+        echo "Scheduling a simple task in pg_timetable..."
+
+        # Ensure timetable schema exists in the correct database
+        SCHEMA_EXISTS=$(psql -U scheduler -d timetable -t -A -c \
+          "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'timetable';")
+
+        if [ -z "$SCHEMA_EXISTS" ]; then
+          echo "ERROR: timetable schema is missing in timetable database!"
+          exit 1
+        fi
+
+        # Create a test chain and extract only the chain_id
+        CHAIN_ID=$(psql -U scheduler -d timetable -t -A -c \
+          "INSERT INTO timetable.chain (chain_name, live) VALUES ('Test Task', TRUE) RETURNING chain_id;" | head -n 1)
+
+        if [ -z "$CHAIN_ID" ]; then
+          echo "ERROR: Failed to create chain!"
+          exit 1
+        fi
+
+        echo "CHAIN_ID is $CHAIN_ID"
+
+        # Create a simple task in the chain
+        psql -U scheduler -d timetable -c \
+          "INSERT INTO timetable.task (chain_id, task_order, kind, command)
+          VALUES ($CHAIN_ID, 1, 'SQL', 'SELECT now();');"
+
+        echo "Task scheduled successfully."
+    - name: "Start pg_timetable"
+      runs: |
+        echo "Starting pg_timetable..."
+        nohup pg_timetable -c "dbname=timetable user=scheduler password=scheduler host=/tmp sslmode=disable" > /tmp/pg_timetable.log 2>&1 &
+        sleep 5  # Give it time to start
+        echo "pg_timetable started."
+    - name: "Verify Task Execution"
+      runs: |
+        echo "Checking if task executed..."
+        sleep 5
+
+        cat /tmp/pg_timetable.log
+
+        # Ensure we check the timetable database
+        RESULT=$(psql -U scheduler -d timetable -t -A -c "SELECT count(*) FROM timetable.execution_log;" | tr -d '[:space:]')
+
+        echo "Checking if task executed..."
+        psql -U scheduler -d timetable -c 'SELECT * FROM timetable.execution_log ORDER BY finished DESC LIMIT 10;'
+
+        # Retrieve and print execution logs
+        echo "Execution Log Entries:"
+        psql -U scheduler -d timetable -c '\d timetable.execution_log'
+
+        if [ -z "$RESULT" ]; then
+          echo "ERROR: timetable.execution_log does not exist in timetable database!"
+          exit 1
+        elif [ "$RESULT" -eq 0 ]; then
+          echo "ERROR: No execution logs found, task may not have run!"
+          exit 1
+        else
+          echo "SUCCESS: Task executed correctly!"
+        fi

--- a/pg_timetable.yaml
+++ b/pg_timetable.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - curl
-      - postgresql-client
 
 pipeline:
   - uses: git-checkout
@@ -34,16 +33,13 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by pg_timetable"
-    dependencies:
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}
           ln -sf /usr/bin/pg_timetable ${{targets.contextdir}}/pg_timetable
     test:
       pipeline:
-        - runs: "[ \"$(stat -c '%N' /pg_timetable 2>/dev/null)\" = \"'/pg_timetable' -> '/usr/bin/pg_timetable'\" ]"
+        - runs: test "$(readlink -fv /pg_timetable)" = "/usr/bin/pg_timetable"
 
 update:
   enabled: true
@@ -56,6 +52,7 @@ test:
     contents:
       packages:
         - postgresql
+        - postgresql-client
         - build-base
         - shadow
         - sudo-rs
@@ -65,6 +62,10 @@ test:
       PGUSER: wolfi
       PGHOST: /tmp
   pipeline:
+    - name: "Verify pg_timetable Version"
+      runs: |
+        echo "Checking pg_timetable version..."
+        pg_timetable --version | grep ${{package.version}}
     - name: "Initialize and Start PostgreSQL"
       runs: |
         echo "Creating PostgreSQL user..."
@@ -98,6 +99,7 @@ test:
         psql -U wolfi -d testdb -c "GRANT ALL PRIVILEGES ON DATABASE testdb TO scheduler;"
     - name: "Initialize pg_timetable Schema"
       runs: |
+        echo "check for pg_timetable version"
         echo "Initializing pg_timetable schema in timetable database..."
         pg_timetable --init -c "dbname=timetable user=scheduler password=scheduler host=/tmp sslmode=disable"
 
@@ -139,35 +141,37 @@ test:
           VALUES ($CHAIN_ID, 1, 'SQL', 'SELECT now();');"
 
         echo "Task scheduled successfully."
-    - name: "Start pg_timetable"
-      runs: |
-        echo "Starting pg_timetable..."
-        nohup pg_timetable -c "dbname=timetable user=scheduler password=scheduler host=/tmp sslmode=disable" > /tmp/pg_timetable.log 2>&1 &
-        sleep 5  # Give it time to start
-        echo "pg_timetable started."
-    - name: "Verify Task Execution"
-      runs: |
-        echo "Checking if task executed..."
-        sleep 5
+    - name: "Start and Test pg_timetable"
+      uses: test/daemon-check-output
+      with:
+        start: pg_timetable -c "dbname=timetable user=scheduler password=scheduler host=/tmp sslmode=disable"
+        timeout: 30
+        expected_output: |
+          Accepting asynchronous chains execution requests
+          Retrieve scheduled chains to run
+          Starting chain
+          Starting task
+          Task executed successfully
+          Chain executed successfully
+        post: |
+          echo "Checking if task executed..."
 
-        cat /tmp/pg_timetable.log
+          # Print pg_timetable logs for debugging
+          cat /tmp/pg_timetable.log
 
-        # Ensure we check the timetable database
-        RESULT=$(psql -U scheduler -d timetable -t -A -c "SELECT count(*) FROM timetable.execution_log;" | tr -d '[:space:]')
+          # Check execution log count
+          RESULT=$(psql -U scheduler -d timetable -t -A -c "SELECT count(*) FROM timetable.execution_log;" | tr -d '[:space:]')
 
-        echo "Checking if task executed..."
-        psql -U scheduler -d timetable -c 'SELECT * FROM timetable.execution_log ORDER BY finished DESC LIMIT 10;'
+          # Retrieve and print execution logs
+          echo "Execution Log Entries:"
+          psql -U scheduler -d timetable -c "SELECT * FROM timetable.execution_log ORDER BY finished DESC LIMIT 10;"
 
-        # Retrieve and print execution logs
-        echo "Execution Log Entries:"
-        psql -U scheduler -d timetable -c '\d timetable.execution_log'
-
-        if [ -z "$RESULT" ]; then
-          echo "ERROR: timetable.execution_log does not exist in timetable database!"
-          exit 1
-        elif [ "$RESULT" -eq 0 ]; then
-          echo "ERROR: No execution logs found, task may not have run!"
-          exit 1
-        else
-          echo "SUCCESS: Task executed correctly!"
-        fi
+          if [ -z "$RESULT" ]; then
+            echo "ERROR: timetable.execution_log does not exist in timetable database!"
+            exit 1
+          elif [ "$RESULT" -eq 0 ]; then
+            echo "ERROR: No execution logs found, task may not have run!"
+            exit 1
+          else
+            echo "SUCCESS: Task executed correctly!"
+          fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
