### PR TITLE
added support to header-check for specific file checking

### DIFF
--- a/doctest.yaml
+++ b/doctest.yaml
@@ -1,7 +1,7 @@
 package:
   name: doctest
   version: 2.4.11
-  epoch: 1
+  epoch: 2
   description: C++11/14/17/20/23 single-header testing framework
   copyright:
     - license: MIT
@@ -43,3 +43,11 @@ update:
     identifier: doctest/doctest
     strip-prefix: v
     tag-filter: v
+
+test:
+  pipeline:
+    - uses: test/tw/header-check
+      with:
+        files: |
+          doctest/doctest.h
+          doctest/extensions/doctest_util.h

--- a/pipelines/test/tw/header-check.yaml
+++ b/pipelines/test/tw/header-check.yaml
@@ -8,8 +8,20 @@ inputs:
     description: check the header files in provided packages
     required: false
     default: "${{context.name}}"
+  files:
+    description: check specific headers by file name
+    required: false
+    default: ""
+  configure-opts:
+    description: any additional configure options required for the headers in this package
+    required: false
+    default: ""
 
 pipeline:
   - name: check header files using header-check
     runs: |
-      header-check "--packages=${{context.name}}"
+      if [ -z "${{inputs.files}}" ]; then
+        header-check --packages="${{inputs.packages}}" --configure-opts="${{inputs.configure-opts}}"
+      else
+        header-check --files="${{inputs.files}}" --configure-opts="${{inputs.configure-opts}}"
+      fi

--- a/tw.yaml
+++ b/tw.yaml
@@ -1,6 +1,6 @@
 package:
   name: tw
-  version: 0.0.4
+  version: 0.0.5
   epoch: 0
   description: Testing tools
   options:
@@ -23,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/tw
       tag: v${{package.version}}
-      expected-commit: 035aca6f5a6fca28f6bece9624d79d638d58226d
+      expected-commit: 2db84dcd432347b915bec03c56e0bdaf10ec60b3
 
   # Make the tw binary in the main package so we don't end up with `tw-tw`
   - runs: |


### PR DESCRIPTION
Some packages include a combination of immediately usable, testable headers, as well as some that aren't.  Here, we add support for naming the list of header files to explicitly test.