### PR TITLE
Fix tests that had both 'uses' and 'runs' in a pipeline.

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -82,7 +82,7 @@ test:
         timeout: 60
         expected_output: |
           running server
-      runs: |
+    - runs: |
         buildctl-daemonless.sh --version
         buildctl-daemonless.sh --help
         buildkitd --version

--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -272,7 +272,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: clang-18
-      runs: |
+    - runs: |
         amdgpu-arch --version
         amdgpu-arch --help
         clang --version

--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -138,7 +138,7 @@ test:
               echo "Got \"$found\" in response from $url. Expected \"$expected\""
               exit 1
           fi
-      runs: |
+    - runs: |
         remsh --version
         remsh --help
 

--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -119,7 +119,7 @@ test:
         - etcd
   pipeline:
     - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         manager --help
     - name: "Test operator"
       runs: |

--- a/git.yaml
+++ b/git.yaml
@@ -134,7 +134,7 @@ test:
       HOME: /tmp
   pipeline:
     - uses: test/hardening-check
-      runs: |
+    - runs: |
         git --help
         scalar version
     - name: Verify git installation

--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -47,10 +47,10 @@ test:
         - curl
         - kustomize
   pipeline:
-    - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         helm-operator version
         helm-operator --help
+    - uses: test/kwok/cluster
     - name: Fetch the testdata from the source repo
       runs: |
         git clone --depth=1 https://github.com/operator-framework/operator-sdk.git

--- a/kubernetes-csi-driver-hostpath.yaml
+++ b/kubernetes-csi-driver-hostpath.yaml
@@ -48,7 +48,7 @@ test:
         - kubernetes-csi-livenessprobe
   pipeline:
     - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         hostpathplugin --version
         hostpathplugin --help
     - runs: |

--- a/llvm.yaml
+++ b/llvm.yaml
@@ -418,7 +418,7 @@ subpackages:
         - uses: test/compiler-hardening-check
           with:
             cc: clang-${{vars.major-version}}
-          runs: |
+        - runs: |
             amdgpu-arch --version
             amdgpu-arch --help
             clang --version

--- a/lvm-driver.yaml
+++ b/lvm-driver.yaml
@@ -67,7 +67,7 @@ test:
         - git
   pipeline:
     - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         lvm-driver --help
     - runs: |
         sleep 5

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -45,7 +45,7 @@ test:
         - kustomize
   pipeline:
     - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         metacontroller --help
     - name: Fetch the testdata from the source repo
       runs: |

--- a/openpmix.yaml
+++ b/openpmix.yaml
@@ -86,7 +86,7 @@ test:
         tag: v${{package.version}}
         expected-commit: 9ea8964e9fb17ebe3aa8ece83926a2b972cfec14
         recurse-submodules: true
-      runs: |
+    - runs: |
         palloc --version
         palloc --help
         pattrs --version

--- a/perl.yaml
+++ b/perl.yaml
@@ -195,7 +195,7 @@ test:
     - uses: test/hardening-check
       with:
         args: --nofortify --nostackprotector
-      runs: |
+    - runs: |
         perl --help
         perl${{package.version}} --version
         perl${{package.version}} --help

--- a/py3-antlr4-python3-runtime.yaml
+++ b/py3-antlr4-python3-runtime.yaml
@@ -109,7 +109,7 @@ test:
       with:
         imports: |
           import antlr4
-      runs: |
+    - runs: |
         pygrun --help
     - runs: pygrun --help
 

--- a/py3-chardet.yaml
+++ b/py3-chardet.yaml
@@ -106,7 +106,7 @@ test:
       with:
         imports: |
           import chardet
-      runs: |
+    - runs: |
         chardetect --version
         chardetect --help
 

--- a/py3-charset-normalizer.yaml
+++ b/py3-charset-normalizer.yaml
@@ -91,7 +91,7 @@ test:
     - uses: python/import
       with:
         import: ${{vars.module-name}}
-      runs: |
+    - runs: |
         normalizer --help
     - runs: |
         normalizer --version

--- a/py3-datadog.yaml
+++ b/py3-datadog.yaml
@@ -109,7 +109,7 @@ test:
         imports: |
           import datadog
           from datadog import initialize
-      runs: |
+    - runs: |
         dog --version
         dog --help
         dogshell --version

--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -111,7 +111,7 @@ test:
       with:
         imports: |
           import docker_squash
-      runs: |
+    - runs: |
         docker-squash --version
         docker-squash --help
 

--- a/py3-ffwd.yaml
+++ b/py3-ffwd.yaml
@@ -105,7 +105,7 @@ test:
       with:
         imports: |
           import ffwd
-      runs: |
+    - runs: |
         ffwd-send --help
 
 update:

--- a/py3-findpython.yaml
+++ b/py3-findpython.yaml
@@ -98,7 +98,7 @@ test:
     - uses: python/import
       with:
         import: ${{vars.pypi-package}}
-      runs: |
+    - runs: |
         findpython --help
         findpython --version
         findpython --all

--- a/py3-gcovr.yaml
+++ b/py3-gcovr.yaml
@@ -113,7 +113,7 @@ test:
       with:
         imports: |
           import gcovr
-      runs: |
+    - runs: |
         gcovr --version
         gcovr --help
     - runs: |

--- a/py3-jsondiff.yaml
+++ b/py3-jsondiff.yaml
@@ -108,7 +108,7 @@ test:
       with:
         imports: |
           import jsondiff
-      runs: |
+    - runs: |
         jdiff --help
 
 update:

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -104,7 +104,7 @@ test:
     - uses: python/import
       with:
         import: ${{vars.pypi-package}}
-      runs: |
+    - runs: |
         jsonschema --version
         jsonschema --help
     - runs: |

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -119,7 +119,7 @@ test:
       with:
         imports: |
           import nltk
-      runs: |
+    - runs: |
         nltk --version
         nltk --help
 

--- a/py3-pbs_installer.yaml
+++ b/py3-pbs_installer.yaml
@@ -100,7 +100,7 @@ test:
     - uses: python/import
       with:
         import: ${{vars.pypi-package}}
-      runs: |
+    - runs: |
         cd $(mktemp -d)
         pbs-install 3.10 -d test1 -v
         version=$(test1/bin/python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -72,7 +72,7 @@ subpackages:
           uses: python/import
           with:
             import: pip
-          runs: |
+        - runs: |
             pip --version
             pip --help
             pip wheel --help

--- a/py3-poetry.yaml
+++ b/py3-poetry.yaml
@@ -123,7 +123,7 @@ test:
     - uses: python/import
       with:
         import: ${{vars.pypi-package}}
-      runs: |
+    - runs: |
         poetry --help
     - runs: |
         poetry --version

--- a/py3-reno.yaml
+++ b/py3-reno.yaml
@@ -110,7 +110,7 @@ test:
       with:
         imports: |
           import reno
-      runs: |
+    - runs: |
         reno --help
 
 update:

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -75,6 +75,6 @@ test:
     - uses: python/import
       with:
         import: wheel
-      runs: |
+    - runs: |
         wheel version
         wheel --help

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -140,10 +140,10 @@ subpackages:
             unzip thingsboard.jar
             ls BOOT-INF/lib/ | grep -q "tomcat-embed-core" || { echo "tomcat-embed-core not found"; exit 1; }
         - name: Test server logs
-          runs: |
-            mkdir -p /var/log/thingsboard/
           uses: test/daemon-check-output
           with:
+            setup: |
+              mkdir -p /var/log/thingsboard/
             start: "start-tb-node.sh"
             timeout: 30
             expected_output: |

--- a/vcluster.yaml
+++ b/vcluster.yaml
@@ -70,7 +70,7 @@ test:
         - jq
   pipeline:
     - uses: test/kwok/cluster
-      runs: |
+    - runs: |
         syncer --help
         vcluster --help
     - name: Ensure accurate version is embedded in the build


### PR DESCRIPTION
All of these packages had a test/pipeline stanza like this

    - uses: thing 
      runs: | some stuff here

That is not intended to be valid, and melange would chose one or the other in that case.
