### PR TITLE
neo4j-2025.1: bump subpackage expected commit

### DIFF
--- a/neo4j-2025.01.yaml
+++ b/neo4j-2025.01.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-2025.01
   version: "2025.01.0"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-3.0-or-later
@@ -68,7 +68,7 @@ subpackages:
         with:
           repository: https://github.com/neo4j/docker-neo4j-publish
           branch: master
-          expected-commit: 7e90062e9965c3d4cf6e878cee72f112bef21490
+          expected-commit: 58586374f1e13c8c7eb1f42fad12bcaf254ed46b
       - working-directory: ${{package.version}}/bullseye/community
         runs: |
           mkdir -p ${{targets.contextdir}}/startup


### PR DESCRIPTION
The docker-neo4j-publish is tag and branch-less and has received commits since this package was last built; update the expected commit to match the HEAD of the master branch.

Fixes: #44391
