### PR TITLE
cleaned up the libb64 test now that we have configure-opts

### DIFF
--- a/libb64-1.2.yaml
+++ b/libb64-1.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libb64-1.2
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: Fast Base64 encoding/decoding routines
   dependencies:
     provides:
@@ -50,3 +50,9 @@ update:
     identifier: libb64/libb64
     strip-prefix: v
     tag-filter: v1.2.
+
+test:
+  pipeline:
+    - uses: test/tw/header-check
+      with:
+        configure-opts: "CPPFLAGS=-DBUFFERSIZE=123456"


### PR DESCRIPTION
Cleaner, simpler test now that we have our configure-opts variable in the test pipeline and header-check tool