### PR TITLE
sudo-rs: provide sudo

### DIFF
--- a/sudo-rs.yaml
+++ b/sudo-rs.yaml
@@ -8,6 +8,9 @@ package:
   checks:
     disabled:
       - setuidgid
+  dependencies:
+    provides:
+      - sudo
 
 environment:
   contents:


### PR DESCRIPTION
Allows packages to depend on sudo without caring about implementation
