### PR TITLE
add test for posix-cc-wrappers and missing runtime dep on gcc

### DIFF
--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,10 +1,13 @@
 package:
   name: posix-cc-wrappers
   version: 1
-  epoch: 4
+  epoch: 5
   description: "Wrappers around GCC and Clang for POSIX conformance"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - gcc
 
 environment:
   contents:
@@ -48,3 +51,13 @@ pipeline:
 update:
   enabled: false
   manual: true
+
+test:
+  pipeline:
+    - runs: |
+        c89 --version
+        c89 --help
+        c99 --version
+        c99 --help
+        cc --version
+        cc --help


### PR DESCRIPTION
The posix-cc-wrappers package installs a symlink at /usr/bin/cc to point to gcc.  But it doesn't have a runtime dependency on gcc, oddly enough, which yields a broken cc out of the box.  Add this dependency.

This problem was identified by trying to add the attached tests, which now succeed.