### PR TITLE
add basic --help sniff test for prometheus-adapter

### DIFF
--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.12.0
-  epoch: 7
+  epoch: 8
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0
@@ -40,3 +40,8 @@ update:
   github:
     identifier: kubernetes-sigs/prometheus-adapter
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        adapter --help 2>&1 | grep -q ^Usage


### PR DESCRIPTION
Run the adapter --help command, which shows "Usage" information, and then exits non-zero (which is why this was missed in previous automated test generation).