### PR TITLE
add basic sniff test for pulumi-kubernetes-operator --help

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.16.0
-  epoch: 10
+  epoch: 11
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -46,3 +46,8 @@ update:
     identifier: pulumi/pulumi-kubernetes-operator
     strip-prefix: v
     tag-filter: v1.1
+
+test:
+  pipeline:
+    - runs: |
+        pulumi-kubernetes-operator --help 2>&1 | grep ^Usage


### PR DESCRIPTION
Added a basic pulumi-kubernetes-operator --help test which displays Usage information.  It exits non-zero, which is why previous automated test generation did not catch this one.