### PR TITLE
test our tzdata package

### DIFF
--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: tzdata
   version: "2025a"
-  epoch: 0
+  epoch: 1
   description: "Timezone data provided by IANA"
   copyright:
     - license: CC-PDDC
@@ -40,3 +40,15 @@ update:
   github:
     identifier: eggert/tz
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - tzutils
+  pipeline:
+    - runs: |
+        echo "[INFO] Calculating many different GMT timezone offsets...this may take several minutes...."
+        for tz in $(find /usr/share/zoneinfo/ -type f); do
+          zdump -v 2>/dev/null $tz | grep -q "gmtoff="
+        done


### PR DESCRIPTION
Comprehensive calculate gmt offsets for all of our shipped timezone data files.  The test takes ~2 minutes or so to run on my local system.