### PR TITLE
apk-tools: re-enable update bot

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -111,7 +111,7 @@ test:
         packages: ${{package.name}}
 
 update:
-  enabled: false
-  exclude-reason: setting the update to false until the latest apk tools fails for previously built packages
-  release-monitor:
-    identifier: 20466
+  enabled: true
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v2.


### PR DESCRIPTION
v2.14.3 had an incompatibility with Wolfi OS and it was withdrawn from
Wolfi, and updates disabled, see:
- https://github.com/wolfi-dev/os/pull/16207

But since then, we successfully upgraded to v2.14.4 in:
- https://github.com/wolfi-dev/os/pull/21906

But since then, we didn't turn the updates back on. Let's turn them
back on.

This PR will cause bot to open a PR with these upstream changes:
- https://github.com/alpinelinux/apk-tools/compare/v2.14.4...v2.14.10

Package Update check says the same, which is good:
```
Update check failures...

apk-tools: package apk-tools: update found newer version 2.14.10 compared with package.version 2.14.4 in melange config
```
