### PR TITLE
update(node-problem-detector): add packages to runtime dependencies

### DIFF
--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - busybox
-      - health-checker-0.8=${{package.full-version}}
-      - log-counter-0.8=${{package.full-version}}
+      - health-checker-${{vars.major-minor-version}}
+      - log-counter-${{vars.major-minor-version}}
       - systemd-dev
     provides:
       - node-problem-detector=${{package.full-version}}

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,13 +1,15 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.20
-  epoch: 8
+  epoch: 9
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - busybox
+      - health-checker-0.8=${{package.full-version}}
+      - log-counter-0.8=${{package.full-version}}
       - systemd-dev
     provides:
       - node-problem-detector=${{package.full-version}}

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - busybox
-      - health-checker-${{vars.major-minor-version}}
-      - log-counter-${{vars.major-minor-version}}
+      - health-checker-${{vars.major-minor-version}}=${{package.full-version}}
+      - log-counter-${{vars.major-minor-version}}=${{package.full-version}}
       - systemd-dev
     provides:
       - node-problem-detector=${{package.full-version}}

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - busybox
-      - health-checker-${{vars.major-minor-version}}=${{package.full-version}}
-      - log-counter-${{vars.major-minor-version}}=${{package.full-version}}
+      - health-checker-${{vars.major-minor-version}}
+      - log-counter-${{vars.major-minor-version}}
       - systemd-dev
     provides:
       - node-problem-detector=${{package.full-version}}


### PR DESCRIPTION
This PR updates the `node-problem-detector-0.8` package to include `health-checker-0.8` and `log-counter-0.8` as runtime dependencies, ensuring they are automatically included in the image build. As a result, these packages no longer need to be manually added to `extra_packages` or hardcoded into `local.baseline_packages` in image config. 