### PR TITLE
prism: bump axios to 1.8.2

### DIFF
--- a/prism.yaml
+++ b/prism.yaml
@@ -33,6 +33,8 @@ pipeline:
       patches: CVE-2025-1302.patch
 
   - runs: |
+      # CVE-2025-27789
+      npm pkg set resolutions.@babel/helpers=7.26.10
       # See 'compiler' build stage of prism/Dockerfile (https://github.com/stoplightio/prism/blob/master/Dockerfile)
       yarn && yarn build
 

--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: 5.12.1
-  epoch: 3
+  epoch: 4
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:

--- a/prism/CVE-2025-1302.patch
+++ b/prism/CVE-2025-1302.patch
@@ -11,7 +11,7 @@ index 7bea0421..4ec7464b 100644
 +    "jsonpath-plus": "10.3.0",
 +    "braces": "3.0.3",
 +    "micromatch": "4.0.8",
-+    "axios": "1.7.9",
++    "axios": "1.8.2",
 +    "cross-spawn": "7.0.6"
    },
    "devDependencies": {


### PR DESCRIPTION
CVE-2025-27152 GHSA-jr5f-v2jv-69x6