### PR TITLE
kubeflow-centraldashboard: bump axios to ^1.8.2

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -60,7 +60,7 @@ pipeline:
         "@grpc/grpc-js": "^1.10.9",
         "serve-static": "^1.16.0",
         "cookie": "0.7.0",
-        "jsonpath-plus": "10.2.0"
+        "jsonpath-plus": "10.3.0"
       }'
 
       # Apply the overrides

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.9.2
-  epoch: 4
+  epoch: 5
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ pipeline:
         "ajv": "^6.12.3",
         "node-fetch": "^2.6.7",
         "node-forge": "^1.3.0",
-        "axios": "^1.6.0",
+        "axios": "^1.8.2",
         "qs": "^6.7.3",
         "underscore": "^1.12.1",
         "minimatch": "^3.0.5",


### PR DESCRIPTION
CVE-2025-27152 GHSA-jr5f-v2jv-69x6