### PR TITLE
ruby*-rails-8.0: bump epoch to build with new version of rack

### DIFF
--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rails-8.0
   version: "8.0.2"
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-rails-8.0
   version: "8.0.2"
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: "8.0.2"
-  epoch: 0
+  epoch: 1
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT


### PR DESCRIPTION
CVE-2025-27610 GHSA-7wqh-767x-r66v