### PR TITLE
Removes crypto go bump

### DIFF
--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.7
-  epoch: 10
+  epoch: 11
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0
@@ -32,8 +32,6 @@ pipeline:
     with:
       deps: |-
         golang.org/x/net@v0.33.0
-        golang.org/x/crypto@v0.35.0
-        golang.org/x/oauth2@v0.27.0
       tidy: false # changes to the dependencies broke this service after bumping crypto. https://github.com/chainguard-dev/image-release-stats/issues/3326
 
   - runs: |


### PR DESCRIPTION
Removes the go bump of the crypto module to v0.35.0, the corresponding image for this package has been broken since we have bumped this package.

Fixes:
Fixes https://github.com/chainguard-dev/image-release-stats/issues/4738. This issue was observed has been noted before: https://github.com/chainguard-dev/image-release-stats/issues/3326

When the net module is bumped to 0.33.0, it also bumps the crypto module to 0.31.0 which addresses the CVE issue below: 
```
wolfictl scan packages/aarch64/haproxy-ingress-0.14.7-r14.apk
🔎 Scanning "packages/aarch64/haproxy-ingress-0.14.7-r14.apk"
└── 📄 /usr/bin/haproxy-ingress-controller
        📦 golang.org/x/crypto v0.21.0 (go-module)
            Critical CVE-2024-45337 GHSA-v778-237x-gjrc fixed in 0.31.0
        📦 golang.org/x/net v0.23.0 (go-module)
            High CVE-2024-45338 GHSA-w32m-9786-jp63 fixed in 0.33.0
  ```
  
The upstream project has bumped all of these dependencies in it main branch and it should be part of the next release. 