### PR TITLE
kubeflow-pipelines-visualization-server: fix CVE-2025-1550

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.4.1"
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0

--- a/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
+++ b/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
@@ -502,7 +502,7 @@ index fa15911..641e5ff 100644
 -keras==2.10.0
 -    # via tensorflow
 -keras-preprocessing==1.1.2
-+keras==3.8.0
++keras==3.9.0
      # via tensorflow
 +keyring==25.6.0
 +    # via keyrings-google-artifactregistry-auth


### PR DESCRIPTION
By bumping keras to 3.9.0.