### PR TITLE
renovate: remove cross-spawn remediation

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
   version: "39.198.1"
-  epoch: 0
+  epoch: 1
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -27,36 +27,6 @@ pipeline:
   - name: npm install
     runs: |
       npm install -g ${{package.name}}@${{package.version}} -prefix ${{targets.contextdir}}/usr/local/
-
-      cd ${{targets.contextdir}}/usr/local/lib
-
-      # CVE-2024-21538 - overwrite vulnerable cross-spawn@7.0.3
-      echo "{
-          \"dependencies\": {
-              \"${{package.name}}\": \"${{package.version}}\"
-          },
-          \"overrides\": {
-              \"cross-spawn@7.0.3\": \"^7.0.5\",
-              \"@yarnpkg/shell\": {
-                  \"cross-spawn@7.0.3\": \"^7.0.5\"
-              }
-          }
-      }" > package.json
-
-      # Delete vulnerable node_modules...
-      rm -rf node_modules
-
-      # ... to reinstall non-vulnerable node_modules.
-      npm i --install-strategy=shallow .
-
-      # Delete artifacts used for & generated from the override install.
-      rm -rf package.json package-lock.json node_modules/.package-lock.json
-
-      rm -rf ${{targets.destdir}}/usr/local/lib/node_modules/renovate/node_modules/@yarnpkg/shell/node_modules/cross-spawn
-
-      sed -i '/"@yarnpkg\/monorepo": "\^0\.0\.0"/d' ${{targets.destdir}}/usr/local/lib/node_modules/renovate/node_modules/@yarnpkg/shell/package.json
-
-      npm install cross-spawn@^7.0.5 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/renovate/node_modules/@yarnpkg/shell
 
       # https://github.com/browserify/resolve/issues/288
       # Mitigates GHSA-2jcg-qqmg-46q6 CVE - malicious monorepo-symlink-test package


### PR DESCRIPTION
The fixed version is already installed by the `npm install` command.