### PR TITLE
clamav: add runtime deps and omit replaces

### DIFF
--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,13 +1,21 @@
 package:
   name: clamav-1.4
   version: 1.4.2
-  epoch: 3
+  epoch: 4
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
   dependencies:
     provides:
       - clamav=${{package.full-version}}
+    runtime:
+      - clamav-clamdscan
+      - clamav-daemon
+      - clamav-db
+      - clamav-libunrar
+      - clamav-milter
+      - clamav-scanner
+      - freshclam
 
 environment:
   contents:
@@ -123,9 +131,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libclamunrar* "${{targets.subpkgdir}}"/usr/lib/
-    dependencies:
-      replaces:
-        - clamav
     description: ClamAV unrar libraries
 
   - name: clamav-daemon
@@ -144,8 +149,6 @@ subpackages:
 
           mv "${{targets.destdir}}"/etc/clamav/clamd.conf.sample "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
     dependencies:
-      replaces:
-        - clamav
       runtime:
         - clamav-clamdscan
         - freshclam
@@ -179,8 +182,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/sigtool "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clambc "${{targets.subpkgdir}}"/usr/bin/
     dependencies:
-      replaces:
-        - clamav
       runtime:
         - freshclam
     description: ClamAV command-line scanner and utils
@@ -204,8 +205,6 @@ subpackages:
             "${{targets.subpkgdir}}"/var/log/clamav \
             "${{targets.subpkgdir}}"/var/lib/clamav
     dependencies:
-      replaces:
-        - clamav
       runtime:
         - freshclam
     description: ClamAV dummy package for compatibility
@@ -224,10 +223,6 @@ subpackages:
           install -d -m755 \
             "${{targets.subpkgdir}}"/var/log/clamav \
             "${{targets.subpkgdir}}"/var/lib/clamav
-    dependencies:
-      replaces:
-        - clamav
-        - clamav-db
     description: Auto-updater for the Clam Antivirus scanner data-files
     test:
       pipeline:


### PR DESCRIPTION
ClamAV needs to install the required runtime dependencies but due to `replaces:` on each sub-package, we couldn't install all of the required packages at the same time. This fixes it.