### PR TITLE
clean(wolfi-baselayout): cleanup xfs deprecated user and group

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 18
+  epoch: 19
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT

--- a/wolfi-baselayout/vendor/etc/group
+++ b/wolfi-baselayout/vendor/etc/group
@@ -27,7 +27,6 @@ tape:x:26:root
 video:x:27:root
 netdev:x:28:
 readproc:x:30:
-xfs:x:33:xfs
 kvm:x:34:kvm
 games:x:35:
 shadow:x:42:

--- a/wolfi-baselayout/vendor/etc/passwd
+++ b/wolfi-baselayout/vendor/etc/passwd
@@ -15,5 +15,4 @@ postmaster:x:14:12:postmaster:/var/mail:/sbin/nologin
 cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
 ftp:x:21:21::/var/lib/ftp:/sbin/nologin
 sshd:x:22:22:sshd:/dev/null:/sbin/nologin
-xfs:x:33:33:X Font Server:/etc/X11/fs:/sbin/nologin
 nobody:x:65534:65534:nobody:/:/sbin/nologin


### PR DESCRIPTION
The X Font Service user account is deprecated. Alpine baselayout already cleaned up their user and groups a year ago [1]. This is following its approach in a gradual way, by beginning with users which are deprecated and that generates uid conflicts in passwd database. In example, the uid 33 is usually associated to web services, like www-data in Debian or http in Arch.

1. https://gitlab.alpinelinux.org/alpine/aports/-/commit/f16d0754d60196f00c3fad7f881d3a9bd6943152

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [x] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions
