### PR TITLE
apk-tools: Lower x86 optimization baseline to avoid issue w/ rosetta emulation

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 0
+  epoch: 1
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -36,6 +36,10 @@ pipeline:
       echo "FULL_VERSION=${{package.version}}-r${{package.epoch}}" > config.mk
 
   - runs: |
+      # Avoid rosetta issue
+      if [ "${{build.arch}}" = "x86_64" ]; then
+        export CFLAGS="-march=x86-64"
+      fi
       make LUA="lua5.3" V=1
 
   - runs: |


### PR DESCRIPTION
Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
