### PR TITLE
openssl: add ELF notes

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: 3.4.1
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,7 @@ environment:
     # file-prefix-map. Also see "Create dbg sourcecode" and
     # split/debug.
     CFLAGS: "-g -ffile-prefix-map=/home/build=/usr/src/${{package.name}}"
+    GCC_SPEC_FILE: openssf-melange.spec
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Add package ELF notes to OpenSSL. This is the last canary affecting
many runtime images (previously git with ELF notes was already added
to all dev tags).

Once this lands, we shall land elf notes by default in openssf
compiler options.
