### PR TITLE
openbao: use relative sources for symlink targets

### DIFF
--- a/openbao-k8s.yaml
+++ b/openbao-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: openbao-k8s
   version: 1.4.0
-  epoch: 32
+  epoch: 33
   description: First-class support for OpenBao and Kubernetes.
   copyright:
     - license: MPL-2.0
@@ -41,7 +41,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
-          ln -sf usr/bin/openbao-k8s "${{targets.subpkgdir}}/usr/bin/vault-k8s"
+          ln -sf openbao-k8s "${{targets.subpkgdir}}/usr/bin/vault-k8s"
     dependencies:
       runtime:
         - merged-bin

--- a/openbao.yaml
+++ b/openbao.yaml
@@ -1,7 +1,7 @@
 package:
   name: openbao
   version: "2.2.0"
-  epoch: 2
+  epoch: 3
   description: OpenBao exists to provide a software solution to manage, store, and distribute sensitive data including secrets, certificates, and keys.
   copyright:
     - license: MPL-2.0
@@ -52,13 +52,13 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
-          ln -sf usr/bin/bao "${{targets.subpkgdir}}/usr/bin/vault"
+          ln -sf bao "${{targets.subpkgdir}}/usr/bin/vault"
 
           install -m755 ./docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
 
           # The upstream helm chart expects the entrypoint in /usr/local/bin
           mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
-          ln -s usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh"
+          ln -s ../../bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh"
     dependencies:
       provides:
         - ${{package.name}}-entrypoint=${{package.full-version}}


### PR DESCRIPTION
Tweak our relative sources so we don't end up with broken symlinks:

```
lrwxrwxrwx    1 root     root            19 Mar 13 04:04 /usr/bin/vault-k8s -> usr/bin/openbao-k8s
lrwxrwxrwx    1 root     root            28 Mar 13 00:13 /usr/local/bin/docker-entrypoint.sh -> usr/bin/docker-entrypoint.sh
```

We want this instead:
```
lrwxrwxrwx    1 root     root            19 Mar 13 04:04 /usr/bin/vault-k8s -> openbao-k8s
lrwxrwxrwx    1 root     root            28 Mar 13 00:13 /usr/local/bin/docker-entrypoint.sh -> ../../bin/docker-entrypoint.sh
```

Related: https://github.com/wolfi-dev/os/pull/43893