### PR TITLE
feat(cve remediation): Remediate CVEs consul-k8s-1.6 package

### DIFF
--- a/consul-k8s-1.6.yaml
+++ b/consul-k8s-1.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: consul-k8s-1.6
   version: 1.6.2
-  epoch: 7
+  epoch: 8
   description: The consul-k8s includes first-class integrations between Consul and Kubernetes.
   copyright:
     - license: MPL-2.0
@@ -32,7 +32,23 @@ pipeline:
         github.com/go-jose/go-jose/v3@v3.0.4
         golang.org/x/crypto@v0.35.0
         golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.36.0
       modroot: ./control-plane
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.36.0
+      modroot: ./cli
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.36.0
+      modroot: ./control-plane/cni
 
   - uses: go/build
     with:


### PR DESCRIPTION
Remediates CVE-2025-22870, CVE-2025-22868 and CVE-2025-22869 using go/bumps.

This groups the remediations.

Confirmed build and test.

Signed-off-by: philroche <phil.roche@chainguard.dev>
