### PR TITLE
bump debezium packages to remove scala runtime dependency

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0

--- a/debezium-connect-entrypoint-3.0.yaml
+++ b/debezium-connect-entrypoint-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connect-entrypoint-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: Helper package to provide necessary files for the Debezium images
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,6 @@ package:
       - iproute2
       - kafka
       - libaio
-      - scala
     provides:
       - debezium-connect-entrypoint=${{package.full-version}}
 

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: "3.0.8"
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Fixes: Removes unnecessary `scala` dependency in debezium-connect-entrypoint package. Scala isn't a runtime dependency.



### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency

