### PR TITLE
Add docker group to sysusers.d as part of the service subpackage

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.0.1"
-  epoch: 1
+  epoch: 2
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -195,6 +195,12 @@ subpackages:
           sed -i "s|\[Service\]|[Service]\nEnvironment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|g" "${{targets.subpkgdir}}"/usr/lib/systemd/system/docker.service
           echo "enable docker.service" > "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/81-docker.preset"
           echo "enable docker.socket" >> "${{targets.subpkgdir}}/usr/lib/systemd/system-preset/81-docker.preset"
+
+          # Create docker group
+          mkdir -p ${{targets.contextdir}}/usr/lib/sysusers.d/
+          cat <<EOF >${{targets.contextdir}}/usr/lib/sysusers.d/${{package.name}}.conf
+          g docker 125
+          EOF
 
 update:
   enabled: true


### PR DESCRIPTION
- Ensures the right group is setup when the services subpackage is installed.