### PR TITLE
nodejs*/python*: Workaround issue with rosetta2 and sahf

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 9
+  epoch: 10
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
 

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: "18.20.7"
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: "20.19.0"
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 6
+  epoch: 7
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -50,7 +50,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: "22.14.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -53,7 +53,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
 

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: "23.10.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -53,7 +53,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
          ;;
       esac
 

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.16
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,6 +61,11 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Rosetta Seemingly doesn't support sahf.
+      if [ ${{build.arch}} == 'x86_64' ]; then
+        export CFLAGS='-mno-sahf'
+      fi
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.11
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,6 +61,11 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Rosetta Seemingly doesn't support sahf.
+      if [ ${{build.arch}} == 'x86_64' ]; then
+        export CFLAGS='-mno-sahf'
+      fi
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.9"
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,6 +68,11 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Rosetta Seemingly doesn't support sahf.
+      if [ ${{build.arch}} == 'x86_64' ]; then
+        export CFLAGS='-mno-sahf'
+      fi
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.2"
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,6 +68,11 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Rosetta Seemingly doesn't support sahf.
+      if [ ${{build.arch}} == 'x86_64' ]; then
+        export CFLAGS='-mno-sahf'
+      fi
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \


### PR DESCRIPTION
There seems to be an issue when running code with the sahf instruction on rosetta2.  We first encounterd this with nodejs and used `-march=x86_64` to fix it. We have since encountered more instances and a reproducer with python.  `python3 -c 'print((-0.01)**2);'` When compiled will cause the same python to hang basically forever maxing out a cpu.

https://github.com/wolfi-dev/os/issues/37196
https://github.com/chainguard-dev/customer-issues/issues/2094