### PR TITLE
azure-cli:improve-package-layout

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -7,7 +7,7 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - py3.10-cryptography #pin to microsoft support python 3.10
+      - py3.10-cryptography #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
 
 environment:
   contents:
@@ -15,10 +15,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.10-cryptography #pin to microsoft support python 3.10
-      - py3.10-pip #pin to microsoft support python 3.10
-      - python-3.10 #pin to microsoft support python 3.10
-      - python-3.10-dev #pin to microsoft support python 3.10
+      - py3.10-cryptography #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - py3.10-pip          #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - python-3.10         #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - python-3.10-dev     #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
 
 pipeline:
   - uses: git-checkout

--- a/azure-cli-dev.yaml
+++ b/azure-cli-dev.yaml
@@ -7,17 +7,17 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - py3-cryptography #use the latest version 
+      - py3-cryptography        #use the latest python run time - USER BEWARE
 environment:
   contents:
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-cryptography #use the latest version 
-      - py3-pip #use the latest version 
-      - python-3 #use the latest version 
-      - python-3-dev #use the latest version 
+      - py3-cryptography        #use the latest python run time - USER BEWARE
+      - py3-pip                 #use the latest python run time - USER BEWARE
+      - python-3                #use the latest python run time - USER BEWARE
+      - python-3-dev            #use the latest python run time - USER BEWARE
 
 pipeline:
   - uses: git-checkout

--- a/azure-cli-dev.yaml
+++ b/azure-cli-dev.yaml
@@ -1,5 +1,5 @@
 package:
-  name: az
+  name: azure-cli-dev
   version: "2.70.0"
   epoch: 0
   description: Azure CLI
@@ -7,18 +7,17 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - py3.10-cryptography #pin to microsoft support python 3.10
-
+      - py3-cryptography #use the latest version 
 environment:
   contents:
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.10-cryptography #pin to microsoft support python 3.10
-      - py3.10-pip #pin to microsoft support python 3.10
-      - python-3.10 #pin to microsoft support python 3.10
-      - python-3.10-dev #pin to microsoft support python 3.10
+      - py3-cryptography #use the latest version 
+      - py3-pip #use the latest version 
+      - python-3 #use the latest version 
+      - python-3-dev #use the latest version 
 
 pipeline:
   - uses: git-checkout

--- a/azure-cli.yaml
+++ b/azure-cli.yaml
@@ -1,5 +1,5 @@
 package:
-  name: az
+  name: azure-cli
   version: "2.70.0"
   epoch: 0
   description: Azure CLI

--- a/azure-cli.yaml
+++ b/azure-cli.yaml
@@ -7,18 +7,17 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - py3.10-cryptography #pin to microsoft support python 3.10
-
+      - py3.10-cryptography   #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
 environment:
   contents:
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.10-cryptography #pin to microsoft support python 3.10
-      - py3.10-pip #pin to microsoft support python 3.10
-      - python-3.10 #pin to microsoft support python 3.10
-      - python-3.10-dev #pin to microsoft support python 3.10
+      - py3.10-cryptography   #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - py3.10-pip            #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - python-3.10           #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
+      - python-3.10-dev       #pin to microsoft supported python runtimes https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Fixes:

* Running `az` command in the wolfi-base container raises warnings about futures and other incompatibilities
 
![image](https://github.com/user-attachments/assets/bff1c795-830d-4afa-8780-fce896ca0841)

* This is most like due to the fact it's been run under python 3.13 rather than a supported [python run-times](https://learn.microsoft.com/en-us/cli/azure/azure-cli-support-lifecycle#python-dependency)
* `az` is also the command but not the [name of the  project](https://github.com/Azure/azure-cli)
* I burnt some time trying to install azure-cli and having both az and azure-cli should help people find it
* I am leaning towards an expand and contract pattern. Rather than deprecating `az` entirely... let's use both and remove in a future PR

Related:

### Pre-review Checklist

#### For package updates (renames) in the base images

When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

