### PR TITLE
step-ca: mitigate CVEs, migrate to go/build and test/daemon-check-output to prevent …

### DIFF
--- a/step-ca.yaml
+++ b/step-ca.yaml
@@ -10,7 +10,6 @@ environment:
   contents:
     packages:
       - pcsc-lite-dev
-      - pkgconf-dev
       - step
 
 pipeline:
@@ -36,7 +35,7 @@ pipeline:
       output: step-ca
       ldflags: |
         -X main.Version=${{package.version}}
-        -X main.BuildTime=$(date -u '+%Y-%m-%d %H:%M UTC')
+        -X main.BuildTime=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/step-ca.yaml
+++ b/step-ca.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-ca
   version: "0.28.2"
-  epoch: 4
+  epoch: 5
   description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.
   copyright:
     - license: Apache-2.0
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
+      - pcsc-lite-dev
+      - pkgconf-dev
+      - step
 
 pipeline:
   - uses: git-checkout
@@ -27,13 +27,16 @@ pipeline:
         github.com/go-jose/go-jose/v3@v3.0.4
         golang.org/x/oauth2@v0.27.0
         golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.36.0
 
-  - runs: |
-      CGO_ENABLED=0 go build -v \
-        -ldflags='-w -X "main.Version=${{package.version}}"' \
-        -o "${{targets.destdir}}/usr/bin/step-ca" ./cmd/step-ca
-
-  - uses: strip
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/step-ca
+      output: step-ca
+      ldflags: |
+        -X main.Version=${{package.version}}
+        -X main.BuildTime=$(date -u '+%Y-%m-%d %H:%M UTC')
 
 update:
   enabled: true
@@ -46,35 +49,30 @@ test:
     contents:
       packages:
         - step
+        - wait-for-it
   pipeline:
     - name: Verify step-ca installation
       runs: |
-        step-ca --version
+        step-ca --version | grep -q "${{package.version}}"
         step-ca --help
-    - name: Start step-ca server
-      runs: |
-        echo $RANDOM > password.txt
-        step ca init --name "Example Inc." \
-          --dns localhost \
-          --address 127.0.0.1:8443 \
-          --provisioner=bob@example.com \
-          --password-file=password.txt 2>&1 | grep -vi root
-        step-ca $(step path)/config/ca.json --password-file password.txt &
-        sleep 2
-    - name: Test step-ca server
-      runs: |
-        step ca health
-
-        # Create a certificate
-        step ca certificate svc.example.com svc.crt svc.key --password-file password.txt
-        [ -f svc.crt ]
-        [ -f svc.key ]
-
-        # Verify the provisioner
-        step certificate inspect svc.crt --short | grep "bob@example.com"
-
-        step ca revoke --cert svc.crt --key svc.key
-    - name: Cleanup
-      runs: |
-        rm -f password.txt svc.crt svc.key
-        pkill step-ca
+    - name: "Start step-ca server"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          echo $RANDOM > password.txt
+          step ca init --name "Example Inc." \
+            --dns localhost \
+            --address 127.0.0.1:8443 \
+            --provisioner=bob@example.com \
+            --password-file=password.txt 2>&1 | grep -vi root
+        start: "step-ca $(step path)/config/ca.json --password-file password.txt"
+        timeout: 30
+        expected_output: |
+          Serving HTTPS
+        post: |
+          wait-for-it -t 10 --strict localhost:8443 -- echo "Server is up"
+          step ca health | grep -qi "ok"
+          step ca certificate svc.example.com svc.crt svc.key --password-file password.txt
+          stat svc.crt svc.key
+          step certificate inspect svc.crt --short | grep "bob@example.com"
+          step ca revoke --cert svc.crt --key svc.key 2>&1 | grep -qi "has been revoked"


### PR DESCRIPTION
Migrate to `go/build` and `test/daemon-check-output` to prevent CI flakes in tests. Mitigates:

```
└── 📄 /usr/bin/step-ca
        📦 golang.org/x/net v0.35.0 (go-module)
            Unknown CVE-2025-22870 fixed in 0.36.0, 0.36.0
            Unknown CVE-2025-22870 fixed in 0.36.0
            Medium CVE-2025-22870 GHSA-qxp5-gwg8-xv66 fixed in 0.36.0
```