### PR TITLE
add a basic test for the java certs public key

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: "20241121"
-  epoch: 1
+  epoch: 2
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
@@ -39,3 +39,15 @@ update:
   enabled: true
   release-monitor:
     identifier: 332224
+
+test:
+  environment:
+    contents:
+      packages:
+        - openssl
+  pipeline:
+    - runs: |
+        /etc/ca-certificates/update.d/java-cacerts
+        openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout
+        openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----BEGIN PUBLIC KEY-----$"
+        openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----END PUBLIC KEY-----$"


### PR DESCRIPTION
Sanity check the ca cert public key installed by java-cacert