### PR TITLE
flux-notification-controller: go/build, bitnami-comapt and tests

### DIFF
--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,17 +1,10 @@
 package:
   name: flux-notification-controller
   version: "1.5.0"
-  epoch: 3
+  epoch: 4
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -27,13 +20,28 @@ pipeline:
         golang.org/x/crypto@v0.35.0
         golang.org/x/net@v0.36.0
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/bin
-      CGO_ENABLED=0 go build \
-        -ldflags="-X main.Version=${{package.version}}" \
-        -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .
+  - uses: go/build
+    with:
+      packages: .
+      output: notification-controller
+      ldflags: -X main.Version=${{package.version}}
 
-  - uses: strip
+subpackages:
+  - name: ${{package.name}}-bitnami-compat
+    description: "Compatibility package for usage with the Bitnami helm chart."
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/fluxcd-notification-controller/bin/
+          ln -sf /usr/bin/notification-controller ${{targets.contextdir}}/opt/bitnami/fluxcd-notification-controller/bin/notification-controller
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        # the test is extensive in the main package and this is the same binary invoked via a symlink.
+        - runs: |
+            /opt/bitnami/fluxcd-notification-controller/bin/notification-controller --help 2>&1 | grep -i "Usage of /opt/bitnami/fluxcd-notification-controller/bin/notification-controller"
 
 update:
   enabled: true
@@ -42,6 +50,7 @@ update:
     strip-prefix: v
     tag-filter: v
 
+# only passes with docker runner: `MELANGE_EXTRA_OPTS="--runner docker" make test/flux-notification-controller`
 test:
   environment:
     contents:
@@ -49,9 +58,23 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - name: Verify notification-controller installation
-      runs: |
-        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
-        kubectl wait --for=condition=Ready nodes --all
-        notification-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
-        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total
+    - name: "start ${{package.name}} and test"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+          kubectl wait --for=condition=Ready nodes --all
+        start: notification-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
+        timeout: 30
+        expected_output: |
+          starting event server
+          starting webhook receiver server
+          starting manager
+          notification.toolkit.fluxcd.io
+          Starting Controller
+          Starting workers
+        post: |
+          #!/bin/sh -e
+          set -o pipefail
+          curl -s localhost:8081/metrics  | grep rest_client_requests_total
+          curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"


### PR DESCRIPTION
uses go/build now, expands tests and add a subpackage for bitnami-compat