### PR TITLE
itstool: Revert back to using default Python

### DIFF
--- a/itstool.yaml
+++ b/itstool.yaml
@@ -1,7 +1,7 @@
 package:
   name: itstool
   version: 2.0.7
-  epoch: 1
+  epoch: 2
   description: ITS-based XML translation tool
   copyright:
     - license: GPL-3.0-or-later
@@ -18,7 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libxml2-py3
-      - python-3.12
+      - python3
 
 pipeline:
   - uses: fetch
@@ -29,7 +29,7 @@ pipeline:
   - runs: autoreconf -vif
 
   - runs: |
-      PYTHON="/usr/bin/python3.12" ./configure \
+      PYTHON="/usr/bin/python3" ./configure \
         --host=${{host.triplet.gnu}} \
         --build=${{host.triplet.gnu}} \
         --prefix=/usr \
@@ -67,7 +67,7 @@ test:
         - diffutils
         - docbook-xml
         - gettext
-        - python3<3.13
+        - python3
   pipeline:
     - runs: |
         itstool --help


### PR DESCRIPTION
libxml-py3 now builds for Python 3.13 which is provided as the default Python; revert previous change that pinned to Python 3.12.

Fixes #45767
