### PR TITLE
libnvidia-container: fix FTBFS

### DIFF
--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: "1.17.4"
-  epoch: 1
+  epoch: 2
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ environment:
       - coreutils # for GNU date
       - curl
       - glibc-dev
-      - go
+      - go-1.23
       - libcap-dev # for sys/capability.h
       - libseccomp
       - libseccomp-dev


### PR DESCRIPTION
Resolve FTBFS with newer golang versions which cause:

 ./main.go:35:10: cannot define new methods on non-local type CDeviceRule

Pin to go-1.23 until upstream project supports >= 1.24

Fixes #45768
