### PR TITLE
gcc: block SAHF instructions by default for compatability with Apple Rosetta 2

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 10
+  epoch: 11
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -72,10 +72,13 @@ pipeline:
           mtune=neoverse-v2
           CFLAGS="-mbranch-protection=standard"
           CXXFLAGS="-mbranch-protection=standard"
+          specs=""
           ;;
         "x86_64")
           march=x86-64-v2
           mtune=sapphirerapids
+          # Currently hangs on Apple Rosetta 2 emulator
+          specs="-mno-sahf"
           ;;
       esac
       cd build
@@ -102,6 +105,7 @@ pipeline:
         --with-system-zlib \
         --with-arch=$march \
         --with-tune=$mtune \
+        --with-specs=$specs \
         --enable-languages=c,c++,fortran,jit,go \
         --enable-bootstrap \
         --enable-gnu-indirect-function \


### PR DESCRIPTION
Apple Rosetta 2 implements many accelerated vector instructions, but
not SAHF which affects a small minority of binaries. Block emitting
SAHF instructions to maintain compatibility with Apple Rosetta 2.

Similar changes may need to be applied to all older gcc; as well as to the clang toolchains if possible (or added to the openssf-compiler-options).
