### PR TITLE
fix(libcxx-static): Make public

### DIFF
--- a/llvm.yaml
+++ b/llvm.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm
   version: "19.1.7"
-  epoch: 3
+  epoch: 4
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -545,8 +545,8 @@ subpackages:
         - llvm-libcxx-19-static=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}${{vars.llvm-prefix}}/lib
-          mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/${{build.arch}}-unknown-linux-gnu/libc++*.a ${{targets.contextdir}}${{vars.llvm-prefix}}/lib/
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/${{build.arch}}-unknown-linux-gnu/libc++*.a ${{targets.contextdir}}/usr/lib/
 
   - name: libcxx1-dev
     description: Development files for LLVM libc++ 1
@@ -581,7 +581,7 @@ subpackages:
         - ${{package.name}}-libunwind-19=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}${{vars.llvm-prefix}}/lib
+          mkdir -p ${{targets.contextdir}}/usr/lib
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/${{build.arch}}-unknown-linux-gnu/libunwind.so.* ${{targets.contextdir}}/usr/lib/
 
   - name: ${{package.name}}-libunwind1-static


### PR DESCRIPTION
The ABI is the same LLVM version to version, make this public as originally intended
