### PR TITLE
tw/ldd-check cleanup batch 1

### DIFF
--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -105,6 +105,4 @@ test:
         valgrind --version
         vgdb --help
         valgrind --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -106,6 +106,4 @@ test:
           varnishd -F -f /etc/varnish/default.vcl -a :6081 -T localhost:6082 -s malloc,256m
         expected_output: "Child (.*) Started"
         timeout: 30
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/wasi-sdk.yaml
+++ b/wasi-sdk.yaml
@@ -96,8 +96,6 @@ subpackages:
             llvm-config --version
             llvm-config --help
         - uses: test/tw/ldd-check
-          with:
-            packages: wasi-sdk-dev
 
 update:
   enabled: true

--- a/wasmer.yaml
+++ b/wasmer.yaml
@@ -37,9 +37,7 @@ subpackages:
           mv target/release/libwasmer.so ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -56,9 +56,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/wayland.yaml
+++ b/wayland.yaml
@@ -76,9 +76,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libwayland-${{range.key}}.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: wayland ${{range.key}} libs
 
 update:

--- a/x265.yaml
+++ b/x265.yaml
@@ -85,8 +85,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: x265-dev
 
 update:
   enabled: true

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -63,9 +63,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib64/lib*.so.* "${{targets.subpkgdir}}"/usr/lib64
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: xfsprogs-doc
     description: "xfsprogs manpages"
@@ -140,6 +138,4 @@ test:
         mkfs.xfs xfs.img
         xfs_admin -L "TestXFS" xfs.img
         xfs_admin -l xfs.img | grep 'TestXFS'
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -78,9 +78,7 @@ subpackages:
     description: xmlsec openssl plugin
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: xmlsec-openssl
+        - uses: test/tw/ldd-check
 
   - name: xmlsec-dev
     pipeline:

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -153,6 +153,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/zed.yaml
+++ b/zed.yaml
@@ -72,6 +72,4 @@ test:
       runs: |
         zed -h
         zed --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -89,8 +89,6 @@ subpackages:
             fi
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: zlib-dev
 
   - name: "minizip"
     description: "a library for manipulation with files from .zip archives"
@@ -123,9 +121,7 @@ test:
     - uses: test/hardening-check
       with:
         package-match: "zlib\\|minizip"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -110,9 +110,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/${{package.name}}/${{package.version}}/zsh/pcre.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/${{package.version}}/zsh
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: zsh FIXME
 
   - name: zsh-vcs
@@ -142,9 +140,7 @@ subpackages:
     description: Zftp Function System for Zsh
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -159,6 +155,4 @@ test:
         zsh-5.9 --version
         zsh --help
         zsh-5.9 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: zstd-dev
 
   - name: "libzstd1"
     description: "libzstd runtime libraries"
@@ -72,9 +70,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libzstd.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
