### PR TITLE
tw/ldd-check cleanup batch 2

### DIFF
--- a/tevent.yaml
+++ b/tevent.yaml
@@ -65,8 +65,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tevent-dev
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -99,8 +99,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: thrift-dev
 
   - name: "libthrift"
     description: "Language-independent software stack for RPC implementation (libthrift library)"
@@ -110,9 +108,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthrift.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthrift-glib"
     description: "Language-independent software stack for RPC implementation (libthrift-glib library)"
@@ -122,9 +118,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthrift_c_glib*.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthriftnb"
     description: "Language-independent software stack for RPC implementation (libthriftnb library)"
@@ -134,9 +128,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthriftnb.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthriftz"
     description: "Language-independent software stack for RPC implementation (libthriftz library)"
@@ -146,9 +138,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthriftz.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -68,8 +68,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tiff-dev
 
 update:
   enabled: true

--- a/tinyxml2.yaml
+++ b/tinyxml2.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tinyxml2-dev
 
 update:
   enabled: true

--- a/tk.yaml
+++ b/tk.yaml
@@ -105,7 +105,5 @@ test:
         wish --help
         wish9.0 --version
         wish9.0 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - uses: test/pkgconf

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -71,6 +71,4 @@ test:
         traffic_manager --version
         traffic_via --version
     - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -38,8 +38,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tree-sitter-dev
 
 update:
   enabled: true
@@ -76,6 +74,4 @@ test:
             $(pkg-config --libs tree-sitter) \
             -o test_parser
         ./test_parser
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/trino.yaml
+++ b/trino.yaml
@@ -163,9 +163,7 @@ subpackages:
           EOF
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
+        - uses: test/tw/ldd-check
 
   - range: plugins
     name: trino-plugin-${{range.key}}
@@ -203,9 +201,7 @@ test:
     - runs: |
         trino --version
         trino --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: "test trino server"
       runs: |
         mkdir -p /usr/lib/trino/etc

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -65,9 +65,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/unibilium.yaml
+++ b/unibilium.yaml
@@ -91,6 +91,4 @@ test:
 
         # Run the test program
         ./test_unibilium 2>&1 | grep -q "Failed to read terminfo"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/userspace-rcu.yaml
+++ b/userspace-rcu.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: userspace-rcu-dev
 
 update:
   enabled: true
@@ -88,6 +86,4 @@ test:
         grep "RCU read lock acquired" output.log
         grep "RCU read lock released" output.log
         grep "RCU thread unregistered successfully" output.log
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/utf8proc.yaml
+++ b/utf8proc.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: utf8proc-dev
 
 update:
   enabled: true

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -113,8 +113,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: util-linux-dev
 
   - name: util-linux-doc
     pipeline:
@@ -138,9 +136,7 @@ subpackages:
     description: ${{range.value}}
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{range.key}}
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-bin
@@ -420,6 +416,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/utmps.yaml
+++ b/utmps.yaml
@@ -70,8 +70,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: utmps-dev
 
   - name: utmps-docs
     pipeline:

--- a/vala.yaml
+++ b/vala.yaml
@@ -76,6 +76,4 @@ test:
         vapigen --help
         vapigen-0.56 --help
     - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
