### PR TITLE
tw/ldd-check cleanup batch 4

### DIFF
--- a/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
@@ -111,9 +111,7 @@ subpackages:
           KUBERNETES_SERVICE_HOST: "127.0.0.1"
           KUBERNETES_SERVICE_PORT: 32764
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: test/kwok/cluster
         # Just make sure the config is okay, kwok doesn't get us very far
         - uses: test/daemon-check-output

--- a/ruby3.4-llhttp.yaml
+++ b/ruby3.4-llhttp.yaml
@@ -83,9 +83,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-ffi
     description: Ruby FFI bindings for llhttp.
@@ -118,9 +116,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.4-puma.yaml
+++ b/ruby3.4-puma.yaml
@@ -58,9 +58,7 @@ test:
         pumactl --version
         puma --help
         pumactl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -150,6 +150,4 @@ test:
         rustc --version
         cargo --help
         rustc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.74.yaml
+++ b/rust-1.74.yaml
@@ -150,6 +150,4 @@ test:
         rustc --version
         cargo --help
         rustc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -130,6 +130,4 @@ test:
         rustc --version
         cargo --help
         rustc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.76.yaml
+++ b/rust-1.76.yaml
@@ -130,6 +130,4 @@ test:
         rustc --version
         cargo --help
         rustc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.77.yaml
+++ b/rust-1.77.yaml
@@ -155,6 +155,4 @@ test:
         cargo new hello_cargo --bin
         cd hello_cargo
         cargo run | grep -q "Hello, world!" || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.78.yaml
+++ b/rust-1.78.yaml
@@ -167,6 +167,4 @@ test:
     - name: Verify rustdoc installation
       runs: |
         rustdoc --version || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.79.yaml
+++ b/rust-1.79.yaml
@@ -169,6 +169,4 @@ test:
     - name: Verify rustdoc installation
       runs: |
         rustdoc --version || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.80.yaml
+++ b/rust-1.80.yaml
@@ -168,6 +168,4 @@ test:
     - name: Verify rustdoc installation
       runs: |
         rustdoc --version || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -165,6 +165,4 @@ test:
     - name: Verify rustdoc installation
       runs: |
         rustdoc --version || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rust-stage0.yaml
+++ b/rust-stage0.yaml
@@ -80,6 +80,4 @@ test:
         rustc --help
         rustdoc --help
         rustfmt --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/s-lang.yaml
+++ b/s-lang.yaml
@@ -66,6 +66,4 @@ test:
     - runs: |
         slsh -e 'message("Hello World!");' | grep -q "Hello World!"
         slsh --version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/s2n-tls.yaml
+++ b/s2n-tls.yaml
@@ -58,9 +58,7 @@ subpackages:
     description: s2n-tls dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: s2n-tls-dev
+        - uses: test/tw/ldd-check
 
 test:
   environment:
@@ -68,9 +66,7 @@ test:
       packages:
         - posix-libc-utils
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
