### PR TITLE
tw/ldd-check cleanup batch 5

### DIFF
--- a/ruby3.2-msgpack.yaml
+++ b/ruby3.2-msgpack.yaml
@@ -95,9 +95,7 @@ test:
         puts "Streaming API test passed"
         puts "All tests passed!"
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -52,6 +52,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-oj.yaml
+++ b/ruby3.2-oj.yaml
@@ -55,6 +55,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -61,9 +61,7 @@ test:
     - name: Check pg is install
       runs: |
         echo "Is pg installed?: $(gem list -i pg)"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.2-psych.yaml
+++ b/ruby3.2-psych.yaml
@@ -46,9 +46,7 @@ vars:
 test:
   pipeline:
     - runs: ruby -e "require 'psych'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -57,9 +57,7 @@ test:
         pumactl --version
         puma --help
         pumactl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.2-stringio.yaml
+++ b/ruby3.2-stringio.yaml
@@ -45,9 +45,7 @@ vars:
 test:
   pipeline:
     - runs: ruby -e "require 'stringio'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-strptime.yaml
+++ b/ruby3.2-strptime.yaml
@@ -58,6 +58,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-systemd-journal.yaml
+++ b/ruby3.2-systemd-journal.yaml
@@ -45,9 +45,7 @@ test:
   pipeline:
     - runs: |
         ruby -e "require 'systemd/journal'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-yajl-ruby.yaml
+++ b/ruby3.2-yajl-ruby.yaml
@@ -67,6 +67,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -61,9 +61,7 @@ subpackages:
       - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-edge
     description: Concurrent ruby edge functionality

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -111,9 +111,7 @@ subpackages:
           KUBERNETES_SERVICE_HOST: "127.0.0.1"
           KUBERNETES_SERVICE_PORT: 32764
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: test/kwok/cluster
         # Just make sure the config is okay, kwok doesn't get us very far
         - uses: test/daemon-check-output

--- a/ruby3.3-llhttp.yaml
+++ b/ruby3.3-llhttp.yaml
@@ -85,9 +85,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-ffi
     description: Ruby FFI bindings for llhttp.
@@ -120,9 +118,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.3-puma.yaml
+++ b/ruby3.3-puma.yaml
@@ -57,9 +57,7 @@ test:
         pumactl --version
         puma --help
         pumactl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -61,9 +61,7 @@ subpackages:
       - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-edge
     description: Concurrent ruby edge functionality


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
