### PR TITLE
tw/ldd-check cleanup batch 6

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -136,8 +136,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ruby-3.2-dev
 
 update:
   enabled: true
@@ -175,6 +173,4 @@ test:
         ri --version
         ri --help
         ruby --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -131,8 +131,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ruby-3.3-dev
 
 update:
   enabled: true
@@ -171,6 +169,4 @@ test:
         ri --version
         ri --help
         ruby --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -144,8 +144,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ruby-3.4-dev
 
 update:
   enabled: true

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
@@ -111,9 +111,7 @@ subpackages:
           KUBERNETES_SERVICE_HOST: "127.0.0.1"
           KUBERNETES_SERVICE_PORT: 32764
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: test/kwok/cluster
         # Just make sure the config is okay, kwok doesn't get us very far
         - uses: test/daemon-check-output

--- a/ruby3.2-charlock_holmes.yaml
+++ b/ruby3.2-charlock_holmes.yaml
@@ -72,9 +72,7 @@ test:
 
         puts "All tests passed!"
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -61,9 +61,7 @@ subpackages:
       - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-edge
     description: Concurrent ruby edge functionality

--- a/ruby3.2-cool.io.yaml
+++ b/ruby3.2-cool.io.yaml
@@ -77,9 +77,7 @@ test:
         # Verify timer functionality
         puts "Cool.io timer executed successfully!"
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-date.yaml
+++ b/ruby3.2-date.yaml
@@ -76,9 +76,7 @@ test:
 
         puts "DateTime library functionality verified successfully!"
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-ffi.yaml
+++ b/ruby3.2-ffi.yaml
@@ -50,9 +50,7 @@ test:
   pipeline:
     - runs: |
         ruby -e "require 'ffi'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
@@ -111,9 +111,7 @@ subpackages:
           KUBERNETES_SERVICE_HOST: "127.0.0.1"
           KUBERNETES_SERVICE_PORT: 32764
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: test/kwok/cluster
         # Just make sure the config is okay, kwok doesn't get us very far
         - uses: test/daemon-check-output

--- a/ruby3.2-http_parser.rb.yaml
+++ b/ruby3.2-http_parser.rb.yaml
@@ -103,9 +103,7 @@ test:
           exit 1
         end
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-io-console.yaml
+++ b/ruby3.2-io-console.yaml
@@ -76,9 +76,7 @@ test:
             exit 1
           end
         '
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-io-event.yaml
+++ b/ruby3.2-io-event.yaml
@@ -86,6 +86,4 @@ test:
         else
           echo "Test passed: io-event gem can be required."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-json.yaml
+++ b/ruby3.2-json.yaml
@@ -41,9 +41,7 @@ vars:
 test:
   pipeline:
     - runs: ruby -e "require 'json'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-llhttp.yaml
+++ b/ruby3.2-llhttp.yaml
@@ -85,9 +85,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-ffi
     description: Ruby FFI bindings for llhttp.
@@ -120,9 +118,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
