### PR TITLE
tw/ldd-check cleanup batch 7

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -146,9 +146,7 @@ subpackages:
               "${{targets.destdir}}/$d"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -146,9 +146,7 @@ subpackages:
               "${{targets.destdir}}/$d"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: "${{package.name}}-base"
+        - uses: test/tw/ldd-check
         - runs: |
             ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -156,9 +156,7 @@ subpackages:
               "${{targets.destdir}}/$d"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: "${{package.name}}-base"
+        - uses: test/tw/ldd-check
         - runs: |
             ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -156,9 +156,7 @@ subpackages:
               "${{targets.destdir}}/$d"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages
@@ -238,9 +236,7 @@ subpackages:
           mv "$fromd/$d/tkinter" "$tod/$d/"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: python/import
           with:
             python: python${{vars.pyversion}}

--- a/qpdf.yaml
+++ b/qpdf.yaml
@@ -57,8 +57,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: qpdf-dev
 
   - name: qpdf-doc
     pipeline:

--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -195,8 +195,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: qt5-qtbase-dev
 
   - name: qt5-qtbase-doc
     pipeline:
@@ -211,12 +209,8 @@ subpackages:
     description: SQLite driver for Qt5's SQL classes
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-sqlite
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-sqlite
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
 
   - name: qt5-qtbase-odbc
     pipeline:
@@ -226,12 +220,8 @@ subpackages:
     description: ODBC driver for Qt5's SQL classes
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-odbc
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-odbc
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
 
   - name: qt5-qtbase-postgresql
     pipeline:
@@ -241,12 +231,8 @@ subpackages:
     description: PostgreSQL driver for Qt5's SQL classes
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-postgresql
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-postgresql
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
 
   - name: qt5-qtbase-mysql
     pipeline:
@@ -263,12 +249,8 @@ subpackages:
     description: TDS driver for Qt5's SQL classes
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-tds
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-tds
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
 
   - name: qt5-qtbase-x11
     pipeline:
@@ -291,15 +273,9 @@ subpackages:
     description: Qt5 GUI-related libraries
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-x11
-        - uses: test/ldd-check
-          with:
-            packages: qt5-qtbase-x11
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -336,6 +312,4 @@ test:
         rcc-qt5 --help
         uic --help
         uic-qt5 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -101,8 +101,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: qt6-qtbase-dev
 
   - name: qt6-qtbase-x11
     pipeline:
@@ -127,9 +125,7 @@ subpackages:
           done
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: qt6-qtbase-doc
     pipeline:
@@ -147,6 +143,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/re2.yaml
+++ b/re2.yaml
@@ -59,8 +59,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: re2-dev
 
 update:
   enabled: true

--- a/readline.yaml
+++ b/readline.yaml
@@ -74,6 +74,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/rhash.yaml
+++ b/rhash.yaml
@@ -62,9 +62,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/librhash.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/rpm.yaml
+++ b/rpm.yaml
@@ -87,8 +87,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: rpm-dev
 
   - name: rpm-doc
     pipeline:

--- a/rrdtool.yaml
+++ b/rrdtool.yaml
@@ -101,8 +101,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: rrdtool-dev
 
   - name: rrdtool-doc
     pipeline:
@@ -127,9 +125,7 @@ subpackages:
     description: Perl interface for rrdtool
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: lua-rrd
     pipeline:

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -68,9 +68,7 @@ subpackages:
           mv librtmp/*.so* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -91,9 +89,7 @@ test:
   pipeline:
     - name: Smoke test for rtmpdump binary
       runs: rtmpdump --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Compile and link a simple C program
       runs: |
         cat <<EOF > test_rtmp.c

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -111,8 +111,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ruby-3.0-dev
 
 update:
   enabled: false
@@ -148,6 +146,4 @@ test:
         ruby --help
         typeprof --version
         typeprof --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -124,8 +124,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ruby-3.1-dev
 
 update:
   enabled: true
@@ -163,6 +161,4 @@ test:
         ri --version
         ri --help
         ruby --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
