### PR TITLE
tw/ldd-check cleanup batch 8

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -219,9 +219,7 @@ subpackages:
             "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}-config"

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -219,9 +219,7 @@ subpackages:
             "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}-config"

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -68,8 +68,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: pkgconf-dev
 
   - name: "pkgconf-doc"
     description: "pkgconf documentation"
@@ -164,6 +162,4 @@ test:
       runs: |
         pkgconf --libs --static zlib
         pkgconf --libs --shared zlib
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/polkit.yaml
+++ b/polkit.yaml
@@ -69,9 +69,7 @@ subpackages:
     description: polkit dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
+        - uses: test/tw/ldd-check
         - uses: test/pkgconf
 
   - name: polkit-lang

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -79,8 +79,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: poppler-dev
 
   - name: poppler-doc
     pipeline:

--- a/popt.yaml
+++ b/popt.yaml
@@ -60,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/procps.yaml
+++ b/procps.yaml
@@ -58,8 +58,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: procps-dev
 
   - name: "libproc-2-0"
     description: "libproc runtime"
@@ -69,9 +67,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libproc*.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libproc-2-0
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/proj.yaml
+++ b/proj.yaml
@@ -71,8 +71,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: proj-dev
 
 update:
   enabled: true

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -78,8 +78,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: protobuf-dev
 
   - name: protoc
     description: Protocol buffer compiler binary and library

--- a/prrte.yaml
+++ b/prrte.yaml
@@ -63,8 +63,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: prrte-dev
 
   - name: prrte-doc
     description: prrte manpages

--- a/pstack.yaml
+++ b/pstack.yaml
@@ -87,6 +87,4 @@ test:
         canal --help
         hdmp -v
         hdmp -h
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/pulseaudio.yaml
+++ b/pulseaudio.yaml
@@ -227,6 +227,4 @@ test:
     - runs: |
         pulseaudio --version
         pulseaudio --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -73,9 +73,7 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -52,6 +52,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/py3-tensorflow-data-validation.yaml
+++ b/py3-tensorflow-data-validation.yaml
@@ -72,6 +72,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
