### PR TITLE
tw/ldd-check cleanup batch 9

### DIFF
--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -66,6 +66,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-opentelemetry.yaml
+++ b/php-8.3-opentelemetry.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-pdo_snowflake.yaml
+++ b/php-8.3-pdo_snowflake.yaml
@@ -87,9 +87,7 @@ test:
         else
           echo "Test passed: pdo snowflake extension is loaded."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -57,6 +57,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-pecl-mcrypt.yaml
+++ b/php-8.3-pecl-mcrypt.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -75,9 +75,7 @@ test:
         else
           echo "Test passed: mongodb extension is functional."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -64,6 +64,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -64,6 +64,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-protobuf.yaml
+++ b/php-8.3-protobuf.yaml
@@ -95,6 +95,4 @@ test:
         echo ($newMessage->getName() === "test" && $newMessage->getId() === 123) ? "OK" : "FAIL";
         EOF
         php test.php | grep -q "OK"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -106,6 +106,4 @@ test:
         else
           echo "Test passed: Redis extension is functional."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-ssh2.yaml
+++ b/php-8.3-ssh2.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-swoole.yaml
+++ b/php-8.3-swoole.yaml
@@ -66,6 +66,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-xdebug.yaml
+++ b/php-8.3-xdebug.yaml
@@ -58,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.3-zstd.yaml
+++ b/php-8.3-zstd.yaml
@@ -60,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
