### PR TITLE
tw/ldd-check cleanup batch 12

### DIFF
--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -75,9 +75,7 @@ test:
         else
           echo "Test passed: mongodb extension is functional."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -64,6 +64,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -64,6 +64,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-protobuf.yaml
+++ b/php-8.1-protobuf.yaml
@@ -95,6 +95,4 @@ test:
         echo ($newMessage->getName() === "test" && $newMessage->getId() === 123) ? "OK" : "FAIL";
         EOF
         php test.php | grep -q "OK"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -106,6 +106,4 @@ test:
         else
           echo "Test passed: Redis extension is functional."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-ssh2.yaml
+++ b/php-8.1-ssh2.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-swoole.yaml
+++ b/php-8.1-swoole.yaml
@@ -66,6 +66,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-xdebug.yaml
+++ b/php-8.1-xdebug.yaml
@@ -58,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.1-zstd.yaml
+++ b/php-8.1-zstd.yaml
@@ -60,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -66,6 +66,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.2-apcu.yaml
+++ b/php-8.2-apcu.yaml
@@ -116,6 +116,4 @@ test:
           if (!ini_get("apc.enable_cli")) exit(1);
           echo "APCu CLI mode enabled";
         '
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.2-ddtrace.yaml
+++ b/php-8.2-ddtrace.yaml
@@ -92,9 +92,7 @@ test:
         else
           echo "Test passed: ddtrace extension is functional."
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/php-8.2-decimal.yaml
+++ b/php-8.2-decimal.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/php-8.2-ds.yaml
+++ b/php-8.2-ds.yaml
@@ -61,6 +61,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
