### PR TITLE
tw/ldd-check cleanup batch 14

### DIFF
--- a/perl-dbi.yaml
+++ b/perl-dbi.yaml
@@ -58,6 +58,4 @@ test:
         perl -e "use DBI; print 'DBI loaded'"
         dbilogstrip --version
         dbilogstrip --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-devel-cover.yaml
+++ b/perl-devel-cover.yaml
@@ -73,6 +73,4 @@ test:
         gcov2perl --version
         cover --help
         gcov2perl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-devel-ppport.yaml
+++ b/perl-devel-ppport.yaml
@@ -52,6 +52,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-digest-md5.yaml
+++ b/perl-digest-md5.yaml
@@ -47,6 +47,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-file-fcntllock.yaml
+++ b/perl-file-fcntllock.yaml
@@ -48,6 +48,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-html-parser.yaml
+++ b/perl-html-parser.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-json-xs.yaml
+++ b/perl-json-xs.yaml
@@ -53,6 +53,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-sub-identify.yaml
+++ b/perl-sub-identify.yaml
@@ -53,6 +53,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-template-toolkit.yaml
+++ b/perl-template-toolkit.yaml
@@ -62,6 +62,4 @@ test:
     - runs: |
         tpage --help
         ttree --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-time-hires.yaml
+++ b/perl-time-hires.yaml
@@ -47,6 +47,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-tk.yaml
+++ b/perl-tk.yaml
@@ -63,6 +63,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-xml-parser.yaml
+++ b/perl-xml-parser.yaml
@@ -52,6 +52,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -52,6 +52,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/perl.yaml
+++ b/perl.yaml
@@ -218,6 +218,4 @@ test:
         EOF
 
         perl /tmp/hello.pl
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/pg-failover-slots-16.yaml
+++ b/pg-failover-slots-16.yaml
@@ -36,9 +36,7 @@ test:
           echo "pg_failover_slots library not found!"
           exit 1
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
