### PR TITLE
tw/ldd-check cleanup batch 16

### DIFF
--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -159,6 +159,4 @@ test:
         rpc.mountd --help
         rpc.statd --help
         showmount --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -70,9 +70,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libnghttp2.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libnghttp2-14
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -205,9 +205,7 @@ subpackages:
           esac
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: nginx-stable-src
     description: Nginx source code
@@ -223,9 +221,7 @@ subpackages:
           ls -latr ${{targets.contextdir}}/usr/src/nginx
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-config-compat
     description: Nginx config compatibility with upstream image

--- a/njs.yaml
+++ b/njs.yaml
@@ -93,9 +93,7 @@ test:
     - runs: |
         njs -v
         njs-debug -v
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/nss.yaml
+++ b/nss.yaml
@@ -87,9 +87,7 @@ subpackages:
         - libnspr
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libnss-dev
     pipeline:

--- a/ntfs-3g.yaml
+++ b/ntfs-3g.yaml
@@ -86,9 +86,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: ntfs-3g-dev
+        - uses: test/tw/ldd-check
 
   - name: ntfs-3g-libs
     pipeline:
@@ -97,9 +95,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin

--- a/ocaml.yaml
+++ b/ocaml.yaml
@@ -89,9 +89,7 @@ subpackages:
             ocamlobjinfo.byte --help
             ocamlopt.byte --version
             ocamlopt.byte --help
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
+        - uses: test/tw/ldd-check
 
   - name: "ocaml-compiler-libs"
     pipeline:
@@ -155,6 +153,4 @@ test:
         ocamlopt.opt --help
         ocamloptp --help
         ocamlprof version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/odbc-cpp-wrapper.yaml
+++ b/odbc-cpp-wrapper.yaml
@@ -53,6 +53,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -52,8 +52,6 @@ subpackages:
             onig-config --version
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: oniguruma-dev
 
 update:
   enabled: true
@@ -64,6 +62,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/openblas.yaml
+++ b/openblas.yaml
@@ -81,9 +81,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: openblas-dev
+        - uses: test/tw/ldd-check
 
   - name: openblas-doc
     pipeline:
@@ -103,9 +101,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblapack.so* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: liblapacke
     pipeline:
@@ -114,9 +110,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblapacke.so* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/openexr.yaml
+++ b/openexr.yaml
@@ -72,9 +72,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: openexr-dev
+        - uses: test/tw/ldd-check
 
   - name: openexr-libiex
     pipeline:
@@ -83,9 +81,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libIex-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libiex
 
   - name: openexr-libilmthread
@@ -95,9 +91,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libIlmThread-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libilmthread
 
   - name: openexr-libopenexr
@@ -107,9 +101,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXR-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexr
 
   - name: openexr-libopenexrcore
@@ -119,9 +111,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXRCore-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexrcore
 
   - name: openexr-libopenexrutil
@@ -131,9 +121,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXRUtil-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexrutil
 
 test:

--- a/openh264.yaml
+++ b/openh264.yaml
@@ -40,8 +40,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: openh264-dev
 
 update:
   enabled: true

--- a/openipmi.yaml
+++ b/openipmi.yaml
@@ -81,9 +81,7 @@ subpackages:
             ipmi_sim --version
             ipmi_sim --help
             ipmilan --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -293,6 +293,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/openjpeg.yaml
+++ b/openjpeg.yaml
@@ -53,8 +53,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: openjpeg-dev
 
   - name: openjpeg-tools
     pipeline:


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
