### PR TITLE
tw/ldd-check cleanup batch 17

### DIFF
--- a/mesa.yaml
+++ b/mesa.yaml
@@ -144,9 +144,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/${{range.value}}.so* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: mesa-${{range.key}}
+        - uses: test/tw/ldd-check
 
   - range: transitive
     name: mesa-${{range.key}}

--- a/mimalloc.yaml
+++ b/mimalloc.yaml
@@ -36,8 +36,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: mimalloc-dev
     dependencies:
       runtime:
         - mimalloc

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -145,9 +145,7 @@ test:
         mlflow ui & sleep 5; curl -vsL localhost:5000
     # Will fail see https://github.com/wolfi-dev/os/issues/34358
     # - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/mold.yaml
+++ b/mold.yaml
@@ -76,6 +76,4 @@ test:
         mold --version
         ld.mold --help
         mold --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -104,6 +104,4 @@ test:
     - runs: |
         js91 --version
         js91 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -67,6 +67,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: mpdecimal-dev
 
   - name: mpdecimal-doc
     description: mpdecimal docs
@@ -62,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -62,6 +62,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/msgpack-c.yaml
+++ b/msgpack-c.yaml
@@ -63,6 +63,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -92,9 +92,7 @@ subpackages:
         - runs: |
             ncursesw6-config --version
             ncursesw6-config --help
-        - uses: test/ldd-check
-          with:
-            packages: ncurses-dev
+        - uses: test/tw/ldd-check
         - uses: test/pkgconf
 
   - name: "ncurses-doc"
@@ -179,6 +177,4 @@ test:
         tput -V
         tset -V
         toe help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/neovim.yaml
+++ b/neovim.yaml
@@ -80,9 +80,7 @@ test:
         nvim -V1 --version || exit 1
         nvim --version
         nvim --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/net-snmp.yaml
+++ b/net-snmp.yaml
@@ -94,9 +94,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/snmp/mibs "${{targets.subpkgdir}}"/usr/share/snmp/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: The NET-SNMP runtime client libraries
 
   - name: net-snmp-agent-libs
@@ -111,9 +109,7 @@ subpackages:
     description: The NET-SNMP runtime agent libraries
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: net-snmp-perl
     pipeline:
@@ -135,9 +131,7 @@ subpackages:
     description: The perl NET-SNMP module and the mib2c tool
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             mib2c version
             traptoemail -h

--- a/nettle.yaml
+++ b/nettle.yaml
@@ -68,8 +68,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: nettle-dev
 
   - name: nettle-utils
     pipeline:

--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -65,6 +65,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/nfs-ganesha.yaml
+++ b/nfs-ganesha.yaml
@@ -60,8 +60,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: nfs-ganesha-dev
 
 update:
   enabled: true
@@ -76,6 +74,4 @@ test:
     - runs: |
         ganesha.nfsd version
         ganesha.nfsd help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
