### PR TITLE
tw/ldd-check cleanup batch 19

### DIFF
--- a/libxrender.yaml
+++ b/libxrender.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libxrender-dev
 
   - name: libxrender-doc
     pipeline:

--- a/libxshmfence.yaml
+++ b/libxshmfence.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libxshmfence-dev
 
 update:
   enabled: true

--- a/libxxf86vm.yaml
+++ b/libxxf86vm.yaml
@@ -43,8 +43,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libxxf86vm-dev
 
   - name: libxxf86vm-doc
     pipeline:

--- a/libyang.yaml
+++ b/libyang.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libyang-dev
 
   - name: libyang-doc
     pipeline:

--- a/lighttpd.yaml
+++ b/lighttpd.yaml
@@ -86,6 +86,4 @@ test:
         lighttpd-angel --version
         lighttpd -h
         lighttpd-angel --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/linux-pam.yaml
+++ b/linux-pam.yaml
@@ -66,8 +66,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: linux-pam-dev
 
   - name: linux-pam-doc
     pipeline:
@@ -96,6 +94,4 @@ test:
         fi
         pam_namespace_helper --version
         pam_namespace_helper --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -274,6 +274,4 @@ test:
         verify-uselistorder --help
         yaml-bench --help
         yaml2obj --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm-libcxx-15.yaml
+++ b/llvm-libcxx-15.yaml
@@ -64,9 +64,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libc++abi.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       provides:
         - llvm-libcxxabi=15
@@ -81,6 +79,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm-libcxx-16.yaml
+++ b/llvm-libcxx-16.yaml
@@ -64,9 +64,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libc++abi.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       provides:
         - llvm-libcxxabi=16
@@ -81,6 +79,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm-libcxx-17.yaml
+++ b/llvm-libcxx-17.yaml
@@ -64,9 +64,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libc++abi.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       provides:
         - llvm-libcxxabi=17
@@ -81,6 +79,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm.yaml
+++ b/llvm.yaml
@@ -655,9 +655,7 @@ subpackages:
           done
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             llvm-config --version
             llvm-config --help
@@ -859,6 +857,4 @@ test:
         lli helloWorld.ll | grep "hello world" || exit 1
         llc helloWorld.ll
         cat helloWorld.s | grep "hello world" || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm15.yaml
+++ b/llvm15.yaml
@@ -118,9 +118,7 @@ subpackages:
           rm -f "${{targets.destdir}}"/usr/lib/$sonamefull
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "llvm15-tools"
     description: "LLVM 15 tools in /usr/bin"
@@ -157,9 +155,7 @@ subpackages:
         - libLLVM-15
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "llvm15-cmake-default"
     description: "LLVM 15 CMake module definitions in /usr/lib/cmake"
@@ -181,6 +177,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm16.yaml
+++ b/llvm16.yaml
@@ -125,9 +125,7 @@ subpackages:
           rm -f "${{targets.destdir}}"/usr/lib/$sonamefull
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "llvm16-dev"
     description: "headers for llvm16"
@@ -154,9 +152,7 @@ subpackages:
         - runs: |
             llvm-config --version
             llvm-config --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -324,6 +320,4 @@ test:
         verify-uselistorder --help
         yaml-bench --help
         yaml2obj --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/llvm17.yaml
+++ b/llvm17.yaml
@@ -125,9 +125,7 @@ subpackages:
           rm -f "${{targets.destdir}}"/usr/lib/$sonamefull
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "llvm17-dev"
     description: "headers for llvm17"
@@ -154,9 +152,7 @@ subpackages:
         - runs: |
             llvm-config --version
             llvm-config --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -324,6 +320,4 @@ test:
         verify-uselistorder --help
         yaml-bench --help
         yaml2obj --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lmdb.yaml
+++ b/lmdb.yaml
@@ -68,8 +68,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: lmdb-dev
 
   - name: lmdb-doc
     pipeline:
@@ -91,6 +89,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
