### PR TITLE
tw/ldd-check cleanup batch 22

### DIFF
--- a/libpciaccess.yaml
+++ b/libpciaccess.yaml
@@ -48,8 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libpciaccess-dev
 
   - name: libpciaccess-doc
     pipeline:
@@ -64,5 +62,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libpciaccess

--- a/libpipeline.yaml
+++ b/libpipeline.yaml
@@ -57,6 +57,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -70,9 +70,7 @@ subpackages:
             libpng16-config --version
             libpng16-config --help
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libpng-utils
     pipeline:
@@ -96,5 +94,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libpng

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -45,6 +45,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -90,6 +90,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libretls.yaml
+++ b/libretls.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libretls-dev
 
   - name: "libretls-doc"
     description: "libretls documentation"
@@ -69,5 +67,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libretls

--- a/librsvg.yaml
+++ b/librsvg.yaml
@@ -143,6 +143,4 @@ test:
         echo '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" style="fill:yellow"/></svg>' > test-pdf.svg
         rsvg-convert -f pdf -o output.pdf test-pdf.svg
         file output.pdf | grep -qi "PDF document"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libsass.yaml
+++ b/libsass.yaml
@@ -104,8 +104,6 @@ test:
         gcc test.c -o test_sass -lsass
         ./test_sass
     - uses: test/tw/ldd-check
-      with:
-        packages: libsass
     - name: "Test variable compilation"
       runs: |
         cat << EOF > test_vars.c

--- a/libsdl2-ttf.yaml
+++ b/libsdl2-ttf.yaml
@@ -60,5 +60,3 @@ test:
         set -euo pipefail
         pkg-config --modversion SDL2_ttf | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl2-ttf

--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -39,9 +39,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -61,5 +59,3 @@ test:
         set -euo pipefail
         pkg-config --modversion sdl2 | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl2

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -82,5 +82,3 @@ test:
         set -euo pipefail
         pkg-config --modversion sdl3 | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl3

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -52,8 +52,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libseccomp-dev
 
   - name: libseccomp-doc
     pipeline:
@@ -75,6 +73,4 @@ test:
     - runs: |
         scmp_sys_resolver version
         scmp_sys_resolver help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libsecret.yaml
+++ b/libsecret.yaml
@@ -71,8 +71,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libsecret-dev
 
   - name: libsecret-lang
     pipeline:
@@ -87,5 +85,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libsecret

--- a/libselinux.yaml
+++ b/libselinux.yaml
@@ -81,8 +81,6 @@ test:
         getenforce
         # Most of the binaries don't have easy --help options to test
     - uses: test/tw/ldd-check
-      with:
-        packages: libselinux
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
