### PR TITLE
tw/ldd-check cleanup batch 23

### DIFF
--- a/libmaxminddb.yaml
+++ b/libmaxminddb.yaml
@@ -48,8 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libmaxminddb-dev
 
   - name: libmaxminddb-doc
     pipeline:
@@ -67,8 +65,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
     description: libmaxminddb libs
 
 update:

--- a/libmd.yaml
+++ b/libmd.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libmd-dev
 
   - name: libmd-doc
     pipeline:
@@ -60,5 +58,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libmd

--- a/libmemcached.yaml
+++ b/libmemcached.yaml
@@ -53,8 +53,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libmemcached-dev
     dependencies:
       runtime:
         - libmemcached
@@ -98,5 +96,3 @@ test:
         memstat --help
         memtouch --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libmemcached

--- a/libmnl.yaml
+++ b/libmnl.yaml
@@ -57,8 +57,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libmnl-dev
 
 update:
   enabled: true
@@ -67,6 +65,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -38,8 +38,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libmspack-dev
     dependencies:
       runtime:
         - libmspack
@@ -54,5 +52,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libmspack

--- a/libnet.yaml
+++ b/libnet.yaml
@@ -58,8 +58,6 @@ subpackages:
             libnet-config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnet-dev
 
 update:
   enabled: true
@@ -70,5 +68,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libnet

--- a/libnetfilter_cthelper.yaml
+++ b/libnetfilter_cthelper.yaml
@@ -36,8 +36,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnetfilter_cthelper-dev
 
 update:
   enabled: true
@@ -47,5 +45,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libnetfilter_cthelper

--- a/libnetfilter_cttimeout.yaml
+++ b/libnetfilter_cttimeout.yaml
@@ -36,8 +36,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnetfilter_cttimeout-dev
 
 update:
   enabled: true
@@ -47,5 +45,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libnetfilter_cttimeout

--- a/libnftnl.yaml
+++ b/libnftnl.yaml
@@ -77,6 +77,4 @@ test:
 
         # Run the application
         ./test
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libnl3.yaml
+++ b/libnl3.yaml
@@ -69,8 +69,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnl3-dev
 
   - name: libnl3-doc
     description: libnl3 docs
@@ -91,9 +89,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin "${{targets.subpkgdir}}"/usr/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             genl-ctrl-list --version
             genl-ctrl-list --help
@@ -182,5 +178,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libnl3

--- a/libnotify.yaml
+++ b/libnotify.yaml
@@ -54,8 +54,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnotify-dev
 
 update:
   enabled: true
@@ -77,8 +75,6 @@ test:
         notify-send --version
         notify-send --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libnotify
     - name: "Test compilation with development files"
       runs: |
         cat > test.c << 'EOF'

--- a/libnspr.yaml
+++ b/libnspr.yaml
@@ -70,6 +70,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libnvme.yaml
+++ b/libnvme.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libnvme-dev
 
   - name: libnvme-python
     description: Python bindings for libnvme
@@ -65,9 +63,7 @@ subpackages:
           with:
             imports: |
               import libnvme
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -85,5 +81,3 @@ test:
       runs: |
         stat /usr/include/libnvme.h
     - uses: test/tw/ldd-check
-      with:
-        packages: libnvme

--- a/libogg.yaml
+++ b/libogg.yaml
@@ -79,5 +79,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libogg

--- a/libpaper.yaml
+++ b/libpaper.yaml
@@ -42,8 +42,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: libpaper-dev
 
   - name: libpaper-doc
     pipeline:
@@ -67,5 +65,3 @@ test:
         paperconf -h
         paper --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libpaper


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
