### PR TITLE
tw/ldd-check cleanup batch 24

### DIFF
--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -83,6 +83,4 @@ test:
         hmac256 --help
         mpicalc --version
         mpicalc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libgeotiff.yaml
+++ b/libgeotiff.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libgeotiff-dev
 
   - name: libgeotiff-doc
     pipeline:
@@ -73,5 +71,3 @@ test:
         makegeo --version
         makegeo --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libgeotiff

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -91,8 +91,6 @@ subpackages:
             ./test_libgit2
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libgit2-dev
 
   - name: "libgit2-static"
     description: "libgit2 static library"
@@ -112,5 +110,3 @@ test:
         git2 --version
         git2 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libgit2

--- a/libglvnd.yaml
+++ b/libglvnd.yaml
@@ -125,5 +125,3 @@ test:
         gcc check_egl_gl_functions.c -o check_egl_gl_functions -ldl
         ./check_egl_gl_functions | grep -E "EGL functions are available.|OpenGL functions are available."
     - uses: test/tw/ldd-check
-      with:
-        packages: libglvnd

--- a/libgpg-error.yaml
+++ b/libgpg-error.yaml
@@ -80,6 +80,4 @@ test:
         yat2m --version
         gpg-error --help
         yat2m --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libgphoto2.yaml
+++ b/libgphoto2.yaml
@@ -82,6 +82,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libhyper.yaml
+++ b/libhyper.yaml
@@ -45,9 +45,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/libice.yaml
+++ b/libice.yaml
@@ -75,8 +75,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libice-dev
 
 update:
   enabled: true
@@ -86,5 +84,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libice

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -80,6 +80,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libimagequant.yaml
+++ b/libimagequant.yaml
@@ -120,5 +120,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libimagequant

--- a/libinput.yaml
+++ b/libinput.yaml
@@ -80,8 +80,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libinput-dev
 
 update:
   enabled: true
@@ -95,5 +93,3 @@ test:
         libinput --version
         libinput --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libinput

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -45,8 +45,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libjpeg-turbo-dev
 
   - name: "libjpeg-turbo-doc"
     description: "libjpeg-turbo documentation"
@@ -88,8 +86,6 @@ test:
         test -f /usr/lib/libjpeg.so
         test -f /usr/lib/libturbojpeg.so
     - uses: test/tw/ldd-check
-      with:
-        packages: libjpeg-turbo
     - name: "Test library linking"
       runs: |
         cat > test.c << 'EOF'

--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -60,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/liblbfgs.yaml
+++ b/liblbfgs.yaml
@@ -55,9 +55,7 @@ subpackages:
         - liblbfgs
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: false
@@ -65,6 +63,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -143,9 +143,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: micromamba
     dependencies:
@@ -191,10 +189,6 @@ test:
         micromamba --help
         bash -c "micromamba shell init -s bash -p ~/micromamba; source ~/.bashrc; micromamba activate; micromamba install python=3.11 requests -c conda-forge"
     - uses: test/tw/ldd-check
-      with:
-        packages: libmamba
     - runs: |
         mamba-package --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
