### PR TITLE
tw/ldd-check cleanup batch 25

### DIFF
--- a/lean4.yaml
+++ b/lean4.yaml
@@ -84,6 +84,4 @@ test:
         #eval add 2 3
         EOF
         lean simple.lean
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libassuan.yaml
+++ b/libassuan.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libassuan-dev
 
   - name: libassuan-doc
     pipeline:
@@ -64,5 +62,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libassuan

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -56,8 +56,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libavif-dev
 
   - name: libavif-apps
     pipeline:
@@ -82,5 +80,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libavif

--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libbpf-dev
 
 update:
   enabled: true
@@ -69,8 +67,6 @@ test:
       runs: |
         test -f /usr/include/bpf/libbpf.h
     - uses: test/tw/ldd-check
-      with:
-        packages: libbpf
     - name: "Check libelf.so library"
       runs: |
         test -f /usr/lib64/libbpf.so

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -58,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -43,8 +43,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libcap-dev
 
   - name: libcap-utils
     description: various utilities included with libcap
@@ -88,6 +86,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libcld2.yaml
+++ b/libcld2.yaml
@@ -109,6 +109,4 @@ test:
         echo 'int main() { const char* text = "Hello, this is a language detection test."; bool is_plain_text = true; bool is_reliable = false; CLD2::Language lang = CLD2::DetectLanguage(text, strlen(text), is_plain_text, &is_reliable); std::cout << "Detected language: " << CLD2::LanguageCode(lang) << std::endl; return 0; }' >> detect_test.cpp
         g++ -I$INCLUDE_DIR detect_test.cpp -o detect_binary -lcld2
         ./detect_binary | grep -q "en"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdbi-dev
 
 update:
   enabled: true
@@ -52,5 +50,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libdbi

--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -55,8 +55,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdrm-dev
 
 update:
   enabled: true
@@ -80,5 +78,3 @@ test:
         modetest --help
         vbltest --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libdrm

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -57,9 +57,7 @@ subpackages:
     test:
       pipeline:
         - runs: stat /usr/lib/libdwarfp.so.${{package.version}}
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libdwarf-dev
     pipeline:
@@ -69,8 +67,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdwarf-dev
     dependencies:
       runtime:
         - libdwarf
@@ -105,8 +101,6 @@ test:
   pipeline:
     - runs: stat /usr/lib/libdwarf.so.${{package.version}}
     - uses: test/tw/ldd-check
-      with:
-        packages: libdwarf
 
 update:
   enabled: true

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -43,8 +43,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libeconf-dev
 
 update:
   enabled: true
@@ -56,8 +54,6 @@ test:
   pipeline:
     - uses: test/pkgconf
     - uses: test/tw/ldd-check
-      with:
-        packages: libeconf
     - name: "Verify econftool availability"
       runs: |
         econftool --help

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -53,8 +53,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libedit-dev
 
 update:
   enabled: false
@@ -66,5 +64,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libedit

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -72,6 +72,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libfaketime.yaml
+++ b/libfaketime.yaml
@@ -27,9 +27,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - runs: |
         faketime '2023-02-01' date +%Y-%m-%d | grep 2023-02-01
 

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -90,6 +90,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
