### PR TITLE
tw/ldd-check cleanup batch 27

### DIFF
--- a/imath.yaml
+++ b/imath.yaml
@@ -51,9 +51,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: imath-dev
+        - uses: test/tw/ldd-check
 
   - name: py3-imath
     pipeline:

--- a/imlib2.yaml
+++ b/imlib2.yaml
@@ -68,6 +68,4 @@ test:
         imlib2_load version
         imlib2_conv --help
         imlib2_load help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/inih.yaml
+++ b/inih.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: inih-dev
 
   - name: inih-static
     description: inih static
@@ -68,6 +66,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/iniparser.yaml
+++ b/iniparser.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: iniparser-dev
 
   - name: "iniparser-doc"
     description: "iniparser documentation"
@@ -72,5 +70,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: iniparser

--- a/iperf3.yaml
+++ b/iperf3.yaml
@@ -77,5 +77,3 @@ test:
         iperf3 --version
         iperf3 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: iperf3

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -87,9 +87,7 @@ subpackages:
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-nft-multi
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -115,8 +113,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: iptables-dev
     dependencies:
       runtime:
         - merged-sbin
@@ -136,9 +132,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/xtables/libip6* usr/lib/xtables/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             ip6tables --version
             ip6tables --help
@@ -212,6 +206,4 @@ test:
         iptables-nft-restore --help
         iptables-restore --help
         iptables-translate --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/isa-l.yaml
+++ b/isa-l.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: isa-l-dev
 
   - name: isa-l-doc
     pipeline:
@@ -70,8 +68,6 @@ test:
         igzip --version
         igzip --help
     - uses: test/tw/ldd-check
-      with:
-        packages: isa-l
     - name: Compare igzip to gzip
       runs: |
         time igzip -3 -n < $(which kubectl) > igzip.gz

--- a/isl.yaml
+++ b/isl.yaml
@@ -62,6 +62,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/jack.yaml
+++ b/jack.yaml
@@ -87,6 +87,4 @@ test:
     - runs: |
         jackd --version
         jackd --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/jansson.yaml
+++ b/jansson.yaml
@@ -46,8 +46,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: jansson-dev
 
 update:
   enabled: true
@@ -58,5 +56,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: jansson

--- a/java-gcj-compat.yaml
+++ b/java-gcj-compat.yaml
@@ -81,9 +81,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/jitterentropy-library.yaml
+++ b/jitterentropy-library.yaml
@@ -61,8 +61,6 @@ test:
       runs: |
         test "$(readlink /usr/lib/libjitterentropy.so.${{vars.major-version}})" = "libjitterentropy.so.${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: jitterentropy-library
     - name: Check library functionality
       runs: |
         cat <<EOF > test.c

--- a/jq.yaml
+++ b/jq.yaml
@@ -78,6 +78,4 @@ test:
     - name: Using jq to transform JSON structure
       runs: |
         echo '[{"id":1,"name":"John"},{"id":2,"name":"Jane"}]' | jq '{users: map({userId: .id, userName: .name})}' | grep -E '"userId": 1|"userId": 2' || exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -74,6 +74,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/jvmkill.yaml
+++ b/jvmkill.yaml
@@ -35,6 +35,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
