### PR TITLE
tw/ldd-check cleanup batch 28

### DIFF
--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -172,6 +172,4 @@ test:
         gtk-launch --help
         gtk3-demo --help
         gtk3-widget-factory --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -184,6 +184,4 @@ test:
         gtk4-launch --version
         gtk4-update-icon-cache --help
         gtk4-launch --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -90,9 +90,7 @@ subpackages:
           rm -f ${{targets.destdir}}/usr/lib/libguac-client-${{range.key}}.*
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: guacamole-server-dev
     description: guacamole-server development files
@@ -128,9 +126,7 @@ test:
         expected_output: |
           istening on host
           Guacamole proxy daemon.*version ${{package.version}}
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/guile.yaml
+++ b/guile.yaml
@@ -90,9 +90,7 @@ subpackages:
     description: guile readline
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -82,9 +82,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*icu.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: Harfbuzz ICU support library
 
   - name: harfbuzz-utils
@@ -128,8 +126,6 @@ test:
         - ttf-dejavu
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
     - name: "Test basic text shaping"
       runs: |
         hb-view --font-file=/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf \

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -95,9 +95,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: hdf5-dev
+        - uses: test/tw/ldd-check
 
   - name: 'hdf5-tools'
     description: 'hdf5 tools'
@@ -144,15 +142,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/${{range.value}}.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -82,9 +82,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: heimdal-libs
+        - uses: test/tw/ldd-check
 
   - name: "heimdal-doc"
     description: "heimdal manpages"

--- a/helix.yaml
+++ b/helix.yaml
@@ -48,6 +48,4 @@ test:
     - runs: |
         hx --version
         hx --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/highway.yaml
+++ b/highway.yaml
@@ -44,9 +44,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libhwy_contrib
     pipeline:
@@ -55,9 +53,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy_contrib.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libhwy_test
     pipeline:
@@ -66,9 +62,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy_test.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: highway-dev
     pipeline:

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -41,8 +41,6 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/hunspell.yaml
+++ b/hunspell.yaml
@@ -40,9 +40,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhunspell-*.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: hunspell-dev
     pipeline:

--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -118,6 +118,4 @@ test:
           hwloc-dump-hwdata --version
           hwloc-dump-hwdata --help
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -121,5 +121,3 @@ test:
         i2cset -V
         i2ctransfer -V
     - uses: test/tw/ldd-check
-      with:
-        packages: i2c-tools

--- a/icu.yaml
+++ b/icu.yaml
@@ -78,8 +78,6 @@ subpackages:
             icu-config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: icu-dev
 
   - name: icu-libs
     description: International Components for Unicode library (libs)
@@ -94,9 +92,7 @@ subpackages:
         - icu-data-full
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: icu-data-full
     description: Full ICU data
@@ -158,8 +154,6 @@ test:
         gencmn help
         gensprep version
     - uses: test/tw/ldd-check
-      with:
-        packages: icu
     - name: "Test basic character conversion"
       runs: |
         # Test UTF-8 to ASCII conversion with skip callback

--- a/imagemagick-7.yaml
+++ b/imagemagick-7.yaml
@@ -132,5 +132,3 @@ test:
         magick-script --help
         montage --help
     - uses: test/tw/ldd-check
-      with:
-        packages: imagemagick-7


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
