### PR TITLE
tw/ldd-check cleanup batch 30

### DIFF
--- a/gengetopt.yaml
+++ b/gengetopt.yaml
@@ -133,9 +133,7 @@ test:
           Options passed:
           String option: hello
           Integer option: 1234
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/geos-3.13.yaml
+++ b/geos-3.13.yaml
@@ -130,5 +130,3 @@ test:
         geosop -v
         geosop --help
     - uses: test/tw/ldd-check
-      with:
-        packages: geos-3.13

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -64,9 +64,7 @@ subpackages:
     description: gettext dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: gettext-dev
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -124,6 +122,4 @@ test:
         ngettext --help
         recode-sr-latin --help
         xgettext --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -90,6 +90,4 @@ test:
       runs: |
         output=$(ggshield api-status 2>&1 || true)
         echo "$output" | grep "Error: A GitGuardian API key is needed to use ggshield."
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -129,9 +129,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: ghostscript-dev
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -172,6 +170,4 @@ test:
         ps2ascii --help
         ps2epsi --help
         unix-lpr.sh --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/glib.yaml
+++ b/glib.yaml
@@ -167,5 +167,3 @@ test:
         gio-querymodules --help
         glib-compile-schemas --help
     - uses: test/tw/ldd-check
-      with:
-        packages: glib

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -558,9 +558,7 @@ subpackages:
         - runs: |
             sotruss --version
             sotruss --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -598,9 +596,7 @@ subpackages:
         - runs: |
             makedb --version
             makedb --help
-        - uses: test/ldd-check
-          with:
-            packages: nss-db
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -614,9 +610,7 @@ subpackages:
           mv "${{targets.destdir}}"/lib/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: nss-hesiod
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -754,9 +748,7 @@ test:
         ldconfig --help
         ld.so --version
         ld.so --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Confirm that we're still compatible with current gcc
       runs: |
         # This was a problem due to some legacy fix-includes in gcc that interfered

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -65,9 +65,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libglslang.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: aom libs
 
   - name: glslang-dev

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gmp-dev
 
 update:
   enabled: true
@@ -60,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gnu-libiconv.yaml
+++ b/gnu-libiconv.yaml
@@ -81,5 +81,3 @@ test:
         gnu-iconv --version
         gnu-iconv --help
     - uses: test/tw/ldd-check
-      with:
-        packages: gnu-libiconv

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -92,8 +92,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gnutls-dev
 
   - name: gnutls-utils
     pipeline:
@@ -126,9 +124,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*xx.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: The C++ interface to GnuTLS
 
 update:
@@ -139,5 +135,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: gnutls

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -144,8 +144,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gobject-introspection-dev
 
 update:
   enabled: true
@@ -156,6 +154,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -62,8 +62,6 @@ test:
         google-authenticator --version || exit 1
         google-authenticator --help
     - uses: test/tw/ldd-check
-      with:
-        packages: google-authenticator
     - name: Init new key test
       runs: |
         yes -1 | google-authenticator --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -111,9 +111,7 @@ test:
         git-credential-gcloud.sh version
         git-credential-gcloud.sh --help
         gsutil help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -59,9 +59,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-minimal
     description: tcmalloc minimal
@@ -71,9 +69,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_minimal.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-debug
     description: tcmalloc debug
@@ -83,9 +79,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_debug.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-minimal-debug
     description: tcmalloc minimal debug
@@ -95,9 +89,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_minimal_debug.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-profiler
     description: tcmalloc profiler
@@ -107,9 +99,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_and_profiler.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: gperftools-dev
     description: gperftools dev


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
