### PR TITLE
tw/ldd-check cleanup batch 31

### DIFF
--- a/fontforge.yaml
+++ b/fontforge.yaml
@@ -171,5 +171,3 @@ test:
         sfddiff --help
         woff --help
     - uses: test/tw/ldd-check
-      with:
-        packages: fontforge

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -61,8 +61,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: freetds-dev
 
   - name: freetds-doc
     description: freetds documentation
@@ -92,8 +90,6 @@ test:
         tsql -C
         fisql -v
     - uses: test/tw/ldd-check
-      with:
-        packages: freetds
     - name: Verify tsql config
       runs: |
         tsql -C | grep -q -E "iconv library:\s+yes"

--- a/frr-10.2.yaml
+++ b/frr-10.2.yaml
@@ -118,5 +118,3 @@ test:
         /usr/lib/frr/bgpd --version | grep ${{package.version}}
         /usr/lib/frr/bfdd --version | grep ${{package.version}}
     - uses: test/tw/ldd-check
-      with:
-        packages: frr-10.2

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -113,5 +113,3 @@ test:
     - runs: |
         fusermount --version
     - uses: test/tw/ldd-check
-      with:
-        packages: fuse2

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -86,9 +86,7 @@ subpackages:
     description: fuse3 libs
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: fuse3-libs
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -50,6 +50,4 @@ test:
         gawk --help
         gawk-5.3.1 --help
         gawkbug --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -164,9 +164,7 @@ subpackages:
       no-provides: true
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: 'libstdc++-11-dev'
     dependencies:
@@ -187,9 +185,7 @@ subpackages:
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: 'gcc-11-default'
     description: 'Use GCC 11 as system gcc'
@@ -275,8 +271,6 @@ test:
         lto-dump-11 --version
         lto-dump-11 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: gcc-11
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -296,9 +296,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc-12
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -290,9 +290,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc-13
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -331,6 +331,4 @@ test:
         gcov-tool-6.5 --help
     # Will fail https://github.com/wolfi-dev/os/issues/34009
     # - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -158,9 +158,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/*++.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libstdc++
+        - uses: test/tw/ldd-check
 
   - name: 'libstdc++-dev'
     pipeline:
@@ -183,9 +181,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libquadmath
+        - uses: test/tw/ldd-check
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"
@@ -195,9 +191,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgfortran.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgfortran
+        - uses: test/tw/ldd-check
 
   - name: "gfortran"
     description: "GNU Fortran Compiler"
@@ -234,9 +228,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgccjit.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgccjit
+        - uses: test/tw/ldd-check
 
   - name: "libgccjit-dev"
     description: "GCC JIT library headers"
@@ -263,9 +255,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgomp.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgomp
+        - uses: test/tw/ldd-check
 
   - name: "libgcc"
     description: "GCC runtime library"
@@ -275,9 +265,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgcc_s.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgcc
+        - uses: test/tw/ldd-check
 
   - name: "libatomic"
     description: "GCC atomic library"
@@ -287,9 +275,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libatomic.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libatomic
+        - uses: test/tw/ldd-check
 
   - name: "libgo"
     description: "GCC go runtime library"
@@ -299,9 +285,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgo.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgo
+        - uses: test/tw/ldd-check
 
   - name: "gcc-go"
     description: "GCC go compiler"
@@ -408,9 +392,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gd.yaml
+++ b/gd.yaml
@@ -71,9 +71,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libgd.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -73,6 +73,4 @@ test:
         gdbserver --version
         gdb --help
         gdbserver --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -44,8 +44,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: gdbm-dev
 
   - name: gdbm-doc
     description: gdbm docs
@@ -71,6 +69,4 @@ test:
         gdbm_dump --help
         gdbm_load --help
         gdbmtool --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -92,6 +92,4 @@ test:
         gdk-pixbuf-csource --help
         gdk-pixbuf-pixdata --help
         gdk-pixbuf-query-loaders --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
