### PR TITLE
tw/ldd-check cleanup batch 32

### DIFF
--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -101,6 +101,4 @@ test:
         erlc hello.erl
 
         erl -noshell -pa . -eval "hello:hello_wolfi()." -s init stop
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/erlang-27.yaml
+++ b/erlang-27.yaml
@@ -112,6 +112,4 @@ test:
         erlc hello.erl
 
         erl -noshell -pa . -eval "hello:hello_wolfi()." -s init stop
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/eudev.yaml
+++ b/eudev.yaml
@@ -81,9 +81,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libudev.so.*  ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: Dynamic library to access udev device information
 
   - name: eudev-netifnames

--- a/execline.yaml
+++ b/execline.yaml
@@ -71,5 +71,3 @@ test:
         eltest --help
         withstdinas help
     - uses: test/tw/ldd-check
-      with:
-        packages: execline

--- a/expat.yaml
+++ b/expat.yaml
@@ -42,8 +42,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: expat-dev
 
   - name: "libexpat1"
     description: "libexpat shared library"
@@ -53,9 +51,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libexpat1
+        - uses: test/tw/ldd-check
 
   - name: expat-doc
     description: expat docs
@@ -112,9 +108,7 @@ test:
 
         gcc -o test test.c -lexpat
         ./test
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: "Verify XML parsing functionality"
       runs: |
         cat > test.xml << EOF

--- a/falco.yaml
+++ b/falco.yaml
@@ -142,8 +142,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: falco-dev
 
 update:
   enabled: true
@@ -215,6 +213,4 @@ test:
     - name: "Check ignored events"
       runs: |
         falco -i
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -146,8 +146,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: ffmpeg-dev
 
   - name: ffmpeg-doc
     pipeline:

--- a/fftw.yaml
+++ b/fftw.yaml
@@ -102,9 +102,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfftw3f*.so* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: fftw-long-double-libs
     pipeline:
@@ -113,9 +111,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfftw3l*.so* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: fftw-double-libs
     pipeline:
@@ -124,9 +120,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfftw3*.so* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   release-monitor:

--- a/file.yaml
+++ b/file.yaml
@@ -73,9 +73,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/misc "${{targets.subpkgdir}}"/usr/share
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "file-doc"
     description: "file documentation"

--- a/flac.yaml
+++ b/flac.yaml
@@ -64,9 +64,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libFLAC.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libflac++
     pipeline:
@@ -75,9 +73,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libFLAC++.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: flac-doc
     pipeline:

--- a/flex.yaml
+++ b/flex.yaml
@@ -57,8 +57,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: flex-dev
 
   - name: "libfl2"
     description: "flex scanner library"
@@ -68,9 +66,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfl.so* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: flex-doc
     description: flex docs

--- a/fluent-bit-3.2.yaml
+++ b/fluent-bit-3.2.yaml
@@ -126,5 +126,3 @@ test:
         fluent-bit --help
         luajit -v
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}

--- a/fluent-bit-plugin-loki.yaml
+++ b/fluent-bit-plugin-loki.yaml
@@ -73,9 +73,7 @@ test:
         done
         echo "Timeout: 'Starting fluent-bit-go-loki' not found in logs"
         exit 1
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/fmt.yaml
+++ b/fmt.yaml
@@ -69,5 +69,3 @@ test:
         g++ -o test_fmt test_fmt.cc -lfmt
         ./test_fmt |grep "hello world"
     - uses: test/tw/ldd-check
-      with:
-        packages: fmt

--- a/fontconfig.yaml
+++ b/fontconfig.yaml
@@ -86,9 +86,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfontconfig.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: fontconfig-dev
     pipeline:
@@ -98,8 +96,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: fontconfig-dev
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
