### PR TITLE
tw/ldd-check cleanup batch 34

### DIFF
--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -368,5 +368,3 @@ test:
         clamsubmit --version
         clamsubmit --help
     - uses: test/tw/ldd-check
-      with:
-        packages: clamav-1.4

--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -334,5 +334,3 @@ test:
         clang-15 --version
         clang-15 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: clang-15

--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -92,11 +92,7 @@ test:
         normalizer --version
         normalizer --help
     - uses: test/tw/ldd-check
-      with:
-        packages: confluent-docker-utils
     - uses: python/import
       with:
         import: confluent.docker_utils
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -72,6 +72,4 @@ test:
         conntrackd --version
         conntrack --help
         conntrackd --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -302,6 +302,4 @@ test:
         who --help
         whoami --help
         yes --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -101,9 +101,7 @@ test:
         - curl
         - jq
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: CouchDB Start Server
       uses: test/daemon-check-output
       with:

--- a/crfsuite.yaml
+++ b/crfsuite.yaml
@@ -53,9 +53,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -142,6 +142,4 @@ test:
         cryptsetup benchmark --pbkdf pbkdf2 --hash sha256
         cryptsetup benchmark --pbkdf argon2i
         cryptsetup benchmark --pbkdf argon2id
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cups.yaml
+++ b/cups.yaml
@@ -86,9 +86,7 @@ subpackages:
           mv ${{targets.destdir}}/etc/cups ${{targets.subpkgdir}}/etc
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ipptool
     description: Perform internet printing protocol requests

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -74,9 +74,7 @@ subpackages:
           strip "${{targets.subpkgdir}}"/usr/lib/libcurl.so.*
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/curl.yaml
+++ b/curl.yaml
@@ -97,9 +97,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libcurl-openssl4
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -89,8 +89,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: cyrus-sasl-dev
 
   - name: "cyrus-sasl-doc"
     description: "cyrus-sasl manpages"
@@ -114,6 +112,4 @@ test:
         saslpasswd2 --version
         saslauthd --help
         sasldblistusers2 help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -45,6 +45,4 @@ test:
         cygdb --help
         cython --version
         cython --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -107,8 +107,6 @@ test:
       PYTHONPATH: ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
     - runs: |
         stat /etc/datadog-agent/conf.d/nvml.d/conf.yaml.example
         stat ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages/datadog_checks/nvml/__init__.py

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -649,6 +649,4 @@ test:
         security-agent version | grep "Security agent"
         process-agent version | grep Agent
         system-probe version | grep "System Probe"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
