### PR TITLE
tw/ldd-check cleanup batch 35

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -150,6 +150,4 @@ test:
         size --help
         strings --help
         strip --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -124,8 +124,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: bluez-dev
 
 update:
   enabled: true
@@ -161,5 +159,3 @@ test:
         mpris-proxy --help
         rfcomm --help
     - uses: test/tw/ldd-check
-      with:
-        packages: bluez

--- a/boost.yaml
+++ b/boost.yaml
@@ -147,8 +147,6 @@ test:
         b2 -v
         bcp --version
     - uses: test/tw/ldd-check
-      with:
-        packages: boost
     - name: "Test basic header compilation"
       runs: |
         cat > test.cpp << 'EOF'

--- a/botan.yaml
+++ b/botan.yaml
@@ -57,8 +57,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: botan-dev
 
 update:
   enabled: true
@@ -72,5 +70,3 @@ test:
     - runs: |
         botan --version
     - uses: test/tw/ldd-check
-      with:
-        packages: botan

--- a/brew.yaml
+++ b/brew.yaml
@@ -83,5 +83,3 @@ test:
         . /etc/profile.d/brew.sh
         HOME=/root brew --version
     - uses: test/tw/ldd-check
-      with:
-        packages: brew

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -50,9 +50,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlicommon.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlicommon1
+        - uses: test/tw/ldd-check
 
   - name: "libbrotlienc1"
     pipeline:
@@ -61,9 +59,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlienc.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlienc1
+        - uses: test/tw/ldd-check
 
   - name: "libbrotlidec1"
     pipeline:
@@ -72,9 +68,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlidec.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlidec1
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/brunsli.yaml
+++ b/brunsli.yaml
@@ -45,6 +45,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: btrfs-progs-dev
 
   - name: py3-btrfs-progs
     description: Python 3 bindings for btrfs-progs
@@ -116,6 +114,4 @@ test:
 
         # Show filesystem info
         btrfs inspect-internal dump-super test.img
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -71,9 +71,7 @@ subpackages:
           ln -s libbz2.so.1 "${{targets.subpkgdir}}/usr/lib/libbz2.so.1.0"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbz2-1
+        - uses: test/tw/ldd-check
 
   - name: "bzip2-dev"
     description: "bzip2 headers"
@@ -84,8 +82,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: bzip2-dev
 
   - name: bzip2-doc
     description: bzip2 docs

--- a/bzip3.yaml
+++ b/bzip3.yaml
@@ -48,8 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: bzip3-dev
 
   - name: libbzip3
     pipeline:
@@ -58,9 +56,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libbzip3.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bzip3-doc
     pipeline:

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: c-ares-dev
 
   - name: "c-ares-doc"
     description: "c-ares documentation"
@@ -68,5 +66,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: c-ares

--- a/cairo.yaml
+++ b/cairo.yaml
@@ -72,8 +72,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: cairo-dev
 
   - name: cairo-gobject
     # dependencies:
@@ -85,9 +83,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libcairo-gobject.so.*  ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: cairo (gobject bindings)
 
   - name: cairo-tools
@@ -190,6 +186,4 @@ test:
 
         gcc -o test_cairo_gobject test_cairo_gobject.c $(pkg-config --cflags --libs cairo-gobject)
         ./test_cairo_gobject
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -46,9 +46,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -396,6 +396,4 @@ test:
         chromedriver --help
         chromium --version
         chromium-browser --version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -78,6 +78,4 @@ test:
         getcifsacl --help
         setcifsacl -h
         cifs.idmap --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
