### PR TITLE
tw/ldd-check cleanup batch 36

### DIFF
--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -54,14 +54,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-event-stream-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -53,14 +53,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-http-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -80,8 +80,6 @@ test:
         echo "Verifying aws-c-io installation..."
         find /usr /usr/local -name 'libaws-c-io.so' || (echo "aws-c-io library not found!" && exit 1)
     - uses: test/tw/ldd-check
-      with:
-        packages: aws-c-io
     - name: "Compile and Run aws-c-io Test Program"
       runs: |
         echo "Testing aws-c-io functionality..."

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -55,8 +55,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-mqtt-dev
 
 update:
   enabled: true
@@ -77,9 +75,7 @@ test:
         - gcc
         - aws-c-mqtt-dev
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: "Compile simple MQTT test program"
       runs: |
         cat << 'EOF' > test.c

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -66,14 +66,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-s3-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -49,14 +49,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-sdkutils-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -49,14 +49,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-checksums-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -65,9 +65,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Verify aws-cli-v2 installation
       runs: |
         aws --version || exit 1

--- a/aws-crt-cpp.yaml
+++ b/aws-crt-cpp.yaml
@@ -80,6 +80,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -46,6 +46,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -46,6 +46,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -49,6 +49,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/az.yaml
+++ b/az.yaml
@@ -111,6 +111,4 @@ test:
         az interactive -h
 
         echo "Expanded command tests passed!"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -103,6 +103,4 @@ test:
         wasm-split --help
         wasm2js --version
         wasm2js --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/bind.yaml
+++ b/bind.yaml
@@ -117,9 +117,7 @@ subpackages:
     description: bind dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-libs
     dependencies:
@@ -142,9 +140,7 @@ subpackages:
     description: bind (libraries)
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-dnssec-root
     pipeline:
@@ -197,9 +193,7 @@ subpackages:
     description: The ISC DNS server plugins
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-tools
     dependencies:


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
