### PR TITLE
tw/ldd-check cleanup batch 1

### DIFF
--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -105,6 +105,4 @@ test:
         valgrind --version
         vgdb --help
         valgrind --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -1,7 +1,7 @@
 package:
   name: valgrind
   version: 3.24.0
-  epoch: 2
+  epoch: 1
   description: "Tool to help find memory-management problems in programs"
   copyright:
     - license: GPL-2.0-or-later

--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -1,7 +1,7 @@
 package:
   name: valgrind
   version: 3.24.0
-  epoch: 1
+  epoch: 2
   description: "Tool to help find memory-management problems in programs"
   copyright:
     - license: GPL-2.0-or-later

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish-modules
   version: 0.25.0
-  epoch: 3
+  epoch: 2
   description: "Collection of Varnish Cache modules (vmods) by Varnish Software"
   copyright:
     - license: BSD-2-Clause

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish-modules
   version: 0.25.0
-  epoch: 2
+  epoch: 3
   description: "Collection of Varnish Cache modules (vmods) by Varnish Software"
   copyright:
     - license: BSD-2-Clause

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -106,6 +106,4 @@ test:
           varnishd -F -f /etc/varnish/default.vcl -a :6081 -T localhost:6082 -s malloc,256m
         expected_output: "Child (.*) Started"
         timeout: 30
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.0"
-  epoch: 2
+  epoch: 1
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.0"
-  epoch: 1
+  epoch: 2
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause

--- a/wasi-sdk.yaml
+++ b/wasi-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasi-sdk
   version: "25"
-  epoch: 2
+  epoch: 1
   description: "WASI-enabled WebAssembly C/C++ toolchain"
   copyright:
     - license: Apache-2.0

--- a/wasi-sdk.yaml
+++ b/wasi-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasi-sdk
   version: "25"
-  epoch: 1
+  epoch: 2
   description: "WASI-enabled WebAssembly C/C++ toolchain"
   copyright:
     - license: Apache-2.0

--- a/wasi-sdk.yaml
+++ b/wasi-sdk.yaml
@@ -96,8 +96,6 @@ subpackages:
             llvm-config --version
             llvm-config --help
         - uses: test/tw/ldd-check
-          with:
-            packages: wasi-sdk-dev
 
 update:
   enabled: true

--- a/wasmer.yaml
+++ b/wasmer.yaml
@@ -37,9 +37,7 @@ subpackages:
           mv target/release/libwasmer.so ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/wasmer.yaml
+++ b/wasmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmer
   version: 5.0.4
-  epoch: 0
+  epoch: 1
   description: The leading WebAssembly Runtime supporting WASI and Emscripten.
   copyright:
     - license: MIT

--- a/wasmer.yaml
+++ b/wasmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmer
   version: 5.0.4
-  epoch: 1
+  epoch: 0
   description: The leading WebAssembly Runtime supporting WASI and Emscripten.
   copyright:
     - license: MIT

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -56,9 +56,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmtime
   version: "30.0.2"
-  epoch: 2
+  epoch: 1
   description: "A fast and secure runtime for WebAssembly"
   copyright:
     - license: Apache-2.0

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmtime
   version: "30.0.2"
-  epoch: 1
+  epoch: 2
   description: "A fast and secure runtime for WebAssembly"
   copyright:
     - license: Apache-2.0

--- a/wayland.yaml
+++ b/wayland.yaml
@@ -1,7 +1,7 @@
 package:
   name: wayland
   version: 1.23.1
-  epoch: 1
+  epoch: 2
   description: A computer display server protocol
   copyright:
     - license: MIT

--- a/wayland.yaml
+++ b/wayland.yaml
@@ -1,7 +1,7 @@
 package:
   name: wayland
   version: 1.23.1
-  epoch: 2
+  epoch: 1
   description: A computer display server protocol
   copyright:
     - license: MIT

--- a/wayland.yaml
+++ b/wayland.yaml
@@ -76,9 +76,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libwayland-${{range.key}}.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: wayland ${{range.key}} libs
 
 update:

--- a/x265.yaml
+++ b/x265.yaml
@@ -1,7 +1,7 @@
 package:
   name: x265
   version: "4.1"
-  epoch: 2
+  epoch: 3
   description: H.265/HEVC encoder
   copyright:
     - license: GPL-2.0-only

--- a/x265.yaml
+++ b/x265.yaml
@@ -1,7 +1,7 @@
 package:
   name: x265
   version: "4.1"
-  epoch: 3
+  epoch: 2
   description: H.265/HEVC encoder
   copyright:
     - license: GPL-2.0-only

--- a/x265.yaml
+++ b/x265.yaml
@@ -85,8 +85,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: x265-dev
 
 update:
   enabled: true

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.13.0"
-  epoch: 1
+  epoch: 0
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -63,9 +63,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib64/lib*.so.* "${{targets.subpkgdir}}"/usr/lib64
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: xfsprogs-doc
     description: "xfsprogs manpages"
@@ -140,6 +138,4 @@ test:
         mkfs.xfs xfs.img
         xfs_admin -L "TestXFS" xfs.img
         xfs_admin -l xfs.img | grep 'TestXFS'
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.13.0"
-  epoch: 0
+  epoch: 1
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.4
-  epoch: 2
+  epoch: 3
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -78,9 +78,7 @@ subpackages:
     description: xmlsec openssl plugin
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: xmlsec-openssl
+        - uses: test/tw/ldd-check
 
   - name: xmlsec-dev
     pipeline:

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.4
-  epoch: 3
+  epoch: 2
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -153,6 +153,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: "21.1.16"
-  epoch: 2
+  epoch: 3
   description: "X Server"
   copyright:
     - license: SGI-B-2.0

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: "21.1.16"
-  epoch: 3
+  epoch: 2
   description: "X Server"
   copyright:
     - license: SGI-B-2.0

--- a/zed.yaml
+++ b/zed.yaml
@@ -72,6 +72,4 @@ test:
       runs: |
         zed -h
         zed --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/zed.yaml
+++ b/zed.yaml
@@ -1,7 +1,7 @@
 package:
   name: zed
   version: "0.177.11"
-  epoch: 0
+  epoch: 1
   description: Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
   copyright:
     - license: GPL-3.0-only

--- a/zed.yaml
+++ b/zed.yaml
@@ -1,7 +1,7 @@
 package:
   name: zed
   version: "0.177.11"
-  epoch: 1
+  epoch: 0
   description: Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
   copyright:
     - license: GPL-3.0-only

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1
-  epoch: 6
+  epoch: 7
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1
-  epoch: 7
+  epoch: 6
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -89,8 +89,6 @@ subpackages:
             fi
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: zlib-dev
 
   - name: "minizip"
     description: "a library for manipulation with files from .zip archives"
@@ -123,9 +121,7 @@ test:
     - uses: test/hardening-check
       with:
         package-match: "zlib\\|minizip"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -110,9 +110,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/${{package.name}}/${{package.version}}/zsh/pcre.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/${{package.version}}/zsh
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: zsh FIXME
 
   - name: zsh-vcs
@@ -142,9 +140,7 @@ subpackages:
     description: Zftp Function System for Zsh
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -159,6 +155,4 @@ test:
         zsh-5.9 --version
         zsh --help
         zsh-5.9 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 31
+  epoch: 30
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 30
+  epoch: 31
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: zstd-dev
 
   - name: "libzstd1"
     description: "libzstd runtime libraries"
@@ -72,9 +70,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libzstd.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: "1.5.7"
-  epoch: 1
+  epoch: 2
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: "1.5.7"
-  epoch: 2
+  epoch: 1
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
