### PR TITLE
tw/ldd-check cleanup batch 2

### DIFF
--- a/tevent.yaml
+++ b/tevent.yaml
@@ -65,8 +65,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tevent-dev
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}

--- a/tevent.yaml
+++ b/tevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: tevent
   version: "0.16.2"
-  epoch: 4
+  epoch: 3
   description: The tevent library
   copyright:
     - license: LGPL-3.0-or-later

--- a/tevent.yaml
+++ b/tevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: tevent
   version: "0.16.2"
-  epoch: 3
+  epoch: 4
   description: The tevent library
   copyright:
     - license: LGPL-3.0-or-later

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -99,8 +99,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: thrift-dev
 
   - name: "libthrift"
     description: "Language-independent software stack for RPC implementation (libthrift library)"
@@ -110,9 +108,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthrift.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthrift-glib"
     description: "Language-independent software stack for RPC implementation (libthrift-glib library)"
@@ -122,9 +118,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthrift_c_glib*.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthriftnb"
     description: "Language-independent software stack for RPC implementation (libthriftnb library)"
@@ -134,9 +128,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthriftnb.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: "libthriftz"
     description: "Language-independent software stack for RPC implementation (libthriftz library)"
@@ -146,9 +138,7 @@ subpackages:
           mv /home/build/melange-out/thrift/usr/lib/libthriftz.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: 0.21.0
-  epoch: 4
+  epoch: 3
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: 0.21.0
-  epoch: 3
+  epoch: 4
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.7.0
-  epoch: 3
+  epoch: 4
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -68,8 +68,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tiff-dev
 
 update:
   enabled: true

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.7.0
-  epoch: 4
+  epoch: 3
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff

--- a/tinyxml2.yaml
+++ b/tinyxml2.yaml
@@ -2,7 +2,7 @@
 package:
   name: tinyxml2
   version: "10.1.0"
-  epoch: 0
+  epoch: 1
   description: Simple, small and efficient C++ XML parser
   copyright:
     - license: Zlib

--- a/tinyxml2.yaml
+++ b/tinyxml2.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tinyxml2-dev
 
 update:
   enabled: true

--- a/tinyxml2.yaml
+++ b/tinyxml2.yaml
@@ -2,7 +2,7 @@
 package:
   name: tinyxml2
   version: "10.1.0"
-  epoch: 1
+  epoch: 0
   description: Simple, small and efficient C++ XML parser
   copyright:
     - license: Zlib

--- a/tk.yaml
+++ b/tk.yaml
@@ -105,7 +105,5 @@ test:
         wish --help
         wish9.0 --version
         wish9.0 --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - uses: test/pkgconf

--- a/tk.yaml
+++ b/tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: tk
   version: 9.0.1
-  epoch: 2
+  epoch: 1
   description: GUI toolkit for the Tcl scripting language
   copyright:
     - license: TCL

--- a/tk.yaml
+++ b/tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: tk
   version: 9.0.1
-  epoch: 1
+  epoch: 2
   description: GUI toolkit for the Tcl scripting language
   copyright:
     - license: TCL

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: "9.2.9"
-  epoch: 0
+  epoch: 1
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -71,6 +71,4 @@ test:
         traffic_manager --version
         traffic_via --version
     - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: "9.2.9"
-  epoch: 1
+  epoch: 0
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0

--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -38,8 +38,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: tree-sitter-dev
 
 update:
   enabled: true
@@ -76,6 +74,4 @@ test:
             $(pkg-config --libs tree-sitter) \
             -o test_parser
         ./test_parser
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -1,7 +1,7 @@
 package:
   name: tree-sitter
   version: "0.25.3"
-  epoch: 1
+  epoch: 2
   description: "Incremental parsing system for programming tools"
   copyright:
     - license: MIT

--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -1,7 +1,7 @@
 package:
   name: tree-sitter
   version: "0.25.3"
-  epoch: 2
+  epoch: 1
   description: "Incremental parsing system for programming tools"
   copyright:
     - license: MIT

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "472"
-  epoch: 0
+  epoch: 1
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "472"
-  epoch: 1
+  epoch: 0
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0

--- a/trino.yaml
+++ b/trino.yaml
@@ -163,9 +163,7 @@ subpackages:
           EOF
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
+        - uses: test/tw/ldd-check
 
   - range: plugins
     name: trino-plugin-${{range.key}}
@@ -203,9 +201,7 @@ test:
     - runs: |
         trino --version
         trino --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: "test trino server"
       runs: |
         mkdir -p /usr/lib/trino/etc

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,7 +1,7 @@
 package:
   name: unbound
   version: 1.22.0
-  epoch: 2
+  epoch: 1
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,7 +1,7 @@
 package:
   name: unbound
   version: 1.22.0
-  epoch: 1
+  epoch: 2
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -65,9 +65,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*.so.* ${{targets.subpkgdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/unibilium.yaml
+++ b/unibilium.yaml
@@ -91,6 +91,4 @@ test:
 
         # Run the test program
         ./test_unibilium 2>&1 | grep -q "Failed to read terminfo"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/unibilium.yaml
+++ b/unibilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: unibilium
   version: 2.1.2
-  epoch: 4
+  epoch: 5
   description: "Terminfo parsing library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/unibilium.yaml
+++ b/unibilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: unibilium
   version: 2.1.2
-  epoch: 5
+  epoch: 4
   description: "Terminfo parsing library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/userspace-rcu.yaml
+++ b/userspace-rcu.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: userspace-rcu-dev
 
 update:
   enabled: true
@@ -88,6 +86,4 @@ test:
         grep "RCU read lock acquired" output.log
         grep "RCU read lock released" output.log
         grep "RCU thread unregistered successfully" output.log
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/userspace-rcu.yaml
+++ b/userspace-rcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: userspace-rcu
   version: "0.15.1"
-  epoch: 2
+  epoch: 1
   description: Userspace RCU (read-copy-update) library
   copyright:
     - license: LGPL-2.1-or-later

--- a/userspace-rcu.yaml
+++ b/userspace-rcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: userspace-rcu
   version: "0.15.1"
-  epoch: 1
+  epoch: 2
   description: Userspace RCU (read-copy-update) library
   copyright:
     - license: LGPL-2.1-or-later

--- a/utf8proc.yaml
+++ b/utf8proc.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: utf8proc-dev
 
 update:
   enabled: true

--- a/utf8proc.yaml
+++ b/utf8proc.yaml
@@ -2,7 +2,7 @@
 package:
   name: utf8proc
   version: 2.10.0
-  epoch: 1
+  epoch: 2
   description: Clean C library for processing UTF-8 Unicode data
   copyright:
     - license: MIT AND Unicode-TOU

--- a/utf8proc.yaml
+++ b/utf8proc.yaml
@@ -2,7 +2,7 @@
 package:
   name: utf8proc
   version: 2.10.0
-  epoch: 2
+  epoch: 1
   description: Clean C library for processing UTF-8 Unicode data
   copyright:
     - license: MIT AND Unicode-TOU

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.40.4"
-  epoch: 31
+  epoch: 32
   description: Random collection of Linux utilities
   copyright:
     - license: |-

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -113,8 +113,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: util-linux-dev
 
   - name: util-linux-doc
     pipeline:
@@ -138,9 +136,7 @@ subpackages:
     description: ${{range.value}}
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: ${{range.key}}
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-bin
@@ -420,6 +416,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.40.4"
-  epoch: 32
+  epoch: 31
   description: Random collection of Linux utilities
   copyright:
     - license: |-

--- a/utmps.yaml
+++ b/utmps.yaml
@@ -70,8 +70,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: utmps-dev
 
   - name: utmps-docs
     pipeline:

--- a/utmps.yaml
+++ b/utmps.yaml
@@ -1,7 +1,7 @@
 package:
   name: utmps
   version: 0.1.2.3
-  epoch: 22
+  epoch: 21
   description: A secure utmp/wtmp implementation
   copyright:
     - license: ISC

--- a/utmps.yaml
+++ b/utmps.yaml
@@ -1,7 +1,7 @@
 package:
   name: utmps
   version: 0.1.2.3
-  epoch: 21
+  epoch: 22
   description: A secure utmp/wtmp implementation
   copyright:
     - license: ISC

--- a/vala.yaml
+++ b/vala.yaml
@@ -1,7 +1,7 @@
 package:
   name: vala
   version: "0.56.18"
-  epoch: 0
+  epoch: 1
   description: Compiler for the GObject type system
   copyright:
     - license: LGPL-2.0-or-later

--- a/vala.yaml
+++ b/vala.yaml
@@ -76,6 +76,4 @@ test:
         vapigen --help
         vapigen-0.56 --help
     - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/vala.yaml
+++ b/vala.yaml
@@ -1,7 +1,7 @@
 package:
   name: vala
   version: "0.56.18"
-  epoch: 1
+  epoch: 0
   description: Compiler for the GObject type system
   copyright:
     - license: LGPL-2.0-or-later


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
