### PR TITLE
tw/ldd-check cleanup batch 5

### DIFF
--- a/ruby3.2-msgpack.yaml
+++ b/ruby3.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-msgpack
   version: "1.8.0"
-  epoch: 0
+  epoch: 1
   description: MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-msgpack.yaml
+++ b/ruby3.2-msgpack.yaml
@@ -95,9 +95,7 @@ test:
         puts "Streaming API test passed"
         puts "All tests passed!"
         EOF
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-msgpack.yaml
+++ b/ruby3.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-msgpack
   version: "1.8.0"
-  epoch: 1
+  epoch: 0
   description: MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-nio4r
   version: 2.7.1
-  epoch: 4
+  epoch: 5
   description: Cross-platform asynchronous I/O primitives for scalable network clients and servers. Inspired by the Java NIO API, but simplified for ease-of-use.
   copyright:
     - license: MIT

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-nio4r
   version: 2.7.1
-  epoch: 5
+  epoch: 4
   description: Cross-platform asynchronous I/O primitives for scalable network clients and servers. Inspired by the Java NIO API, but simplified for ease-of-use.
   copyright:
     - license: MIT

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -52,6 +52,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-oj.yaml
+++ b/ruby3.2-oj.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-oj
   version: "3.16.10"
-  epoch: 0
+  epoch: 1
   description: The fastest JSON parser and object serializer.
   copyright:
     - license: MIT

--- a/ruby3.2-oj.yaml
+++ b/ruby3.2-oj.yaml
@@ -55,6 +55,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-oj.yaml
+++ b/ruby3.2-oj.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-oj
   version: "3.16.10"
-  epoch: 1
+  epoch: 0
   description: The fastest JSON parser and object serializer.
   copyright:
     - license: MIT

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pg
   version: 1.5.9
-  epoch: 2
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -61,9 +61,7 @@ test:
     - name: Check pg is install
       runs: |
         echo "Is pg installed?: $(gem list -i pg)"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pg
   version: 1.5.9
-  epoch: 1
+  epoch: 2
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause

--- a/ruby3.2-psych.yaml
+++ b/ruby3.2-psych.yaml
@@ -46,9 +46,7 @@ vars:
 test:
   pipeline:
     - runs: ruby -e "require 'psych'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-psych.yaml
+++ b/ruby3.2-psych.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-psych
   version: "5.2.3"
-  epoch: 0
+  epoch: 1
   description: Psych is a YAML parser and emitter.
   copyright:
     - license: MIT

--- a/ruby3.2-psych.yaml
+++ b/ruby3.2-psych.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-psych
   version: "5.2.3"
-  epoch: 1
+  epoch: 0
   description: Psych is a YAML parser and emitter.
   copyright:
     - license: MIT

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -57,9 +57,7 @@ test:
         pumactl --version
         puma --help
         pumactl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-puma
   version: "6.6.0"
-  epoch: 0
+  epoch: 1
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-puma
   version: "6.6.0"
-  epoch: 1
+  epoch: 0
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.2-stringio.yaml
+++ b/ruby3.2-stringio.yaml
@@ -45,9 +45,7 @@ vars:
 test:
   pipeline:
     - runs: ruby -e "require 'stringio'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-stringio.yaml
+++ b/ruby3.2-stringio.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-stringio
   version: "3.1.5"
-  epoch: 1
+  epoch: 0
   description: Pseudo `IO` class from/to `String`.
   copyright:
     - license: Ruby

--- a/ruby3.2-stringio.yaml
+++ b/ruby3.2-stringio.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-stringio
   version: "3.1.5"
-  epoch: 0
+  epoch: 1
   description: Pseudo `IO` class from/to `String`.
   copyright:
     - license: Ruby

--- a/ruby3.2-strptime.yaml
+++ b/ruby3.2-strptime.yaml
@@ -58,6 +58,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.2-strptime.yaml
+++ b/ruby3.2-strptime.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-strptime
   version: 0.2.5
-  epoch: 6
+  epoch: 7
   description: a fast strptime/strftime engine which uses VM.
   copyright:
     - license: BSD-2-Clause

--- a/ruby3.2-strptime.yaml
+++ b/ruby3.2-strptime.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-strptime
   version: 0.2.5
-  epoch: 7
+  epoch: 6
   description: a fast strptime/strftime engine which uses VM.
   copyright:
     - license: BSD-2-Clause

--- a/ruby3.2-systemd-journal.yaml
+++ b/ruby3.2-systemd-journal.yaml
@@ -45,9 +45,7 @@ test:
   pipeline:
     - runs: |
         ruby -e "require 'systemd/journal'"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.2-systemd-journal.yaml
+++ b/ruby3.2-systemd-journal.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-systemd-journal
   version: "2.1.0"
-  epoch: 0
+  epoch: 1
   description: Provides the ability to navigate and read entries from the systemd journal in ruby, as well as write events to the journal.
   copyright:
     - license: MIT

--- a/ruby3.2-systemd-journal.yaml
+++ b/ruby3.2-systemd-journal.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-systemd-journal
   version: "2.1.0"
-  epoch: 1
+  epoch: 0
   description: Provides the ability to navigate and read entries from the systemd journal in ruby, as well as write events to the journal.
   copyright:
     - license: MIT

--- a/ruby3.2-yajl-ruby.yaml
+++ b/ruby3.2-yajl-ruby.yaml
@@ -69,6 +69,4 @@ var-transforms:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -61,9 +61,7 @@ subpackages:
       - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-edge
     description: Concurrent ruby edge functionality

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-concurrent-ruby
   version: "1.3.5"
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-concurrent-ruby
   version: "1.3.5"
-  epoch: 1
+  epoch: 0
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -111,9 +111,7 @@ subpackages:
           KUBERNETES_SERVICE_HOST: "127.0.0.1"
           KUBERNETES_SERVICE_PORT: 32764
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - uses: test/kwok/cluster
         # Just make sure the config is okay, kwok doesn't get us very far
         - uses: test/daemon-check-output

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 3
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 2
+  epoch: 3
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/ruby3.3-llhttp.yaml
+++ b/ruby3.3-llhttp.yaml
@@ -2,7 +2,7 @@ package:
   name: ruby3.3-llhttp
   version: 2023.03.29
   # NOTE: There are also environment variables in this melange which may have to be bumped between upgrades.
-  epoch: 1
+  epoch: 0
   description: Ruby bindings for llhttp.
   copyright:
     - license: MIT

--- a/ruby3.3-llhttp.yaml
+++ b/ruby3.3-llhttp.yaml
@@ -85,9 +85,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-ffi
     description: Ruby FFI bindings for llhttp.
@@ -120,9 +118,7 @@ subpackages:
           - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/ruby3.3-llhttp.yaml
+++ b/ruby3.3-llhttp.yaml
@@ -2,7 +2,7 @@ package:
   name: ruby3.3-llhttp
   version: 2023.03.29
   # NOTE: There are also environment variables in this melange which may have to be bumped between upgrades.
-  epoch: 0
+  epoch: 1
   description: Ruby bindings for llhttp.
   copyright:
     - license: MIT

--- a/ruby3.3-puma.yaml
+++ b/ruby3.3-puma.yaml
@@ -57,9 +57,7 @@ test:
         pumactl --version
         puma --help
         pumactl --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.3-puma.yaml
+++ b/ruby3.3-puma.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-puma
   version: "6.6.0"
-  epoch: 1
+  epoch: 0
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.3-puma.yaml
+++ b/ruby3.3-puma.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-puma
   version: "6.6.0"
-  epoch: 0
+  epoch: 1
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -61,9 +61,7 @@ subpackages:
       - uses: ruby/clean
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-edge
     description: Concurrent ruby edge functionality

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-concurrent-ruby
   version: "1.3.5"
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-concurrent-ruby
   version: "1.3.5"
-  epoch: 1
+  epoch: 0
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
