### PR TITLE
tw/ldd-check cleanup batch 16

### DIFF
--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-utils
   version: 2.8.2
-  epoch: 22
+  epoch: 21
   description: kernel-mode NFS
   copyright:
     - license: GPL-2.0-only

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-utils
   version: 2.8.2
-  epoch: 21
+  epoch: 22
   description: kernel-mode NFS
   copyright:
     - license: GPL-2.0-only

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -159,6 +159,4 @@ test:
         rpc.mountd --help
         rpc.statd --help
         showmount --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: "1.65.0"
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: "1.65.0"
-  epoch: 1
+  epoch: 0
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -70,9 +70,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libnghttp2.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libnghttp2-14
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -205,9 +205,7 @@ subpackages:
           esac
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: nginx-stable-src
     description: Nginx source code
@@ -223,9 +221,7 @@ subpackages:
           ls -latr ${{targets.contextdir}}/usr/src/nginx
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-config-compat
     description: Nginx config compatibility with upstream image

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: "1.26.3"
-  epoch: 1
+  epoch: 0
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: "1.26.3"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: "0.8.9"
-  epoch: 0
+  epoch: 1
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause

--- a/njs.yaml
+++ b/njs.yaml
@@ -93,9 +93,7 @@ test:
     - runs: |
         njs -v
         njs-debug -v
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: "0.8.9"
-  epoch: 1
+  epoch: 0
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause

--- a/nss.yaml
+++ b/nss.yaml
@@ -1,7 +1,7 @@
 package:
   name: nss
   version: "3.109"
-  epoch: 1
+  epoch: 0
   description: "Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications."
   copyright:
     - license: MPL-2.0

--- a/nss.yaml
+++ b/nss.yaml
@@ -87,9 +87,7 @@ subpackages:
         - libnspr
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libnss-dev
     pipeline:

--- a/nss.yaml
+++ b/nss.yaml
@@ -1,7 +1,7 @@
 package:
   name: nss
   version: "3.109"
-  epoch: 0
+  epoch: 1
   description: "Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications."
   copyright:
     - license: MPL-2.0

--- a/ntfs-3g.yaml
+++ b/ntfs-3g.yaml
@@ -86,9 +86,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: ntfs-3g-dev
+        - uses: test/tw/ldd-check
 
   - name: ntfs-3g-libs
     pipeline:
@@ -97,9 +95,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin

--- a/ntfs-3g.yaml
+++ b/ntfs-3g.yaml
@@ -2,7 +2,7 @@
 package:
   name: ntfs-3g
   version: 2022.10.3
-  epoch: 20
+  epoch: 21
   description: Stable, full-featured, read-write NTFS
   copyright:
     - license: GPL-2.0-only

--- a/ntfs-3g.yaml
+++ b/ntfs-3g.yaml
@@ -2,7 +2,7 @@
 package:
   name: ntfs-3g
   version: 2022.10.3
-  epoch: 21
+  epoch: 20
   description: Stable, full-featured, read-write NTFS
   copyright:
     - license: GPL-2.0-only

--- a/ocaml.yaml
+++ b/ocaml.yaml
@@ -89,9 +89,7 @@ subpackages:
             ocamlobjinfo.byte --help
             ocamlopt.byte --version
             ocamlopt.byte --help
-        - uses: test/ldd-check
-          with:
-            packages: ${{package.name}}
+        - uses: test/tw/ldd-check
 
   - name: "ocaml-compiler-libs"
     pipeline:
@@ -155,6 +153,4 @@ test:
         ocamlopt.opt --help
         ocamloptp --help
         ocamlprof version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ocaml.yaml
+++ b/ocaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: ocaml
   version: 5.3.0
-  epoch: 1
+  epoch: 2
   description: "The core OCaml system: compilers, runtime system, base libraries"
   copyright:
     - license: LGPL-2.1-only WITH OCaml-LGPL-linking-exception

--- a/ocaml.yaml
+++ b/ocaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: ocaml
   version: 5.3.0
-  epoch: 2
+  epoch: 1
   description: "The core OCaml system: compilers, runtime system, base libraries"
   copyright:
     - license: LGPL-2.1-only WITH OCaml-LGPL-linking-exception

--- a/odbc-cpp-wrapper.yaml
+++ b/odbc-cpp-wrapper.yaml
@@ -53,6 +53,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/odbc-cpp-wrapper.yaml
+++ b/odbc-cpp-wrapper.yaml
@@ -2,7 +2,7 @@
 package:
   name: odbc-cpp-wrapper
   version: "1.1"
-  epoch: 1
+  epoch: 2
   description: An object-oriented C++-wrapper of the ODBC API
   copyright:
     - license: Apache-2.0

--- a/odbc-cpp-wrapper.yaml
+++ b/odbc-cpp-wrapper.yaml
@@ -2,7 +2,7 @@
 package:
   name: odbc-cpp-wrapper
   version: "1.1"
-  epoch: 2
+  epoch: 1
   description: An object-oriented C++-wrapper of the ODBC API
   copyright:
     - license: Apache-2.0

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -52,8 +52,6 @@ subpackages:
             onig-config --version
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: oniguruma-dev
 
 update:
   enabled: true
@@ -64,6 +62,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -1,7 +1,7 @@
 package:
   name: oniguruma
   version: 6.9.10
-  epoch: 1
+  epoch: 2
   description: "a regular expressions library"
   copyright:
     - license: BSD-2-Clause

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -1,7 +1,7 @@
 package:
   name: oniguruma
   version: 6.9.10
-  epoch: 2
+  epoch: 1
   description: "a regular expressions library"
   copyright:
     - license: BSD-2-Clause

--- a/openblas.yaml
+++ b/openblas.yaml
@@ -2,7 +2,7 @@
 package:
   name: openblas
   version: "0.3.29"
-  epoch: 1
+  epoch: 2
   description: fast BSD-licensed BLAS based on gotoBLAS2, with LAPACK
   copyright:
     - license: BSD-3-Clause

--- a/openblas.yaml
+++ b/openblas.yaml
@@ -2,7 +2,7 @@
 package:
   name: openblas
   version: "0.3.29"
-  epoch: 2
+  epoch: 1
   description: fast BSD-licensed BLAS based on gotoBLAS2, with LAPACK
   copyright:
     - license: BSD-3-Clause

--- a/openblas.yaml
+++ b/openblas.yaml
@@ -81,9 +81,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: openblas-dev
+        - uses: test/tw/ldd-check
 
   - name: openblas-doc
     pipeline:
@@ -103,9 +101,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblapack.so* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: liblapacke
     pipeline:
@@ -114,9 +110,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblapacke.so* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/openh264.yaml
+++ b/openh264.yaml
@@ -1,7 +1,7 @@
 package:
   name: openh264
   version: "2.6.0"
-  epoch: 1
+  epoch: 2
   description: OpenH264 is a codec library which supports H.264 encoding and decoding
   copyright:
     - license: BSD-2-Clause

--- a/openh264.yaml
+++ b/openh264.yaml
@@ -1,7 +1,7 @@
 package:
   name: openh264
   version: "2.6.0"
-  epoch: 2
+  epoch: 1
   description: OpenH264 is a codec library which supports H.264 encoding and decoding
   copyright:
     - license: BSD-2-Clause

--- a/openh264.yaml
+++ b/openh264.yaml
@@ -40,8 +40,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: openh264-dev
 
 update:
   enabled: true

--- a/openipmi.yaml
+++ b/openipmi.yaml
@@ -1,7 +1,7 @@
 package:
   name: openipmi
   version: 2.0.36
-  epoch: 3
+  epoch: 2
   description: IPMI (Intelligent Platform Management Interface) library and tools
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later OR BSD-3-Clause

--- a/openipmi.yaml
+++ b/openipmi.yaml
@@ -1,7 +1,7 @@
 package:
   name: openipmi
   version: 2.0.36
-  epoch: 2
+  epoch: 3
   description: IPMI (Intelligent Platform Management Interface) library and tools
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later OR BSD-3-Clause

--- a/openipmi.yaml
+++ b/openipmi.yaml
@@ -81,9 +81,7 @@ subpackages:
             ipmi_sim --version
             ipmi_sim --help
             ipmilan --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -293,6 +293,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 6
+  epoch: 7
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 7
+  epoch: 6
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later

--- a/openjpeg.yaml
+++ b/openjpeg.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjpeg
   version: 2.5.3
-  epoch: 1
+  epoch: 2
   description: "Open-source implementation of JPEG2000 image codec"
   copyright:
     - license: BSD-2-Clause

--- a/openjpeg.yaml
+++ b/openjpeg.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjpeg
   version: 2.5.3
-  epoch: 2
+  epoch: 1
   description: "Open-source implementation of JPEG2000 image codec"
   copyright:
     - license: BSD-2-Clause

--- a/openjpeg.yaml
+++ b/openjpeg.yaml
@@ -53,8 +53,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: openjpeg-dev
 
   - name: openjpeg-tools
     pipeline:


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
