### PR TITLE
tw/ldd-check cleanup batch 18

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.17.3"
-  epoch: 2
+  epoch: 3
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -414,9 +414,7 @@ test:
     environment:
       LS_JAVA_HOME: /usr/lib/jvm/default-jvm
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Ensure default plugins were actually installed
       runs: |
         for plugin in ${{vars.separately-packaged-plugins}}

--- a/lsof.yaml
+++ b/lsof.yaml
@@ -63,8 +63,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: lsof-dev
 
   - name: lsof-doc
     pipeline:

--- a/lsof.yaml
+++ b/lsof.yaml
@@ -1,7 +1,7 @@
 package:
   name: lsof
   version: 4.99.4
-  epoch: 2
+  epoch: 3
   description: List Open Files
   copyright:
     - license: lsof

--- a/lua-cjson.yaml
+++ b/lua-cjson.yaml
@@ -42,6 +42,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lua-cjson.yaml
+++ b/lua-cjson.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-cjson
   version: 2.1.0.12
-  epoch: 5
+  epoch: 6
   description: "Lua CJSON is a fast JSON encoding/parsing module for Lua"
   copyright:
     - license: MIT

--- a/lua-lpeg.yaml
+++ b/lua-lpeg.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-lpeg
   version: 1.1.0
-  epoch: 2
+  epoch: 3
   description: "Pattern-matching library for Lua"
   copyright:
     - license: MIT

--- a/lua-lpeg.yaml
+++ b/lua-lpeg.yaml
@@ -58,9 +58,7 @@ subpackages:
             ${{targets.contextdir}}/usr/share/lua/5.1/re.lua
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -69,6 +67,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lua-luv.yaml
+++ b/lua-luv.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-luv
   version: "1.50.0.1"
-  epoch: 1
+  epoch: 2
   description: "Bare libuv bindings for Lua"
   copyright:
     - license: Apache-2.0

--- a/lua-luv.yaml
+++ b/lua-luv.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: lua-luv-dev
 
 update:
   enabled: true
@@ -75,6 +73,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lua-mpack.yaml
+++ b/lua-mpack.yaml
@@ -53,9 +53,7 @@ subpackages:
             install
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/lua-mpack.yaml
+++ b/lua-mpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-mpack
   version: 1.0.12
-  epoch: 0
+  epoch: 1
   description: "Libmpack bindings for Lua"
   copyright:
     - license: MIT

--- a/lua-resty-balancer.yaml
+++ b/lua-resty-balancer.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-balancer
   version: 0.05
-  epoch: 5
+  epoch: 6
   description: "A generic consistent hash implementation for OpenResty/Lua"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-balancer.yaml
+++ b/lua-resty-balancer.yaml
@@ -36,6 +36,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lua5.3-lzlib.yaml
+++ b/lua5.3-lzlib.yaml
@@ -40,6 +40,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lua5.3-lzlib.yaml
+++ b/lua5.3-lzlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua5.3-lzlib
   version: 0.4.3
-  epoch: 5
+  epoch: 6
   description: "zlib binding for lua"
   copyright:
     - license: MIT

--- a/lua5.3.yaml
+++ b/lua5.3.yaml
@@ -149,9 +149,7 @@ subpackages:
           packages:
             - apk-tools
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             set +x
             mm=${{vars.luaMM}}

--- a/lua5.3.yaml
+++ b/lua5.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua5.3
   version: 5.3.6
-  epoch: 6
+  epoch: 7
   description: Powerful light-weight programming language
   copyright:
     - license: MIT

--- a/lua5.4.yaml
+++ b/lua5.4.yaml
@@ -148,9 +148,7 @@ subpackages:
           packages:
             - apk-tools
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
         - runs: |
             set +x
             mm=${{vars.luaMM}}

--- a/lua5.4.yaml
+++ b/lua5.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua5.4
   version: 5.4.7
-  epoch: 2
+  epoch: 3
   description: Powerful light-weight programming language
   copyright:
     - license: MIT

--- a/luajit.yaml
+++ b/luajit.yaml
@@ -1,7 +1,7 @@
 package:
   name: luajit
   version: 2.1_p20210510
-  epoch: 10
+  epoch: 11
   description: OpenResty's branch of LuaJIT
   copyright:
     - license: MIT

--- a/luajit.yaml
+++ b/luajit.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: luajit-dev
 
   - name: luajit-doc
     description: luajit docs
@@ -66,6 +64,4 @@ test:
         lua -v
         luajit -v
         luajit-2.1.0-beta3 -v
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lvm2.yaml
+++ b/lvm2.yaml
@@ -2,7 +2,7 @@
 package:
   name: lvm2
   version: "2.03.31"
-  epoch: 20
+  epoch: 21
   description: Logical Volume Manager 2 utilities
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/lvm2.yaml
+++ b/lvm2.yaml
@@ -102,9 +102,7 @@ subpackages:
           mv ${{targets.destdir}}/lib/libdevmapper.so.* ${{targets.subpkgdir}}/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -117,9 +115,7 @@ subpackages:
           mv ${{targets.destdir}}/lib/libdevmapper-event.so.* ${{targets.subpkgdir}}/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -131,9 +127,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -279,6 +273,4 @@ test:
         dmsetup.static --help
         dmstats.static --help
         lvm.static version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lz4
   version: 1.10.0
-  epoch: 2
+  epoch: 3
   description: "lossless high performance compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -63,9 +63,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblz4.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: liblz4-1
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/man-db.yaml
+++ b/man-db.yaml
@@ -82,6 +82,4 @@ test:
         whatis --help
         accessdb --version
         accessdb --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/man-db.yaml
+++ b/man-db.yaml
@@ -2,7 +2,7 @@
 package:
   name: man-db
   version: 2.13.0
-  epoch: 1
+  epoch: 2
   description: The man command and related utilities for examining on-line help files
   copyright:
     - license: GPL-2.0-or-later

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -74,8 +74,6 @@ subpackages:
             mysql_config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: mariadb-connector-c-dev
 
 update:
   enabled: true
@@ -84,6 +82,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: "3.4.4"
-  epoch: 1
+  epoch: 2
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
