### PR TITLE
tw/ldd-check cleanup batch 22

### DIFF
--- a/libpciaccess.yaml
+++ b/libpciaccess.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpciaccess
   version: 0.18.1
-  epoch: 4
+  epoch: 3
   description: X11 PCI access library
   copyright:
     - license: X11

--- a/libpciaccess.yaml
+++ b/libpciaccess.yaml
@@ -48,8 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libpciaccess-dev
 
   - name: libpciaccess-doc
     pipeline:
@@ -64,5 +62,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libpciaccess

--- a/libpciaccess.yaml
+++ b/libpciaccess.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpciaccess
   version: 0.18.1
-  epoch: 3
+  epoch: 4
   description: X11 PCI access library
   copyright:
     - license: X11

--- a/libpipeline.yaml
+++ b/libpipeline.yaml
@@ -57,6 +57,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpipeline.yaml
+++ b/libpipeline.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpipeline
   version: 1.5.8
-  epoch: 0
+  epoch: 1
   description: C pipeline manipulation library
   copyright:
     - license: GPL-3.0-or-later

--- a/libpipeline.yaml
+++ b/libpipeline.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpipeline
   version: 1.5.8
-  epoch: 1
+  epoch: 0
   description: C pipeline manipulation library
   copyright:
     - license: GPL-3.0-or-later

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -70,9 +70,7 @@ subpackages:
             libpng16-config --version
             libpng16-config --help
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libpng-utils
     pipeline:
@@ -96,5 +94,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libpng

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: "1.6.47"
-  epoch: 2
+  epoch: 1
   description: Portable Network Graphics library
   copyright:
     - license: Libpng

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: "1.6.47"
-  epoch: 1
+  epoch: 2
   description: Portable Network Graphics library
   copyright:
     - license: Libpng

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -45,6 +45,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpsl-native
   version: 7.4.0
-  epoch: 5
+  epoch: 4
   description: this library provides functionality missing from .NET Core via system calls
   copyright:
     - license: MIT

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpsl-native
   version: 7.4.0
-  epoch: 4
+  epoch: 5
   description: this library provides functionality missing from .NET Core via system calls
   copyright:
     - license: MIT

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpsl
   version: 0.21.5
-  epoch: 4
+  epoch: 5
   description: C library for the Publix Suffix List
   copyright:
     - license: MIT

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -90,6 +90,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpsl
   version: 0.21.5
-  epoch: 5
+  epoch: 4
   description: C library for the Publix Suffix List
   copyright:
     - license: MIT

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -59,6 +59,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.7.0
-  epoch: 2
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/libretls.yaml
+++ b/libretls.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libretls-dev
 
   - name: "libretls-doc"
     description: "libretls documentation"
@@ -69,5 +67,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libretls

--- a/libretls.yaml
+++ b/libretls.yaml
@@ -1,7 +1,7 @@
 package:
   name: libretls
   version: 3.8.1
-  epoch: 5
+  epoch: 4
   description: "port of libtls from libressl to openssl"
   copyright:
     - license: 'ISC AND ( BSD-3-Clause OR MIT )'

--- a/libretls.yaml
+++ b/libretls.yaml
@@ -1,7 +1,7 @@
 package:
   name: libretls
   version: 3.8.1
-  epoch: 4
+  epoch: 5
   description: "port of libtls from libressl to openssl"
   copyright:
     - license: 'ISC AND ( BSD-3-Clause OR MIT )'

--- a/librsvg.yaml
+++ b/librsvg.yaml
@@ -2,7 +2,7 @@
 package:
   name: librsvg
   version: 2.59.2
-  epoch: 2
+  epoch: 1
   description: SAX-based renderer for SVG files into a GdkPixbuf
   copyright:
     - license: LGPL-2.1-or-later

--- a/librsvg.yaml
+++ b/librsvg.yaml
@@ -143,6 +143,4 @@ test:
         echo '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" style="fill:yellow"/></svg>' > test-pdf.svg
         rsvg-convert -f pdf -o output.pdf test-pdf.svg
         file output.pdf | grep -qi "PDF document"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/librsvg.yaml
+++ b/librsvg.yaml
@@ -2,7 +2,7 @@
 package:
   name: librsvg
   version: 2.59.2
-  epoch: 1
+  epoch: 2
   description: SAX-based renderer for SVG files into a GdkPixbuf
   copyright:
     - license: LGPL-2.1-or-later

--- a/libsass.yaml
+++ b/libsass.yaml
@@ -104,8 +104,6 @@ test:
         gcc test.c -o test_sass -lsass
         ./test_sass
     - uses: test/tw/ldd-check
-      with:
-        packages: libsass
     - name: "Test variable compilation"
       runs: |
         cat << EOF > test_vars.c

--- a/libsass.yaml
+++ b/libsass.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsass
   version: "3.6.6"
-  epoch: 4
+  epoch: 3
   description: C/C++ implementation of a Sass compiler
   copyright:
     - license: MIT

--- a/libsass.yaml
+++ b/libsass.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsass
   version: "3.6.6"
-  epoch: 3
+  epoch: 4
   description: C/C++ implementation of a Sass compiler
   copyright:
     - license: MIT

--- a/libsdl2-ttf.yaml
+++ b/libsdl2-ttf.yaml
@@ -60,5 +60,3 @@ test:
         set -euo pipefail
         pkg-config --modversion SDL2_ttf | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl2-ttf

--- a/libsdl2-ttf.yaml
+++ b/libsdl2-ttf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl2-ttf
   version: 2.24.0
-  epoch: 3
+  epoch: 4
   description: A library that allows you to use TrueType fonts in your SDL applications (Version 2)
   copyright:
     - license: Zlib

--- a/libsdl2-ttf.yaml
+++ b/libsdl2-ttf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl2-ttf
   version: 2.24.0
-  epoch: 4
+  epoch: 3
   description: A library that allows you to use TrueType fonts in your SDL applications (Version 2)
   copyright:
     - license: Zlib

--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl2
   version: "2.32.2"
-  epoch: 1
+  epoch: 2
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
     - license: Zlib

--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl2
   version: "2.32.2"
-  epoch: 2
+  epoch: 1
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
     - license: Zlib

--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -39,9 +39,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -61,5 +59,3 @@ test:
         set -euo pipefail
         pkg-config --modversion sdl2 | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl2

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl3
   version: "3.2.8"
-  epoch: 2
+  epoch: 3
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
     - license: Zlib

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -82,5 +82,3 @@ test:
         set -euo pipefail
         pkg-config --modversion sdl3 | grep -q "${{package.version}}"
     - uses: test/tw/ldd-check
-      with:
-        packages: libsdl3

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl3
   version: "3.2.8"
-  epoch: 3
+  epoch: 2
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
     - license: Zlib

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -52,8 +52,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libseccomp-dev
 
   - name: libseccomp-doc
     pipeline:
@@ -75,6 +73,4 @@ test:
     - runs: |
         scmp_sys_resolver version
         scmp_sys_resolver help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libseccomp
   version: "2.6.0"
-  epoch: 1
+  epoch: 2
   description: interface to the Linux Kernel's syscall filtering mechanism
   copyright:
     - license: LGPL-2.1-or-later

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libseccomp
   version: "2.6.0"
-  epoch: 2
+  epoch: 1
   description: interface to the Linux Kernel's syscall filtering mechanism
   copyright:
     - license: LGPL-2.1-or-later

--- a/libsecret.yaml
+++ b/libsecret.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsecret
   version: "0.21.6"
-  epoch: 3
+  epoch: 2
   description: Library for storing and retrieving passwords and other secrets
   copyright:
     - license: LGPL-2.0-or-later

--- a/libsecret.yaml
+++ b/libsecret.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsecret
   version: "0.21.6"
-  epoch: 2
+  epoch: 3
   description: Library for storing and retrieving passwords and other secrets
   copyright:
     - license: LGPL-2.0-or-later

--- a/libsecret.yaml
+++ b/libsecret.yaml
@@ -71,8 +71,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libsecret-dev
 
   - name: libsecret-lang
     pipeline:
@@ -87,5 +85,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libsecret

--- a/libselinux.yaml
+++ b/libselinux.yaml
@@ -1,7 +1,7 @@
 package:
   name: libselinux
   version: "3.8.1"
-  epoch: 2
+  epoch: 3
   description: "SELinux library and simple utilities"
   copyright:
     - license: libselinux-1.0

--- a/libselinux.yaml
+++ b/libselinux.yaml
@@ -81,8 +81,6 @@ test:
         getenforce
         # Most of the binaries don't have easy --help options to test
     - uses: test/tw/ldd-check
-      with:
-        packages: libselinux
 
 update:
   enabled: true

--- a/libselinux.yaml
+++ b/libselinux.yaml
@@ -1,7 +1,7 @@
 package:
   name: libselinux
   version: "3.8.1"
-  epoch: 3
+  epoch: 2
   description: "SELinux library and simple utilities"
   copyright:
     - license: libselinux-1.0


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
