### PR TITLE
tw/ldd-check cleanup batch 24

### DIFF
--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgcrypt
   version: 1.11.0
-  epoch: 2
+  epoch: 3
   description: General purpose crypto library based on the code used in GnuPG
   copyright:
     - license: LGPL-2.1-or-later

--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgcrypt
   version: 1.11.0
-  epoch: 3
+  epoch: 2
   description: General purpose crypto library based on the code used in GnuPG
   copyright:
     - license: LGPL-2.1-or-later

--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -83,6 +83,4 @@ test:
         hmac256 --help
         mpicalc --version
         mpicalc --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libgeotiff.yaml
+++ b/libgeotiff.yaml
@@ -49,8 +49,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libgeotiff-dev
 
   - name: libgeotiff-doc
     pipeline:
@@ -73,5 +71,3 @@ test:
         makegeo --version
         makegeo --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libgeotiff

--- a/libgeotiff.yaml
+++ b/libgeotiff.yaml
@@ -2,7 +2,7 @@
 package:
   name: libgeotiff
   version: "1.7.4"
-  epoch: 2
+  epoch: 3
   description: TIFF based interchange format for georeferenced raster imagery
   copyright:
     - license: MIT

--- a/libgeotiff.yaml
+++ b/libgeotiff.yaml
@@ -2,7 +2,7 @@
 package:
   name: libgeotiff
   version: "1.7.4"
-  epoch: 3
+  epoch: 2
   description: TIFF based interchange format for georeferenced raster imagery
   copyright:
     - license: MIT

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -91,8 +91,6 @@ subpackages:
             ./test_libgit2
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libgit2-dev
 
   - name: "libgit2-static"
     description: "libgit2 static library"
@@ -112,5 +110,3 @@ test:
         git2 --version
         git2 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libgit2

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.9.0
-  epoch: 3
+  epoch: 2
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.9.0
-  epoch: 2
+  epoch: 3
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0

--- a/libglvnd.yaml
+++ b/libglvnd.yaml
@@ -125,5 +125,3 @@ test:
         gcc check_egl_gl_functions.c -o check_egl_gl_functions -ldl
         ./check_egl_gl_functions | grep -E "EGL functions are available.|OpenGL functions are available."
     - uses: test/tw/ldd-check
-      with:
-        packages: libglvnd

--- a/libglvnd.yaml
+++ b/libglvnd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libglvnd
   version: 1.7.0
-  epoch: 5
+  epoch: 4
   description: The GL Vendor-Neutral Dispatch library
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Apache-2.0

--- a/libglvnd.yaml
+++ b/libglvnd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libglvnd
   version: 1.7.0
-  epoch: 4
+  epoch: 5
   description: The GL Vendor-Neutral Dispatch library
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Apache-2.0

--- a/libgpg-error.yaml
+++ b/libgpg-error.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgpg-error
   version: "1.51"
-  epoch: 1
+  epoch: 0
   description: Support library for libgcrypt
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libgpg-error.yaml
+++ b/libgpg-error.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgpg-error
   version: "1.51"
-  epoch: 0
+  epoch: 1
   description: Support library for libgcrypt
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libgpg-error.yaml
+++ b/libgpg-error.yaml
@@ -80,6 +80,4 @@ test:
         yat2m --version
         gpg-error --help
         yat2m --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libgphoto2.yaml
+++ b/libgphoto2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgphoto2
   version: 2.5.31
-  epoch: 1
+  epoch: 2
   description: "The core library of gphoto2, designed to allow access to digital camera by external programs"
   copyright:
     - license: LGPL-2.1-or-later

--- a/libgphoto2.yaml
+++ b/libgphoto2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgphoto2
   version: 2.5.31
-  epoch: 2
+  epoch: 1
   description: "The core library of gphoto2, designed to allow access to digital camera by external programs"
   copyright:
     - license: LGPL-2.1-or-later

--- a/libgphoto2.yaml
+++ b/libgphoto2.yaml
@@ -82,6 +82,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libhyper.yaml
+++ b/libhyper.yaml
@@ -45,9 +45,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/libhyper.yaml
+++ b/libhyper.yaml
@@ -1,7 +1,7 @@
 package:
   name: libhyper
   version: "1.6.0"
-  epoch: 1
+  epoch: 0
   description: "An HTTP library for Rust"
   copyright:
     - license: MIT

--- a/libhyper.yaml
+++ b/libhyper.yaml
@@ -1,7 +1,7 @@
 package:
   name: libhyper
   version: "1.6.0"
-  epoch: 0
+  epoch: 1
   description: "An HTTP library for Rust"
   copyright:
     - license: MIT

--- a/libice.yaml
+++ b/libice.yaml
@@ -75,8 +75,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libice-dev
 
 update:
   enabled: true
@@ -86,5 +84,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libice

--- a/libice.yaml
+++ b/libice.yaml
@@ -1,7 +1,7 @@
 package:
   name: libice
   version: 1.1.2
-  epoch: 3
+  epoch: 2
   description: X11 Inter-Client Exchange library
   copyright:
     - license: X11

--- a/libice.yaml
+++ b/libice.yaml
@@ -1,7 +1,7 @@
 package:
   name: libice
   version: 1.1.2
-  epoch: 2
+  epoch: 3
   description: X11 Inter-Client Exchange library
   copyright:
     - license: X11

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: "2.3.8"
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: "2.3.8"
-  epoch: 1
+  epoch: 0
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -80,6 +80,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libimagequant.yaml
+++ b/libimagequant.yaml
@@ -120,5 +120,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libimagequant

--- a/libimagequant.yaml
+++ b/libimagequant.yaml
@@ -1,7 +1,7 @@
 package:
   name: libimagequant
   version: "4.3.4"
-  epoch: 2
+  epoch: 3
   description: Palette quantization library that powers pngquant and other PNG optimizers
   copyright:
     - license: GPL-3.0-or-later

--- a/libimagequant.yaml
+++ b/libimagequant.yaml
@@ -1,7 +1,7 @@
 package:
   name: libimagequant
   version: "4.3.4"
-  epoch: 3
+  epoch: 2
   description: Palette quantization library that powers pngquant and other PNG optimizers
   copyright:
     - license: GPL-3.0-or-later

--- a/libinput.yaml
+++ b/libinput.yaml
@@ -2,7 +2,7 @@
 package:
   name: libinput
   version: 1.27.1
-  epoch: 2
+  epoch: 3
   description: Library for handling input devices
   copyright:
     - license: MIT

--- a/libinput.yaml
+++ b/libinput.yaml
@@ -80,8 +80,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libinput-dev
 
 update:
   enabled: true
@@ -95,5 +93,3 @@ test:
         libinput --version
         libinput --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libinput

--- a/libinput.yaml
+++ b/libinput.yaml
@@ -2,7 +2,7 @@
 package:
   name: libinput
   version: 1.27.1
-  epoch: 3
+  epoch: 2
   description: Library for handling input devices
   copyright:
     - license: MIT

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -45,8 +45,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libjpeg-turbo-dev
 
   - name: "libjpeg-turbo-doc"
     description: "libjpeg-turbo documentation"
@@ -88,8 +86,6 @@ test:
         test -f /usr/lib/libjpeg.so
         test -f /usr/lib/libturbojpeg.so
     - uses: test/tw/ldd-check
-      with:
-        packages: libjpeg-turbo
     - name: "Test library linking"
       runs: |
         cat > test.c << 'EOF'

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 3.1.0
-  epoch: 2
+  epoch: 3
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 3.1.0
-  epoch: 3
+  epoch: 2
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib

--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -2,7 +2,7 @@
 package:
   name: liblangtag
   version: 0.6.7
-  epoch: 1
+  epoch: 2
   description: Interface library to access/deal with tags for identifying languages
   copyright:
     - license: LGPL-3.0-or-later OR MPL-2.0

--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -60,6 +60,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -2,7 +2,7 @@
 package:
   name: liblangtag
   version: 0.6.7
-  epoch: 2
+  epoch: 1
   description: Interface library to access/deal with tags for identifying languages
   copyright:
     - license: LGPL-3.0-or-later OR MPL-2.0

--- a/liblbfgs.yaml
+++ b/liblbfgs.yaml
@@ -55,9 +55,7 @@ subpackages:
         - liblbfgs
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: false
@@ -65,6 +63,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/liblbfgs.yaml
+++ b/liblbfgs.yaml
@@ -1,7 +1,7 @@
 package:
   name: liblbfgs
   version: 1.10
-  epoch: 0
+  epoch: 1
   description: A library of Limited-memory Broyden-Fletcher-Goldfarb-Shanno (L-BFGS)
   copyright:
     - license: MIT

--- a/liblbfgs.yaml
+++ b/liblbfgs.yaml
@@ -1,7 +1,7 @@
 package:
   name: liblbfgs
   version: 1.10
-  epoch: 1
+  epoch: 0
   description: A library of Limited-memory Broyden-Fletcher-Goldfarb-Shanno (L-BFGS)
   copyright:
     - license: MIT

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmamba
   version: 2.0.5
-  epoch: 1
+  epoch: 2
   description: Cross-Platform Package Manager
   copyright:
     - license: BSD-3-Clause

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmamba
   version: 2.0.5
-  epoch: 2
+  epoch: 1
   description: Cross-Platform Package Manager
   copyright:
     - license: BSD-3-Clause

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -143,9 +143,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: micromamba
     dependencies:
@@ -191,10 +189,6 @@ test:
         micromamba --help
         bash -c "micromamba shell init -s bash -p ~/micromamba; source ~/.bashrc; micromamba activate; micromamba install python=3.11 requests -c conda-forge"
     - uses: test/tw/ldd-check
-      with:
-        packages: libmamba
     - runs: |
         mamba-package --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
