### PR TITLE
tw/ldd-check cleanup batch 25

### DIFF
--- a/lean4.yaml
+++ b/lean4.yaml
@@ -84,6 +84,4 @@ test:
         #eval add 2 3
         EOF
         lean simple.lean
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/lean4.yaml
+++ b/lean4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lean4
   version: "4.17.0"
-  epoch: 1
+  epoch: 0
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: Apache-2.0

--- a/lean4.yaml
+++ b/lean4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lean4
   version: "4.17.0"
-  epoch: 0
+  epoch: 1
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: Apache-2.0

--- a/libassuan.yaml
+++ b/libassuan.yaml
@@ -44,8 +44,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libassuan-dev
 
   - name: libassuan-doc
     pipeline:
@@ -64,5 +62,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libassuan

--- a/libassuan.yaml
+++ b/libassuan.yaml
@@ -1,7 +1,7 @@
 package:
   name: libassuan
   version: "3.0.2"
-  epoch: 2
+  epoch: 3
   description: IPC library used by some GnuPG related software
   copyright:
     - license: LGPL-2.1-or-later

--- a/libassuan.yaml
+++ b/libassuan.yaml
@@ -1,7 +1,7 @@
 package:
   name: libassuan
   version: "3.0.2"
-  epoch: 3
+  epoch: 2
   description: IPC library used by some GnuPG related software
   copyright:
     - license: LGPL-2.1-or-later

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -56,8 +56,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libavif-dev
 
   - name: libavif-apps
     pipeline:
@@ -82,5 +80,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libavif

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: "1.2.1"
-  epoch: 1
+  epoch: 0
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: "1.2.1"
-  epoch: 0
+  epoch: 1
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause

--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libbpf-dev
 
 update:
   enabled: true
@@ -69,8 +67,6 @@ test:
       runs: |
         test -f /usr/include/bpf/libbpf.h
     - uses: test/tw/ldd-check
-      with:
-        packages: libbpf
     - name: "Check libelf.so library"
       runs: |
         test -f /usr/lib64/libbpf.so

--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbpf
   version: 1.5.0
-  epoch: 3
+  epoch: 4
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: GPL-2.0-only

--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbpf
   version: 1.5.0
-  epoch: 4
+  epoch: 3
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: GPL-2.0-only

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -58,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbsd
   version: 0.12.2
-  epoch: 3
+  epoch: 2
   description: commonly-used BSD functions not implemented by all libcs
   copyright:
     - license: BSD-3-Clause

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbsd
   version: 0.12.2
-  epoch: 2
+  epoch: 3
   description: commonly-used BSD functions not implemented by all libcs
   copyright:
     - license: BSD-3-Clause

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -43,8 +43,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libcap-dev
 
   - name: libcap-utils
     description: various utilities included with libcap
@@ -88,6 +86,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.75"
-  epoch: 2
+  epoch: 3
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.75"
-  epoch: 3
+  epoch: 2
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -41,8 +41,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdbi-dev
 
 update:
   enabled: true
@@ -52,5 +50,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libdbi

--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdbi
   version: 0.9.0
-  epoch: 5
+  epoch: 4
   description: "Database independent abstraction layer for C"
   copyright:
     - license: LGPL-2.1-or-later

--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdbi
   version: 0.9.0
-  epoch: 4
+  epoch: 5
   description: "Database independent abstraction layer for C"
   copyright:
     - license: LGPL-2.1-or-later

--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -55,8 +55,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdrm-dev
 
 update:
   enabled: true
@@ -80,5 +78,3 @@ test:
         modetest --help
         vbltest --help
     - uses: test/tw/ldd-check
-      with:
-        packages: libdrm

--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -2,7 +2,7 @@
 package:
   name: libdrm
   version: 2.4.124
-  epoch: 2
+  epoch: 3
   description: Userspace interface to kernel DRM services
   copyright:
     - license: MIT

--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -2,7 +2,7 @@
 package:
   name: libdrm
   version: 2.4.124
-  epoch: 3
+  epoch: 2
   description: Userspace interface to kernel DRM services
   copyright:
     - license: MIT

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -57,9 +57,7 @@ subpackages:
     test:
       pipeline:
         - runs: stat /usr/lib/libdwarfp.so.${{package.version}}
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libdwarf-dev
     pipeline:
@@ -69,8 +67,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libdwarf-dev
     dependencies:
       runtime:
         - libdwarf
@@ -105,8 +101,6 @@ test:
   pipeline:
     - runs: stat /usr/lib/libdwarf.so.${{package.version}}
     - uses: test/tw/ldd-check
-      with:
-        packages: libdwarf
 
 update:
   enabled: true

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdwarf
   version: 0.11.1
-  epoch: 3
+  epoch: 4
   description: Parsing library for DWARF2 and later debugging file format
   copyright:
     - license: LGPL-2.1-only

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdwarf
   version: 0.11.1
-  epoch: 4
+  epoch: 3
   description: Parsing library for DWARF2 and later debugging file format
   copyright:
     - license: LGPL-2.1-only

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -43,8 +43,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libeconf-dev
 
 update:
   enabled: true
@@ -56,8 +54,6 @@ test:
   pipeline:
     - uses: test/pkgconf
     - uses: test/tw/ldd-check
-      with:
-        packages: libeconf
     - name: "Verify econftool availability"
       runs: |
         econftool --help

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libeconf
   version: "0.7.7"
-  epoch: 5
+  epoch: 4
   description: Enhanced Config File Parser
   copyright:
     - license: MIT

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libeconf
   version: "0.7.7"
-  epoch: 4
+  epoch: 5
   description: Enhanced Config File Parser
   copyright:
     - license: MIT

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -53,8 +53,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: libedit-dev
 
 update:
   enabled: false
@@ -66,5 +64,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: libedit

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 8
+  epoch: 9
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 9
+  epoch: 8
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -72,6 +72,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevent
   version: 2.1.12
-  epoch: 6
+  epoch: 7
   description: An event notification library
   copyright:
     - license: BSD-3-Clause

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevent
   version: 2.1.12
-  epoch: 7
+  epoch: 6
   description: An event notification library
   copyright:
     - license: BSD-3-Clause

--- a/libfaketime.yaml
+++ b/libfaketime.yaml
@@ -27,9 +27,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - runs: |
         faketime '2023-02-01' date +%Y-%m-%d | grep 2023-02-01
 

--- a/libfaketime.yaml
+++ b/libfaketime.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfaketime
   version: 0.9.10
-  epoch: 0
+  epoch: 1
   description: "libfaketime modifies the system time for a single application"
   copyright:
     - license: GPL-2.0

--- a/libfaketime.yaml
+++ b/libfaketime.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfaketime
   version: 0.9.10
-  epoch: 1
+  epoch: 0
   description: "libfaketime modifies the system time for a single application"
   copyright:
     - license: GPL-2.0

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -90,6 +90,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: "3.4.7"
-  epoch: 4
+  epoch: 3
   description: "portable foreign function interface library"
   copyright:
     - license: MIT

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: "3.4.7"
-  epoch: 3
+  epoch: 4
   description: "portable foreign function interface library"
   copyright:
     - license: MIT


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
