### PR TITLE
tw/ldd-check cleanup batch 28

### DIFF
--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-3
   version: "3.24.49"
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v3)
   copyright:
     - license: LGPL-2.1-or-later

--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-3
   version: "3.24.49"
-  epoch: 1
+  epoch: 0
   description: The GTK+ Toolkit (v3)
   copyright:
     - license: LGPL-2.1-or-later

--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -172,6 +172,4 @@ test:
         gtk-launch --help
         gtk3-demo --help
         gtk3-widget-factory --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-4
   version: "4.18.2"
-  epoch: 1
+  epoch: 0
   description: The GTK+ Toolkit (v4)
   copyright:
     - license: LGPL-2.1-or-later

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -184,6 +184,4 @@ test:
         gtk4-launch --version
         gtk4-update-icon-cache --help
         gtk4-launch --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-4
   version: "4.18.2"
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v4)
   copyright:
     - license: LGPL-2.1-or-later

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -90,9 +90,7 @@ subpackages:
           rm -f ${{targets.destdir}}/usr/lib/libguac-client-${{range.key}}.*
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: guacamole-server-dev
     description: guacamole-server development files
@@ -128,9 +126,7 @@ test:
         expected_output: |
           istening on host
           Guacamole proxy daemon.*version ${{package.version}}
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: 1.5.5
-  epoch: 2
+  epoch: 3
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: 1.5.5
-  epoch: 3
+  epoch: 2
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0

--- a/guile.yaml
+++ b/guile.yaml
@@ -1,7 +1,7 @@
 package:
   name: guile
   version: 3.0.10
-  epoch: 2
+  epoch: 1
   description: portable, embeddable Scheme implementation written in C
   copyright:
     - license: LGPL-3.0-or-later AND GPL-3.0-or-later

--- a/guile.yaml
+++ b/guile.yaml
@@ -1,7 +1,7 @@
 package:
   name: guile
   version: 3.0.10
-  epoch: 1
+  epoch: 2
   description: portable, embeddable Scheme implementation written in C
   copyright:
     - license: LGPL-3.0-or-later AND GPL-3.0-or-later

--- a/guile.yaml
+++ b/guile.yaml
@@ -90,9 +90,7 @@ subpackages:
     description: guile readline
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -1,7 +1,7 @@
 package:
   name: harfbuzz
   version: "10.4.0"
-  epoch: 2
+  epoch: 1
   description: Text shaping library
   copyright:
     - license: MIT

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -82,9 +82,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*icu.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: Harfbuzz ICU support library
 
   - name: harfbuzz-utils
@@ -128,8 +126,6 @@ test:
         - ttf-dejavu
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
     - name: "Test basic text shaping"
       runs: |
         hb-view --font-file=/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf \

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -1,7 +1,7 @@
 package:
   name: harfbuzz
   version: "10.4.0"
-  epoch: 1
+  epoch: 2
   description: Text shaping library
   copyright:
     - license: MIT

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -95,9 +95,7 @@ subpackages:
       - uses: split/dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: hdf5-dev
+        - uses: test/tw/ldd-check
 
   - name: 'hdf5-tools'
     description: 'hdf5 tools'
@@ -144,15 +142,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/${{range.value}}.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -2,7 +2,7 @@ package:
   name: hdf5
   description: Library for accessing Hierarchical Data Format version 5 files
   version: "1.14.6"
-  epoch: 2
+  epoch: 1
   url: https://www.hdfgroup.org/solutions/hdf5/
   copyright:
     - license: BSD-3-Clause

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -2,7 +2,7 @@ package:
   name: hdf5
   description: Library for accessing Hierarchical Data Format version 5 files
   version: "1.14.6"
-  epoch: 1
+  epoch: 2
   url: https://www.hdfgroup.org/solutions/hdf5/
   copyright:
     - license: BSD-3-Clause

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 10
+  epoch: 9
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 9
+  epoch: 10
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -82,9 +82,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: heimdal-libs
+        - uses: test/tw/ldd-check
 
   - name: "heimdal-doc"
     description: "heimdal manpages"

--- a/helix.yaml
+++ b/helix.yaml
@@ -48,6 +48,4 @@ test:
     - runs: |
         hx --version
         hx --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/helix.yaml
+++ b/helix.yaml
@@ -1,7 +1,7 @@
 package:
   name: helix
   version: "25.01.1"
-  epoch: 0
+  epoch: 1
   description: "A post-modern modal text editor."
   copyright:
     - license: MPL-2.0

--- a/helix.yaml
+++ b/helix.yaml
@@ -1,7 +1,7 @@
 package:
   name: helix
   version: "25.01.1"
-  epoch: 1
+  epoch: 0
   description: "A post-modern modal text editor."
   copyright:
     - license: MPL-2.0

--- a/highway.yaml
+++ b/highway.yaml
@@ -1,7 +1,7 @@
 package:
   name: highway
   version: 1.2.0
-  epoch: 2
+  epoch: 3
   description: Performance-portable, length-agnostic SIMD with runtime dispatch
   copyright:
     - license: Apache-2.0

--- a/highway.yaml
+++ b/highway.yaml
@@ -1,7 +1,7 @@
 package:
   name: highway
   version: 1.2.0
-  epoch: 3
+  epoch: 2
   description: Performance-portable, length-agnostic SIMD with runtime dispatch
   copyright:
     - license: Apache-2.0

--- a/highway.yaml
+++ b/highway.yaml
@@ -44,9 +44,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libhwy_contrib
     pipeline:
@@ -55,9 +53,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy_contrib.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: libhwy_test
     pipeline:
@@ -66,9 +62,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhwy_test.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: highway-dev
     pipeline:

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -41,8 +41,6 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,7 +1,7 @@
 package:
   name: hiredis
   version: 1.2.0
-  epoch: 3
+  epoch: 4
   description: Minimalistic C client for Redis
   copyright:
     - license: BSD-3-Clause

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,7 +1,7 @@
 package:
   name: hiredis
   version: 1.2.0
-  epoch: 4
+  epoch: 3
   description: Minimalistic C client for Redis
   copyright:
     - license: BSD-3-Clause

--- a/hunspell.yaml
+++ b/hunspell.yaml
@@ -1,7 +1,7 @@
 package:
   name: hunspell
   version: 1.7.2
-  epoch: 2
+  epoch: 3
   description: Spell checker and morphological analyzer library and program
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1

--- a/hunspell.yaml
+++ b/hunspell.yaml
@@ -1,7 +1,7 @@
 package:
   name: hunspell
   version: 1.7.2
-  epoch: 3
+  epoch: 2
   description: Spell checker and morphological analyzer library and program
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1

--- a/hunspell.yaml
+++ b/hunspell.yaml
@@ -40,9 +40,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libhunspell-*.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: hunspell-dev
     pipeline:

--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: hwloc
   version: "2.12.0"
-  epoch: 2
+  epoch: 1
   description: Portable abstraction of hierarchical hardware architectures
   copyright:
     - license: BSD-3-Clause

--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: hwloc
   version: "2.12.0"
-  epoch: 1
+  epoch: 2
   description: Portable abstraction of hierarchical hardware architectures
   copyright:
     - license: BSD-3-Clause

--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -118,6 +118,4 @@ test:
           hwloc-dump-hwdata --version
           hwloc-dump-hwdata --help
         fi
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -121,5 +121,3 @@ test:
         i2cset -V
         i2ctransfer -V
     - uses: test/tw/ldd-check
-      with:
-        packages: i2c-tools

--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: i2c-tools
   version: "4.4"
-  epoch: 4
+  epoch: 5
   description: Tools for monitoring I2C devices
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: i2c-tools
   version: "4.4"
-  epoch: 5
+  epoch: 4
   description: Tools for monitoring I2C devices
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: "75.1"
-  epoch: 9
+  epoch: 8
   description: "International Components for Unicode library"
   copyright:
     - license: MIT

--- a/icu.yaml
+++ b/icu.yaml
@@ -78,8 +78,6 @@ subpackages:
             icu-config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: icu-dev
 
   - name: icu-libs
     description: International Components for Unicode library (libs)
@@ -94,9 +92,7 @@ subpackages:
         - icu-data-full
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: icu-data-full
     description: Full ICU data
@@ -158,8 +154,6 @@ test:
         gencmn help
         gensprep version
     - uses: test/tw/ldd-check
-      with:
-        packages: icu
     - name: "Test basic character conversion"
       runs: |
         # Test UTF-8 to ASCII conversion with skip callback

--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: "75.1"
-  epoch: 8
+  epoch: 9
   description: "International Components for Unicode library"
   copyright:
     - license: MIT

--- a/imagemagick-7.yaml
+++ b/imagemagick-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: imagemagick-7
   version: "7.1.1.46"
-  epoch: 0
+  epoch: 1
   description: ImageMagick® is a free, open-source software suite, used for editing and manipulating digital images.
   copyright:
     - license: GPL-3.0-only

--- a/imagemagick-7.yaml
+++ b/imagemagick-7.yaml
@@ -132,5 +132,3 @@ test:
         magick-script --help
         montage --help
     - uses: test/tw/ldd-check
-      with:
-        packages: imagemagick-7

--- a/imagemagick-7.yaml
+++ b/imagemagick-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: imagemagick-7
   version: "7.1.1.46"
-  epoch: 1
+  epoch: 0
   description: ImageMagick® is a free, open-source software suite, used for editing and manipulating digital images.
   copyright:
     - license: GPL-3.0-only


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
