### PR TITLE
tw/ldd-check cleanup batch 30

### DIFF
--- a/gengetopt.yaml
+++ b/gengetopt.yaml
@@ -133,9 +133,7 @@ test:
           Options passed:
           String option: hello
           Integer option: 1234
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gengetopt.yaml
+++ b/gengetopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: gengetopt
   version: 2.23
-  epoch: 1
+  epoch: 0
   description: "A tool to write command line option parsing code for C programs"
   copyright:
     - license: GPL-3.0-or-later

--- a/gengetopt.yaml
+++ b/gengetopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: gengetopt
   version: 2.23
-  epoch: 0
+  epoch: 1
   description: "A tool to write command line option parsing code for C programs"
   copyright:
     - license: GPL-3.0-or-later

--- a/geos-3.13.yaml
+++ b/geos-3.13.yaml
@@ -130,5 +130,3 @@ test:
         geosop -v
         geosop --help
     - uses: test/tw/ldd-check
-      with:
-        packages: geos-3.13

--- a/geos-3.13.yaml
+++ b/geos-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: geos-3.13
   version: "3.13.1"
-  epoch: 2
+  epoch: 3
   description: GEOS is a library providing OpenGIS and JTS spatial operations in C++.
   copyright:
     - license: LGPL-2.1-or-later

--- a/geos-3.13.yaml
+++ b/geos-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: geos-3.13
   version: "3.13.1"
-  epoch: 3
+  epoch: 2
   description: GEOS is a library providing OpenGIS and JTS spatial operations in C++.
   copyright:
     - license: LGPL-2.1-or-later

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -64,9 +64,7 @@ subpackages:
     description: gettext dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: gettext-dev
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -124,6 +122,4 @@ test:
         ngettext --help
         recode-sr-latin --help
         xgettext --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,7 +1,7 @@
 package:
   name: gettext
   version: 0.22.5
-  epoch: 1
+  epoch: 2
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,7 +1,7 @@
 package:
   name: gettext
   version: 0.22.5
-  epoch: 2
+  epoch: 1
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -1,7 +1,7 @@
 package:
   name: ggshield
   version: "1.37.0"
-  epoch: 0
+  epoch: 1
   description: Find and fix 360+ types of hardcoded secrets and 70+ types of infrastructure-as-code misconfigurations.
   copyright:
     - license: MIT

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -1,7 +1,7 @@
 package:
   name: ggshield
   version: "1.37.0"
-  epoch: 1
+  epoch: 0
   description: Find and fix 360+ types of hardcoded secrets and 70+ types of infrastructure-as-code misconfigurations.
   copyright:
     - license: MIT

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -90,6 +90,4 @@ test:
       runs: |
         output=$(ggshield api-status 2>&1 || true)
         echo "$output" | grep "Error: A GitGuardian API key is needed to use ggshield."
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -129,9 +129,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: ghostscript-dev
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -172,6 +170,4 @@ test:
         ps2ascii --help
         ps2epsi --help
         unix-lpr.sh --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -1,7 +1,7 @@
 package:
   name: ghostscript
   version: "10.05.0"
-  epoch: 0
+  epoch: 1
   description: Interpreter for the PostScript language and for PDF
   copyright:
     - license: AGPL-3.0-or-later

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -1,7 +1,7 @@
 package:
   name: ghostscript
   version: "10.05.0"
-  epoch: 1
+  epoch: 0
   description: Interpreter for the PostScript language and for PDF
   copyright:
     - license: AGPL-3.0-or-later

--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
   version: "2.84.0"
-  epoch: 2
+  epoch: 3
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later

--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
   version: "2.84.0"
-  epoch: 3
+  epoch: 2
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later

--- a/glib.yaml
+++ b/glib.yaml
@@ -167,5 +167,3 @@ test:
         gio-querymodules --help
         glib-compile-schemas --help
     - uses: test/tw/ldd-check
-      with:
-        packages: glib

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -558,9 +558,7 @@ subpackages:
         - runs: |
             sotruss --version
             sotruss --help
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -598,9 +596,7 @@ subpackages:
         - runs: |
             makedb --version
             makedb --help
-        - uses: test/ldd-check
-          with:
-            packages: nss-db
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -614,9 +610,7 @@ subpackages:
           mv "${{targets.destdir}}"/lib/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: nss-hesiod
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -754,9 +748,7 @@ test:
         ldconfig --help
         ld.so --version
         ld.so --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Confirm that we're still compatible with current gcc
       runs: |
         # This was a problem due to some legacy fix-includes in gcc that interfered

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 23
+  epoch: 24
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 24
+  epoch: 23
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -2,7 +2,7 @@
 package:
   name: glslang
   version: 1.3.261.1
-  epoch: 3
+  epoch: 4
   description: Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator
   copyright:
     - license: BSD-3-Clause

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -2,7 +2,7 @@
 package:
   name: glslang
   version: 1.3.261.1
-  epoch: 4
+  epoch: 3
   description: Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator
   copyright:
     - license: BSD-3-Clause

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -65,9 +65,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libglslang.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: aom libs
 
   - name: glslang-dev

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -50,8 +50,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gmp-dev
 
 update:
   enabled: true
@@ -60,6 +58,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 4
+  epoch: 5
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 5
+  epoch: 4
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later

--- a/gnu-libiconv.yaml
+++ b/gnu-libiconv.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnu-libiconv
   version: "1.18"
-  epoch: 2
+  epoch: 1
   description: GNU charset conversion library for libc which doesn't implement it
   copyright:
     - license: LGPL-2.1-or-later

--- a/gnu-libiconv.yaml
+++ b/gnu-libiconv.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnu-libiconv
   version: "1.18"
-  epoch: 1
+  epoch: 2
   description: GNU charset conversion library for libc which doesn't implement it
   copyright:
     - license: LGPL-2.1-or-later

--- a/gnu-libiconv.yaml
+++ b/gnu-libiconv.yaml
@@ -81,5 +81,3 @@ test:
         gnu-iconv --version
         gnu-iconv --help
     - uses: test/tw/ldd-check
-      with:
-        packages: gnu-libiconv

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -92,8 +92,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gnutls-dev
 
   - name: gnutls-utils
     pipeline:
@@ -126,9 +124,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*xx.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: The C++ interface to GnuTLS
 
 update:
@@ -139,5 +135,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: gnutls

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: "3.8.9"
-  epoch: 2
+  epoch: 3
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: "3.8.9"
-  epoch: 3
+  epoch: 2
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: "1.84.0"
-  epoch: 1
+  epoch: 0
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -144,8 +144,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: gobject-introspection-dev
 
 update:
   enabled: true
@@ -156,6 +154,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: "1.84.0"
-  epoch: 0
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT

--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -62,8 +62,6 @@ test:
         google-authenticator --version || exit 1
         google-authenticator --help
     - uses: test/tw/ldd-check
-      with:
-        packages: google-authenticator
     - name: Init new key test
       runs: |
         yes -1 | google-authenticator --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3

--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-authenticator
   version: "1.11"
-  epoch: 2
+  epoch: 1
   description: Google Authenticator PAM module
   copyright:
     - license: Apache-2.0

--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-authenticator
   version: "1.11"
-  epoch: 1
+  epoch: 2
   description: Google Authenticator PAM module
   copyright:
     - license: Apache-2.0

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: "515.0.0"
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: "515.0.0"
-  epoch: 1
+  epoch: 0
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -111,9 +111,7 @@ test:
         git-credential-gcloud.sh version
         git-credential-gcloud.sh --help
         gsutil help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -2,7 +2,7 @@
 package:
   name: gperftools
   version: "2.16"
-  epoch: 0
+  epoch: 1
   description: Fast, multi-threaded malloc and nifty performance analysis tools
   copyright:
     - license: BSD-3-Clause

--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -59,9 +59,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-minimal
     description: tcmalloc minimal
@@ -71,9 +69,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_minimal.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-debug
     description: tcmalloc debug
@@ -83,9 +79,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_debug.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-minimal-debug
     description: tcmalloc minimal debug
@@ -95,9 +89,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_minimal_debug.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: tcmalloc-profiler
     description: tcmalloc profiler
@@ -107,9 +99,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libtcmalloc_and_profiler.so.* ${{targets.contextdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: gperftools-dev
     description: gperftools dev

--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -2,7 +2,7 @@
 package:
   name: gperftools
   version: "2.16"
-  epoch: 1
+  epoch: 0
   description: Fast, multi-threaded malloc and nifty performance analysis tools
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
