### PR TITLE
tw/ldd-check cleanup batch 31

### DIFF
--- a/fontforge.yaml
+++ b/fontforge.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontforge
   version: "20230101"
-  epoch: 3
+  epoch: 4
   description: Free (libre) font editor
   copyright:
     - license: GPL-3.0-or-later

--- a/fontforge.yaml
+++ b/fontforge.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontforge
   version: "20230101"
-  epoch: 4
+  epoch: 3
   description: Free (libre) font editor
   copyright:
     - license: GPL-3.0-or-later

--- a/fontforge.yaml
+++ b/fontforge.yaml
@@ -171,5 +171,3 @@ test:
         sfddiff --help
         woff --help
     - uses: test/tw/ldd-check
-      with:
-        packages: fontforge

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetds
   version: "1.4.26"
-  epoch: 5
+  epoch: 6
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
     - license: GPL-2.0-or-later

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetds
   version: "1.4.26"
-  epoch: 6
+  epoch: 5
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
     - license: GPL-2.0-or-later

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -61,8 +61,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: freetds-dev
 
   - name: freetds-doc
     description: freetds documentation
@@ -92,8 +90,6 @@ test:
         tsql -C
         fisql -v
     - uses: test/tw/ldd-check
-      with:
-        packages: freetds
     - name: Verify tsql config
       runs: |
         tsql -C | grep -q -E "iconv library:\s+yes"

--- a/frr-10.2.yaml
+++ b/frr-10.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: frr-10.2
   version: "10.2.2"
-  epoch: 1
+  epoch: 0
   description: The FRRouting Protocol Suite
   copyright:
     - license: GPL-2.0-only

--- a/frr-10.2.yaml
+++ b/frr-10.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: frr-10.2
   version: "10.2.2"
-  epoch: 0
+  epoch: 1
   description: The FRRouting Protocol Suite
   copyright:
     - license: GPL-2.0-only

--- a/frr-10.2.yaml
+++ b/frr-10.2.yaml
@@ -118,5 +118,3 @@ test:
         /usr/lib/frr/bgpd --version | grep ${{package.version}}
         /usr/lib/frr/bfdd --version | grep ${{package.version}}
     - uses: test/tw/ldd-check
-      with:
-        packages: frr-10.2

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse2
   version: 2.9.9
-  epoch: 33
+  epoch: 32
   description: A library that makes it possible to implement a filesystem in a userspace program.
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -113,5 +113,3 @@ test:
     - runs: |
         fusermount --version
     - uses: test/tw/ldd-check
-      with:
-        packages: fuse2

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse2
   version: 2.9.9
-  epoch: 32
+  epoch: 33
   description: A library that makes it possible to implement a filesystem in a userspace program.
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse3
   version: 3.16.2
-  epoch: 6
+  epoch: 5
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse3
   version: 3.16.2
-  epoch: 5
+  epoch: 6
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -86,9 +86,7 @@ subpackages:
     description: fuse3 libs
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: fuse3-libs
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -50,6 +50,4 @@ test:
         gawk --help
         gawk-5.3.1 --help
         gawkbug --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -1,7 +1,7 @@
 package:
   name: gawk
   version: 5.3.1
-  epoch: 2
+  epoch: 1
   description: "GNU awk pattern-matching language"
   copyright:
     - license: GPL-3.0-or-later

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -1,7 +1,7 @@
 package:
   name: gawk
   version: 5.3.1
-  epoch: 1
+  epoch: 2
   description: "GNU awk pattern-matching language"
   copyright:
     - license: GPL-3.0-or-later

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 6
+  epoch: 5
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -168,9 +168,7 @@ subpackages:
       no-provides: true
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: 'libstdc++-11-dev'
     dependencies:
@@ -191,9 +189,7 @@ subpackages:
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: 'gcc-11-default'
     description: 'Use GCC 11 as system gcc'
@@ -279,8 +275,6 @@ test:
         lto-dump-11 --version
         lto-dump-11 --help
     - uses: test/tw/ldd-check
-      with:
-        packages: gcc-11
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 10
+  epoch: 11
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 11
+  epoch: 10
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -300,9 +300,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc-12
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 9
+  epoch: 10
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -294,9 +294,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc-13
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 10
+  epoch: 9
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 6
+  epoch: 5
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -331,6 +331,4 @@ test:
         gcov-tool-6.5 --help
     # Will fail https://github.com/wolfi-dev/os/issues/34009
     # - uses: test/pkgconf
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 11
+  epoch: 12
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -162,9 +162,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/*++.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libstdc++
+        - uses: test/tw/ldd-check
 
   - name: 'libstdc++-dev'
     pipeline:
@@ -187,9 +185,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libquadmath
+        - uses: test/tw/ldd-check
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"
@@ -199,9 +195,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgfortran.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgfortran
+        - uses: test/tw/ldd-check
 
   - name: "gfortran"
     description: "GNU Fortran Compiler"
@@ -238,9 +232,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgccjit.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgccjit
+        - uses: test/tw/ldd-check
 
   - name: "libgccjit-dev"
     description: "GCC JIT library headers"
@@ -267,9 +259,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgomp.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgomp
+        - uses: test/tw/ldd-check
 
   - name: "libgcc"
     description: "GCC runtime library"
@@ -279,9 +269,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgcc_s.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgcc
+        - uses: test/tw/ldd-check
 
   - name: "libatomic"
     description: "GCC atomic library"
@@ -291,9 +279,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libatomic.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libatomic
+        - uses: test/tw/ldd-check
 
   - name: "libgo"
     description: "GCC go runtime library"
@@ -303,9 +289,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libgo.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libgo
+        - uses: test/tw/ldd-check
 
   - name: "gcc-go"
     description: "GCC go compiler"
@@ -412,9 +396,7 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 12
+  epoch: 11
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gd.yaml
+++ b/gd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gd
   version: 2.3.3
-  epoch: 9
+  epoch: 10
   description: Library for the dynamic creation of images by programmers
   copyright:
     - license: GD

--- a/gd.yaml
+++ b/gd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gd
   version: 2.3.3
-  epoch: 10
+  epoch: 9
   description: Library for the dynamic creation of images by programmers
   copyright:
     - license: GD

--- a/gd.yaml
+++ b/gd.yaml
@@ -71,9 +71,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libgd.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.2"
-  epoch: 0
+  epoch: 1
   description: The GNU Debugger
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.2"
-  epoch: 1
+  epoch: 0
   description: The GNU Debugger
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -73,6 +73,4 @@ test:
         gdbserver --version
         gdb --help
         gdbserver --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -44,8 +44,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: gdbm-dev
 
   - name: gdbm-doc
     description: gdbm docs
@@ -71,6 +69,4 @@ test:
         gdbm_dump --help
         gdbm_load --help
         gdbmtool --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: "1.24"
-  epoch: 3
+  epoch: 4
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: "1.24"
-  epoch: 4
+  epoch: 3
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdk-pixbuf
   version: 2.42.12
-  epoch: 1
+  epoch: 2
   description: GTK+ image loading library
   copyright:
     - license: LGPL-2.1-or-later

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdk-pixbuf
   version: 2.42.12
-  epoch: 2
+  epoch: 1
   description: GTK+ image loading library
   copyright:
     - license: LGPL-2.1-or-later

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -92,6 +92,4 @@ test:
         gdk-pixbuf-csource --help
         gdk-pixbuf-pixdata --help
         gdk-pixbuf-query-loaders --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
