### PR TITLE
tw/ldd-check cleanup batch 35

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 1
+  epoch: 2
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -150,6 +150,4 @@ test:
         size --help
         strings --help
         strip --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 2
+  epoch: 1
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -124,8 +124,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: bluez-dev
 
 update:
   enabled: true
@@ -161,5 +159,3 @@ test:
         mpris-proxy --help
         rfcomm --help
     - uses: test/tw/ldd-check
-      with:
-        packages: bluez

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.80"
-  epoch: 0
+  epoch: 1
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND MIT

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.80"
-  epoch: 1
+  epoch: 0
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND MIT

--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: 1.87.0
-  epoch: 2
+  epoch: 3
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"

--- a/boost.yaml
+++ b/boost.yaml
@@ -147,8 +147,6 @@ test:
         b2 -v
         bcp --version
     - uses: test/tw/ldd-check
-      with:
-        packages: boost
     - name: "Test basic header compilation"
       runs: |
         cat > test.cpp << 'EOF'

--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: 1.87.0
-  epoch: 3
+  epoch: 2
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"

--- a/botan.yaml
+++ b/botan.yaml
@@ -57,8 +57,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: botan-dev
 
 update:
   enabled: true
@@ -72,5 +70,3 @@ test:
     - runs: |
         botan --version
     - uses: test/tw/ldd-check
-      with:
-        packages: botan

--- a/botan.yaml
+++ b/botan.yaml
@@ -1,7 +1,7 @@
 package:
   name: botan
   version: "3.7.1"
-  epoch: 3
+  epoch: 4
   description: "Cryptography Toolkit"
   copyright:
     - license: BSD-2-Clause

--- a/botan.yaml
+++ b/botan.yaml
@@ -1,7 +1,7 @@
 package:
   name: botan
   version: "3.7.1"
-  epoch: 4
+  epoch: 3
   description: "Cryptography Toolkit"
   copyright:
     - license: BSD-2-Clause

--- a/brew.yaml
+++ b/brew.yaml
@@ -1,7 +1,7 @@
 package:
   name: brew
   version: "4.4.25"
-  epoch: 1
+  epoch: 0
   description: "The homebrew package manager"
   copyright:
     - license: BSD-2-Clause

--- a/brew.yaml
+++ b/brew.yaml
@@ -83,5 +83,3 @@ test:
         . /etc/profile.d/brew.sh
         HOME=/root brew --version
     - uses: test/tw/ldd-check
-      with:
-        packages: brew

--- a/brew.yaml
+++ b/brew.yaml
@@ -1,7 +1,7 @@
 package:
   name: brew
   version: "4.4.25"
-  epoch: 0
+  epoch: 1
   description: "The homebrew package manager"
   copyright:
     - license: BSD-2-Clause

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: 1.1.0
-  epoch: 4
+  epoch: 5
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: 1.1.0
-  epoch: 5
+  epoch: 4
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -50,9 +50,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlicommon.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlicommon1
+        - uses: test/tw/ldd-check
 
   - name: "libbrotlienc1"
     pipeline:
@@ -61,9 +59,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlienc.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlienc1
+        - uses: test/tw/ldd-check
 
   - name: "libbrotlidec1"
     pipeline:
@@ -72,9 +68,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlidec.so.* "${{targets.subpkgdir}}"/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbrotlidec1
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/brunsli.yaml
+++ b/brunsli.yaml
@@ -45,6 +45,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/brunsli.yaml
+++ b/brunsli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brunsli
   version: 0.1
-  epoch: 1
+  epoch: 2
   description: Practical JPEG Repacker
   copyright:
     - license: MIT

--- a/brunsli.yaml
+++ b/brunsli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brunsli
   version: 0.1
-  epoch: 2
+  epoch: 1
   description: Practical JPEG Repacker
   copyright:
     - license: MIT

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -1,7 +1,7 @@
 package:
   name: btrfs-progs
   version: "6.13"
-  epoch: 1
+  epoch: 2
   description: BTRFS filesystem utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: btrfs-progs-dev
 
   - name: py3-btrfs-progs
     description: Python 3 bindings for btrfs-progs
@@ -116,6 +114,4 @@ test:
 
         # Show filesystem info
         btrfs inspect-internal dump-super test.img
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -1,7 +1,7 @@
 package:
   name: btrfs-progs
   version: "6.13"
-  epoch: 2
+  epoch: 1
   description: BTRFS filesystem utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -71,9 +71,7 @@ subpackages:
           ln -s libbz2.so.1 "${{targets.subpkgdir}}/usr/lib/libbz2.so.1.0"
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libbz2-1
+        - uses: test/tw/ldd-check
 
   - name: "bzip2-dev"
     description: "bzip2 headers"
@@ -84,8 +82,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: bzip2-dev
 
   - name: bzip2-doc
     description: bzip2 docs

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 11
+  epoch: 12
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 12
+  epoch: 11
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/bzip3.yaml
+++ b/bzip3.yaml
@@ -48,8 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: bzip3-dev
 
   - name: libbzip3
     pipeline:
@@ -58,9 +56,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libbzip3.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bzip3-doc
     pipeline:

--- a/bzip3.yaml
+++ b/bzip3.yaml
@@ -2,7 +2,7 @@
 package:
   name: bzip3
   version: 1.5.1
-  epoch: 2
+  epoch: 1
   description: Better and stronger spiritual successor to BZip2
   copyright:
     - license: LGPL-3.0-or-later

--- a/bzip3.yaml
+++ b/bzip3.yaml
@@ -2,7 +2,7 @@
 package:
   name: bzip3
   version: 1.5.1
-  epoch: 1
+  epoch: 2
   description: Better and stronger spiritual successor to BZip2
   copyright:
     - license: LGPL-3.0-or-later

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: 1.34.4
-  epoch: 3
+  epoch: 2
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -47,8 +47,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: c-ares-dev
 
   - name: "c-ares-doc"
     description: "c-ares documentation"
@@ -68,5 +66,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: c-ares

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: 1.34.4
-  epoch: 2
+  epoch: 3
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT

--- a/cairo.yaml
+++ b/cairo.yaml
@@ -72,8 +72,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: cairo-dev
 
   - name: cairo-gobject
     # dependencies:
@@ -85,9 +83,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libcairo-gobject.so.*  ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: cairo (gobject bindings)
 
   - name: cairo-tools
@@ -190,6 +186,4 @@ test:
 
         gcc -o test_cairo_gobject test_cairo_gobject.c $(pkg-config --cflags --libs cairo-gobject)
         ./test_cairo_gobject
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cairo.yaml
+++ b/cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: cairo
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: A vector graphics library
   copyright:
     - license: LGPL-2.0-or-later OR MPL-1.1

--- a/cairo.yaml
+++ b/cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: cairo
   version: "1.18.4"
-  epoch: 1
+  epoch: 0
   description: A vector graphics library
   copyright:
     - license: LGPL-2.0-or-later OR MPL-1.1

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -46,9 +46,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: false

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,7 +1,7 @@
 package:
   name: checkov
   version: 3.0.34
-  epoch: 2
+  epoch: 1
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,7 +1,7 @@
 package:
   name: checkov
   version: 3.0.34
-  epoch: 1
+  epoch: 2
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -8,7 +8,7 @@
 package:
   name: chromium
   version: "134.0.6998.117"
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -8,7 +8,7 @@
 package:
   name: chromium
   version: "134.0.6998.117"
-  epoch: 1
+  epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -396,6 +396,4 @@ test:
         chromedriver --help
         chromium --version
         chromium-browser --version
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.2"
-  epoch: 22
+  epoch: 21
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -77,6 +77,4 @@ test:
         getcifsacl --help
         setcifsacl -h
         cifs.idmap --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.2"
-  epoch: 21
+  epoch: 22
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
