### PR TITLE
tw/ldd-check cleanup batch 36

### DIFF
--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -54,14 +54,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-event-stream-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-event-stream
   version: "0.5.4"
-  epoch: 1
+  epoch: 0
   description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
   copyright:
     - license: Apache-2.0

--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-event-stream
   version: "0.5.4"
-  epoch: 0
+  epoch: 1
   description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
   copyright:
     - license: Apache-2.0

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -53,14 +53,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-http-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-http
   version: "0.9.5"
-  epoch: 1
+  epoch: 0
   description: AWS C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   copyright:
     - license: Apache-2.0

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-http
   version: "0.9.5"
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   copyright:
     - license: Apache-2.0

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-io
   version: "0.17.0"
-  epoch: 3
+  epoch: 2
   description: Module for the AWS SDK for C handling all IO and TLS work for application protocols
   copyright:
     - license: Apache-2.0

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -80,8 +80,6 @@ test:
         echo "Verifying aws-c-io installation..."
         find /usr /usr/local -name 'libaws-c-io.so' || (echo "aws-c-io library not found!" && exit 1)
     - uses: test/tw/ldd-check
-      with:
-        packages: aws-c-io
     - name: "Compile and Run aws-c-io Test Program"
       runs: |
         echo "Testing aws-c-io functionality..."

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-io
   version: "0.17.0"
-  epoch: 2
+  epoch: 3
   description: Module for the AWS SDK for C handling all IO and TLS work for application protocols
   copyright:
     - license: Apache-2.0

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -55,8 +55,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-mqtt-dev
 
 update:
   enabled: true
@@ -77,9 +75,7 @@ test:
         - gcc
         - aws-c-mqtt-dev
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: "Compile simple MQTT test program"
       runs: |
         cat << 'EOF' > test.c

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-mqtt
   version: "0.12.2"
-  epoch: 2
+  epoch: 1
   description: AWS C99 implementation of the MQTT 3.1.1 specification
   copyright:
     - license: Apache-2.0

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-mqtt
   version: "0.12.2"
-  epoch: 1
+  epoch: 2
   description: AWS C99 implementation of the MQTT 3.1.1 specification
   copyright:
     - license: Apache-2.0

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-s3
   version: "0.7.13"
-  epoch: 1
+  epoch: 0
   description: "AWS C99 library implementation for communicating with the S3 service"
   copyright:
     - license: Apache-2.0

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-s3
   version: "0.7.13"
-  epoch: 0
+  epoch: 1
   description: "AWS C99 library implementation for communicating with the S3 service"
   copyright:
     - license: Apache-2.0

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -66,14 +66,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-s3-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -49,14 +49,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-c-sdkutils-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-sdkutils
   version: "0.2.3"
-  epoch: 2
+  epoch: 1
   description: C99 library implementing AWS SDK specific utilities
   copyright:
     - license: Apache-2.0

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-sdkutils
   version: "0.2.3"
-  epoch: 1
+  epoch: 2
   description: C99 library implementing AWS SDK specific utilities
   copyright:
     - license: Apache-2.0

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-checksums
   version: "0.2.3"
-  epoch: 1
+  epoch: 2
   description: AWS Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations
   copyright:
     - license: Apache-2.0

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -49,14 +49,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: aws-checksums-dev
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-checksums
   version: "0.2.3"
-  epoch: 2
+  epoch: 1
   description: AWS Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations
   copyright:
     - license: Apache-2.0

--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -3,7 +3,7 @@
 package:
   name: aws-cli-2
   version: "2.24.24"
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0

--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -65,9 +65,7 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
     - name: Verify aws-cli-v2 installation
       runs: |
         aws --version || exit 1

--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -3,7 +3,7 @@
 package:
   name: aws-cli-2
   version: "2.24.24"
-  epoch: 1
+  epoch: 0
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0

--- a/aws-crt-cpp.yaml
+++ b/aws-crt-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-crt-cpp
   version: "0.31.1"
-  epoch: 2
+  epoch: 1
   description: "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++"
   copyright:
     - license: Apache-2.0

--- a/aws-crt-cpp.yaml
+++ b/aws-crt-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-crt-cpp
   version: "0.31.1"
-  epoch: 1
+  epoch: 2
   description: "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++"
   copyright:
     - license: Apache-2.0

--- a/aws-crt-cpp.yaml
+++ b/aws-crt-cpp.yaml
@@ -80,6 +80,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-cloudwatch
   version: 1.9.4
-  epoch: 15
+  epoch: 16
   description: A Fluent Bit output plugin for CloudWatch Logs
   copyright:
     - license: Apache-2.0

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -46,6 +46,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-cloudwatch
   version: 1.9.4
-  epoch: 16
+  epoch: 15
   description: A Fluent Bit output plugin for CloudWatch Logs
   copyright:
     - license: Apache-2.0

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-firehose
   version: 1.7.2
-  epoch: 15
+  epoch: 16
   description: A Fluent Bit output plugin for Amazon Kinesis Data Firehose
   copyright:
     - license: Apache-2.0

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -46,6 +46,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-firehose
   version: 1.7.2
-  epoch: 16
+  epoch: 15
   description: A Fluent Bit output plugin for Amazon Kinesis Data Firehose
   copyright:
     - license: Apache-2.0

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: 1.10.2
-  epoch: 16
+  epoch: 17
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -49,6 +49,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: 1.10.2
-  epoch: 17
+  epoch: 16
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0

--- a/az.yaml
+++ b/az.yaml
@@ -111,6 +111,4 @@ test:
         az interactive -h
 
         echo "Expanded command tests passed!"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.70.0"
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT

--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.70.0"
-  epoch: 1
+  epoch: 0
   description: Azure CLI
   copyright:
     - license: MIT

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -1,7 +1,7 @@
 package:
   name: binaryen
   version: "122"
-  epoch: 1
+  epoch: 0
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -1,7 +1,7 @@
 package:
   name: binaryen
   version: "122"
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -103,6 +103,4 @@ test:
         wasm-split --help
         wasm2js --version
         wasm2js --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: "9.20.6"
-  epoch: 0
+  epoch: 1
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0

--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: "9.20.6"
-  epoch: 1
+  epoch: 0
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0

--- a/bind.yaml
+++ b/bind.yaml
@@ -117,9 +117,7 @@ subpackages:
     description: bind dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-libs
     dependencies:
@@ -142,9 +140,7 @@ subpackages:
     description: bind (libraries)
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-dnssec-root
     pipeline:
@@ -197,9 +193,7 @@ subpackages:
     description: The ISC DNS server plugins
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: bind-tools
     dependencies:


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
