### PR TITLE
tw/ldd-check cleanup batch 37

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -7,7 +7,7 @@
 package:
   name: abseil-cpp
   version: "20250127.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0

--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -77,5 +77,3 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: abseil-cpp

--- a/acl.yaml
+++ b/acl.yaml
@@ -69,8 +69,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-          with:
-            packages: libacl1
 
   - name: acl-doc
     description: acl docs

--- a/acl.yaml
+++ b/acl.yaml
@@ -1,7 +1,7 @@
 package:
   name: acl
   version: 2.3.2
-  epoch: 6
+  epoch: 7
   description: "access control list utilities"
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later

--- a/aom.yaml
+++ b/aom.yaml
@@ -61,8 +61,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: aom-dev
 
   - name: aom-libs
     pipeline:
@@ -71,9 +69,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libaom.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: aom libs
 
 update:

--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: "3.12.0"
-  epoch: 1
+  epoch: 2
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause

--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -77,8 +77,6 @@ test:
         - openjdk-${{vars.java-runtime-version}}-default-jdk
   pipeline:
     - uses: test/tw/ldd-check
-      with:
-        packages: apache-activemq-artemis
     - name: "Setup activemq-artemis broker and start service"
       runs: |
         mkdir /var/lib/artemis-instance

--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.40.0"
-  epoch: 1
+  epoch: 2
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -65,8 +65,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: apk-tools-dev
 
   - name: apk-tools-doc
     description: apk-tools docs
@@ -88,9 +86,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/lua "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     dependencies:
       runtime:
         - merged-sbin
@@ -111,9 +107,7 @@ test:
         apk update
         apk --version
         apk info apk-tools
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 2
+  epoch: 3
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/apr-util.yaml
+++ b/apr-util.yaml
@@ -1,7 +1,7 @@
 package:
   name: apr-util
   version: 1.6.3
-  epoch: 5
+  epoch: 6
   description: The Apache Portable Runtime Utility Library
   copyright:
     # Some files also contain RSA-MD.

--- a/apr-util.yaml
+++ b/apr-util.yaml
@@ -80,9 +80,7 @@ subpackages:
     description: The Apache Portable Runtime Utility Library - Database driver for PostgreSQL
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: apr-util-dbd_sqlite3
     pipeline:
@@ -92,9 +90,7 @@ subpackages:
     description: The Apache Portable Runtime Utility Library - Database driver for SQLite3
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: apr-util-ldap
     pipeline:
@@ -119,6 +115,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/async-profiler.yaml
+++ b/async-profiler.yaml
@@ -37,9 +37,7 @@ test:
         /usr/bin/asprof --help
         asprof --version
         asprof --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/async-profiler.yaml
+++ b/async-profiler.yaml
@@ -1,7 +1,7 @@
 package:
   name: async-profiler
   version: 3.0
-  epoch: 1
+  epoch: 2
   description: A low overhead sampling profiler for Java
   copyright:
     - license: Apache-2.0

--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -66,8 +66,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: at-spi2-core-dev
 
   - name: at-spi2-core-lang
     pipeline:
@@ -92,9 +90,7 @@ subpackages:
     description: GTK+2.0 module that bridges ATK to D-Bus at-spi
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true
@@ -114,5 +110,3 @@ test:
 
         test -d /usr/share/defaults/at-spi2
     - uses: test/tw/ldd-check
-      with:
-        packages: at-spi2-core

--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: at-spi2-core
   version: "2.56.0"
-  epoch: 0
+  epoch: 1
   description: Protocol definitions and daemon for D-Bus at-spi
   copyright:
     - license: LGPL-2.0-or-later

--- a/attr.yaml
+++ b/attr.yaml
@@ -65,8 +65,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: attr-dev
 
   - name: "libattr1"
     description: "library for managing filesystem extended attributes"
@@ -76,9 +74,7 @@ subpackages:
           mv "${{targets.destdir}}"/lib/libattr.so.* "${{targets.subpkgdir}}"/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libattr1
+        - uses: test/tw/ldd-check
 
   - name: attr-doc
     description: attr docs

--- a/attr.yaml
+++ b/attr.yaml
@@ -1,7 +1,7 @@
 package:
   name: attr
   version: 2.5.2
-  epoch: 6
+  epoch: 7
   description: "utilities for managing filesystem extended attributes"
   copyright:
     - license: GPL-2.0-or-later

--- a/audit.yaml
+++ b/audit.yaml
@@ -82,9 +82,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/lib*.so.* ${{targets.contextdir}}/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: libaudit
+        - uses: test/tw/ldd-check
 
   - name: py3-audit
     description: python bindings for audit
@@ -97,9 +95,7 @@ subpackages:
         - uses: python/import
           with:
             import: audit
-        - uses: test/ldd-check
-          with:
-            packages: py3-audit
+        - uses: test/tw/ldd-check
 
   - name: audit-static
     pipeline:
@@ -116,9 +112,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: audit-dev
+        - uses: test/tw/ldd-check
 
   - name: audit-doc
     pipeline:
@@ -144,6 +138,4 @@ test:
         audisp-remote --help
         aureport --help
         ausearch --help
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/audit.yaml
+++ b/audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: audit
   version: 4.0.3
-  epoch: 2
+  epoch: 3
   description: User space tools for kernel auditing
   copyright:
     - license: LGPL-2.1-or-later

--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-auth
   version: "0.8.7"
-  epoch: 0
+  epoch: 1
   description: "C99 library implementation of AWS client-side authentication: standard credentials providers and signing"
   copyright:
     - license: Apache-2.0

--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -61,9 +61,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-cal.yaml
+++ b/aws-c-cal.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-cal
   version: "0.8.7"
-  epoch: 0
+  epoch: 1
   description: "AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for cryptography primitives"
   copyright:
     - license: Apache-2.0

--- a/aws-c-cal.yaml
+++ b/aws-c-cal.yaml
@@ -57,9 +57,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-common
   version: "0.12.1"
-  epoch: 0
+  epoch: 1
   description: Core c99 package for AWS SDK for C including cross-platform primitives, configuration, data structures, and error handling
   copyright:
     - license: Apache-2.0

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -53,9 +53,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/aws-c-compression.yaml
+++ b/aws-c-compression.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-compression
   version: "0.3.1"
-  epoch: 1
+  epoch: 2
   description: C99 implementation of huffman encoding/decoding
   copyright:
     - license: Apache-2.0

--- a/aws-c-compression.yaml
+++ b/aws-c-compression.yaml
@@ -51,9 +51,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
This cleans up use of ldd-check, replacing
test/ldd-check with test/tw/ldd-check and dropping
the defaults where applicable.
