### PR TITLE
neon: Add ldd-check test

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "8172"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0
@@ -105,6 +105,9 @@ test:
   pipeline:
     # Will fail see https://github.com/wolfi-dev/os/issues/34360
     # - uses: test/pkgconf
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/libexec/neon/v14/lib:/usr/libexec/neon/v15/lib:/usr/libexec/neon/v16/lib:/usr/libexec/neon/v17/lib"
     - name: Test neon_local command
       runs: |
         neon_local --version

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "8172"
-  epoch: 1
+  epoch: 0
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Unfortunately, we cannot generate the list of extra library paths dynamically, so it will need to stay hardcoded for now.

Fixes: #40839
Relates: #40629