### PR TITLE
added a --help test for helm-push

### DIFF
--- a/helm-push.yaml
+++ b/helm-push.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-push
   version: 0.10.4
-  epoch: 22
+  epoch: 23
   description: Helm plugin to push chart package to ChartMuseum
   copyright:
     - license: Apache-2.0
@@ -74,3 +74,8 @@ update:
   github:
     identifier: chartmuseum/helm-push
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        /usr/libexec/helm-plugins/helm-push/bin/helm-cm-push --help


### PR DESCRIPTION
So....  This is a basic helm-push --help test that works, showing a usage statement and exiting 0.  That's great.

However, I also tried to run a bunch of the other commands installed by this package in /usr/libexec, and none of those succeeded for various reasons.  Perhaps that's okay, if they're not really used...but it would probably be better if we deleted them.