### PR TITLE
chore(datadog-agent): bump epoch

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.63.3"
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump epoch to build the package with the fix [1]

1. https://github.com/wolfi-dev/os/commit/d12c9f2737049cafbb4339a1b3a747ea91500abc
