### PR TITLE
chore(sts): remove workflow permission for eol-mover

### DIFF
--- a/.github/chainguard/lifecycle-eol-mover.sts.yaml
+++ b/.github/chainguard/lifecycle-eol-mover.sts.yaml
@@ -5,6 +5,5 @@ issuer: https://accounts.google.com
 subject: "105314035764875766195"
 
 permissions:
-  contents: write
-  pull_requests: write
-  workflows: write
+  contents: write # to push to branches of the repo
+  pull_requests: write # to open and modify PRs


### PR DESCRIPTION
I don't think this permission is actually used for anything, so let's cut it in the name of "least privilege". If this breaks something, we'll fix it then.
