### PR TITLE
libarchive: backport CVE fixes

### DIFF
--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -1,7 +1,7 @@
 package:
   name: libarchive
   version: 3.7.7
-  epoch: 1
+  epoch: 2
   description: "multi-format archive and compression library"
   copyright:
     - license: BSD-2-Clause
@@ -28,6 +28,10 @@ pipeline:
     with:
       uri: https://libarchive.org/downloads/libarchive-${{package.version}}.tar.xz
       expected-sha256: 879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee
+
+  - uses: patch
+    with:
+      patches: CVE-2024-57970.patch
 
   - uses: autoconf/configure
     with:

--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: CVE-2024-57970.patch
+      patches: CVE-2024-57970.patch CVE-2025-1632_CVE-2025-25724.patch
 
   - uses: autoconf/configure
     with:

--- a/libarchive/CVE-2024-57970.patch
+++ b/libarchive/CVE-2024-57970.patch
@@ -1,0 +1,31 @@
+From 82912103214506316bd9990d73f33d743d55f570 Mon Sep 17 00:00:00 2001
+From: Tim Kientzle <kientzle@acm.org>
+Date: Mon, 9 Dec 2024 21:09:29 -0800
+Subject: [PATCH] Handle truncation in the middle of a GNU long linkname
+ (#2422)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Thanks to gbdngb12 김동건 for reporting this.
+
+Resolves Issue #2415
+---
+ libarchive/archive_read_support_format_tar.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_tar.c b/libarchive/archive_read_support_format_tar.c
+index 4aaf1b90ce..b1344ae57d 100644
+--- a/libarchive/archive_read_support_format_tar.c
++++ b/libarchive/archive_read_support_format_tar.c
+@@ -1146,7 +1146,9 @@ header_gnu_longlink(struct archive_read *a, struct tar *tar,
+ 	struct archive_string linkpath;
+ 	archive_string_init(&linkpath);
+ 	err = read_body_to_string(a, tar, &linkpath, h, unconsumed);
+-	archive_entry_set_link(entry, linkpath.s);
++	if (err == ARCHIVE_OK) {
++		archive_entry_set_link(entry, linkpath.s);
++	}
+ 	archive_string_free(&linkpath);
+ 	return (err);
+ }

--- a/libarchive/CVE-2025-1632_CVE-2025-25724.patch
+++ b/libarchive/CVE-2025-1632_CVE-2025-25724.patch
@@ -1,0 +1,79 @@
+From c9bc934e7e91d302e0feca6e713ccc38d6d01532 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Peter=20K=C3=A4stle?= <peter@piie.net>
+Date: Mon, 10 Mar 2025 16:43:04 +0100
+Subject: [PATCH] fix CVE-2025-1632 and CVE-2025-25724 (#2532)
+
+Hi,
+
+please find my approach to fix the CVE-2025-1632 and CVE-2025-25724
+vulnerabilities in this pr.
+As both error cases did trigger a NULL pointer deref (and triggered
+hopefully everywhere a coredump), we can safely replace the actual
+information by a predefined invalid string without breaking any
+functionality.
+
+---------
+
+Signed-off-by: Peter Kaestle <peter@piie.net>
+---
+ tar/util.c       |  5 ++++-
+ unzip/bsdunzip.c | 10 +++++++---
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/tar/util.c b/tar/util.c
+index 3b099cb5f..f3cbdf0bb 100644
+--- a/tar/util.c
++++ b/tar/util.c
+@@ -749,7 +749,10 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
+ #else
+ 	ltime = localtime(&tim);
+ #endif
+-	strftime(tmp, sizeof(tmp), fmt, ltime);
++	if (ltime)
++		strftime(tmp, sizeof(tmp), fmt, ltime);
++	else
++		sprintf(tmp, "-- -- ----");
+ 	fprintf(out, " %s ", tmp);
+ 	safe_fprintf(out, "%s", archive_entry_pathname(entry));
+ 
+diff --git a/unzip/bsdunzip.c b/unzip/bsdunzip.c
+index 7c8cafc3e..4a9028b79 100644
+--- a/unzip/bsdunzip.c
++++ b/unzip/bsdunzip.c
+@@ -876,6 +876,7 @@ list(struct archive *a, struct archive_entry *e)
+ 	char buf[20];
+ 	time_t mtime;
+ 	struct tm *tm;
++	const char *pathname;
+ 
+ 	mtime = archive_entry_mtime(e);
+ 	tm = localtime(&mtime);
+@@ -884,22 +885,25 @@ list(struct archive *a, struct archive_entry *e)
+ 	else
+ 		strftime(buf, sizeof(buf), "%m-%d-%g %R", tm);
+ 
++	pathname = archive_entry_pathname(e);
++	if (!pathname)
++		pathname = "";
+ 	if (!zipinfo_mode) {
+ 		if (v_opt == 1) {
+ 			printf(" %8ju  %s   %s\n",
+ 			    (uintmax_t)archive_entry_size(e),
+-			    buf, archive_entry_pathname(e));
++			    buf, pathname);
+ 		} else if (v_opt == 2) {
+ 			printf("%8ju  Stored  %7ju   0%%  %s  %08x  %s\n",
+ 			    (uintmax_t)archive_entry_size(e),
+ 			    (uintmax_t)archive_entry_size(e),
+ 			    buf,
+ 			    0U,
+-			    archive_entry_pathname(e));
++			    pathname);
+ 		}
+ 	} else {
+ 		if (Z1_opt)
+-			printf("%s\n",archive_entry_pathname(e));
++			printf("%s\n", pathname);
+ 	}
+ 	ac(archive_read_data_skip(a));
+ }


### PR DESCRIPTION
These patches are self-contained and apply cleanly, so instead of waiting for upstream to cut a release (which hasn't happened since October), apply the fixes directly ourselves.