### PR TITLE
update x/net to fix cve GHSA-qxp5-gwg8-xv66

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -27,7 +27,7 @@ pipeline:
       deps: |-
         github.com/go-jose/go-jose/v3@v3.0.4
         golang.org/x/crypto@v0.31.0
-        golang.org/x/net@v0.33.0
+        golang.org/x/net@v0.36.0
       replaces: |
         github.com/go-jose/go-jose/v4=github.com/go-jose/go-jose/v4@v4.0.5
 

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: "7.8.1"
-  epoch: 3
+  epoch: 4
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT


### PR DESCRIPTION
Fixes CVE-2025-22870
