### PR TITLE
apk-tools: disable cache by default

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 1
+  epoch: 2
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -30,6 +30,11 @@ pipeline:
       repository: https://gitlab.alpinelinux.org/alpine/apk-tools.git
       tag: v${{package.version}}
       expected-commit: 9d074efdc12bc41b5d24190595a5269a770e852a
+
+  - uses: patch
+    with:
+      patches: |
+        database-initiate-apk_flags-to-NO_CACHE-by-default.patch
 
   - runs: |
       sed -i -e 's:-Werror::' Make.rules

--- a/apk-tools/database-initiate-apk_flags-to-NO_CACHE-by-default.patch
+++ b/apk-tools/database-initiate-apk_flags-to-NO_CACHE-by-default.patch
@@ -1,0 +1,30 @@
+From effcaa0a3df6e04c672803cf71201ec63ca31e0e Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 18 Mar 2025 15:40:44 +0000
+Subject: [PATCH] database: initiate apk_flags to NO_CACHE by default
+
+This ensures broken cache, missing cache, corrupted cache does not
+impact apk operations.
+
+Also it ensures after the operation is completed, the caches are clean
+(never created) keeping individual container layers small.
+---
+ src/database.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/database.c b/src/database.c
+index dc5e4fd..13b6fb0 100644
+--- a/src/database.c
++++ b/src/database.c
+@@ -47,7 +47,7 @@ enum {
+ };
+ 
+ int apk_verbosity = 1;
+-unsigned int apk_flags = 0, apk_force = 0;
++unsigned int apk_flags = APK_NO_CACHE, apk_force = 0;
+ 
+ static apk_blob_t tmpprefix = { .len=8, .ptr = ".apknew." };
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
apk-tools fails to work correctly with missing cache, corrupted cache,
incompete cache, or on filesystems mounted without incorrect
timestamps. As cache appears to be based on lstat timestamps, rather
than on etags.

Also, apkindex cache in containers use up disk space and create
non-minimised layers. Thus in general for containers operating by
default without cache, is preffered mode of operation.

With this change, apkindex will be downloaded upon each invocation apk
update. Meaning to change in performance for single apk invocation,
but may cause additional apkindex downloads (potential of additional
10MB network traffic, from second invocation onwards), but on the flip
side the resulting layer will be minimised. Slightly increased
dockerfile build time, with a guranteed smaller end image.
