### PR TITLE
fix(libcxx*): Drop cxx related provides for LLVM 17

### DIFF
--- a/llvm.yaml
+++ b/llvm.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm
   version: "19.1.7"
-  epoch: 5
+  epoch: 6
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -505,7 +505,6 @@ subpackages:
     dependencies:
       provider-priority: ${{vars.major-version}}
       provides:
-        - llvm-libcxxabi-17=${{package.full-version}}
         - llvm-libcxxabi-18=${{package.full-version}}
         - llvm-libcxxabi-19=${{package.full-version}}
     pipeline:
@@ -518,7 +517,6 @@ subpackages:
     dependencies:
       provider-priority: ${{vars.major-version}}
       provides:
-        - llvm-libcxx-17=${{package.full-version}}
         - llvm-libcxx-18=${{package.full-version}}
         - llvm-libcxx-19=${{package.full-version}}
     pipeline:
@@ -534,7 +532,6 @@ subpackages:
     description: Static library for LLVM libc++ 1
     dependencies:
       provides:
-        - llvm-libcxx-17-static=${{package.full-version}}
         - llvm-libcxx-18-static=${{package.full-version}}
         - llvm-libcxx-19-static=${{package.full-version}}
     pipeline:
@@ -546,7 +543,6 @@ subpackages:
     description: Development files for LLVM libc++ 1
     dependencies:
       provides:
-        - llvm-libcxx-17-dev=${{package.full-version}}
         - llvm-libcxx-18-dev=${{package.full-version}}
         - llvm-libcxx-19-dev=${{package.full-version}}
       runtime:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -18,3 +18,7 @@ libcxxabi1-19.1.7-r1.apk
 libcxxabi1-19.1.7-r2.apk
 libcxxabi1-19.1.7-r3.apk
 libcxxabi1-19.1.7-r4.apk
+libcxx1-19.1.7-r5.apk
+libcxx1-dev-19.1.7-r5.apk
+libcxx1-static-19.1.7-r5.apk
+libcxxabi1-19.1.7-r5.apk


### PR DESCRIPTION
LLVM 19 CXX headers are causing compilation failures when used with LLVM 17; trim provides for libcxx related packages for this version so that the version specific package is used instead.

Related: #44381
