### PR TITLE
Rebuild nodejs with -march=x86-64-v2 -mno-sahf

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 10
+  epoch: 11
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
 

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: "18.20.7"
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: "20.19.0"
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -51,7 +51,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 7
+  epoch: 8
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -50,7 +50,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
       # Compiling with O2 instead of Os increases binary size by ~10%

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: "22.14.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -53,7 +53,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
 

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: "23.10.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -53,7 +53,7 @@ pipeline:
          common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       "x86_64")
-         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -mno-sahf"
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
          ;;
       esac
 


### PR DESCRIPTION
Merging a previous PR, largely did nothing[1], as epoch bumps were
superseeded by manpage split prs, and github let this be merged
without a conflict, but also not actually building anything.

Rebuild all nodejs, drop any -march/-mno-sahf settings, which will use
gcc-14 defaults, which are now set to be -march=x86-64-v2 -mno-sahf.

[1] See https://github.com/wolfi-dev/os/commit/c38130cc3f7869652376a837e96946e36163a99f
