### PR TITLE
python: rebuild against gcc which defaults to -mno-sahf

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.16
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,11 +61,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Rosetta Seemingly doesn't support sahf.
-      if [ ${{build.arch}} == 'x86_64' ]; then
-        export CFLAGS='-mno-sahf'
-      fi
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.11
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,11 +61,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Rosetta Seemingly doesn't support sahf.
-      if [ ${{build.arch}} == 'x86_64' ]; then
-        export CFLAGS='-mno-sahf'
-      fi
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.9"
-  epoch: 5
+  epoch: 6
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,11 +68,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Rosetta Seemingly doesn't support sahf.
-      if [ ${{build.arch}} == 'x86_64' ]; then
-        export CFLAGS='-mno-sahf'
-      fi
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.2"
-  epoch: 5
+  epoch: 6
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -68,11 +68,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Rosetta Seemingly doesn't support sahf.
-      if [ ${{build.arch}} == 'x86_64' ]; then
-        export CFLAGS='-mno-sahf'
-      fi
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \


### PR DESCRIPTION
Now that gcc-14 defaults to -mno-sahf, there is no need to encode it
in the individual python melange files. Drop the extra code, to avoid
repeating oneself.

This is a no effective change, kind/cleanup. As previous epoch bump has already built with mno-sahf.

Also see:
- https://github.com/wolfi-dev/os/pull/47063
- https://github.com/wolfi-dev/os/pull/47344
