### PR TITLE
kmod: search /usr/lib/modules instead of /lib/modules

### DIFF
--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "34.1"
-  epoch: 0
+  epoch: 2
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -44,6 +44,7 @@ pipeline:
         --build=${{host.triplet.gnu}} \
         --target=${{host.triplet.gnu}} \
         --prefix=/usr \
+        --with-module-directory=/usr/lib/modules \
         --with-zlib \
         --with-xz \
         --with-zstd \


### PR DESCRIPTION
I don't know that this is safe. Several packages depend on kmod. Theoretically they're all running in containers and aren't loading any modules, unless they're running in a container with `/lib/modules` mounted from the host.