### PR TITLE
gcc more no sahf

### DIFF
--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -68,10 +68,13 @@ pipeline:
               mtune=neoverse-v2
               CFLAGS="-mbranch-protection=standard"
               CXXFLAGS="-mbranch-protection=standard"
+              specs=""
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
+              # Currently hangs on Apple Rosetta 2 emulator
+              specs="-mno-sahf"
               ;;
           esac
           CFLAGS="$CFLAGS" \
@@ -97,6 +100,7 @@ pipeline:
             --with-system-zlib \
             --with-arch=$march \
             --with-tune=$mtune \
+            --with-specs=$specs \
             --enable-languages=c,c++ \
             --enable-bootstrap \
             --enable-gnu-indirect-function \

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -45,7 +45,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
       expected-sha512: 88f17d5a5e69eeb53aaf0a9bc9daab1c4e501d145b388c5485ebeb2cc36178fbb2d3e49ebef4a8c007a05e88471a06b97cf9b08870478249f77fbfa3d4abd9a8
 
   - name: Fix false invalid march extension crc on arm64

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 9
+  epoch: 10
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -68,10 +68,13 @@ pipeline:
               mtune=neoverse-v2
               CFLAGS="-mbranch-protection=standard"
               CXXFLAGS="-mbranch-protection=standard"
+              specs=""
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
+              # Currently hangs on Apple Rosetta 2 emulator
+              specs="-mno-sahf"
               ;;
           esac
           CFLAGS="$CFLAGS" \
@@ -97,6 +100,7 @@ pipeline:
             --with-system-zlib \
             --with-arch=$march \
             --with-tune=$mtune \
+            --with-specs=$specs \
             --enable-languages=c,c++ \
             --enable-bootstrap \
             --enable-gnu-indirect-function \

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -45,7 +45,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
       expected-sha512: 5bd29402cad2deb5d9388d0236c7146414d77e5b8d5f1c6c941c7a1f47691c3389f08656d5f6e8e2d6717bf2c81f018d326f632fb468f42925b40bd217fc4853
 
   - name: Fix false invalid march extension crc on arm64

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -62,10 +62,13 @@ pipeline:
               mtune=neoverse-v2
               CFLAGS="-mbranch-protection=standard"
               CXXFLAGS="-mbranch-protection=standard"
+              specs=""
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
+              # Currently hangs on Apple Rosetta 2 emulator
+              specs="-mno-sahf"
               ;;
           esac
           CFLAGS="$CFLAGS" \
@@ -91,6 +94,7 @@ pipeline:
             --with-system-zlib \
             --with-arch=$march \
             --with-tune=$mtune \
+            --with-specs=$specs \
             --enable-languages=c,c++ \
             --enable-bootstrap \
             --enable-gnu-indirect-function \

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -44,7 +44,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
       expected-sha512: ed5f2f4c6ed2c796fcf2c93707159e9dbd3ddb1ba063d549804dd68cdabbb6d550985ae1c8465ae9a336cfe29274a6eb0f42e21924360574ebd8e5d5c7c9a801
 
   - working-directory: /home/build/build

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 13
+  epoch: 14
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/etc/clang/x86_64-unknown-linux-gnu-clang.cfg
+++ b/openssf-compiler-options/etc/clang/x86_64-unknown-linux-gnu-clang.cfg
@@ -1,5 +1,5 @@
 # Optimisations
--march=x86-64-v2 -mtune=sapphirerapids
+-march=x86-64-v2 -mtune=sapphirerapids -mno-sahf
 
 # for x86_64
 -fcf-protection=full


### PR DESCRIPTION
- **gcc: enable -mno-sahf in version streams**
  Enable -mno-sahf in all gcc version streams that default to x86-64-v2
  march.
  

- **openssf-compiler-options: enable -mno-sahf for clang toolchains**
  llvm/clang does not have --with-specs like toolchain configure time
  election of minimum abi, thus enforce -mno-sahf via
  openssf-compiler-options config files for llvm/clang.
  