### PR TITLE
Call corepack enable fixing a FTBFS

### DIFF
--- a/teleport.yaml
+++ b/teleport.yaml
@@ -1,7 +1,7 @@
 package:
   name: teleport
   version: "17.3.2"
-  epoch: 0
+  epoch: 1
   description: The easiest, and most secure way to access and protect all of your infrastructure.
   copyright:
     - license: AGPL-3.0-only
@@ -63,6 +63,7 @@ pipeline:
       export PATH="$HOME/.rustup/toolchains/stable-${ARCH}-unknown-linux-gnu/bin:$PATH"
       rustup target add wasm32-unknown-unknown
 
+      corepack enable
       pnpm config set package-import-method copy
 
       # Install dependencies and build web assets


### PR DESCRIPTION
Adding a separate call to `corepack enable` resolves a hang when building the teleport package. From what I saw during the build process one of the later commands either `pnpm config set...` or `make ensure-js-deps` ended up unsuccessfully calling `corepack enable` and for some reason putting in a separate step works. I'm not familiar with these languages so this could be wrong.

This fixes https://github.com/chainguard-dev/internal-dev/issues/10583