### PR TITLE
Add a runtime dep

### DIFF
--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,10 +1,13 @@
 package:
   name: pnpm
   version: "10.6.4"
-  epoch: 0
+  epoch: 1
   description: "Fast, disk space efficient package manager"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - nodejs-18
 
 environment:
   contents:
@@ -75,10 +78,6 @@ update:
     tag-filter: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - nodejs-18
   pipeline:
     - runs: |
         set -o pipefail


### PR DESCRIPTION
The package pnpm is missing a runtime dependency which was only added to the test environment for the package.

This fixes https://github.com/wolfi-dev/os/issues/47343