### PR TITLE
Use extra-library-paths with ldd-check

### DIFF
--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 4
+  epoch: 5
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 5
+  epoch: 4
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -110,9 +110,9 @@ subpackages:
     description: freerdp library
     test:
       pipeline:
-       - uses: test/tw/ldd-check
-         with:
-           extra-library-paths: "/usr/lib/freerdp2/"
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/freerdp2/"
 
 update:
   enabled: true

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -108,6 +108,11 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv ${{targets.destdir}}/usr/lib/* ${{targets.subpkgdir}}/usr/lib
     description: freerdp library
+    test:
+      pipeline:
+       - uses: test/tw/ldd-check
+         with:
+           extra-library-paths: "/usr/lib/freerdp2/"
 
 update:
   enabled: true


### PR DESCRIPTION
Add the ldd-check test and utilize the extra-library-paths option so that the test passes.

This fixes https://github.com/wolfi-dev/os/issues/41300