### PR TITLE
 pecan and webob: new packages

### DIFF
--- a/py3-pecan.yaml
+++ b/py3-pecan.yaml
@@ -1,0 +1,118 @@
+package:
+  name: py3-pecan
+  version: "1.6.1"
+  epoch: 0
+  description: "A WSGI object-dispatching web framework, designed to be lean and fast with few dependencies."
+  copyright:
+    - license: BSD-3-Clause AND MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pecan
+
+data:
+  - name: py-versions
+    items:
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pecan/pecan
+      tag: ${{package.version}}
+      expected-commit: 0fdeb676789426287476b1938b211bc8554a57c4
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-webob
+        - py${{range.key}}-mako
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - py${{range.key}}-setuptools
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - curl
+      pipeline:
+        - runs: |
+            rm -rf test_project
+            pecan create test_project
+            cd test_project
+            python${{range.key}} setup.py develop
+            pecan serve config.py &
+            curl --silent --retry 3 --retry-delay 5 --retry-connrefused http://localhost:8080/ | grep "Welcome to Pecan!" || {
+              echo "pecan did not start correctly on Python ${{range.key}}"
+              exit 1
+            }
+            pkill pecan
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pecan/pecan

--- a/py3-webob.yaml
+++ b/py3-webob.yaml
@@ -1,0 +1,93 @@
+package:
+  name: py3-webob
+  version: "1.8.9"
+  epoch: 0
+  description: "WebOb provides objects for HTTP requests and responses wrapping the WSGI request environment."
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: webob
+
+data:
+  - name: py-versions
+    items:
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Pylons/webob
+      tag: ${{package.version}}
+      expected-commit: 5216c0db6fc31f18d5ee892afffbb4bc05e73403
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+      runtime:
+        # Only actually needed for Pythons >= 3.13
+        - py${{range.key}}-legacy-cgi
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-pytest
+      pipeline:
+        - uses: git-checkout
+          with:
+            repository: https://github.com/Pylons/webob
+            tag: ${{package.version}}
+            expected-commit: 5216c0db6fc31f18d5ee892afffbb4bc05e73403
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - runs: |
+            python${{range.key}} -m pytest tests
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: Pylons/webob
+    use-tag: true


### PR DESCRIPTION
New packages for pecan and webob to support use in Ceph.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)