### PR TITLE
apache-activemq-artemis - fix FTBFS with update to commit hash

### DIFF
--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.40.0"
-  epoch: 0
+  epoch: 1
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ pipeline:
     with:
       repository: https://github.com/apache/activemq-artemis
       tag: ${{package.version}}
-      expected-commit: 665d2763c3a3a063fccc62dc68a30576d24958c6
+      expected-commit: 2c3903ff71de7ecc6830d5f051dfc94d6df9b187
 
   - uses: maven/pombump
 


### PR DESCRIPTION
The commit hash seems to have changed after release of 2.4.0 (which was 1 week ago).
h