### PR TITLE
py3-bcrypt-3.2: new version stream

### DIFF
--- a/py3-bcrypt-3.2.yaml
+++ b/py3-bcrypt-3.2.yaml
@@ -1,0 +1,81 @@
+package:
+  name: py3-bcrypt-3.2
+  version: "3.2.2"
+  epoch: 0
+  description: Modern password hashing for your software and your servers
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: bcrypt
+  import: bcrypt
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+      - py3-supported-cffi
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: a86360fef7859054c6a8050cf67e62127f5e2643
+      repository: https://github.com/pyca/bcrypt
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-3.2
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-cffi
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}-3.2
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}-3.2
+        - py3.11-${{vars.pypi-package}}-3.2
+        - py3.12-${{vars.pypi-package}}-3.2
+        - py3.13-${{vars.pypi-package}}-3.2
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pyca/bcrypt
+    use-tag: true
+    tag-filter: 3.2.

--- a/py3-bcrypt-3.2.yaml
+++ b/py3-bcrypt-3.2.yaml
@@ -40,7 +40,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - py3-${{vars.pypi-package}}-3.2
+        - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-cffi
     pipeline:
@@ -64,13 +64,12 @@ subpackages:
         - py3.11-${{vars.pypi-package}}-3.2
         - py3.12-${{vars.pypi-package}}-3.2
         - py3.13-${{vars.pypi-package}}-3.2
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import ${{vars.import}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-bcrypt-3.2.yaml
+++ b/py3-bcrypt-3.2.yaml
@@ -40,7 +40,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-3.2
       runtime:
         - py${{range.key}}-cffi
     pipeline:


### PR DESCRIPTION
New version stream of py3-bcrypt to support a pre-Rust backend version for compatibility with Ceph.

Related: #43573

### Pre-review Checklist

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
