### PR TITLE
add new mysql-shell

### DIFF
--- a/mysql-shell-9.1.yaml
+++ b/mysql-shell-9.1.yaml
@@ -1,0 +1,59 @@
+package:
+  name: mysql-shell-9.1
+  version: 9.1.0
+  epoch: 0
+  description: MySQL Shell is a new command line scriptable shell for MySQL. It supports JavaScript and Python.
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - mysql-9.1
+    provides:
+      - mysql-shell=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - cmake
+      - git
+      - libssh-dev
+      - mysql-9.1-client
+      - mysql-9.1-dev
+      - openssl-dev
+      - python-3.13-dev
+  environment:
+    MYSQL_SOURCE_DIR: /usr
+    MYSQL_BUILD_DIR: /usr/include/mysql
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mysql/mysql-shell
+      tag: ${{package.version}}
+      expected-commit: 3aeed61a48d1a8124411d2a0a088461fcfde3d8a
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DMYSQL_SOURCE_DIR=$MYSQL_SOURCE_DIR \
+        -DMYSQL_BUILD_DIR=$MYSQL_BUILD_DIR \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DHAVE_PYTHON=1 \
+        -DWITH_SSL=system \
+        -DWITH_TESTS=OFF
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mysql/mysql-shell
+    strip-prefix: mysql-
+    use-tag: true
+    tag-filter: mysql-9.1.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
