### PR TITLE
pg-failover-slots-16 - be explicit on postgres-16-dev

### DIFF
--- a/pg-failover-slots-16.yaml
+++ b/pg-failover-slots-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg-failover-slots-16
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: PG Failover Slots extension for PostgreSQL 16
   copyright:
     - license: BSD-3-Clause
@@ -12,7 +12,7 @@ environment:
       - automake
       - build-base
       - busybox
-      - postgresql-dev
+      - postgresql-16-dev
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
This will make the test pass which is currently failing.

After postgres-dev moved to postgres-17, this test begin to fail.
