### PR TITLE
ruby-yajl-ruby git deep clone so commit checkout works.

### DIFF
--- a/ruby3.2-yajl-ruby.yaml
+++ b/ruby3.2-yajl-ruby.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-yajl-ruby
   version: 1.4.3
-  epoch: 6
+  epoch: 7
   description: ruby C bindings for Yajl library
   copyright:
     - license: MIT
@@ -27,6 +27,7 @@ vars:
   #
   # This commit matches the 1.4.3 release on rubygems.org so it's used to check
   # the repository out and build the 1.4.3 version of yajl-ruby
+  # https://github.com/brianmario/yajl-ruby/issues/216
   commit: e8de283a6d64f0902740fd09e858fc3d7d803161
 
 pipeline:
@@ -37,6 +38,7 @@ pipeline:
       branch: master
       destination: ${{vars.gem}}
       repository: https://github.com/brianmario/yajl-ruby
+      depth: -1
 
   - working-directory: ${{vars.gem}}
     pipeline:

--- a/ruby3.3-yajl-ruby.yaml
+++ b/ruby3.3-yajl-ruby.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-yajl-ruby
   version: 1.4.3
-  epoch: 0
+  epoch: 1
   description: ruby C bindings for Yajl library
   copyright:
     - license: MIT
@@ -27,6 +27,7 @@ vars:
   #
   # This commit matches the 1.4.3 release on rubygems.org so it's used to check
   # the repository out and build the 1.4.3 version of yajl-ruby
+  # https://github.com/brianmario/yajl-ruby/issues/216
   commit: e8de283a6d64f0902740fd09e858fc3d7d803161
 
 pipeline:
@@ -37,6 +38,7 @@ pipeline:
       branch: master
       destination: ${{vars.gem}}
       repository: https://github.com/brianmario/yajl-ruby
+      depth: -1
 
   - working-directory: ${{vars.gem}}
     pipeline:

--- a/ruby3.4-yajl-ruby.yaml
+++ b/ruby3.4-yajl-ruby.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-yajl-ruby
   version: 1.4.3
-  epoch: 3
+  epoch: 4
   description: ruby C bindings for Yajl library
   copyright:
     - license: MIT
@@ -27,6 +27,7 @@ vars:
   #
   # This commit matches the 1.4.3 release on rubygems.org so it's used to check
   # the repository out and build the 1.4.3 version of yajl-ruby
+  # https://github.com/brianmario/yajl-ruby/issues/216
   commit: 63760720e58d8cb818d59ae6c4f3d96760cd7854
 
 pipeline:
@@ -37,6 +38,7 @@ pipeline:
       branch: master
       destination: ${{vars.gem}}
       repository: https://github.com/brianmario/yajl-ruby
+      depth: -1
 
   - working-directory: ${{vars.gem}}
     pipeline:


### PR DESCRIPTION
These were all failing to build from source because the shallow clone that git does by default could not find the provided hash.

hopefully developer will create a tag as requested
 https://github.com/brianmario/yajl-ruby/issues/216
