### PR TITLE
Drop the runtime dep on nodejs

### DIFF
--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,13 +1,10 @@
 package:
   name: pnpm
   version: "10.6.5"
-  epoch: 0
+  epoch: 1
   description: "Fast, disk space efficient package manager"
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - nodejs-18
 
 environment:
   contents:
@@ -78,6 +75,10 @@ update:
     tag-filter: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - nodejs-18
   pipeline:
     - runs: |
         set -o pipefail


### PR DESCRIPTION
I'd previously moved a test environment dependency to a run time dependency (https://github.com/wolfi-dev/os/pull/47381) but that caused some issues with image builds. This reverts that change.

The failure message was:

```
resolving apk packages: for arch \"arm64\": solving \"pnpm\" constraint: resolving \"pnpm-10.6.5-r0.apk\" deps:
solving \"nodejs-18\" constraint:   nodejs-18-18.14.0-r1.apk disqualified because nodejs-22-22.14.0-r2.apk already provides cmd:node
  nodejs-18-18.14.1-r0.apk disqualified because nodejs-22-22.14.0-r2.apk already provides cmd:node
  nodejs-18-18.14.2-r0.apk disqualified because nodejs-22-22.14.0-r2.apk already provides cmd:node
  nodejs-18-18.15.0-r0.apk disqualified because nodejs-22-22.14.0-r2.apk already provides cmd:node
  nodejs-18-18.15.0-r1.apk disqualified because nodejs-22-22.14.0-r2.apk already provides cmd:node
```