### PR TITLE
feat: add spiffe-csi package

### DIFF
--- a/spiffe-csi.yaml
+++ b/spiffe-csi.yaml
@@ -1,0 +1,32 @@
+package:
+  name: spiffe-csi
+  version: 0.2.6
+  epoch: 0
+  description: Container Storage Interface components for SPIFFE
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/spiffe/spiffe-csi
+      tag: v${{package.version}}
+      expected-commit: f4db4547700926cdac7b7e79fe4441c8a15f89b8
+
+  - uses: go/build
+    with:
+      packages: "./cmd/spiffe-csi-driver"
+      output: spiffe-csi-driver
+
+update:
+  enabled: true
+  github:
+    identifier: spiffe/spiffe-csi
+    strip-prefix: v

--- a/spiffe-csi.yaml
+++ b/spiffe-csi.yaml
@@ -25,6 +25,15 @@ pipeline:
       packages: "./cmd/spiffe-csi-driver"
       output: spiffe-csi-driver
 
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package to place binaries in the location expected by upstream helm charts
+    pipeline:
+      - runs: |
+          # The helm chart expects the binaries to be in / instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/spiffe-csi-driver ${{targets.subpkgdir}}/spiffe-csi-driver
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
Fixes: #47472

- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
  - It appears that the latest version is the only supported/maintained release 