### PR TITLE
added a test for nrjmx, and fixed its runtime deps

### DIFF
--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -1,12 +1,14 @@
 package:
   name: nrjmx
   version: "2.7.0"
-  epoch: 0
+  epoch: 1
   description: Command line tool to connect to a JMX server and retrieve the MBeans it exposes
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - java-common
+      - openjdk-17-default-jvm
       - openjdk-17-jre
 
 environment:
@@ -50,3 +52,8 @@ update:
   github:
     identifier: newrelic/nrjmx
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        nrjmx  --help


### PR DESCRIPTION
Added a test for nrjmx, which identified a couple of missing runtime dependencies.  It ships a shell script which depends on "java" being in the PATH.  Added java-common and a jvm.