### PR TITLE
add py3-cattle, py3-gdapi-python and py3-rancher-client-python

### DIFF
--- a/py3-cattle.yaml
+++ b/py3-cattle.yaml
@@ -53,6 +53,11 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: Fix conflicting dependencies
+        runs: |
+          # We will have the gdapi-python package installed in the runtime dependencies.
+          python${{range.key}} -m pip uninstall -y gdapi-python
+          sed -i '/^Requires-Dist: gdapi-python/d' ${{targets.contextdir}}/usr/lib/python${{range.key}}/site-packages/cattle-${{package.version}}.dist-info/METADATA
       - uses: strip
     test:
       pipeline:

--- a/py3-cattle.yaml
+++ b/py3-cattle.yaml
@@ -70,7 +70,7 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
         - runs: |
-            cattle-${{range.key}} --help 2>&1 | grep -q "ConnectionError"
+            cattle-${{range.key}} --url $CATTLE_URL --access-key $CATTLE_ACCESS_KEY --secret-key $CATTLE_SECRET_KEY --version 2>&1 | grep -q "Connection refused"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-cattle.yaml
+++ b/py3-cattle.yaml
@@ -53,18 +53,24 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
-      - name: Fix conflicting dependencies
+      - name: Create versioned binary
         runs: |
-          # We will have the gdapi-python package installed in the runtime dependencies.
-          python${{range.key}} -m pip uninstall -y gdapi-python
-          sed -i '/^Requires-Dist: gdapi-python/d' ${{targets.contextdir}}/usr/lib/python${{range.key}}/site-packages/cattle-${{package.version}}.dist-info/METADATA
+          mv ${{targets.contextdir}}/usr/bin/cattle ${{targets.contextdir}}/usr/bin/cattle-${{range.key}}
+          ln -sf /usr/bin/cattle-${{range.key}} ${{targets.contextdir}}/usr/bin/cattle
       - uses: strip
     test:
+      environment:
+        environment:
+          CATTLE_URL: http://localhost:8080/v1
+          CATTLE_ACCESS_KEY: 4C27AB31828A4E469C09
+          CATTLE_SECRET_KEY: fDxEzyxdFMWbmugstPpzykj2qA84Tn9DPDiAc3Sb
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+        - runs: |
+            cattle-${{range.key}} --help 2>&1 | grep -q "ConnectionError"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -78,16 +84,3 @@ subpackages:
 update:
   enabled: false
   exclude-reason: No releases since 2015.
-
-test:
-  environment:
-    environment:
-      CATTLE_URL: http://localhost:8080/v1
-      CATTLE_ACCESS_KEY: 4C27AB31828A4E469C09
-      CATTLE_SECRET_KEY: fDxEzyxdFMWbmugstPpzykj2qA84Tn9DPDiAc3Sb
-  pipeline:
-    - uses: python/import
-      with:
-        import: cattle
-    - runs: |
-        cattle --help 2>&1 | grep -q "ConnectionError"

--- a/py3-cattle.yaml
+++ b/py3-cattle.yaml
@@ -1,0 +1,88 @@
+package:
+  name: py3-cattle
+  version: "0.5.4"
+  epoch: 0
+  description: Command line client for cattle
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - cattle=${{package.full-version}}
+      - cattle-cli=${{package.full-version}}
+      - rancher-cattle-cli=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-supported-build
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+
+vars:
+  pypi-package: cattle
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/c/cattle/cattle-${{package.version}}.tar.gz
+      expected-sha256: 6ae8b377d9a70a4351598b84854785ee5f4cb4b1a29abf5c33454bb58de2470e
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-gdapi-python
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: false
+  exclude-reason: No releases since 2015.
+
+test:
+  environment:
+    environment:
+      CATTLE_URL: http://localhost:8080/v1
+      CATTLE_ACCESS_KEY: 4C27AB31828A4E469C09
+      CATTLE_SECRET_KEY: fDxEzyxdFMWbmugstPpzykj2qA84Tn9DPDiAc3Sb
+  pipeline:
+    - uses: python/import
+      with:
+        import: cattle
+    - runs: |
+        cattle --help 2>&1 | grep -q "ConnectionError"

--- a/py3-gdapi-python.yaml
+++ b/py3-gdapi-python.yaml
@@ -58,13 +58,24 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: Create versioned binary
+        runs: |
+          mv ${{targets.contextdir}}/usr/bin/gdapi ${{targets.contextdir}}/usr/bin/gdapi-${{range.key}}
+          ln -sf /usr/bin/gdapi-${{range.key}} ${{targets.contextdir}}/usr/bin/gdapi
       - uses: strip
     test:
+      environment:
+        environment:
+          GDAPI_URL: http://localhost:8080/v1
+          GDAPI_ACCESS_KEY: 4C27AB31828A4E469C09
+          GDAPI_SECRET_KEY: fDxEzyxdFMWbmugstPpzykj2qA84Tn9DPDiAc3Sb
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             import: gdapi
+        - runs: |
+            gdapi-${{range.key}} --url $GDAPI_URL --access-key $GDAPI_ACCESS_KEY --secret-key $GDAPI_SECRET_KEY 2>&1 | grep -q "Connection refused"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-gdapi-python.yaml
+++ b/py3-gdapi-python.yaml
@@ -1,0 +1,80 @@
+package:
+  name: py3-gdapi-python
+  version: "0.5.4"
+  epoch: 0
+  description: Python Binding to API spec
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - gdapi-python=${{package.full-version}}
+      - rancher-gdapi-python=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-supported-build
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+
+vars:
+  pypi-package: gdapi-python
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/gdapi-python
+      expected-commit: 31d74507d96c8f053a08bda129cc63f96ca60161
+      tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: py3-fix-hashing.patch
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-six
+        - py${{range.key}}-requests
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: gdapi
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: false
+  exclude-reason: No releases since 2016.

--- a/py3-gdapi-python/py3-fix-hashing.patch
+++ b/py3-gdapi-python/py3-fix-hashing.patch
@@ -1,0 +1,32 @@
+# In Python 3, hashlib requires a bytes-like object rather than a str.
+# This commit fixes "TypeError: Strings must be encoded before hashing"
+# by encoding self._url before passing it to hashlib.update().
+From 577673dda5d27f48b2d6cda5cd7eba10c898e24f Mon Sep 17 00:00:00 2001
+From: Dentrax <furkan.turkal@chainguard.dev>
+Date: Thu, 20 Mar 2025 15:21:40 +0300
+Subject: [PATCH] fix(gdapi.py): encode strings for hashing in Python 3
+
+Signed-off-by: Dentrax <furkan.turkal@chainguard.dev>
+---
+ gdapi.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdapi.py b/gdapi.py
+index 21bc00a..b3ed324 100755
+--- a/gdapi.py
++++ b/gdapi.py
+@@ -513,9 +513,9 @@ class Client(object):
+ 
+     def _get_schema_hash(self):
+         h = hashlib.new('sha1')
+-        h.update(self._url)
++        h.update(self._url.encode("utf-8"))
+         if self._access_key is not None:
+-            h.update(self._access_key)
++            h.update(self._access_key.encode("utf-8"))
+         return h.hexdigest()
+ 
+     def _get_cached_schema_file_name(self):
+-- 
+2.39.5 (Apple Git-154)
+

--- a/py3-rancher-client-python.yaml
+++ b/py3-rancher-client-python.yaml
@@ -1,0 +1,75 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: py3-rancher-client-python
+  version: "0.1.0.0_git20250320"
+  epoch: 0
+  description: A Python client for Rancher APIs
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - rancher-client-python=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-supported-build
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+
+vars:
+  pypi-package: client-python
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/client-python
+      branch: master
+      expected-commit: f617457722f95eded2a74b301ab08d79502a5c3f
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-requests
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: rancher
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: false
+  exclude-reason: No releases since 2018.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
