### PR TITLE
cifs-utils - cleanup empty sbin/ dir

### DIFF
--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.2"
-  epoch: 20
+  epoch: 21
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later
@@ -35,7 +35,6 @@ pipeline:
   - uses: autoconf/make
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/sbin
       make install DESTDIR="${{targets.destdir}}" ROOTSBINDIR=/usr/bin
 
   - uses: strip


### PR DESCRIPTION
cifs-utils is failing the usrmerge lint test because it contains an empty sbin/ directory.

So get rid of that.
