### PR TITLE
Complete 3.13 transition for py3-supported-python

### DIFF
--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-supported-python
   version: 1
-  epoch: 4
+  epoch: 5
   description: metapackage to install all supported versions of python
   copyright:
     - license: "MIT"
@@ -23,7 +23,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 subpackages:
   - name: ${{package.name}}-dev


### PR DESCRIPTION
Bumping priority from 300 to 313 on py3-supported-python.
