### PR TITLE
jq: remediate CVE-2024-53427

### DIFF
--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: 1.7.1
-  epoch: 3
+  epoch: 4
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -23,6 +23,12 @@ pipeline:
       repository: https://github.com/jqlang/jq.git
       tag: jq-${{package.version}}
       expected-commit: 71c2ab509a8628dbbad4bc7b3f98a64aa90d3297
+
+  - uses: patch
+    with:
+      patches: |
+        0001-fix-jv_number_value-should-cache-the-double-value-of.patch
+        0002-Reject-NaN-with-payload-while-parsing-JSON.patch
 
   - runs: |
       autoreconf -vfi
@@ -79,3 +85,7 @@ test:
       runs: |
         echo '[{"id":1,"name":"John"},{"id":2,"name":"Jane"}]' | jq '{users: map({userId: .id, userName: .name})}' | grep -E '"userId": 1|"userId": 2' || exit 1
     - uses: test/tw/ldd-check
+    - name: CVE-2024-53427
+      runs: |
+        output=$(echo '["NaN1"]' | jq -r '.[] | try (fromjson | isnan) catch .')
+        [ "$output" = "Invalid numeric literal at EOF at line 1, column 4 (while parsing 'NaN1')" ]

--- a/jq/0001-fix-jv_number_value-should-cache-the-double-value-of.patch
+++ b/jq/0001-fix-jv_number_value-should-cache-the-double-value-of.patch
@@ -1,0 +1,68 @@
+From ec8e87015abc1c0ee55f1d36fec6e6ad09bde51d Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Sun, 16 Feb 2025 22:08:36 +0900
+Subject: [PATCH 1/2] fix: `jv_number_value` should cache the double value of
+ literal numbers (#3245)
+
+The code of `jv_number_value` is intended to cache the double value of
+literal numbers, but it does not work because it accepts the `jv` struct
+by value. This patch fixes the behavior by checking if the double value
+is `NaN`, which indicates the unconverted value. This patch improves the
+performance of major use cases; e.g. `range(1000000)` runs 25% faster.
+
+(cherry picked from commit b86ff49f46a4a37e5a8e75a140cb5fd6e1331384)
+---
+ src/jv.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/jv.c b/src/jv.c
+index e23d8ec..9329eae 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -206,9 +206,6 @@ enum {
+   JVP_NUMBER_DECIMAL = 1
+ };
+ 
+-#define JV_NUMBER_SIZE_INIT      (0)
+-#define JV_NUMBER_SIZE_CONVERTED (1)
+-
+ #define JVP_FLAGS_NUMBER_NATIVE       JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_NATIVE, 0))
+ #define JVP_FLAGS_NUMBER_LITERAL      JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_DECIMAL, 1))
+ 
+@@ -589,8 +586,12 @@ static jv jvp_literal_number_new(const char * literal) {
+     jv_mem_free(n);
+     return JV_INVALID;
+   }
++  if (decNumberIsNaN(&n->num_decimal)) {
++    jv_mem_free(n);
++    return jv_number(NAN);
++  }
+ 
+-  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, JV_NUMBER_SIZE_INIT, {&n->refcnt}};
++  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, 0, {&n->refcnt}};
+   return r;
+ }
+ 
+@@ -698,9 +699,8 @@ double jv_number_value(jv j) {
+   if (JVP_HAS_FLAGS(j, JVP_FLAGS_NUMBER_LITERAL)) {
+     jvp_literal_number* n = jvp_literal_number_ptr(j);
+ 
+-    if (j.size != JV_NUMBER_SIZE_CONVERTED) {
++    if (isnan(n->num_double)) {
+       n->num_double = jvp_literal_number_to_double(j);
+-      j.size = JV_NUMBER_SIZE_CONVERTED;
+     }
+ 
+     return n->num_double;
+@@ -731,7 +731,7 @@ int jvp_number_is_nan(jv n) {
+     return decNumberIsNaN(pdec);
+   }
+ #endif
+-  return n.u.number != n.u.number;
++  return isnan(n.u.number);
+ }
+ 
+ int jvp_number_cmp(jv a, jv b) {
+-- 
+2.43.0
+

--- a/jq/0002-Reject-NaN-with-payload-while-parsing-JSON.patch
+++ b/jq/0002-Reject-NaN-with-payload-while-parsing-JSON.patch
@@ -1,0 +1,33 @@
+From 7a7cea283237cd24557c0b39954ebcd260802f34 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Wed, 5 Mar 2025 07:43:54 +0900
+Subject: [PATCH 2/2] Reject NaN with payload while parsing JSON
+
+This commit drops support for parsing NaN with payload in JSON like
+`NaN123` and fixes CVE-2024-53427. Other JSON extensions like `NaN` and
+`Infinity` are still supported. Fixes #3023, fixes #3196, fixes #3246.
+
+(cherry picked from commit a09a4dfd55e6c24d04b35062ccfe4509748b1dd3)
+---
+ src/jv.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/jv.c b/src/jv.c
+index 9329eae..e26f74d 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -587,6 +587,11 @@ static jv jvp_literal_number_new(const char * literal) {
+     return JV_INVALID;
+   }
+   if (decNumberIsNaN(&n->num_decimal)) {
++    // Reject NaN with payload.
++    if (n->num_decimal.digits > 1 || *n->num_decimal.lsu != 0) {
++      jv_mem_free(n);
++      return JV_INVALID;
++    }
+     jv_mem_free(n);
+     return jv_number(NAN);
+   }
+-- 
+2.43.0
+


### PR DESCRIPTION
Cherrypick patches from master branch, to remediate CVE-2024-53427.

Also add testcase that checks that CVE is patched, as it changes
behaviour: NaN1 fromjson used to be 'true' and now is invalid.

CVE-2024-53427

Also see:
- https://github.com/jqlang/jq/issues/3196
- https://github.com/advisories/GHSA-8mxc-vqrq-gcm8
- https://github.com/jqlang/jq/pull/3245
- https://github.com/jqlang/jq/commit/b86ff49f46a4a37e5a8e75a140cb5fd6e1331384
- https://github.com/jqlang/jq/commit/a09a4dfd55e6c24d04b35062ccfe4509748b1dd3