### PR TITLE
Ensure 'Chainguard welcome' message is displayed for applicable -compat packages

### DIFF
--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-3.9
   version: 3.9.0
-  epoch: 2
+  epoch: 3
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -81,6 +81,10 @@ subpackages:
           ln -sf /opt/bitnami/scripts/kafka/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -sf /opt/bitnami/scripts/kafka/run.sh ${{targets.subpkgdir}}/run.sh
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - name: "Test compatibility with bitnami/kafka image"
           runs: |
@@ -88,6 +92,9 @@ subpackages:
             test -L /run.sh
             test "$(readlink /entrypoint.sh)" = "/opt/bitnami/scripts/kafka/entrypoint.sh"
             test "$(readlink /run.sh)" = "/opt/bitnami/scripts/kafka/run.sh"
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: kafka
 
 test:
   environment:

--- a/pipelines/bitnami/compat.yaml
+++ b/pipelines/bitnami/compat.yaml
@@ -1,7 +1,8 @@
-name: Build Bitnami Compatibility Package
+name: Fetches scripts required for creating Bitnami-compatible packages.
 
 needs:
   packages:
+    - findutils
     - git
 
 inputs:
@@ -43,8 +44,38 @@ pipeline:
 
       if [ -d "./bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs" ]; then
         cp -rf ./bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs/* ${{targets.contextdir}}/
+        echo "INFO: Copied prebuildfs files to context directory."
       fi
 
       if [ -d "./bitnami/${{inputs.image}}/${{inputs.version-path}}/rootfs" ]; then
         cp -rf ./bitnami/${{inputs.image}}/${{inputs.version-path}}/rootfs/* ${{targets.contextdir}}/
+        echo "INFO: Copied rootfs files to context directory."
+      fi
+
+      # Upstream repo will print a "Welcome to Bitnami" log message in some cases.
+      # Whilst the script appears to expose a 'DISABLE_WELCOME_MESSAGE' env var,
+      # it's better to replace this to ensure no confusion for our end-users.
+      # Find all instances of libbitnami.sh in the copied files
+      LIBBITNAMI_FILES=$(find ${{targets.contextdir}} -name "libbitnami.sh" 2>/dev/null)
+
+      if [ -n "$LIBBITNAMI_FILES" ]; then
+        echo "INFO: Found the following libbitnami.sh files to replace:"
+        echo "$LIBBITNAMI_FILES"
+
+        # Replace each instance with our simplified version, and amended log message.
+        for LIBBITNAMI_FILE in $LIBBITNAMI_FILES; do
+          echo "INFO: Replacing $LIBBITNAMI_FILE with our version."
+
+          printf '%s\n' \
+            '#!/bin/bash' \
+            '. /opt/bitnami/scripts/liblog.sh' \
+            'print_welcome_page() {' \
+            '    echo "Welcome to the Chainguard image for: ${BITNAMI_APP_NAME}, providing compatibility with the Bitnami Helm Chart."' \
+            '}' > "$LIBBITNAMI_FILE"
+
+          # Make it executable
+          chmod +x "$LIBBITNAMI_FILE"
+        done
+
+        echo "INFO: Replaced instances of libbitnami.sh with Chainguard version (amended welcome message)."
       fi

--- a/pipelines/bitnami/validate-welcome-message.yaml
+++ b/pipelines/bitnami/validate-welcome-message.yaml
@@ -1,0 +1,62 @@
+# Simple usage example:
+# - uses: bitnami/validate-welcome-message
+#   with:
+#     app-name: etcd
+
+name: Validates Chainguard welcome message presence in service startup logs.
+
+description: |
+  This pipeline, validates that Bitnami-compatible packages which are launched
+  via entrypoint sctipts, correctly log a "Welcome to Chainguard" message.
+  Essentially, we're validating that the bitnami/compat pipeline was successful,
+  in replacing the default welcome message.
+
+inputs:
+  app-name:
+    description: |
+      The name of the application (i.e etcd, mysql, redis)
+    required: true
+    
+  entrypoint-path:
+    description: |
+      Path to the entrypoint script, relative to /opt/bitnami/scripts/
+      Defaults to "${app-name}/entrypoint.sh" if not specified
+    required: false
+    
+  startup-delay:
+    description: |
+      Number of seconds to wait after starting the service before checking logs
+    required: false
+    default: 5
+
+pipeline:
+  - name: Validate Startup welcome message
+    runs: |
+      # Determine the entrypoint path
+      if [ -n "${{inputs.entrypoint-path}}" ]; then
+        ENTRYPOINT_PATH="${{inputs.entrypoint-path}}"
+      else
+        ENTRYPOINT_PATH="${{inputs.app-name}}/entrypoint.sh"
+      fi
+
+      # Set BITNAMI_APP_NAME environment variable before starting the service
+      export BITNAMI_APP_NAME="${{inputs.app-name}}"
+      
+      echo "Starting service: /opt/bitnami/scripts/$ENTRYPOINT_PATH"
+      /opt/bitnami/scripts/$ENTRYPOINT_PATH > /tmp/service.log 2>&1 &
+      
+      echo "Waiting ${{inputs.startup-delay}} seconds for service to initialize..."
+      sleep ${{inputs.startup-delay}}
+            
+      # Verify the custom welcome message is present
+      cat /tmp/service.log
+      EXPECTED_MESSAGE="Welcome to the Chainguard image for: ${{inputs.app-name}}, providing compatibility with the Bitnami Helm Chart."
+      
+      if grep -q "$EXPECTED_MESSAGE" /tmp/service.log; then
+        echo "Custom welcome message correctly present when launching the entrypoint."
+      else
+        echo "Did not find our custom welcome message when launching the entrypoint."
+        echo "Expected: \"$EXPECTED_MESSAGE\""
+        echo "Please investigate the bitnami/compat package and ensure libbitnami.sh has been properly modified."
+        exit 1
+      fi


### PR DESCRIPTION
We provide images which are compatible with various upstream deployment methods, including helm charts. Some of thse deployment methods may require additional packaging tweaks. For example, a helm chart may expect a binary in a different location, or a specific upstream entrypoint script.

Some of these upstream entrypoint scripts, may print out a welcome message. The changes in this PR introduce a custom 'Chainguard welcome' message, which re-enforce these are Chainguard packages/images, providing compatibility with upstream.

-------
_[Previously tried](https://github.com/wolfi-dev/os/pull/46504) to land all updates together, but difficult to get passing CI - landing pipeline changes (this PR) first, then will land package test updates separate._