### PR TITLE
Add test to validate welcome message on startup. Ignore netlink errors

### DIFF
--- a/clickhouse-25.2.yaml
+++ b/clickhouse-25.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.2
   version: "25.2.2.39"
-  epoch: 0
+  epoch: 2
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -169,6 +169,15 @@ subpackages:
           ln -s /dev/stderr ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
           mkdir -p ${{targets.contextdir}}/var/lib
           ln -s /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: clickhouse
 
 update:
   enabled: true
@@ -189,7 +198,7 @@ test:
         - username: nonroot
           gid: 1001
           uid: 1001
-      run-as: 1001
+      run-as: 0
     contents:
       packages:
         - bash


### PR DESCRIPTION
Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597. 

Also fix test failure when run in CI, by running melange test as root - not an issue locally, we've had to do similar for other package tests