### PR TITLE
fix CVE-2025-29907 on opensearch-dashboards-2

### DIFF
--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -132,6 +132,10 @@ subpackages:
           dependencies='{"cypress": "^13.5.1"}'
           jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
 
+          # fix CVE-2025-29907
+          dependencies='{"jspdf": "^3.0.1"}'
+          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
+
           yarn osd bootstrap --allow-root 2>/dev/null
           node /home/build/scripts/plugin_helpers build --allow-root --skip-archive
 

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-2
   version: "2.19.1" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 2
+  epoch: 3
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump jspdf dependency to fix CVE-2025-29907
