### PR TITLE
New packages for pytest-xdist plugin

### DIFF
--- a/py3-execnet.yaml
+++ b/py3-execnet.yaml
@@ -1,0 +1,82 @@
+# Generated from https://pypi.org/project/execnet/
+package:
+  name: py3-execnet
+  version: 2.1.1
+  epoch: 0
+  description: "distributed Python deployment and communication"
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: execnet
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e1332b1b02b82bb0639e398bd1290cc2f6a3e536
+      repository: https://github.com/pytest-dev/execnet
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-pytest
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - uses: git-checkout
+          with:
+            expected-commit: e1332b1b02b82bb0639e398bd1290cc2f6a3e536
+            repository: https://github.com/pytest-dev/execnet
+            tag: v${{package.version}}
+        - runs: |
+            python${{range.key}} -m pytest testing
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: pytest-dev/execnet
+    use-tag: true
+    strip-prefix: v

--- a/py3-pytest-xdist.yaml
+++ b/py3-pytest-xdist.yaml
@@ -1,0 +1,84 @@
+# Generated from https://pypi.org/project/pytest-xdist/
+package:
+  name: py3-pytest-xdist
+  version: 3.6.1
+  epoch: 0
+  description: "pytest plugin for distributed testing, most importantly across multiple CPUs."
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pytest-xdist
+  import: xdist
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4dd2978031eaf7017c84a1cc77667379a2b11c64
+      repository: https://github.com/pytest-dev/pytest-xdist
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-pytest
+        - py${{range.key}}-execnet
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-pytest
+            - py${{range.key}}-filelock
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+        - uses: git-checkout
+          with:
+            expected-commit: 4dd2978031eaf7017c84a1cc77667379a2b11c64
+            repository: https://github.com/pytest-dev/pytest-xdist
+            tag: v${{package.version}}
+        - runs: |
+            python${{range.key}} -m pytest -n auto testing
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: pytest-dev/pytest-xdist
+    strip-prefix: v


### PR DESCRIPTION
Add new packages for:

- pytest-xdist
- execnet

to support parallel execution of pytest test suites, reducing overall execution time.

Related #43573

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
