### PR TITLE
openjdk-24: enable linkable runtime modules

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -131,8 +131,6 @@ pipeline:
       # symlink for `java-common` to work (which expects jre in $_java_home/jre)
       ln -sf . "${{targets.contextdir}}/$_java_home/jre"
 
-  - uses: strip
-
 subpackages:
   - name: "${{package.name}}-dbg"
     description: "OpenJDK 24 Java Debug Symbols"
@@ -172,7 +170,6 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
-      - uses: strip
 
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.
@@ -263,7 +260,7 @@ test:
         java -jar app.jar
 
         # Test jlink
-        jlink --verbose --module-path "app.jar:$JAVA_HOME/jmods" \
+        jlink --verbose --module-path "app.jar" \
           --add-modules test.modules \
           --output test-project-jre
 

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.1"
-  epoch: 0
+  epoch: 1
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-or-later
@@ -21,6 +21,8 @@ package:
       - libxtst
       - ttf-dejavu
       - zlib
+    provides:
+      - ${{package.name}}-jmods
 
 environment:
   contents:
@@ -97,6 +99,7 @@ pipeline:
         --with-libjpeg=system \
         --with-giflib=system \
         --with-lcms=system \
+        --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
         --with-version-string=""
@@ -171,17 +174,6 @@ subpackages:
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
 
-  - name: "${{package.name}}-jmods"
-    description: "OpenJDK 24 jmods"
-    dependencies:
-      provides:
-        - openjdk-jmods=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-24-openjdk/jmods \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.
   # See: https://bugs.openjdk.org/browse/JDK-8344056
@@ -241,7 +233,6 @@ test:
     contents:
       packages:
         - openjdk-24-default-jdk
-        - openjdk-24-jmods
     environment:
       JAVA_HOME: /usr/lib/jvm/java-24-openjdk
   pipeline:


### PR DESCRIPTION
This new jdk feature should enable jlink feature, without need to have
a separate copy of jmods. This will reduce jdk:24-dev tag size
significantly.

See https://openjdk.org/jeps/493