### PR TITLE
shadow: set bindir to /usr/bin

### DIFF
--- a/shadow.yaml
+++ b/shadow.yaml
@@ -2,7 +2,7 @@
 package:
   name: shadow
   version: "4.17.4"
-  epoch: 0
+  epoch: 1
   description: PAM login and passwd utilities
   copyright:
     - license: BSD-3-Clause
@@ -56,7 +56,8 @@ pipeline:
         --without-nscd \
         --without-group-name-max-length \
         --with-fcaps \
-        --sbindir=/usr/bin
+        --sbindir=/usr/bin \
+        --bindir=/usr/bin
 
   - uses: autoconf/make
 
@@ -178,21 +179,24 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/bin/getsubids ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/getsubids ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/new*idmap ${{targets.subpkgdir}}/usr/bin/
 
           mkdir -p ${{targets.subpkgdir}}/etc
           mv ${{targets.destdir}}/etc/subuid ${{targets.subpkgdir}}/etc/
           mv ${{targets.destdir}}/etc/subgid ${{targets.subpkgdir}}/etc/
-
-          # Leaving this empty directory trips up the usrmerge linter
-          rmdir ${{targets.destdir}}/bin
     description: Utilities for using subordinate UIDs and GIDs
     dependencies:
       runtime:
         - merged-bin
         - merged-sbin
         - wolfi-baselayout
+    test:
+      pipeline:
+        - runs: |
+            getsubids root 2>&1 | grep "Error fetching ranges"
+            newgidmap 2>&1 | grep "usage: newgidmap"
+            newuidmap 2>&1 | grep "usage: newuidmap"
 
 update:
   enabled: true


### PR DESCRIPTION
This avoids having to explicitly clean up the empty `/bin` directory (which we do to avoid tripping up the usrmerge linter).

Also add smoke tests for the package I'm changing, to make sure I got it right.