### PR TITLE
gitlab-pages-17.10: bump Go packages to remediate CVEs

### DIFF
--- a/gitlab-pages-17.10.yaml
+++ b/gitlab-pages-17.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-pages-17.10
   version: "17.10.0"
-  epoch: 0
+  epoch: 1
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT
@@ -27,6 +27,12 @@ pipeline:
       repository: https://gitlab.com/gitlab-org/gitlab-pages.git
       tag: v${{package.version}}
       expected-commit: 65acdbd5f1f909e09f7b8e72a2ba00a0546a35be
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.36.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
CVE-2025-22868
CVE-2025-22870