### PR TITLE
Keycloak: Expand compat package tests

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -203,7 +203,6 @@ subpackages:
                     /opt/bitnami/scripts/keycloak/run.sh
                 timeout: 60
                 expected_output: |
-                  Welcome to the Bitnami keycloak container
                   keycloak setup finished!
                   server listening on
                   Keycloak ${{package.version}}

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: "26.1.4"
-  epoch: 0
+  epoch: 1
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -221,6 +221,9 @@ subpackages:
                     exit 1
                   }
                   echo "$url had expected output: $response"
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: keycloak
 
 test:
   pipeline:


### PR DESCRIPTION
Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597.