### PR TITLE
Logstash: Expand compat package tests

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -315,7 +315,6 @@ subpackages:
                     /opt/bitnami/scripts/logstash/run.sh
                 timeout: 120
                 expected_output: |
-                  Welcome to the Bitnami logstash container
                   Starting Logstash setup
                   Starting Logstash
                   Starting http input listener

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -171,6 +171,10 @@ subpackages:
   - name: ${{package.name}}-compat
     description: Compatibility with the upstream image
     dependencies:
+      runtime:
+        - coreutils
+        - sed
+        - yq
       replaces:
         - ${{package.name}}
         - ${{package.name}}-with-output-opensearch

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -424,7 +424,7 @@ test:
           uid: 1001
       run-as: 0
     paths:
-      - path: /home/build
+      - path: /tmp
         type: directory
         recursive: true
         uid: 1001

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.17.3"
-  epoch: 3
+  epoch: 4
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -328,6 +328,9 @@ subpackages:
                     exit 1
                   }
                   echo "$url had expected output: $response"
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: logstash
 
   - name: ${{package.name}}-env2yaml
     description: Merge environment variables into logstash.yml

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -423,6 +423,13 @@ test:
           gid: 1001
           uid: 1001
       run-as: 0
+    paths:
+      - path: /home/build
+        type: directory
+        recursive: true
+        uid: 1001
+        gid: 1001
+        permissions: 0o770
     contents:
       packages:
         - openjdk-17-default-jdk

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -414,6 +414,15 @@ subpackages:
 
 test:
   environment:
+    accounts:
+      groups:
+        - groupname: nonroot
+          gid: 1001
+      users:
+        - username: logstash
+          gid: 1001
+          uid: 1001
+      run-as: 0
     contents:
       packages:
         - openjdk-17-default-jdk


### PR DESCRIPTION
Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597.

Adds required runtime dependencies to -compat package, which where previously defined as runtime dependencies at the image level. This aligns with other similar packages.