### PR TITLE
minio-client: Expand compat package tests

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -73,10 +73,22 @@ subpackages:
           # Restore path
           find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - bash
+            - busybox
+            - coreutils
+            - curl
+            - jq
       pipeline:
         - runs: |
             run-script --version
             run-script --help
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: minio-client
 
 update:
   enabled: true

--- a/mc.yaml
+++ b/mc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mc
   version: "0.20250312.172924"
-  epoch: 0
+  epoch: 1
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597.

Adds required runtime dependencies to -compat package, which where previously defined as runtime dependencies at the image level. This aligns with other similar packages.