### PR TITLE
py3-opt-einsum: generate a versioned numpy dependency

### DIFF
--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-opt-einsum
   version: 3.4.0
-  epoch: 2
+  epoch: 3
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
Otherwise this package will always pull the numpy corresponding to the most recent Python version.