### PR TITLE
Use JDK17 for Cassandra 5.0, which aligns with upstream

### DIFF
--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.3"
-  epoch: 3
+  epoch: 4
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -21,7 +21,7 @@ var-transforms:
 
 vars:
   py-version: 3.11
-  java-version: 11
+  java-version: 17
 
 environment:
   contents:
@@ -39,7 +39,6 @@ environment:
       - python-${{vars.py-version}}-dev
   environment:
     JAVA_HOME: /usr/lib/jvm/java-${{vars.java-version}}-openjdk
-    CASSANDRA_USE_JDK11: true
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Noticed that Cassandra v5.0 uses JDK17, and previous releases use JDK11. Upgrades to JDK17 to align with upstream.

```bash
% docker run --rm --entrypoint java cassandra:5.0.3 -version
openjdk version "17.0.14" 2025-01-21
OpenJDK Runtime Environment Temurin-17.0.14+7 (build 17.0.14+7)
OpenJDK 64-Bit Server VM Temurin-17.0.14+7 (build 17.0.14+7, mixed mode, sharing)
```