### PR TITLE
py3-*: use versioned numpy runtime dependency where appropriate

### DIFF
--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: 0.11.1
-  epoch: 3
+  epoch: 4
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-scipy
     pipeline:
       - uses: py/pip-build-install

--- a/py3-forestci.yaml
+++ b/py3-forestci.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-forestci
   version: '0.7'
-  epoch: 2
+  epoch: 3
   description: 'forestci: confidence intervals for scikit-learn forest algorithms'
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-scikit-learn
     pipeline:
       - uses: py/pip-build-install

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 5
+  epoch: 6
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD-3-Clause
@@ -39,7 +39,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-cloudpickle
         - py${{range.key}}-future
         - py${{range.key}}-networkx

--- a/py3-itables.yaml
+++ b/py3-itables.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-itables
   version: "2.2.5"
-  epoch: 0
+  epoch: 1
   description: Interactive Tables in Jupyter
   copyright:
     - license: MIT
@@ -47,7 +47,7 @@ subpackages:
       runtime:
         - py${{range.key}}-ipython
         - py${{range.key}}-pandas
-        - numpy
+        - py${{range.key}}-numpy
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-keras-applications.yaml
+++ b/py3-keras-applications.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-applications
   version: 1.0.8
-  epoch: 3
+  epoch: 4
   description: Reference implementations of popular deep learning models
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-h5py
     pipeline:
       - uses: py/pip-build-install

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.9.1
-  epoch: 3
+  epoch: 4
   description: Natural Language Toolkit
   copyright:
     - license: BSD-3-Clause
@@ -45,7 +45,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-click
         - py${{range.key}}-joblib
         - py${{range.key}}-matplotlib

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: "4.2.1"
-  epoch: 0
+  epoch: 1
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-alembic
         - py${{range.key}}-cmaes
         - py${{range.key}}-colorlog

--- a/py3-scikit-optimize.yaml
+++ b/py3-scikit-optimize.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-optimize
   version: 0.9.0
-  epoch: 4
+  epoch: 5
   description: Sequential model-based optimization toolbox.
   copyright:
     - license: BSD-3-Clause
@@ -44,7 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - numpy
+        - py${{range.key}}-numpy
         - py${{range.key}}-joblib
         - py${{range.key}}-matplotlib
         - py${{range.key}}-pillow


### PR DESCRIPTION
These packages currently resolve their numpy dependency to the correct version because another of their dependencies correctly depends on the versioned numpy package, meaning the resolver selects a numpy-providing package which satisfies both those constraints.

Without those other transitive constraints (which could potentially be removed in future), installing these packages for any Python version will incorrectly pull in numpy for the latest Python version.