### PR TITLE
thingsboard: updates for nodejs-20

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "3.9.1"
-  epoch: 3
+  epoch: 4
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ environment:
       - jq
       - lcms2
       - maven
-      - nodejs-16
+      - nodejs-20
       - openjdk-17-default-jdk
       - ttf-dejavu
       - xz
@@ -49,7 +49,7 @@ subpackages:
     description: "Executes user-defined JavaScript functions in isolation for the ThingsBoard rule engine."
     dependencies:
       runtime:
-        - nodejs-16
+        - nodejs-20
     pipeline:
       - name: Move tb-js-executor to target directories
         runs: |
@@ -74,7 +74,7 @@ subpackages:
             "cookie": "^0.7.0"
           }'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
-          jq '.dependencies.express = "^4.19.2"' package.json > temp.json && mv temp.json package.json
+          jq '.dependencies.express = "^4.21.2"' package.json > temp.json && mv temp.json package.json
       - name: Install nodejs dependencies
         runs: |
           cd "${{targets.subpkgdir}}/usr/share/tb-js-executor"
@@ -153,7 +153,7 @@ subpackages:
     description: "Hosts static web UI content using a lightweight Express.js component"
     dependencies:
       runtime:
-        - nodejs-16
+        - nodejs-20
     pipeline:
       - name: Move tb-web-ui to target directories
         runs: |
@@ -168,16 +168,13 @@ subpackages:
         runs: |
           cd "${{targets.subpkgdir}}/usr/share/tb-web-ui"
           resolutions='{
-            "color-string": "^1.5.5",
-            "follow-redirects": "^1.15.6",
-            "minimist": "^1.2.6",
             "json5": "^2.2.2",
             "moment": "^2.29.4",
             "tinymce": "^7.0.0",
             "cookie": "^0.7.0"
           }'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
-          jq '.dependencies.express = "^4.19.2"' package.json > temp.json && mv temp.json package.json
+          jq '.dependencies.express = "^4.21.2"' package.json > temp.json && mv temp.json package.json
       - name: Install nodejs dependencies
         runs: |
           cd "${{targets.subpkgdir}}/usr/share/tb-web-ui"

--- a/thingsboard/pombump-properties.yaml
+++ b/thingsboard/pombump-properties.yaml
@@ -1,3 +1,5 @@
 properties:
   - property: logback.version
     value: "1.5.13"
+  - property: jgit.version
+    value: "7.2.0.202503040940-r"


### PR DESCRIPTION
Thingsboard 3.9+ moved to Node.js 20:

https://github.com/thingsboard/thingsboard/pull/11767

Adjust our build/runtime and dependencies to match upstream. Let's also pick up `express-4.21.2` as it fixes [GHSA-rhx6-c78j-4q9w](https://expressjs.com/en/changelog/).