### PR TITLE
add subpkgs for some standalone tools

### DIFF
--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.1"
-  epoch: 1
+  epoch: 2
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -81,6 +81,16 @@ pipeline:
 
   - uses: strip
 
+data:
+  - name: tools
+    items:
+      asm: ""
+      covdata: ""
+      cover: ""
+      test2json: ""
+      nm: ""
+      objdump: ""
+
 subpackages:
   - name: "${{package.name}}-doc"
     description: "go documentation"
@@ -91,6 +101,17 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - range: tools
+    name: "${{package.name}}-${{range.key}}"
+    description: "standalone go tool ${{range.key}}"
+    dependencies:
+      provides:
+        - go-${{range.key}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          find "${{targets.destdir}}/usr/lib/go/pkg/tool" -type f -name "${{range.key}}" \
+            -exec install -Dm755 \{\} "${{targets.contextdir}}/usr/bin/${{range.key}}" \;
 
 update:
   enabled: true


### PR DESCRIPTION
I find myself wanting the standalone versions of some of these tools already built and shipped as part of the main go pkg, except without the full go toolchain. for example, `test2json` is ~1mb compressed standalone, a much easier pill to swallow then always needing the full `go` apk.

I only included a handful of tools here for only the latest version, but there are more. I'm happy to add them all if we think its useful, or we can just start with these.

I "namespaced" these under `go-${{range.key}}` since I don't see much precedence for shipping these, and I don't think they have any use outside of `go` specific things.