### PR TITLE
bump epoch to 6 and add istio-operator build pipeline

### DIFF
--- a/istio-1.25.yaml
+++ b/istio-1.25.yaml
@@ -116,6 +116,13 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/istio
           mv manifests ${{targets.subpkgdir}}/var/lib/istio/manifests
+    test:
+      pipeline:
+        - runs: |
+            # check version/tag/commit are not "unknown" for operator
+            operator version -o json | jq .clientVersion.version | grep -q ${{package.version}}
+            operator version -o json | jq .clientVersion.revision | grep -qv unknown
+            operator version -o json | jq .clientVersion.tag | grep -qv unknown
 
   - name: istio-pilot-agent-${{vars.major-minor-version}}
     pipeline:

--- a/istio-1.25.yaml
+++ b/istio-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-1.25
   version: "1.25.0"
-  epoch: 5
+  epoch: 6
   description: Istio is an open source service mesh that layers transparently onto existing distributed applications.
   copyright:
     - license: Apache-2.0
@@ -99,6 +99,23 @@ subpackages:
     dependencies:
       provides:
         - istio-install-cni-compat=${{package.full-version}}
+
+  - name: istio-operator-${{vars.major-minor-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./operator/cmd/mesh
+          output: operator
+          # Extracted from https://github.com/istio/istio/blob/4358b84b911a80ba09ef36ac00ad85535a77e7ca/common/scripts/report_build_info.sh#L41-L48
+          # Use this instead for buildStatus once our pipeline stops dirtying the git tree: "$(if git diff-index --quiet HEAD --; then echo "Clean"; else echo "Modified"; fi)"
+          ldflags: |
+            -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+            -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+            -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+            -X istio.io/istio/pkg/version.buildStatus="Clean"
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/lib/istio
+          mv manifests ${{targets.subpkgdir}}/var/lib/istio/manifests
 
   - name: istio-pilot-agent-${{vars.major-minor-version}}
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
istio-1.25: new package
<!--
Please include references to any related issues or delete this section otherwise.
 -->
We are currently building istio-operator up to v1.23 with the main istio project. This PR adds the istio-operator project to allow building v1.25. We can then fix this [customer escalation ](https://github.com/orgs/chainguard-dev/projects/45/views/62?pane=issue&itemId=102751033&issue=chainguard-dev%7Ccustomer-issues%7C2131)
Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates