### PR TITLE
fix(protobuf-c): Rebuild with latest libprotobuf

### DIFF
--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: "1.5.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 2
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
protobuf-c currently pulls in an older version of libprotobuf which is problematic for anything rebuilt with the latest libprotobuf