### PR TITLE
bump packages that depend on so:libfuse3.so.3 (now .4)

### DIFF
--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: "3.14.0"
-  epoch: 0
+  epoch: 1
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs
   version: "1.14"
-  epoch: 1
+  epoch: 2
   description: FUSE implementation for overlayfs
   copyright:
     - license: GPL-2.0-or-later

--- a/sshfs.yaml
+++ b/sshfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sshfs
   version: 3.7.4
-  epoch: 2
+  epoch: 3
   description: A network filesystem client to connect to SSH servers
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/48018

change fuselibs to provide `libfuse3.so.4` instead of `libfuse3.so.3`

```
- 	Provides:         []string{"so:libfuse3.so.3=3"},
+ 	Provides:         []string{"so:libfuse3.so.4=4"},
```
https://github.com/wolfi-dev/os/runs/39297893757

These packages need to be rebuilt so they depend on `.so.4`

Draft so we can see the diffs.