### PR TITLE
pre-commit: use hash not tag for pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    # Use commit hashes here, not tags.
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
     hooks:
       - id: check-yaml
       - id: forbid-submodules


### PR DESCRIPTION
Help guard against supply chain attacks.
