### PR TITLE
bump packages that depend on libprotobuf

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "19.0.1"
-  epoch: 2
+  epoch: 3
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: "0.40.0"
-  epoch: 2
+  epoch: 3
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/py3-onnx.yaml
+++ b/py3-onnx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-onnx
   version: 1.17.0
-  epoch: 5
+  epoch: 6
   description: Open Neural Network Exchange
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
```
$ curl -sL https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$1 == "P" {printf "%s-", $2} $1 == "V" {printf "%s.apk", $2} $1 == "D" { printf " %s", substr($0, 3)} /^$/ {printf "\n"}' | grep "so:libprotobuf.so.29.3.0" | cut -d" " -f1 # this is approximate
opentelemetry-plugin-nginx-0_git20250115-r0.apk
libpulsar-3.7.0-r1.apk
py3.10-onnx-1.17.0-r5.apk
py3.11-onnx-1.17.0-r5.apk
py3.12-onnx-1.17.0-r5.apk
py3.13-onnx-1.17.0-r5.apk
falco-0.40.0-r2.apk
libarrow_flight-19.0.1-r2.apk
apache-arrow-19.0.1-r2.apk
```

