### PR TITLE
nginx-prometheus-exporter: adds missing symlink

### DIFF
--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -76,7 +76,7 @@ subpackages:
             - name: Verify the symlinks were created
               runs: |
                 test "$(readlink /opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter)" = "/usr/bin/nginx-prometheus-exporter"
-                test "$(readlink /opt/bitnami/nginx-exporter/bin/exporter)" = "/usr/bin/nginx-prometheus-exporter"
+                test "$(readlink /usr/bin/exporter)" = "/usr/bin/nginx-prometheus-exporter"
             - runs: /opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter --version
 
 update:

--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -48,6 +48,7 @@ subpackages:
           version-path: ${{vars.major-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx-exporter/bin
+          mkdir -p ${{targets.contextdir}}/usr/bin
           ln -sf /usr/bin/nginx-prometheus-exporter ${{targets.contextdir}}/opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter
           ln -sf /usr/bin/nginx-prometheus-exporter ${{targets.contextdir}}/usr/bin/exporter
     test:

--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-prometheus-exporter
   version: "1.4.1"
-  epoch: 6
+  epoch: 7
   description: NGINX Prometheus Exporter for NGINX and NGINX Plus
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/nginx-exporter/bin
           ln -sf /usr/bin/nginx-prometheus-exporter ${{targets.contextdir}}/opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter
+          ln -sf /usr/bin/nginx-prometheus-exporter ${{targets.contextdir}}/usr/bin/exporter
     test:
       environment:
         contents:
@@ -72,7 +73,9 @@ subpackages:
             # We don't need to have `test/daemon-check-output` pipeline here as upstream entrypoint doesn't
             # wrap with the `entrypoint.sh`, so we're covered by in the main pipeline test.
             - name: Verify the symlinks were created
-              runs: test "$(readlink /opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter)" = "/usr/bin/nginx-prometheus-exporter"
+              runs: |
+                test "$(readlink /opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter)" = "/usr/bin/nginx-prometheus-exporter"
+                test "$(readlink /opt/bitnami/nginx-exporter/bin/exporter)" = "/usr/bin/nginx-prometheus-exporter"
             - runs: /opt/bitnami/nginx-exporter/bin/nginx-prometheus-exporter --version
 
 update:


### PR DESCRIPTION
Adds missing `exporter` symlink: https://github.com/bitnami/charts/blob/3521264684c5a1b09a50a5c8c50453cc9af62f02/bitnami/nginx/templates/deployment.yaml#L351C15-L351C23