### PR TITLE
azure-service-operator-compat: fix binary symlink path

### DIFF
--- a/azure-service-operator.yaml
+++ b/azure-service-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-service-operator
   version: 2.12.0
-  epoch: 0
+  epoch: 1
   description: Azure Service Operator to provision Azure resources and connect your applications to them from within Kubernetes.
   copyright:
     - license: MIT
@@ -31,10 +31,15 @@ subpackages:
   - name: ${{package.name}}-compat
     pipeline:
       - name: Ensure symlinks
-        runs: ln -sf /usr/bin/manager ${{targets.contextdir}}/manager
+        runs: ln -sf /usr/bin/${{package.name}} ${{targets.contextdir}}/manager
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
-        - runs: stat /manager
+        - runs: test -f $(readlink -f /manager)
+        - runs: test "$(readlink /manager)" = "/usr/bin/${{package.name}}"
 
 update:
   enabled: true


### PR DESCRIPTION
This PR fixes the operator binary path and compat package build and test accordingly.