### PR TITLE
nsd: Don't explicitly set CC

### DIFF
--- a/nsd.yaml
+++ b/nsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: nsd
   version: "4.11.1"
-  epoch: 0
+  epoch: 1
   description: "The NLnet Labs Name Server Daemon (NSD) is an authoritative, RFC compliant DNS nameserver."
   copyright:
     - license: BSD-3-Clause
@@ -38,8 +38,6 @@ pipeline:
       autoreconf -vif
 
   - uses: autoconf/configure
-    with:
-      opts: CC=/usr/bin/gcc
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Setting CC=/usr/bin/gcc bypasses our openssf compiler options wrapper and isn't needed.

