### PR TITLE
libv8: new package

### DIFF
--- a/libv8.yaml
+++ b/libv8.yaml
@@ -36,8 +36,8 @@ pipeline:
       git checkout tags/${{package.version}} -b ${{package.version}}
       gclient sync
 
-      gn gen out/${{build.arch}}.release --args='clang_base_path="/usr/lib/llvm-${{vars.llvm-version}}" clang_version=${{vars.llvm-version}}, is_debug=false'
-  
+      gn gen out/${{build.arch}}.release --args='clang_base_path="/usr/lib/llvm-${{vars.llvm-version}}" clang_version=${{vars.llvm-version}} is_debug=false'
+
   - if: ${{build.arch}} == "x86_64"
     working-directory: /home/libv8/v8
     runs: |
@@ -65,11 +65,13 @@ pipeline:
 #       pipeline:
 #         - uses: test/tw/ldd-check
 #     description: libv8 dev
-
 update:
   enabled: true
+  ignore-regex-patterns:
+    - .*-pgo$
   github:
     identifier: v8/v8
+    use-tag: true
 
 test:
   pipeline:

--- a/libv8.yaml
+++ b/libv8.yaml
@@ -12,10 +12,16 @@ environment:
     packages:
       - bash-binsh
       - busybox
+      - clang
+      - compiler-rt
       - curl
       - git
+      - pkgconf
       - python3
       - wolfi-base
+
+vars:
+  llvm-version: 19
 
 pipeline:
   - runs: |
@@ -30,7 +36,26 @@ pipeline:
       git checkout tags/${{package.version}} -b ${{package.version}}
       gclient sync
 
-      cat ./build/install-build-deps.py
+      gn gen out/${{build.arch}}.release --args='clang_base_path="/usr/lib/llvm-${{vars.llvm-version}}" clang_version=${{vars.llvm-version}}, is_debug=false'
+  
+  - if: ${{build.arch}} == "x86_64"
+    working-directory: /home/libv8/v8
+    runs: |
+      cat >> out/${{build.arch}}.release <<EOF
+      target_cpu = "x86"
+      v8_target_cpu = "x86"
+      EOF
+
+  - if: ${{build.arch}} == "aarch64"
+    working-directory: /home/libv8/v8
+    runs: |
+      cat >> out/${{build.arch}}.release <<EOF
+      target_cpu = "arm64"
+      v8_target_cpu = "arm64"
+      EOF
+
+  - working-directory: /home/libv8/v8
+    runs: ninja -C out/${{build.arch}}.release
 
 # subpackages:
 #   - name: ${{package.name}}-dev

--- a/libv8.yaml
+++ b/libv8.yaml
@@ -1,6 +1,6 @@
 package:
   name: libv8
-  version: 13.6.158
+  version: 13.6.174
   epoch: 0
   description: V8 is Google's open source JavaScript engine.
   copyright:
@@ -41,7 +41,7 @@ pipeline:
   - if: ${{build.arch}} == "x86_64"
     working-directory: /home/libv8/v8
     runs: |
-      cat >> out/${{build.arch}}.release <<EOF
+      cat >> out/${{build.arch}}.release/args.gn <<EOF
       target_cpu = "x86"
       v8_target_cpu = "x86"
       EOF
@@ -49,13 +49,17 @@ pipeline:
   - if: ${{build.arch}} == "aarch64"
     working-directory: /home/libv8/v8
     runs: |
-      cat >> out/${{build.arch}}.release <<EOF
+      cat >> out/${{build.arch}}.release/args.gn <<EOF
       target_cpu = "arm64"
       v8_target_cpu = "arm64"
       EOF
 
   - working-directory: /home/libv8/v8
-    runs: ninja -C out/${{build.arch}}.release
+    runs: |
+      export PATH=/home/depot_tools:$PATH
+      ln -sf /usr/lib/llvm-${{vars.llvm-version}}/lib/clang/${{vars.llvm-version}}/lib/${{build.arch}}-unknown-linux-gnu /usr/lib/llvm-${{vars.llvm-version}}/lib/clang/${{vars.llvm-version}}/lib/i386-unknown-linux-gnu
+      
+      ninja -C out/${{build.arch}}.release
 
 # subpackages:
 #   - name: ${{package.name}}-dev

--- a/libv8.yaml
+++ b/libv8.yaml
@@ -1,0 +1,51 @@
+package:
+  name: libv8
+  version: 13.6.158
+  epoch: 0
+  description: V8 is Google's open source JavaScript engine.
+  copyright:
+    - license: Apache-2.0
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - bash-binsh
+      - busybox
+      - curl
+      - git
+      - python3
+      - wolfi-base
+
+pipeline:
+  - runs: |
+      git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /home/depot_tools
+      export PATH=/home/depot_tools:$PATH
+
+      mkdir -p /home/libv8
+      cd /home/libv8
+      fetch v8
+      cd v8
+
+      git checkout tags/${{package.version}} -b ${{package.version}}
+      gclient sync
+
+      cat ./build/install-build-deps.py
+
+# subpackages:
+#   - name: ${{package.name}}-dev
+#     pipeline:
+#       - uses: split/dev
+#     test:
+#       pipeline:
+#         - uses: test/tw/ldd-check
+#     description: libv8 dev
+
+update:
+  enabled: true
+  github:
+    identifier: v8/v8
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Dependency for sagemaker

Related: https://github.com/chainguard-dev/image-requests/issues/5554

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
