### PR TITLE
Add cluster-api

### DIFF
--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -1,0 +1,144 @@
+package:
+  name: cluster-api-1.9
+  version: "1.9.6"
+  epoch: 0
+  description: Cluster API meta package
+  dependencies:
+    provides:
+      - cluster-api=${{package.full-version}}
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 813e90d8daef60b715764ce4729b40d82f811cc1
+      repository: https://github.com/kubernetes-sigs/cluster-api
+      tag: v${{package.version}}
+
+subpackages:
+  - name: ${{package.name}}-controller
+    description: cluster-api core controller
+    dependencies:
+      provides:
+        - cluster-api-controller=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: manager
+          packages: .
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  - name: ${{package.name}}-kubeadm-bootstrap-controller
+    description: cluster-api core controller
+    dependencies:
+      provides:
+        - cluster-api-kubeadm-bootstrap-controller=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: kubeadm-bootstrap-controller
+          packages: ./bootstrap/kubeadm
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  - name: ${{package.name}}-kubeadm-controlplane-controller
+    description: cluster-api core controller
+    dependencies:
+      provides:
+        - cluster-api-kubeadm-controlplane-controller=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: kubeadm-controlplane-controller
+          packages: ./controlplane/kubeadm
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  - name: ${{package.name}}-clusterctl
+    description: cluster-api command line tool
+    dependencies:
+      provides:
+        - clusterctl=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: clusterctl
+          packages: ./cmd/clusterctl
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    test:
+      pipeline:
+        - runs: |
+            clusterctl version | grep -q ${{package.version}}
+            clusterctl --help | grep -q "Get started with Cluster API using clusterctl"
+            clusterctl config repositories | grep helm
+
+test:
+  environment:
+    contents:
+      packages:
+        - kubectl
+        - kind
+        - kwok
+        - busybox
+        - kwok
+        - kwokctl
+        - kubernetes # has a runtime dependency on kubectl
+        - etcd
+        - ${{package.name}}-controller
+        - ${{package.name}}-kubeadm-bootstrap-controller
+        - ${{package.name}}-kubeadm-controlplane-controller
+        - ${{package.name}}-clusterctl
+        - curl
+  pipeline:
+    - uses: git-checkout
+      with:
+        expected-commit: 813e90d8daef60b715764ce4729b40d82f811cc1
+        repository: https://github.com/kubernetes-sigs/cluster-api
+        tag: v${{package.version}}
+    - uses: test/kwok/cluster
+    - runs: |
+        kubectl apply -f config/crd/bases/
+    - uses: test/daemon-check-output
+      with:
+        start: manager --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081
+        expected_output: |
+          Starting workers
+          Starting webhook server
+          Starting EventSource
+          All workers finished
+    - uses: test/daemon-check-output
+      with:
+        start: kubeadm-controlplane-controller
+        expected_output: |
+          Registering webhook
+          Conversion webhook enabled
+          Starting manager
+          problem running manager
+    - uses: test/daemon-check-output
+      with:
+        start: kubeadm-bootstrap-controller
+        expected_output: |
+          Stopping and waiting for webhooks
+          Stopping and waiting for HTTP servers
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/cluster-api
+    strip-prefix: v
+    tag-filter: v

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -91,14 +91,6 @@ test:
   environment:
     contents:
       packages:
-        - kubectl
-        - kind
-        - kwok
-        - busybox
-        - kwok
-        - kwokctl
-        - kubernetes # has a runtime dependency on kubectl
-        - etcd
         - ${{package.name}}-controller
         - ${{package.name}}-kubeadm-bootstrap-controller
         - ${{package.name}}-kubeadm-controlplane-controller

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -29,6 +29,7 @@ data:
       kubeadm-bootstrap-controller: bootstrap/kubeadm
       kubeadm-controlplane-controller: controlplane/kubeadm
       clusterctl: cmd/clusterctl
+      controller: .
 
 subpackages:
   - range: backends-go-builds
@@ -56,29 +57,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           ln -s /usr/bin/${{range.key}} ${{targets.contextdir}}/${{range.key}}
 
-  - name: ${{package.name}}-controller
-    description: cluster-api core controller
-    dependencies:
-      provides:
-        - cluster-api-controller=${{package.full-version}}
-    pipeline:
-      - uses: go/build
-        with:
-          output: manager
-          packages: .
-          ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
-            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
-            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
-  - name: ${{package.name}}-controller-compat
-    description: cluster-api core controller compat package
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          ln -s /usr/bin/manager ${{targets.contextdir}}/manager
-
 ## The package requires a full blown kubernetes cluster for complete testing so most of the tests are just to test the execution of the binaries for each component
 test:
   environment:
@@ -102,7 +80,7 @@ test:
     - uses: test/daemon-check-output
       with:
         setup: kubectl apply -f config/crd/bases/
-        start: /manager --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081
+        start: /controller --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081
         expected_output: |
           Starting workers
           Starting webhook server

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -28,8 +28,8 @@ subpackages:
           output: manager
           packages: .
           ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
@@ -44,8 +44,8 @@ subpackages:
           output: kubeadm-bootstrap-controller
           packages: ./bootstrap/kubeadm
           ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
@@ -60,8 +60,8 @@ subpackages:
           output: kubeadm-controlplane-controller
           packages: ./controlplane/kubeadm
           ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
@@ -76,8 +76,8 @@ subpackages:
           output: clusterctl
           packages: ./cmd/clusterctl
           ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=$(git describe --dirty --tags --always) \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=$(git rev-parse HEAD) \
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     test:

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -36,7 +36,7 @@ subpackages:
     description: cluster-api core components
     dependencies:
       provides:
-        - ${{package.name}}-${{range.key}}=${{package.full-version}}
+        - cluster-api-${{range.key}}=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:
@@ -52,7 +52,7 @@ subpackages:
     description: cluster-api core controller
     dependencies:
       provides:
-        - ${{package.name}}-controller=${{package.full-version}}
+        - cluster-api-controller=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -48,6 +48,14 @@ subpackages:
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
+  - range: backends-go-builds
+    name: ${{package.name}}-${{range.key}}-compat
+    description: cluster-api core ${{range.key}} compat packages
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -s /usr/bin/${{range.key}} ${{targets.contextdir}}/${{range.key}}
+
   - name: ${{package.name}}-controller
     description: cluster-api core controller
     dependencies:
@@ -64,6 +72,13 @@ subpackages:
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
+  - name: ${{package.name}}-controller-compat
+    description: cluster-api core controller compat package
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -s /usr/bin/manager ${{targets.contextdir}}/manager
+
 test:
   environment:
     contents:
@@ -72,7 +87,10 @@ test:
         - ${{package.name}}-kubeadm-bootstrap-controller
         - ${{package.name}}-kubeadm-controlplane-controller
         - ${{package.name}}-clusterctl
-        - curl
+        - ${{package.name}}-kubeadm-bootstrap-controller-compat
+        - ${{package.name}}-kubeadm-controlplane-controller-compat
+        - ${{package.name}}-controller-compat
+        - ${{package.name}}-clusterctl-compat
   pipeline:
     - uses: git-checkout
       with:
@@ -82,11 +100,10 @@ test:
     - uses: test/kwok/cluster
     - runs: |
         kwokctl scale node --replicas 3
-    - runs: |
-        kubectl apply -f config/crd/bases/
     - uses: test/daemon-check-output
       with:
-        start: manager --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081
+        setup: kubectl apply -f config/crd/bases/
+        start: /manager --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081
         expected_output: |
           Starting workers
           Starting webhook server
@@ -94,7 +111,7 @@ test:
           All workers finished
     - uses: test/daemon-check-output
       with:
-        start: kubeadm-controlplane-controller
+        start: /kubeadm-controlplane-controller
         expected_output: |
           Registering webhook
           Conversion webhook enabled
@@ -102,14 +119,14 @@ test:
           problem running manager
     - uses: test/daemon-check-output
       with:
-        start: kubeadm-bootstrap-controller
+        start: /kubeadm-bootstrap-controller
         expected_output: |
           Stopping and waiting for webhooks
           Stopping and waiting for HTTP servers
     - runs: |
-        clusterctl version | grep -q ${{package.version}}
-        clusterctl --help | grep -q "Get started with Cluster API using clusterctl"
-        clusterctl config repositories | grep helm
+        /clusterctl version | grep -q ${{package.version}}
+        /clusterctl --help | grep -q "Get started with Cluster API using clusterctl"
+        /clusterctl config repositories | grep helm
 
 update:
   enabled: true

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -131,5 +131,6 @@ update:
   enabled: true
   github:
     identifier: kubernetes-sigs/cluster-api
+    tag-filter-prefix: v1.9
     strip-prefix: v
     tag-filter: v

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -79,6 +79,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           ln -s /usr/bin/manager ${{targets.contextdir}}/manager
 
+## The package requires a full blown kubernetes cluster for complete testing so most of the tests are just to test the execution of the binaries for each component
 test:
   environment:
     contents:
@@ -98,8 +99,6 @@ test:
         repository: https://github.com/kubernetes-sigs/cluster-api
         tag: v${{package.version}}
     - uses: test/kwok/cluster
-    - runs: |
-        kwokctl scale node --replicas 3
     - uses: test/daemon-check-output
       with:
         setup: kubectl apply -f config/crd/bases/

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -23,12 +23,36 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
         golang.org/x/net@v0.36.0
 
+data:
+  - name: backends-go-builds
+    items:
+      kubeadm-bootstrap-controller: bootstrap/kubeadm
+      kubeadm-controlplane-controller: controlplane/kubeadm
+      clusterctl: cmd/clusterctl
+
 subpackages:
+  - range: backends-go-builds
+    name: ${{package.name}}-${{range.key}}
+    description: cluster-api core components
+    dependencies:
+      provides:
+        - ${{package.name}}-${{range.key}}=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: ${{range.key}}
+          packages: ./${{range.value}}
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
   - name: ${{package.name}}-controller
     description: cluster-api core controller
     dependencies:
       provides:
-        - cluster-api-controller=${{package.full-version}}
+        - ${{package.name}}-controller=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:
@@ -39,60 +63,6 @@ subpackages:
             -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
-  - name: ${{package.name}}-kubeadm-bootstrap-controller
-    description: cluster-api core controller
-    dependencies:
-      provides:
-        - cluster-api-kubeadm-bootstrap-controller=${{package.full-version}}
-    pipeline:
-      - uses: go/build
-        with:
-          output: kubeadm-bootstrap-controller
-          packages: ./bootstrap/kubeadm
-          ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
-            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
-            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
-  - name: ${{package.name}}-kubeadm-controlplane-controller
-    description: cluster-api core controller
-    dependencies:
-      provides:
-        - cluster-api-kubeadm-controlplane-controller=${{package.full-version}}
-    pipeline:
-      - uses: go/build
-        with:
-          output: kubeadm-controlplane-controller
-          packages: ./controlplane/kubeadm
-          ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
-            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
-            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
-  - name: ${{package.name}}-clusterctl
-    description: cluster-api command line tool
-    dependencies:
-      provides:
-        - clusterctl=${{package.full-version}}
-    pipeline:
-      - uses: go/build
-        with:
-          output: clusterctl
-          packages: ./cmd/clusterctl
-          ldflags: |
-            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
-            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
-            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
-            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-    test:
-      pipeline:
-        - runs: |
-            clusterctl version | grep -q ${{package.version}}
-            clusterctl --help | grep -q "Get started with Cluster API using clusterctl"
-            clusterctl config repositories | grep helm
 
 test:
   environment:
@@ -110,6 +80,8 @@ test:
         repository: https://github.com/kubernetes-sigs/cluster-api
         tag: v${{package.version}}
     - uses: test/kwok/cluster
+    - runs: |
+        kwokctl scale node --replicas 3
     - runs: |
         kubectl apply -f config/crd/bases/
     - uses: test/daemon-check-output
@@ -134,6 +106,10 @@ test:
         expected_output: |
           Stopping and waiting for webhooks
           Stopping and waiting for HTTP servers
+    - runs: |
+        clusterctl version | grep -q ${{package.version}}
+        clusterctl --help | grep -q "Get started with Cluster API using clusterctl"
+        clusterctl config repositories | grep helm
 
 update:
   enabled: true

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -16,6 +16,13 @@ pipeline:
       repository: https://github.com/kubernetes-sigs/cluster-api
       tag: v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.36.0
+
 subpackages:
   - name: ${{package.name}}-controller
     description: cluster-api core controller


### PR DESCRIPTION
Add cluster-api meta package version 1.9.6 with subpackages and pipelines
The package requires a full blown kubernetes cluster for complete testing so most of the tests are just to test the execution of the binaries for each component

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
cluster-api-1.9: new package
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:
#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates