### PR TITLE
kafka-3.9: pin bitnami/compat pipeline

### DIFF
--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-3.9
   version: 3.9.0
-  epoch: 3
+  epoch: 4
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -72,6 +72,7 @@ subpackages:
         with:
           image: kafka
           version-path: ${{vars.major-minor-version}}/debian-12
+          commit: a56b1a5abf56c21bafb3b273feea3bd499f26a97
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/kafka/
           ln -s /usr/lib/kafka/bin ${{targets.subpkgdir}}/opt/bitnami/kafka/bin


### PR DESCRIPTION
Pins to the last commit which contains a public release of kafka-3.9

See a similar strategy employed for other old kafka versions in enterprise-packages.