### PR TITLE
Set foundations as owners of curl due to past regressions with updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@ pipelines/ @wolfi-dev/foundations-squad
 abseil-cpp.yaml      @wolfi-dev/foundations-squad
 ca-certificates.yaml @wolfi-dev/foundations-squad
 clang-*.yaml         @wolfi-dev/foundations-squad
+curl.yaml            @wolfi-dev/foundations-squad
 gcc*.yaml            @wolfi-dev/foundations-squad
 glibc.yaml           @wolfi-dev/foundations-squad
 llvm*.yaml           @wolfi-dev/foundations-squad


### PR DESCRIPTION
There's an update of curl forthcoming and to avoid any issues we'd prefer that the Foundations team have eyes on the update and it not get automatically merged.