### PR TITLE
ingress-nginx-controller-1.12 - set depth to -1 on git checkout

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.1
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 14
+  epoch: 15
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -185,6 +185,7 @@ pipeline:
       branch: master
       expected-commit: ${{vars.MODSECURITY_NGINX_VERSION}}
       destination: ModSecurity-nginx-${{vars.MODSECURITY_NGINX_VERSION}}
+      depth: -1
 
   - name: Build ingress-nginx controller from source
     runs: |


### PR DESCRIPTION
When checking out a branch with an expected commit as is done here, you really need depth=-1 or build will break every time that upstream git branch gets a commit.

see
* https://github.com/chainguard-dev/melange/pull/1868 
* https://github.com/wolfi-dev/os/issues/47661
