### PR TITLE
Fix CVE-2025-29923 on grafana-11

### DIFF
--- a/grafana-11.5.yaml
+++ b/grafana-11.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.5
   version: "11.5.3"
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -44,6 +44,7 @@ pipeline:
         github.com/openfga/openfga@v1.8.6
         github.com/golang-jwt/jwt/v4@v4.5.2
         github.com/golang-jwt/jwt/v5@v5.2.2
+        github.com/redis/go-redis/v9@v9.6.3
 
   - name: Build
     runs: |


### PR DESCRIPTION
Bump go-redis/v9 to 9.6.3 to fix GHSA-92cp-5422-2mw7