### PR TITLE
oauth2-proxy/7.8.2 package update

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -22,16 +22,6 @@ pipeline:
       uri: https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: 96f23df77e6b31425579edb631492e9fe3a014bb296c5a261eeb6b9ada5c7787
 
-  - uses: go/bump
-    with:
-      deps: |-
-        github.com/go-jose/go-jose/v3@v3.0.4
-        golang.org/x/crypto@v0.31.0
-        golang.org/x/net@v0.36.0
-        golang.org/x/oauth2@v0.27.0
-      replaces: |
-        github.com/go-jose/go-jose/v4=github.com/go-jose/go-jose/v4@v4.0.5
-
   - uses: go/build
     with:
       packages: .

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
-  version: "7.8.1"
-  epoch: 4
+  version: "7.8.2"
+  epoch: 0
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 047e054e0bf690543711cfda9b9f02ef5a52fd46586fb2ec4613711d3675d808
+      expected-sha256: 96f23df77e6b31425579edb631492e9fe3a014bb296c5a261eeb6b9ada5c7787
 
   - uses: go/bump
     with:


### PR DESCRIPTION
New version has fixes for the CVEs:
* GHSA-92cp-5422-2mw7
* GHSA-mh63-6h87-95cp