### PR TITLE
Add welcome message tests to -compat packages. Add bash to runtime dependency

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -98,6 +98,7 @@ test:
   environment:
     contents:
       packages:
+        - iproute2
         - memcached-bitnami-compat
         - openssl
         - stunnel
@@ -149,18 +150,23 @@ test:
             openssl req -new -key example.key -out example.csr -subj "/CN=example.com" -config openssl.cnf
             openssl x509 -req -days 2 -in example.csr -signkey example.key -out example.crt
 
-            memcached -Z -o ssl_chain_cert=example.crt,ssl_key=example.key&
+            # Find free ports for memcached and stunnel.
+            # Avoids intermittent port conflicts errors that were occurring in CI runs.
+            MEMCACHED_PORT=$(for p in $(shuf -i 30000-40000 -n 10); do ss -ltn | awk '{print $4}' | grep -q ":$p\$" || { echo $p; break; }; done)
+            ACCEPT_PORT=$(for p in $(shuf -i 30000-40000 -n 10); do ss -ltn | awk '{print $4}' | grep -q ":$p\$" || { echo $p; break; }; done)
+
+            memcached -Z -p $MEMCACHED_PORT -o ssl_chain_cert=example.crt,ssl_key=example.key&
 
             cat <<EOF > stunnel.cnf
             [memcached]
             client = yes
-            accept = 127.0.0.1:11212
-            connect = 127.0.0.1:11211
+            accept = 127.0.0.1:$ACCEPT_PORT
+            connect = 127.0.0.1:$MEMCACHED_PORT
             cert = example.crt
             key = example.key
             EOF
             stunnel stunnel.cnf
 
             echo "hello memcached" > test
-            memcp -s 127.0.0.1:11212 test
-            memcat -s 127.0.0.1:11212 test |grep "hello memcached"
+            memcp -s 127.0.0.1:$ACCEPT_PORT test
+            memcat -s 127.0.0.1:$ACCEPT_PORT test | grep "hello memcached"

--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: "1.6.38"
-  epoch: 0
+  epoch: 1
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -63,6 +63,9 @@ subpackages:
 
   - name: memcached-bitnami-compat
     description: "compat package with bitnami/memcached image"
+    dependencies:
+      runtime:
+        - bash
     pipeline:
       - uses: bitnami/compat
         with:
@@ -72,10 +75,17 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/memcached/conf/sasl2
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/memcached/conf.default
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - runs: |
             run-script --version
             run-script --help
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: memcached
 
 update:
   enabled: true

--- a/minio.yaml
+++ b/minio.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio
   version: "0.20250312.180418"
-  epoch: 2
+  epoch: 3
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later
@@ -47,6 +47,9 @@ pipeline:
 subpackages:
   - name: minio-bitnami-2025-compat
     description: "compat package with bitnami/minio image"
+    dependencies:
+      runtime:
+        - bash
     pipeline:
       - name: Check if the 2025/debian-12 path exists in GitHub
         runs: |
@@ -87,10 +90,17 @@ subpackages:
           # Restore path
           find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - runs: |
             run-script --version
             run-script --help
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: minio
 
 update:
   enabled: true


### PR DESCRIPTION
1. Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597. 

2. Adds bash as runtime dependency, which are / where previously done at the image level.

3. Ensures use of free port in tests - avoids intermittent CI failure.