### PR TITLE
remove extra -operator from the subpkg name to avoid inconsistencies

### DIFF
--- a/knative-operator-1.17.yaml
+++ b/knative-operator-1.17.yaml
@@ -46,7 +46,7 @@ pipeline:
       cp -r ./cmd/operator/kodata/* ${{targets.contextdir}}/var/run/ko/
 
 subpackages:
-  - name: ${{package.name}}-operator-compat
+  - name: ${{package.name}}-compat
     description: Compat package for ${{package.name}}
     pipeline:
       - runs: |

--- a/knative-operator-1.17.yaml
+++ b/knative-operator-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-operator-1.17
   version: 1.17.5
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
