### PR TITLE
Add welcome message tests to -compat packages

### DIFF
--- a/mysql-9.1.yaml
+++ b/mysql-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-9.1
   version: 9.1.0
-  epoch: 3
+  epoch: 4
   description: "The MySQL open source relational database"
   copyright:
     - license: GPL-2.0-only # https://downloads.mysql.com/docs/licenses/mysqld-9.0-gpl-en.pdf
@@ -218,6 +218,9 @@ subpackages:
               Installing database
               Configuring authentication
               MySQL setup finished
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: mysql
 
 update:
   enabled: true

--- a/pgpool2-4.5.yaml
+++ b/pgpool2-4.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2-4.5
   version: 4.5.5
-  epoch: 2
+  epoch: 3
   description: Middleware that works between PostgreSQL servers and a PostgreSQL database client.
   copyright:
     - license: BSD-3-Clause AND MIT
@@ -123,6 +123,9 @@ subpackages:
         - runs: |
             test -f /opt/bitnami/pgpool/bin/pgpool
             test -f /opt/bitnami/postgresql/bin/psql
+        - uses: bitnami/validate-welcome-message
+          with:
+            app-name: pgpool
 
 update:
   enabled: false


### PR DESCRIPTION
Adds test to validate the welcome message displayed upon invocation of entrypoint script, is the Chainguard version. Follow-on from: https://github.com/wolfi-dev/os/pull/47597.