### PR TITLE
sts policy: add a read issues policy to scrape past AI detected errors

### DIFF
--- a/.github/chainguard/scrape-error-comments.sts.yaml
+++ b/.github/chainguard/scrape-error-comments.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# detect@jrawlings-chainguard.iam.gserviceaccount.com
+subject: "114294174394359664841"
+
+permissions:
+  metadata: read
+  issues: read # read comments on issues so we can ingest past ai detected errors


### PR DESCRIPTION
This will not be a permanent policy, it will be used to gather past AI detection errors and the corresponding PR info.

There is a GitHub policy to block the use of PAT tokens so an octo-sts policy is required to read the comments from a dev environment.
