### PR TITLE
add runtime deps for kube-proxy

### DIFF
--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.32
   version: "1.32.3"
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -150,6 +150,12 @@ subpackages:
 
   - name: kube-proxy-${{vars.kubernetes-version}}
     description: Kubernetes network proxy that runs on each node
+    dependencies:
+      runtime:
+        - iptables
+        - nftables
+        - kmod
+        - conntrack-tools
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin


### PR DESCRIPTION
[Move runtime deps from image level.](https://github.com/chainguard-images/images-private/pull/8330)
[conntrack is currently missing.](https://github.com/orgs/chainguard-dev/projects/45/views/62?pane=issue&itemId=103608053&issue=chainguard-dev%7Ccustomer-issues%7C2148)