### PR TITLE
add rancher-system-agent

### DIFF
--- a/rancher-system-agent.yaml
+++ b/rancher-system-agent.yaml
@@ -1,0 +1,79 @@
+package:
+  name: rancher-system-agent
+  version: 0.3.11
+  epoch: 0
+  description: rancher-system-agent is a daemon designed to run on a system and apply "plans" to the system.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/system-agent
+      tag: v${{package.version}}
+      expected-commit: b8c28d00ff30fecf8029f0e5f75252b4cb7f5565
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X github.com/rancher/system-agent/pkg/version.Version=${{package.version}}
+        -X github.com/rancher/system-agent/pkg/version.GitCommit=$(git rev-parse HEAD)
+      modroot: .
+      output: rancher-system-agent
+      packages: .
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - -rc
+  github:
+    identifier: rancher/system-agent
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        rancher-system-agent --help
+        rancher-system-agent --version | grep -qi "${{package.version}}"
+    - uses: test/kwok/cluster
+    - name: Test startup
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          # https://github.com/rancher/system-agent/blob/main/examples/configuration/README.md
+          mkdir -p /etc/rancher/agent
+          cat <<EOF > /etc/rancher/agent/config.yaml
+          workDirectory: /var/lib/rancher/agent/work
+          localPlanDirectory: /var/lib/rancher/agent/plans
+          remoteEnabled: true
+          connectionInfoFile: /etc/rancher/agent/conninfo.yaml
+          preserveWorkDirectory: true
+          EOF
+          chmod 0600 /etc/rancher/agent/config.yaml
+          cat <<EOF > /etc/rancher/agent/conninfo.yaml
+          kubeConfig: |-
+            kubeConfig: |-
+              apiVersion: v1
+              kind: Config
+              clusters:
+              - name: "kubernetes"
+                cluster:
+                  server: "https://my-k8s-apiserver"
+              users:
+              - name: "cluster-admin"
+                user:
+                  token: <redacted>
+              contexts:
+              - name: "kubernetes"
+                context:
+                  user: "cluster-admin"
+                  cluster: "kubernetes"
+              current-context: "kubernetes"
+          namespace: mynamespace
+          secretName: mysecret
+          EOF
+          chmod 0600 /etc/rancher/agent/conninfo.yaml
+        start: rancher-system-agent sentinel
+        timeout: 5
+        expected_output: |
+          test

--- a/rancher-system-agent.yaml
+++ b/rancher-system-agent.yaml
@@ -13,6 +13,14 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: b8c28d00ff30fecf8029f0e5f75252b4cb7f5565
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.36.0
+        golang.org/x/oauth2@v0.27.0
+      replaces: k8s.io/kubernetes=github.com/rancher/kubernetes@v1.29.14
+
   - uses: go/build
     with:
       ldflags: |

--- a/rancher-system-agent.yaml
+++ b/rancher-system-agent.yaml
@@ -35,45 +35,27 @@ test:
     - runs: |
         rancher-system-agent --help
         rancher-system-agent --version | grep -qi "${{package.version}}"
-    - uses: test/kwok/cluster
     - name: Test startup
-      uses: test/daemon-check-output
-      with:
-        setup: |
-          # https://github.com/rancher/system-agent/blob/main/examples/configuration/README.md
-          mkdir -p /etc/rancher/agent
-          cat <<EOF > /etc/rancher/agent/config.yaml
-          workDirectory: /var/lib/rancher/agent/work
-          localPlanDirectory: /var/lib/rancher/agent/plans
-          remoteEnabled: true
-          connectionInfoFile: /etc/rancher/agent/conninfo.yaml
-          preserveWorkDirectory: true
-          EOF
-          chmod 0600 /etc/rancher/agent/config.yaml
-          cat <<EOF > /etc/rancher/agent/conninfo.yaml
-          kubeConfig: |-
-            kubeConfig: |-
-              apiVersion: v1
-              kind: Config
-              clusters:
-              - name: "kubernetes"
-                cluster:
-                  server: "https://my-k8s-apiserver"
-              users:
-              - name: "cluster-admin"
-                user:
-                  token: <redacted>
-              contexts:
-              - name: "kubernetes"
-                context:
-                  user: "cluster-admin"
-                  cluster: "kubernetes"
-              current-context: "kubernetes"
-          namespace: mynamespace
-          secretName: mysecret
-          EOF
-          chmod 0600 /etc/rancher/agent/conninfo.yaml
-        start: rancher-system-agent sentinel
-        timeout: 5
-        expected_output: |
-          test
+      runs: |
+        mkdir -p /etc/rancher/agent
+        cat <<EOF > /etc/rancher/agent/config.yaml
+        workDirectory: /var/lib/rancher/agent/work
+        localPlanDirectory: /var/lib/rancher/agent/plans
+        remoteEnabled: true
+        connectionInfoFile: /etc/rancher/agent/conninfo.yaml
+        preserveWorkDirectory: true
+        EOF
+        chmod 0600 /etc/rancher/agent/config.yaml
+        cat <<EOF > /etc/rancher/agent/conninfo.yaml
+        kubeConfig: |-
+          $(kubectl config view --raw)
+        namespace: mynamespace
+        secretName: mysecret
+        EOF
+        chmod 0600 /etc/rancher/agent/conninfo.yaml
+        # By following the following documentation, we can't able to spin the agent
+        # properly with the kwok kubeconfig file. It might be because of the
+        # agent's configuration system may not be able to read the kubeconfig file
+        # or doesn't expand the variables properly.
+        # https://github.com/rancher/system-agent/blob/main/examples/configuration/README.md
+        rancher-system-agent sentinel 2>&1 | grep -qi "try setting KUBERNETES_MASTER environment variable"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
