### PR TITLE
Fix rancher builds by updating sha values in relevant packages

### DIFF
--- a/rancher-agent-2.10.yaml
+++ b/rancher-agent-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-agent-2.10
   version: "2.10.3"
-  epoch: 8
+  epoch: 4
   description: Complete container management platform - agent
   copyright:
     - license: Apache-2.0

--- a/rancher-agent-2.10.yaml
+++ b/rancher-agent-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-agent-2.10
   version: "2.10.3"
-  epoch: 4
+  epoch: 9
   description: Complete container management platform - agent
   copyright:
     - license: Apache-2.0

--- a/rancher-charts-2.10.yaml
+++ b/rancher-charts-2.10.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-charts-2.10
   version: "0_git20250326"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - charts
   copyright:
     - license: Apache-2.0

--- a/rancher-fleet.yaml
+++ b/rancher-fleet.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-fleet
   version: "0.12.0"
-  epoch: 1
+  epoch: 2
   description: Deploy workloads from Git to large fleets of Kubernetes clusters
   copyright:
     - license: Apache-2.0

--- a/rancher-helm3-charts.yaml
+++ b/rancher-helm3-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-helm3-charts
   version: "0_git20250326"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - helm3 charts
   copyright:
     - license: Apache-2.0

--- a/rancher-kontainer-driver-metadata-2.10.yaml
+++ b/rancher-kontainer-driver-metadata-2.10.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: rancher-kontainer-driver-metadata-2.10
-  version: 0_git20250325
+  version: 0_git20250326
   epoch: 0
   description: Complete container management platform - kontainer driver metadata
   copyright:

--- a/rancher-kontainer-driver-metadata-2.10.yaml
+++ b/rancher-kontainer-driver-metadata-2.10.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: rancher-kontainer-driver-metadata-2.10
-  version: 0_git20250225
+  version: 0_git20250325
   epoch: 0
   description: Complete container management platform - kontainer driver metadata
   copyright:
@@ -18,9 +18,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/rancher/kontainer-driver-metadata/
+      repository: https://github.com/rancher/kontainer-driver-metadata
       branch: release-v2.10
-      expected-commit: f0aade6d997db927613f7dc74cac62b047fb960e
+      expected-commit: 72eb5ba7055da8322a262d97a5ed50b2b7c7751d
 
   - runs: |
       mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata
@@ -34,7 +34,7 @@ test:
 
 update:
   enabled: true
-  git:
+  git: {}
   schedule:
     period: daily
     reason: Commit at head of branch moves frequently

--- a/rancher-loglevel.yaml
+++ b/rancher-loglevel.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-loglevel
   version: 0.1.6
-  epoch: 2
+  epoch: 3
   description: Complete container management platform - loglevel
   copyright:
     - license: Apache-2.0

--- a/rancher-partner-charts.yaml
+++ b/rancher-partner-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-partner-charts
   version: "0_git20250326"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - partner charts
   copyright:
     - license: Apache-2.0

--- a/rancher-rke2-charts.yaml
+++ b/rancher-rke2-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-rke2-charts
   version: "0_git20250326"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - rke2 charts
   copyright:
     - license: Apache-2.0

--- a/rancher-rke2-charts.yaml
+++ b/rancher-rke2-charts.yaml
@@ -19,7 +19,7 @@ pipeline:
       repository: https://github.com/rancher/rke2-charts
       branch: main
       destination: ./charts
-      expected-commit: 4ad4f786a1d7907d33fc6ce2e9a0df4ed519ef25
+      expected-commit: 70a3c85484794b9092099c2a01f56ff629be19d6
 
   - working-directory: ./charts
     runs: |

--- a/rancher-system-charts-2.10.yaml
+++ b/rancher-system-charts-2.10.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: rancher-system-charts-2.10
-  version: "0_git20250325"
+  version: "0_git20250326"
   epoch: 1
   description: Complete container management platform - system charts
   copyright:

--- a/rancher-system-charts-2.10.yaml
+++ b/rancher-system-charts-2.10.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-system-charts-2.10
   version: "0_git20250325"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - system charts
   copyright:
     - license: Apache-2.0

--- a/rancher-webhook-0.6.yaml
+++ b/rancher-webhook-0.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-webhook-0.6
   version: "0.6.5"
-  epoch: 0
+  epoch: 1
   description: Rancher webhook for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Here we are bumping the version and sha values for packages that rancher-agent-2.10 rely on. This will enable post-submits to proceed.