### PR TITLE
ingress-nginx-controller-1.12.1-r16/git tag fix for scanners

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.1
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 15
+  epoch: 16
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -189,9 +189,12 @@ pipeline:
 
   - name: Build ingress-nginx controller from source
     runs: |
+      # need to retag the repo because we've made changes and the module builds based on the git tags
+      git tag v${{package.version}}
+
       export PKG="k8s.io/ingress-nginx"
       export COMMIT_SHA=$(git rev-parse --short HEAD)
-      export REPO_INFO=$(git config --get remote.origin.url)$
+      export REPO_INFO=$(git config --get remote.origin.url)
 
       mkdir -p ${{targets.destdir}}
 


### PR DESCRIPTION
Discovered an issue where grype was not scanning any of the ingress-nginx-controller binaries. This was because their go module versions were being set as v0.0.0-date_hash instead of their actual semantic version (1.10.6, 1.11.5, etc).
To fix this had to add a git tag after we make changes to the repository (go/bump, cherry-picks, etc) with the tag of their semantic version.

Also removed a random "$" from REPO_INFO env var.
