### PR TITLE
Libnvidia container use ldd check

### DIFF
--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: "1.17.5"
-  epoch: 0
+  epoch: 1
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0
@@ -72,10 +72,9 @@ test:
   pipeline:
     - name: Ensure the libraries are linked correctly
       runs: |
-        ldd /usr/lib/libnvidia-container.so
-        ldd /usr/lib/libnvidia-container-go.so
         nvidia-container-cli --help
     - uses: test/pkgconf
+    - uses: test/tw/ldd-check
     - name: Test nvidia-container-cli
       runs: nvidia-container-cli --version
     - name: Test nvidia-container-cli with privileged mode

--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -70,13 +70,12 @@ test:
         - sudo-rs
         - shadow # for useradd
   pipeline:
-    - name: Ensure the libraries are linked correctly
-      runs: |
-        nvidia-container-cli --help
     - uses: test/pkgconf
     - uses: test/tw/ldd-check
     - name: Test nvidia-container-cli
-      runs: nvidia-container-cli --version
+      runs: |
+        nvidia-container-cli --help
+        nvidia-container-cli --version
     - name: Test nvidia-container-cli with privileged mode
       runs: |
         set +e

--- a/spdlog.yaml
+++ b/spdlog.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdlog
   version: "1.15.1"
-  epoch: 2
+  epoch: 3
   description: Fast C++ logging library.
   copyright:
     - license: MIT
@@ -61,6 +61,7 @@ test:
         - posix-libc-utils
         - spdlog-dev
   pipeline:
+    - uses: test/tw/ldd-check
     - name: "Verify spdlog headers and library installation"
       runs: |
         # Check for the main spdlog header file


### PR DESCRIPTION
I was looking for packages which called `ldd` directly to test `.so` files instead of using the `ldd-check` test from tw and found one and also added the test to spdlog.