### PR TITLE
ingress-nginx-controller: Revert otel plugin version to the compatible version

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.1
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 16
+  epoch: 17
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -167,10 +167,10 @@ vars:
   # see https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/324
   MODSECURITY_NGINX_VERSION: "17405e09fa123eaa24186dd1be0cfaf9fbdf4c5b"
   # Instrumentation for nginx plugin: https://github.com/open-telemetry/opentelemetry-cpp-contrib
-  # NOTE: this is really really critical and the config can break in backwards compatible way!!
+  # NOTE: this is really REALLY CRITICAL and the config breaks!!!
   # We should always use the SHA available in release-x.y branch of upstream project (e.g. https://github.com/kubernetes/ingress-nginx/blob/release-1.12/images/nginx/rootfs/build.sh#L532)
-  # please check https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/62cbae68035af2102e5fdd68c9f34ba12430fa26...main for regression
-  OTEL_SHA: "62cbae68035af2102e5fdd68c9f34ba12430fa26"
+  # please check https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/8933841f0a7f8737f61404cf0a64acf6b079c8a5...main for regression
+  OTEL_SHA: "8933841f0a7f8737f61404cf0a64acf6b079c8a5"
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION

Fixes:
The SHA of the OTEL plugin must match the upstream project!


