### PR TITLE
unbound: add compat package for mailcow

### DIFF
--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,10 +1,14 @@
 package:
   name: unbound
   version: 1.22.0
-  epoch: 1
+  epoch: 2
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-conf
+      - bash-binsh
 
 environment:
   contents:
@@ -41,7 +45,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: unbound-doc
+  - name: ${{package.name}}-doc
     description: unbound manpages
     pipeline:
       - uses: split/manpages
@@ -49,7 +53,7 @@ subpackages:
       pipeline:
         - uses: test/docs
 
-  - name: "unbound-dev"
+  - name: ${{package.name}}-dev
     description: "headers for unbound"
     pipeline:
       - uses: split/dev
@@ -57,7 +61,7 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
 
-  - name: "unbound-libs"
+  - name: ${{package.name}}-libs
     description: "libraries for unbound"
     pipeline:
       - runs: |
@@ -66,6 +70,50 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-conf
+    description: "configuration for unbound"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc
+          mv ${{targets.destdir}}/etc/unbound ${{targets.subpkgdir}}/etc
+    dependencies:
+      provider-priority: 2
+
+  - name: ${{package.name}}-mailcow-compat
+    description: Compat package for the Mailcow unbound image
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://github.com/mailcow/mailcow-dockerized
+          expected-commit: c3c68360dc7602cba14dc60c6b9bbe665312328f
+          tag: 2025-03
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/mailcow/unbound
+          mkdir -p ${{targets.contextdir}}/etc/unbound
+
+          install -m755 data/Dockerfiles/unbound/docker-entrypoint.sh ${{targets.contextdir}}/opt/mailcow/unbound/docker-entrypoint.sh
+          install -m644 data/conf/unbound/unbound.conf ${{targets.contextdir}}/etc/unbound/unbound.conf
+    dependencies:
+      provides:
+        - ${{package.name}}-conf=${{package.full-version}}
+      runtime:
+        - bind-tools
+        - coreutils
+        - curl
+        - bash
+        - openssl
+        - unbound
+      provider-priority: 1
+    test:
+      environment:
+        contents:
+          packages:
+            - shadow
+      pipeline:
+        - runs: |
+            useradd unbound
+            /opt/mailcow/unbound/docker-entrypoint.sh unbound -V
 
 update:
   enabled: true


### PR DESCRIPTION
Add unbound-mailcow-compat package to support use of unbound in mailcow compatible images.

Move default unbound.conf into new unbound-conf package and use a provides=unbound-conf with a lower priority to allow the mailcow configuration to be switched in when needed.

