### PR TITLE
add py3-tox

### DIFF
--- a/py3-pyproject_api.yaml
+++ b/py3-pyproject_api.yaml
@@ -1,0 +1,81 @@
+package:
+  name: py3-pyproject_api
+  version: 1.9.0
+  epoch: 0
+  description: API to interact with the python pyproject.toml based projects
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pyproject_api
+  import: pyproject_api
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: aace737496bcab66c9a1526c00afc680dcf7bb22
+      repository: https://github.com/tox-dev/pyproject-api
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-packaging
+        - py${{range.key}}-tomli
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  github:
+    identifier: tox-dev/pyproject-api
+    use-tag: true

--- a/py3-tox.yaml
+++ b/py3-tox.yaml
@@ -22,13 +22,9 @@ data:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - py3-supported-build-base-dev
       - py3-supported-hatch-vcs
       - py3-supported-hatchling
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -80,18 +76,12 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/bin/tox-3.13 ${{targets.subpkgdir}}/usr/bin/tox
     test:
       pipeline:
         - uses: python/import
           with:
             python: python3.10
             import: ${{vars.pypi-package}}
-        - runs: tox --version
-        - runs: test "$(readlink /usr/bin/tox)" = "/usr/bin/tox-3.13"
 
 update:
   enabled: true

--- a/py3-tox.yaml
+++ b/py3-tox.yaml
@@ -1,0 +1,93 @@
+package:
+  name: py3-tox
+  version: 4.24.2
+  epoch: 0
+  description: Command line driven CI frontend and development task automation tool
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: tox
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-build-base-dev
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tox-dev/tox
+      tag: ${{package.version}}
+      expected-commit: 05835bfe5db31dfaa71d9fb146602ffcc6b7bfb9
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-colorama
+        - py${{range.key}}-tomli
+        - py${{range.key}}-pluggy
+        - py${{range.key}}-packaging
+        - py${{range.key}}-chardet
+        - py${{range.key}}-platformdirs
+        - py${{range.key}}-filelock
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - runs: |
+          # Subpackage creates tox binary and resulting conflict when adding py3-supported-tox.
+          mv ${{targets.subpkgdir}}/usr/bin/tox ${{targets.subpkgdir}}/usr/bin/tox-${{range.key}}
+          ln -sf /usr/bin/tox-${{range.key}} ${{targets.subpkgdir}}/usr/bin/tox
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - runs: |
+            tox-${{range.key}} --version
+            test "$(readlink /usr/bin/tox)" = "/usr/bin/tox-${{range.key}}"
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: tox-dev/tox

--- a/py3-tox.yaml
+++ b/py3-tox.yaml
@@ -45,6 +45,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
+        - py${{range.key}}-cachetools
         - py${{range.key}}-colorama
         - py${{range.key}}-tomli
         - py${{range.key}}-pluggy
@@ -52,6 +53,8 @@ subpackages:
         - py${{range.key}}-chardet
         - py${{range.key}}-platformdirs
         - py${{range.key}}-filelock
+        - py${{range.key}}-pyproject_api
+        - py${{range.key}}-virtualenv
       provider-priority: ${{range.value}}
     pipeline:
       - uses: py/pip-build-install
@@ -60,7 +63,6 @@ subpackages:
       - runs: |
           # Subpackage creates tox binary and resulting conflict when adding py3-supported-tox.
           mv ${{targets.subpkgdir}}/usr/bin/tox ${{targets.subpkgdir}}/usr/bin/tox-${{range.key}}
-          ln -sf /usr/bin/tox-${{range.key}} ${{targets.subpkgdir}}/usr/bin/tox
       - uses: strip
     test:
       pipeline:
@@ -68,9 +70,7 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
-        - runs: |
-            tox-${{range.key}} --version
-            test "$(readlink /usr/bin/tox)" = "/usr/bin/tox-${{range.key}}"
+        - runs: tox-${{range.key}} --version
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -80,12 +80,18 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf /usr/bin/tox-3.13 ${{targets.subpkgdir}}/usr/bin/tox
     test:
       pipeline:
         - uses: python/import
           with:
             python: python3.10
             import: ${{vars.pypi-package}}
+        - runs: tox --version
+        - runs: test "$(readlink /usr/bin/tox)" = "/usr/bin/tox-3.13"
 
 update:
   enabled: true


### PR DESCRIPTION
Needed by the Rancher package.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
