### PR TITLE
ingress-nginx-controller: Revert otel plugin version to the compatible version

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -60,8 +60,6 @@ var-transforms:
     to: nginx-ingress-major
 
 environment:
-  environment:
-    GCC_SPEC_FILE: /dev/null
   contents:
     packages:
       - abseil-cpp-dev

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -86,14 +86,16 @@ environment:
       - git
       - glibc-dev
       - go
-      - grpc-dev
+      - grpc-dev~1.70.1-r2
+      - grpc~1.70.1-r2
       - icu-dev
       - libaio-dev
       - libcap
       - libcap-utils
       - libedit-dev
       - libmaxminddb-dev
-      - libprotobuf
+      - libprotobuf~3.29.3
+      - so:libprotobuf.so.29.3.0
       - libsrt
       - libtool
       - libxml2
@@ -131,7 +133,8 @@ environment:
       - pcre-dev
       - perl-dev
       - pkgconf
-      - protobuf-dev
+      - protobuf-dev~3.29.3
+      - protoc~3.29.3
       - python3
       - re2-dev
       - scanelf
@@ -622,6 +625,10 @@ subpackages:
   - name: ingress-nginx-opentelemetry-plugin-${{vars.nginx-ingress-major-minor}}
     description: OTel plugin for ingress nginx controller ${{vars.nginx-ingress-major-minor}}
     dependencies:
+      runtime:
+        - grpc~1.70.1-r2
+        - libprotobuf~3.29.3
+        - so:libprotobuf.so.29.3.0
       provides:
         - ingress-nginx-opentelemetry-plugin=${{package.full-version}}
     pipeline:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -168,7 +168,7 @@ vars:
   MODSECURITY_NGINX_VERSION: "17405e09fa123eaa24186dd1be0cfaf9fbdf4c5b"
   # Instrumentation for nginx plugin: https://github.com/open-telemetry/opentelemetry-cpp-contrib
   # NOTE: THIS IS REALLY REALLY REALLY CRITICAL AND THE CONFIG CAN BREAK IN BACKWARDS COMPATIBLE WAY!!
-  # WE SHOULD ALWAYS USE THE SHA AVAILABLE IN RELEASE-X.Y BRANCH OF UPSTREAM PROJECT (e.g. https://github.com/kubernetes/ingress-nginx/blob/release-1.12/images/nginx/rootfs/build.sh#L532)
+  # WE SHOULD ALWAYS USE THE SHA AVAILABLE IN RELEASE-X.Y BRANCH OF UPSTREAM PROJECT (e.g. https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.1/images/nginx/rootfs/build.sh#L528)
   OTEL_SHA: "8933841f0a7f8737f61404cf0a64acf6b079c8a5"
 
 pipeline:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -782,6 +782,20 @@ test:
     # -T: test the configuration file: nginx checks the configuration for correct syntax, and then tries to open files referred in the configuration.
     # additionally dump configuration files to standard output (1.9.2).
     - runs: nginx -T
+    - name: Test opentelemetry_config directive
+      runs: |
+        touch empty
+        cat <<"EOF" >/etc/nginx/nginx.conf
+        pid /tmp/nginx/nginx.pid;
+        load_module /etc/nginx/modules/otel_ngx_module.so;
+        error_log stderr;
+        events {}
+        http {
+        opentelemetry_config empty;
+        }
+        daemon off;
+        EOF
+        nginx -T 2>&1 | grep "Missing required exporter field"
     - uses: test/tw/ldd-check
     - name: Test file capabilities
       runs: |

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -60,6 +60,8 @@ var-transforms:
     to: nginx-ingress-major
 
 environment:
+  environment:
+    GCC_SPEC_FILE: /dev/null
   contents:
     packages:
       - abseil-cpp-dev

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -84,16 +84,15 @@ environment:
       - git
       - glibc-dev
       - go
-      - grpc-dev~1.70.1-r2
-      - grpc~1.70.1-r2
+      - grpc-dev~1.70.1-r2 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
+      - grpc~1.70.1-r2 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
       - icu-dev
       - libaio-dev
       - libcap
       - libcap-utils
       - libedit-dev
       - libmaxminddb-dev
-      - libprotobuf~3.29.3
-      - so:libprotobuf.so.29.3.0
+      - libprotobuf~3.29.3 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
       - libsrt
       - libtool
       - libxml2
@@ -131,11 +130,12 @@ environment:
       - pcre-dev
       - perl-dev
       - pkgconf
-      - protobuf-dev~3.29.3
-      - protoc~3.29.3
+      - protobuf-dev~3.29.3 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
+      - protoc~3.29.3 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
       - python3
       - re2-dev
       - scanelf
+      - so:libprotobuf.so.29.3.0 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
       - ssdeep
       - systemd-dev
       - util-linux
@@ -624,9 +624,9 @@ subpackages:
     description: OTel plugin for ingress nginx controller ${{vars.nginx-ingress-major-minor}}
     dependencies:
       runtime:
-        - grpc~1.70.1-r2
-        - libprotobuf~3.29.3
-        - so:libprotobuf.so.29.3.0
+        - grpc~1.70.1-r2 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
+        - libprotobuf~3.29.3 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
+        - so:libprotobuf.so.29.3.0 # This is temporary, due to Otel proto files incompatibility with our 3.29.4 version of protobuf
       provides:
         - ingress-nginx-opentelemetry-plugin=${{package.full-version}}
     pipeline:

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.1
   # There are manual changes to review between each package update. See 'vars:' section
-  epoch: 16
+  epoch: 17
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -167,10 +167,9 @@ vars:
   # see https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/324
   MODSECURITY_NGINX_VERSION: "17405e09fa123eaa24186dd1be0cfaf9fbdf4c5b"
   # Instrumentation for nginx plugin: https://github.com/open-telemetry/opentelemetry-cpp-contrib
-  # NOTE: this is really really critical and the config can break in backwards compatible way!!
-  # We should always use the SHA available in release-x.y branch of upstream project (e.g. https://github.com/kubernetes/ingress-nginx/blob/release-1.12/images/nginx/rootfs/build.sh#L532)
-  # please check https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/62cbae68035af2102e5fdd68c9f34ba12430fa26...main for regression
-  OTEL_SHA: "62cbae68035af2102e5fdd68c9f34ba12430fa26"
+  # NOTE: THIS IS REALLY REALLY REALLY CRITICAL AND THE CONFIG CAN BREAK IN BACKWARDS COMPATIBLE WAY!!
+  # WE SHOULD ALWAYS USE THE SHA AVAILABLE IN RELEASE-X.Y BRANCH OF UPSTREAM PROJECT (e.g. https://github.com/kubernetes/ingress-nginx/blob/release-1.12/images/nginx/rootfs/build.sh#L532)
+  OTEL_SHA: "8933841f0a7f8737f61404cf0a64acf6b079c8a5"
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
in the recent 1.12.x release, the SHA start with 8933

ref: https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.1/images/nginx/rootfs/build.sh#L528