### PR TITLE
add(new): pvc-autoresizer package non-fips

### DIFF
--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -19,9 +19,6 @@ pipeline:
         golang.org/x/net@v0.36.0
         golang.org/x/oauth2@v0.27.0
 
-  - runs: |
-      export CGO_ENABLED=0
-
   - uses: go/build
     with:
       packages: ./cmd
@@ -39,6 +36,24 @@ test:
     - name: Help tests for pvc-autoresizer
       runs: |
         pvc-autoresizer --help
+    - runs: |
+        # We expect the below command to fail.
+
+        export PROMETHEUS_URL="http://invalid-prometheus-server/api/v1/query"
+        export KUBERNETES_SERVICE_HOST=127.0.0.1
+        export KUBERNETES_SERVICE_PORT=8080
+
+        # Run pvc-autoresizer with the invalid URL
+        pvc-autoresizer --prometheus-url=$PROMETHEUS_URL --namespaces=default > /tmp/negative_output.log 2>&1 || true
+
+        cat /tmp/negative_output.log
+
+        if grep -q "unable to load in-cluster config" /tmp/negative_output.log; then
+          echo "Negative test passed: Expected error message found."
+        else
+          echo "Negative test failed: Expected error message not found."
+          exit 1
+        fi
 
 update:
   enabled: true

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -38,22 +38,8 @@ test:
         pvc-autoresizer --help
     - runs: |
         # We expect the below command to fail.
-
-        export PROMETHEUS_URL="http://invalid-prometheus-server/api/v1/query"
-        export KUBERNETES_SERVICE_HOST=127.0.0.1
-        export KUBERNETES_SERVICE_PORT=8080
-
-        # Run pvc-autoresizer with the invalid URL
-        pvc-autoresizer --prometheus-url=$PROMETHEUS_URL --namespaces=default > /tmp/negative_output.log 2>&1 || true
-
-        cat /tmp/negative_output.log
-
-        if grep -q "unable to load in-cluster config" /tmp/negative_output.log; then
-          echo "Negative test passed: Expected error message found."
-        else
-          echo "Negative test failed: Expected error message not found."
-          exit 1
-        fi
+        set -e
+        pvc-autoresizer --prometheus-url=http://invalid-prometheus-server/api/v1/query --namespaces=default 2>&1 | grep -i "unable to load in-cluster config"
 
 update:
   enabled: true

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -30,6 +30,11 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
           ln -sf /usr/bin/pvc-autoresizer ${{targets.subpkgdir}}/pvc-autoresizer
+    test:
+      pipeline:
+        - name: Check symlink
+          runs: |
+            stat /pvc-autoresizer
 
 test:
   pipeline:

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -27,6 +27,13 @@ pipeline:
       packages: ./cmd
       output: pvc-autoresizer
 
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/pvc-autoresizer ${{targets.subpkgdir}}/pvc-autoresizer
+
 test:
   pipeline:
     - name: Help tests for pvc-autoresizer

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -1,6 +1,6 @@
 package:
   name: pvc-autoresizer
-  version: 0.17.1
+  version: 0.17.2
   epoch: 0
   description: Auto-resize PersistentVolumeClaim objects based on Prometheus metrics
   copyright:
@@ -9,7 +9,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 8f1c575669c5cb57435695324cf5fee3cd7f2f35
+      expected-commit: eaa64de023df465ae879623b82427bd324dd25d8
       repository: https://github.com/topolvm/pvc-autoresizer
       tag: v${{package.version}}
 

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -1,0 +1,47 @@
+package:
+  name: pvc-autoresizer
+  version: 0.17.1
+  epoch: 0
+  description: Auto-resize PersistentVolumeClaim objects based on Prometheus metrics
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 8f1c575669c5cb57435695324cf5fee3cd7f2f35
+      repository: https://github.com/topolvm/pvc-autoresizer
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@0.36.0
+        golang.org/x/oauth2@0.27.0
+
+  - runs: |
+      export CGO_ENABLED=0
+
+  - uses: go/build
+    with:
+      packages: ./cmd
+      output: pvc-autoresizer
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - busybox
+        - prometheus
+  pipeline:
+    - name: Help tests for pvc-autoresizer
+      runs: |
+        pvc-autoresizer --help
+
+update:
+  enabled: true
+  github:
+    identifier: topolvm/pvc-autoresizer
+    strip-prefix: v
+    tag-filter: v

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -16,8 +16,8 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
-        golang.org/x/net@0.36.0
-        golang.org/x/oauth2@0.27.0
+        golang.org/x/net@v0.36.0
+        golang.org/x/oauth2@v0.27.0
 
   - runs: |
       export CGO_ENABLED=0

--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -28,12 +28,6 @@ pipeline:
       output: pvc-autoresizer
 
 test:
-  environment:
-    contents:
-      packages:
-        - curl
-        - busybox
-        - prometheus
   pipeline:
     - name: Help tests for pvc-autoresizer
       runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/topolvm/pvc-autoresizer

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
