### PR TITLE
add missing files to /fluent-bit

### DIFF
--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-for-fluent-bit
   version: 2.32.5
-  epoch: 0
+  epoch: 1
   description: AWS provides a Fluent Bit image with plugins for both CloudWatch Logs and Kinesis Data Firehose.
   copyright:
     - license: Apache-2.0
@@ -67,9 +67,10 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/fluent-bit/bin
           mkdir -p "${{targets.subpkgdir}}"/ecs
           ln -sf /etc/ecs ${{targets.subpkgdir}}/ecs
-          ln -sf /etc/fluent-bit/ ${{targets.subpkgdir}}/fluent-bit/
           ln -sf /etc/fluent-bit/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -sf /usr/bin/fluent-bit ${{targets.subpkgdir}}/fluent-bit/bin/fluent-bit
+          ln -sf /etc/fluent-bit/configs ${{targets.subpkgdir}}/fluent-bit
+          ln -sf /etc/fluent-bit/parsers ${{targets.subpkgdir}}/fluent-bit
       - uses: strip
 
 update:
@@ -80,3 +81,34 @@ update:
     identifier: aws/aws-for-fluent-bit
     strip-prefix: v
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - jq
+  pipeline:
+    - name: "Forward dummy log stream and verify output"
+      runs: |
+        cat <<EOF > dummy.conf
+        [SERVICE]
+          Flush        1
+          Daemon       Off
+          Log_Level    info
+
+        [INPUT]
+            Name         dummy
+            Dummy        {"log":"test-message"}
+            Samples      5
+
+        [OUTPUT]
+            Name         stdout
+            Match        *
+        EOF
+
+        fluent-bit -c dummy.conf | tee /tmp/fluent-bit.log &
+        PID=$!
+        sleep 5
+        kill $PID
+        grep "test-message" /tmp/fluent-bit.log

--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -83,11 +83,6 @@ update:
     use-tag: true
 
 test:
-  environment:
-    contents:
-      packages:
-        - curl
-        - jq
   pipeline:
     - name: "Forward dummy log stream and verify output"
       runs: |
@@ -96,12 +91,10 @@ test:
           Flush        1
           Daemon       Off
           Log_Level    info
-
         [INPUT]
             Name         dummy
             Dummy        {"log":"test-message"}
             Samples      5
-
         [OUTPUT]
             Name         stdout
             Match        *


### PR DESCRIPTION
Our package has `/parsers `& /`configs` at the wrong location. 
```
/ # ls -l /fluent-bit/
total 312
drwxr-xr-x    2 root     root          4096 Jan  1  1970 bin
lrwxrwxrwx    1 root     root            22 Feb  8 08:05 cloudwatch.so -> /usr/bin/cloudwatch.so
drwxr-xr-x    2 root     root          4096 Jan  1  1970 etc
lrwxrwxrwx    1 root     root            20 Feb  9 12:05 firehose.so -> /usr/bin/firehose.so
lrwxrwxrwx    1 root     root            16 Jan 13 18:16 fluent-bit -> /etc/fluent-bit/
lrwxrwxrwx    1 root     root            19 Feb  8 08:05 kinesis.so -> /usr/bin/kinesis.so
-rw-r--r--    1 root     root        309306 Mar 18 06:09 schema.json
/ # ls -l /etc/fluent-bit/
total 20
-rw-r--r--    1 root     root             7 Jan 13 18:16 AWS_FOR_FLUENT_BIT_VERSION
drwxr-xr-x    2 root     root          4096 Jan  1  1970 configs
-rwxr-xr-x    1 root     root           235 Jan 13 18:16 entrypoint.sh
drwxr-xr-x    2 root     root          4096 Jan  1  1970 etc
drwxr-xr-x    2 root     root          4096 Jan  1  1970 parsers
```