### PR TITLE
apk-tools: create /lib usrmerge patch

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 2
+  epoch: 3
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -31,8 +31,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 9d074efdc12bc41b5d24190595a5269a770e852a
 
-  - runs: |
-      git am 292.patch
+  - uses: patch
+    with:
+      patches: 292.patch usrmerge-lib.patch
 
   - runs: |
       sed -i -e 's:-Werror::' Make.rules

--- a/apk-tools/usrmerge-lib.patch
+++ b/apk-tools/usrmerge-lib.patch
@@ -1,0 +1,17 @@
+diff --git a/src/database.c b/src/database.c
+index dc5e4fd..f33ebbc 100644
+--- a/src/database.c
++++ b/src/database.c
+@@ -1299,6 +1299,12 @@ static int apk_db_create(struct apk_database *db)
+ 	mknodat(db->root_fd, "dev/console", S_IFCHR | 0600, makedev(5, 1));
+ 	mkdirat(db->root_fd, "etc", 0755);
+ 	mkdirat(db->root_fd, "etc/apk", 0755);
++	struct stat lib_stat;
++	if (lstat("/lib", &lib_stat) == 0 && S_ISLNK(lib_stat.st_mode)) {
++		mkdirat(db->root_fd, "usr", 0755);
++		mkdirat(db->root_fd, "usr/lib", 0755);
++		symlinkat("usr/lib", db->root_fd, "lib");
++	}
+ 	mkdirat(db->root_fd, "lib", 0755);
+ 	mkdirat(db->root_fd, "lib/apk", 0755);
+ 	mkdirat(db->root_fd, "lib/apk/db", 0755);


### PR DESCRIPTION
A small patch which moves `/lib/apk` to `/usr/lib/apk`. apk-tools upstream plans for handling usrmerge included auto-detecting the DB location and moving the lockfile to /run for FHS compliance. This does none of that, it's really just enough to make `--initdb` work for an already usrmerged system.

```
97cabd7f6480:~# apk add --allow-untrusted -X /work/packages --initdb --root tmp wolfi-baselayout
(1/2) Installing ca-certificates-bundle (20241121-r2)
(2/2) Installing wolfi-baselayout (20230201-r21)
OK: 0 MiB in 2 packages
97cabd7f6480:~# ls -l tmp
total 44
lrwxrwxrwx    1 root     root             7 Mar 27 20:07 bin -> usr/bin
drwxr-xr-x    2 root     root          4096 Mar 27 20:07 dev
drwxr-xr-x    7 root     root          4096 Mar 27 20:07 etc
drwxrwxr-x    2 root     root          4096 Mar 27 20:07 home
lrwxrwxrwx    1 root     root             7 Mar 27 20:07 lib -> usr/lib
lrwxrwxrwx    1 root     root             3 Mar 27 20:07 lib64 -> lib
drwxrwxr-x    2 root     root          4096 Mar 27 20:07 opt
dr-xr-xr-x    2 root     root          4096 Mar 27 20:07 proc
drwx------    2 root     root          4096 Mar 27 20:07 root
drwxrwxr-x    2 root     root          4096 Mar 27 20:07 run
lrwxrwxrwx    1 root     root             7 Mar 27 20:07 sbin -> usr/bin
drwxrwxr-x    2 root     root          4096 Mar 27 20:07 sys
drwxrwxrwt    2 root     root          4096 Mar 27 20:07 tmp
drwxr-xr-x    5 root     root          4096 Mar 27 20:07 usr
drwxr-xr-x    7 root     root          4096 Mar 27 20:07 var
97cabd7f6480:~#
```