### PR TITLE
Add the ldd-check test to samba and add runtime deps

### DIFF
--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: "4.22.0"
-  epoch: 0
+  epoch: 1
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -152,6 +152,11 @@ subpackages:
 
   - name: samba-common-server-libs
     description: Samba libraries shared by common-tools and servers
+    dependencies:
+      runtime:
+        - libauth-samba
+        - samba-libs
+        - samba-util-libs
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/samba
@@ -165,6 +170,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/samba/libsmbd-base-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/libsmbldaphelper-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/pdb "${{targets.contextdir}}"/usr/lib/samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/samba/"
 
   - name: libsmbclient
     description: The SMB client library
@@ -172,6 +182,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libsmbclient.so.* "${{targets.contextdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-client
     description: Samba client programs
@@ -206,8 +219,8 @@ subpackages:
       environment:
         contents:
           packages:
-            - samba-server
-            - libauth-samba
+            - samba-server # needed for Test Samba client
+            - libauth-samba # needed for Test Samba client
       pipeline:
         - runs: |
             dbwrap_tool --version
@@ -239,15 +252,25 @@ subpackages:
 
   - name: samba-server-libs
     description: Samba libraries shared by server and windbind
+    dependencies:
+      runtime:
+        - samba-common-server-libs
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/libdcerpc-samba4-private-samba.so "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/samba/libidmap-private-samba.so "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/samba/libnss-info-private-samba.so "${{targets.contextdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: winbind
     description: Samba user and group resolver
+    dependencies:
+      runtime:
+        - libauth-samba
+        - samba-server-libs
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/samba
@@ -256,6 +279,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/sbin/winbindd "${{targets.contextdir}}"/usr/sbin
           mv "${{targets.destdir}}"/usr/lib/samba/idmap "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/nss_info "${{targets.contextdir}}"/usr/lib/samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-util-libs
     description: Samba utility libraries
@@ -273,6 +299,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/samba/libcom-err-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/libreplace-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/libstable-sort-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: libwbclient
     description: Samba winbind client libraries
@@ -280,6 +309,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libwbclient.so.* "${{targets.contextdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-winbind-clients
     description: Samba winbind client tools
@@ -303,6 +335,9 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libnss_winbind.so* "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libnss_wins.so* "${{targets.contextdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-winbind-krb5-locator
     description: Samba winbind krb5 locator
@@ -310,6 +345,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/krb5 "${{targets.contextdir}}"/usr/lib/samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-pam-winbind
     description: PAM module for winbind
@@ -317,6 +355,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/lib/security
           mv "${{targets.destdir}}"/usr/lib/security/* "${{targets.contextdir}}"/lib/security
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-server
     description: Samba server
@@ -358,8 +399,14 @@ subpackages:
     dependencies:
       runtime:
         - py${{vars.py-version}}-tdb
+        - samba-libs-py3
+        - samba-server
+        - samba-server-libs
       provides:
         - py3-samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-test
     description: Samba server and client testing tools
@@ -379,8 +426,11 @@ subpackages:
     dependencies:
       runtime:
         - py${{vars.py-version}}-tdb
+        - samba-libs-py3
+           - samba-server-libs
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - runs: |
             gentest --version
             gentest --help
@@ -396,6 +446,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/samba
           mv "${{targets.destdir}}"/usr/lib/samba/libauth-private-samba.so "${{targets.contextdir}}"/usr/lib/samba
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: samba-libs
     description: Samba core libraries shared by common-tools, server and clients
@@ -485,6 +538,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libsmbldap.so.* "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libtevent-util.so.* "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libldb.so.* "${{targets.contextdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/samba.yaml
+++ b/samba.yaml
@@ -410,6 +410,11 @@ subpackages:
 
   - name: samba-test
     description: Samba server and client testing tools
+    dependencies:
+      runtime:
+        - py${{vars.py-version}}-tdb
+        - samba-libs-py3
+        - samba-server-libs
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/bin
@@ -423,11 +428,6 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/lib/samba/libdlz-bind9-for-torture-private-samba.so "${{targets.contextdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/samba/libtorture-private-samba.so "${{targets.contextdir}}"/usr/lib
-    dependencies:
-      runtime:
-        - py${{vars.py-version}}-tdb
-        - samba-libs-py3
-           - samba-server-libs
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
Multiple subpackages required the addition of runtime dependencies for the ldd-check to pass because those subpackages were missing other shared objects.