### PR TITLE
remove provides to avoid conflicts

### DIFF
--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: "1.10.1"
-  epoch: 0
+  epoch: 1
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0
@@ -42,9 +42,6 @@ subpackages:
         runs: |
           # The helm chart expects to be able to call "./cluster-proportional-autoscaler"
           ln -s /usr/bin/cluster-proportional-autoscaler "cluster-proportional-autoscaler"
-    dependencies:
-      runtime:
-        - cluster-proportional-autoscaler
 
 update:
   enabled: true


### PR DESCRIPTION
Remove `provides`, since it causes conflicts wen trying to add to FIPS image.

```
  cluster-proportional-autoscaler-1.10.1-r0:
    conflicts: cluster-proportional-autoscaler-fips-1.10.1-r0[cmd:cluster-proportional-autoscaler=1.10.1-r0]
    satisfies: cluster-proportional-autoscaler-compat-1.10.1-r0[cluster-proportional-autoscaler]
  cluster-proportional-autoscaler-fips-1.10.1-r0:
    conflicts: cluster-proportional-autoscaler-1.10.1-r0[cmd:cluster-proportional-autoscaler=1.10.1-r0]
    satisfies: world[cluster-proportional-autoscaler-fips]
```