### PR TITLE
add package mongodb-kubernetes-operator

### DIFF
--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -8,9 +8,8 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - bash
       - coreutils
-      - dash-binsh
+      - bash-binsh
 
 environment:
   contents:
@@ -32,12 +31,24 @@ pipeline:
       deps: |-
         golang.org/x/net@v0.36.0
         golang.org/x/oauth2@v0.27.0
+  
+  - uses: go/build
+    with: 
+      output: manager
+      packages: ./cmd/manager/main.go
 
-  - runs: |
-      mkdir -p ${{targets.contextdir}}/usr/local/bin
-      CGO_ENABLED=0 go build -o manager cmd/manager/main.go
-      cp -av manager ${{targets.contextdir}}/
-      cp -av build/bin/* ${{targets.contextdir}}/usr/local/bin/
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # link /usr/bin/manager to /manager due to hardcoded command "./manager" in entrypoint script
+          # see "./${OPERATOR}" https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/build/bin/entrypoint#L13
+          # and OPERATOR env variable is set to "manager" https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/scripts/dev/templates/operator/Dockerfile.operator#L6
+          # mkdir -p ${{targets.subpkgdir}}/
+          # ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          cp -av build/bin/* ${{targets.subpkgdir}}/usr/local/bin/
 
 test:
   environment:
@@ -60,10 +71,9 @@ test:
         kubectl wait --for=condition=Established crd --all --timeout=60s
     - name: "Verify entrypoint"
       uses: test/daemon-check-output
-      working-directory: /
       with:
         start: |
-          /usr/local/bin/entrypoint
+          manager
         timeout: 60
         expected_output: |
           Watching all namespaces

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -11,14 +11,6 @@ package:
       - coreutils
       - bash-binsh
 
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
-
 pipeline:
   - uses: git-checkout
     with:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -8,6 +8,8 @@ package:
     - license: MIT
   dependencies:
     runtime:
+      - bash
+      - coreutils
       - dash-binsh
 
 environment:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -8,8 +8,7 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - bash
-      - coreutils
+      - dash-binsh
 
 environment:
   contents:
@@ -25,6 +24,12 @@ pipeline:
       repository: https://github.com/mongodb/mongodb-kubernetes-operator
       tag: v${{package.version}}
       expected-commit: f3170c62c794768d123b81cf1793525e098891ed
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.36.0
+        golang.org/x/oauth2@v0.27.0
 
   - runs: |
       mkdir -p ${{targets.contextdir}}/usr/local/bin

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -44,11 +44,16 @@ subpackages:
           # link /usr/bin/manager to /manager due to hardcoded command "./manager" in entrypoint script
           # see "./${OPERATOR}" https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/build/bin/entrypoint#L13
           # and OPERATOR env variable is set to "manager" https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/scripts/dev/templates/operator/Dockerfile.operator#L6
-          # mkdir -p ${{targets.subpkgdir}}/
-          # ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
 
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
           cp -av build/bin/* ${{targets.subpkgdir}}/usr/local/bin/
+    test:
+      pipeline:
+        - runs: |
+            stat /manager
+            stat /usr/local/bin/entrypoint
 
 test:
   environment:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: mongodb-kubernetes-operator
-  version: "0.0.0_git20250328"
+  version: 0.12.0
   epoch: 0
   description: Kubernetes Operator which deploys MongoDB Community into Kubernetes clusters.
   copyright:
@@ -23,7 +23,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/mongodb/mongodb-kubernetes-operator
-      branch: master
+      tag: v${{package.version}}
+      expected-commit: f3170c62c794768d123b81cf1793525e098891ed
 
   - runs: |
       mkdir -p ${{targets.contextdir}}/usr/local/bin
@@ -64,7 +65,7 @@ test:
 
 update:
   enabled: true
-  git: {}
-  schedule:
-    period: weekly
-    reason: This project doesn't do releases and everything is commit based
+  github:
+    identifier: mongodb/mongodb-kubernetes-operator
+    strip-prefix: v
+    use-tag: true

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -31,9 +31,9 @@ pipeline:
       deps: |-
         golang.org/x/net@v0.36.0
         golang.org/x/oauth2@v0.27.0
-  
+
   - uses: go/build
-    with: 
+    with:
       output: manager
       packages: ./cmd/manager/main.go
 

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,0 +1,69 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: mongodb-kubernetes-operator
+  version: "0.0.0_git20250325"
+  epoch: 0
+  description: Kubernetes Operator which deploys MongoDB Community into Kubernetes clusters.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - bash
+      - coreutils
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mongodb/mongodb-kubernetes-operator
+      branch: master
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/usr/local/bin
+      CGO_ENABLED=0 go build -o manager cmd/manager/main.go
+      cp -av manager ${{targets.contextdir}}/
+      cp -av build/bin/* ${{targets.contextdir}}/usr/local/bin/
+
+
+test:
+  environment:
+    environment:
+      OPERATOR: manager
+      USER_UID: 2000
+      USER_NAME: mongodb-kubernetes-operator
+      MONGODB_REPO_URL: "quay.io/mongodb"
+      MONGODB_IMAGE: "mongodb-community-server"
+      AGENT_IMAGE: "quay.io/mongodb/mongodb-agent-ubi:108.0.2.8729-1"
+      VERSION_UPGRADE_HOOK_IMAGE: "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.9"
+      READINESS_PROBE_IMAGE: "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.22"
+      WATCH_NAMESPACE: "*"
+      SKIP_IPTABLES: 1
+    contents:
+      packages:
+        - curl
+        - iptables
+        - kind
+        - systemd
+        - shadow-subids
+  pipeline:
+  - name: "Setup KWOK cluster"
+    uses: test/kwok/cluster
+  - name: "Test"
+    working-directory: /
+    runs: |
+      kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/51761b993543fb4865741bf4ef15f7b1c99a2e72/config/manager/manager.yaml
+      kubectl wait --for=condition=Ready nodes --all
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: This project doesn't do releases and everything is commit based

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: mongodb-kubernetes-operator
-  version: "0.0.0_git20250325"
+  version: "0.0.0_git20250328"
   epoch: 0
   description: Kubernetes Operator which deploys MongoDB Community into Kubernetes clusters.
   copyright:
@@ -44,23 +44,24 @@ test:
       VERSION_UPGRADE_HOOK_IMAGE: "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.9"
       READINESS_PROBE_IMAGE: "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.22"
       WATCH_NAMESPACE: "*"
-      SKIP_IPTABLES: 1
-    contents:
-      packages:
-        - curl
-        - iptables
-        - kind
-        - systemd
-        - shadow-subids
   pipeline:
   - name: "Setup KWOK cluster"
     uses: test/kwok/cluster
-  - name: "Test"
-    working-directory: /
+  - name: "Install mongodbcommunity.mongodb.com CRD that the operator watches"
     runs: |
-      kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/51761b993543fb4865741bf4ef15f7b1c99a2e72/config/manager/manager.yaml
-      kubectl wait --for=condition=Ready nodes --all
-
+      kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/51761b993543fb4865741bf4ef15f7b1c99a2e72/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+      kubectl wait --for=condition=Established crd --all --timeout=60s
+  - name: "Verify entrypoint"
+    uses: test/daemon-check-output
+    working-directory: /
+    with:
+        start: |
+          /usr/local/bin/entrypoint
+        timeout: 60
+        expected_output: |
+          Watching all namespaces
+          Registering Components
+          Starting the Cmd
 update:
   enabled: true
   git: {}

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -31,7 +31,6 @@ pipeline:
       cp -av manager ${{targets.contextdir}}/
       cp -av build/bin/* ${{targets.contextdir}}/usr/local/bin/
 
-
 test:
   environment:
     environment:
@@ -45,16 +44,16 @@ test:
       READINESS_PROBE_IMAGE: "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.22"
       WATCH_NAMESPACE: "*"
   pipeline:
-  - name: "Setup KWOK cluster"
-    uses: test/kwok/cluster
-  - name: "Install mongodbcommunity.mongodb.com CRD that the operator watches"
-    runs: |
-      kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/51761b993543fb4865741bf4ef15f7b1c99a2e72/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
-      kubectl wait --for=condition=Established crd --all --timeout=60s
-  - name: "Verify entrypoint"
-    uses: test/daemon-check-output
-    working-directory: /
-    with:
+    - name: "Setup KWOK cluster"
+      uses: test/kwok/cluster
+    - name: "Install mongodbcommunity.mongodb.com CRD that the operator watches"
+      runs: |
+        kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/51761b993543fb4865741bf4ef15f7b1c99a2e72/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+        kubectl wait --for=condition=Established crd --all --timeout=60s
+    - name: "Verify entrypoint"
+      uses: test/daemon-check-output
+      working-directory: /
+      with:
         start: |
           /usr/local/bin/entrypoint
         timeout: 60
@@ -62,6 +61,7 @@ test:
           Watching all namespaces
           Registering Components
           Starting the Cmd
+
 update:
   enabled: true
   git: {}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
