### PR TITLE
Bump vitess-21 epoch to remediate CVE-2025-30208

### DIFF
--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.3"
-  epoch: 3
+  epoch: 4
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump the package to force a rebuild and pull in the new 'vite' npm package.

Fixes GHSA-x574-m823-4x7w
