### PR TITLE
openssf-compiler-options: Provide linker flags via `link` spec

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 15
+  epoch: 16
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf-nomelange.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf-nomelange.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
@@ -1,4 +1,7 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
 
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf-nomelange.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf-nomelange.spec
@@ -1,2 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
@@ -1,4 +1,7 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
 
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
We're currently providing linker flags using the `-Wl,...` mechanism via the `self_spec` definition.  This works, but confuses GCC when no input files have been provided (as is the case when running `gcc -v`, for example).  GCC thinks that there's actually something being compiled, and then errors out when it finds that there's no `main` function defined.

The spec file has a better way to specify linker flags: we can append to the `link` spec and pass the flags directly.  It fixes the problem with `gcc -v` while still DTRT when linking programs.

Closes: #48510