### PR TITLE
new: syslog-ng

### DIFF
--- a/syslog-ng.yaml
+++ b/syslog-ng.yaml
@@ -1,0 +1,201 @@
+package:
+  name: syslog-ng
+  version: 4.8.1
+  epoch: 0
+  description: Next generation logging daemon
+  copyright:
+    - license: GPL-2.0-or-later
+    - license: LGPL-2.1-or-later
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+
+environment:
+  contents:
+    packages:
+      - autoconf-archive
+      - bison
+      - build-base
+      - curl-dev
+      - eventlog-dev
+      - file
+      - flex
+      - flex-dev
+      - gettext-dev
+      - glib-dev
+      - gperf
+      - hiredis-dev
+      - ivykis-dev
+      - json-c-dev
+      - libcap-dev
+      - libdbi-dev
+      - libnet-dev
+      - libtool
+      - openssl-dev
+      - pcre2-dev
+      - pkgconf-dev
+      - rabbitmq-c-dev
+
+data:
+  - name: modules
+    items:
+      add-contextual-data: add-contextual-data
+      amqp: afamqp
+      graphite: graphite
+      http: http
+      map-value-pairs: map-value-pairs
+      redis: redis
+      sql: afsql
+      stardate: stardate
+      stomp: afstomp
+      xml: xml
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/syslog-ng/syslog-ng
+      expected-commit: abbee2c1fe2e325db570ef85c9e076053197b23d
+      tag: syslog-ng-${{package.version}}
+
+  # NOTE(jamespage)
+  # --disable-cloud-auth
+  # --disable-example-modules
+  # fail to link due to a missing hardcode_action variable for CXX
+  # due to issue with openssf-compiler-options
+  # https://github.com/wolfi-dev/os/pull/48511
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-ipv6 \
+        --enable-manpages \
+        --disable-geoip2 \
+        --disable-java \
+        --disable-java-modules \
+        --disable-linux-caps \
+        --disable-mongodb \
+        --disable-python-modules \
+        --disable-riemann \
+        --disable-smtp \
+        --disable-systemd \
+        --disable-cloud-auth \
+        --disable-example-modules \
+        --disable-python \
+        --enable-amqp \
+        --enable-geoip \
+        --enable-http \
+        --enable-json \
+        --enable-native \
+        --enable-rdrand \
+        --enable-redis \
+        --enable-sql \
+        --enable-stomp \
+        --with-ivykis=system \
+        --with-jsonc=system \
+        --with-librabbitmq-client=system
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          # Move configuration snippets etc back to destdir for inclusion in main package - this
+          # is a minor issue with split/dev and the *include* match it uses
+          mv ${{targets.subpkgdir}}/usr/share/syslog-ng/include ${{targets.destdir}}/usr/share/syslog-ng
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    description: ${{package.name}} dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: ${{package.name}} manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+  - range: modules
+    name: ${{package.name}}-${{range.key}}
+    description: ${{package.name}} module for ${{range.key}}
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/syslog-ng
+          mv ${{targets.destdir}}/usr/lib/syslog-ng/lib${{range.value}}.so ${{targets.subpkgdir}}/usr/lib/syslog-ng
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-modules-all
+    description: Virtual package that installs all ${{package.name}} modules
+    dependencies:
+      runtime:
+        - ${{package.name}}-add-contextual-data
+        - ${{package.name}}-amqp
+        - ${{package.name}}-graphite
+        - ${{package.name}}-http
+        - ${{package.name}}-map-value-pairs
+        - ${{package.name}}-redis
+        - ${{package.name}}-sql
+        - ${{package.name}}-stardate
+        - ${{package.name}}-stomp
+        - ${{package.name}}-xml
+    test:
+      pipeline:
+        - runs: |
+            for module in add-contextual-data afamqp graphite http map-value-pairs redis afsql stardate afstomp xml; do
+              syslog-ng --module-registry | grep -q "Module: $module" || {
+                echo "FAIL: $module not registered"
+                exit 1
+              }
+              echo "PASS: $module registered"
+            done
+
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/
+          mv ${{targets.destdir}}/etc/syslog-ng.conf ${{targets.subpkgdir}}/etc
+    description: default ${{package.name}} config file
+
+test:
+  pipeline:
+    - name: Verify syslog-ng installation with default configuration
+      runs: |
+        syslog-ng --version | grep ${{package.version}}
+        # Start daemon with default configuration
+        syslog-ng
+
+        # Test control socket and misc function
+        syslog-ng-ctl stats
+
+        # Check log level change
+        syslog-ng-ctl log-level debug
+        grep "Verbosity changed" /var/log/messages
+
+        # Check configuration releoase
+        syslog-ng-ctl reload | grep successful
+        grep "Configuration reload finished" /var/log/messages
+
+        # Check logging
+        logger "Wolfi foobar test"
+        grep "Wolfi foobar test" /var/log/messages
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: syslog-ng/syslog-ng
+    strip-prefix: syslog-ng-

--- a/syslog-ng.yaml
+++ b/syslog-ng.yaml
@@ -101,6 +101,7 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-dev
+    description: ${{package.name}} dev
     pipeline:
       - uses: split/dev
       - runs: |
@@ -110,16 +111,15 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
-    description: ${{package.name}} dev
     test:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-doc
+    description: ${{package.name}} manpages
     pipeline:
       - uses: split/manpages
-    description: ${{package.name}} manpages
     test:
       pipeline:
         - uses: test/docs
@@ -164,11 +164,11 @@ subpackages:
             done
 
   - name: ${{package.name}}-config
+    description: default ${{package.name}} config file
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/
           mv ${{targets.destdir}}/etc/syslog-ng.conf ${{targets.subpkgdir}}/etc
-    description: default ${{package.name}} config file
 
 test:
   pipeline:


### PR DESCRIPTION
Add new package for syslog-ng, supporting use with unbound-mailcow-compat which uses syslog-ng for all logging.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
