### PR TITLE
fix CVE-2024-12905 for tileserver-gl

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.2.0"
-  epoch: 0
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -53,6 +53,12 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: cd613e2fb5303e5a406f8c17c82ac4435db758c8
       destination: app
+
+  - working-directory: app
+    pipeline:
+      - uses: patch
+        with:
+          patches: ../CVE-2024-12905.patch
 
   # install packages
   - working-directory: app

--- a/tileserver-gl/CVE-2024-12905.patch
+++ b/tileserver-gl/CVE-2024-12905.patch
@@ -1,0 +1,25 @@
+From dd8c11959c194c7f60159d3a6dfbbbdf28fe1985 Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Mon, 31 Mar 2025 09:22:29 +0000
+Subject: [PATCH] update tar-fs dependency to fix CVE-2024-12905
+
+---
+ package-lock.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package-lock.json b/package-lock.json
+index c56f024..fdc77ab 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -8294,7 +8294,7 @@
+         "pump": "^3.0.0",
+         "rc": "^1.2.7",
+         "simple-get": "^4.0.0",
+-        "tar-fs": "^2.0.0",
++        "tar-fs": "^2.1.2",
+         "tunnel-agent": "^0.6.0"
+       },
+       "bin": {
+-- 
+2.47.2
+


### PR DESCRIPTION
bump tar-fs dependency to 2.1.2 to fix GHSA-pq67-2wwv-3xjx
