### PR TITLE
unbound: misc updates for unbound-mailcow-compat

### DIFF
--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,13 +1,13 @@
 package:
   name: unbound
   version: 1.22.0
-  epoch: 2
+  epoch: 3
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - ${{package.name}}-conf
+      - ${{package.name}}-config
       - bash-binsh
 
 environment:
@@ -60,6 +60,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
+        - uses: test/tw/ldd-check
 
   - name: ${{package.name}}-libs
     description: "libraries for unbound"
@@ -71,14 +72,12 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: ${{package.name}}-conf
+  - name: ${{package.name}}-config
     description: "configuration for unbound"
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc
           mv ${{targets.destdir}}/etc/unbound ${{targets.subpkgdir}}/etc
-    dependencies:
-      provider-priority: 2
 
   - name: ${{package.name}}-mailcow-compat
     description: Compat package for the Mailcow unbound image
@@ -91,12 +90,26 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/mailcow/unbound
           mkdir -p ${{targets.contextdir}}/etc/unbound
+          mkdir -p ${{targets.contextdir}}/etc/supervisor
 
           install -m755 data/Dockerfiles/unbound/docker-entrypoint.sh ${{targets.contextdir}}/opt/mailcow/unbound/docker-entrypoint.sh
+          ln -sf /opt/mailcow/unbound/docker-entrypoint.sh ${{targets.subpkgdir}}/docker-entrypoint.sh
+
+          install -m755 data/Dockerfiles/unbound/healthcheck.sh ${{targets.contextdir}}/opt/mailcow/unbound/healthcheck.sh
+          ln -sf /opt/mailcow/unbound/healthcheck.sh ${{targets.subpkgdir}}/healthcheck.sh
+
+          install -m755 data/Dockerfiles/unbound/stop-supervisor.sh ${{targets.contextdir}}/opt/mailcow/unbound/stop-supervisor.sh
+          mkdir -p ${{targets.contextdir}}/usr/local/sbin
+          ln -sf /opt/mailcow/unbound/stop-supervisor.sh ${{targets.subpkgdir}}/usr/local/sbin/stop-supervisor.sh
+
+          install -m644 data/Dockerfiles/unbound/supervisord.conf ${{targets.contextdir}}/etc/supervisor/supervisord.conf
+          install -m644 data/Dockerfiles/unbound/syslog-ng.conf ${{targets.contextdir}}/etc/syslog-ng.conf
           install -m644 data/conf/unbound/unbound.conf ${{targets.contextdir}}/etc/unbound/unbound.conf
     dependencies:
       provides:
-        - ${{package.name}}-conf=${{package.full-version}}
+        - ${{package.name}}-config
+        - supervisor-config
+        - syslog-ng-config
       runtime:
         - bind-tools
         - coreutils
@@ -104,7 +117,10 @@ subpackages:
         - bash
         - openssl
         - unbound
-      provider-priority: 1
+        - syslog-ng
+        - supervisor
+        - iputils
+      provider-priority: -1
     test:
       environment:
         contents:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -74,3 +74,4 @@ go-fips-1.20-doc-1.20.9-r0.apk
 ko-fips-0.14.1-r0.apk
 openssl-fips-test-0.1-r0.apk
 cluster-api-controller-1.9.6-r0.apk
+unbound-mailcow-compat-1.22.0-r2.apk


### PR DESCRIPTION
Expand support in mailcow-compat subpackage for supervisord and syslog-ng configuration and a service healthcheck all sourced from the mailcow-dockerized repository.

Rename -conf -> -config (which seems to be more of a standard) and adjust priority around default of 0 so  that alternative configuration files can be switched in without  broader impact.

Drop unbound-mailcow-compat 1.22.0-r2  - r3 sets the provider-priority to -1 to ensure compatibility with  -config packages which don't set a provider-priority - drop r2  version of package to avoid this being used with new unbound    package versions.
