### PR TITLE
add rancher-machine

### DIFF
--- a/rancher-machine.yaml
+++ b/rancher-machine.yaml
@@ -5,18 +5,24 @@ package:
   # tags, they are not newer releases than 0.15.0-rancherN. This is a forked version of
   # docker/machine and upstream also archieved and deprecated. So it's OK to use the
   # master branch here.
-  version: "0.15.0.126_git20250401"
+  version: "0.15.0.126"
   epoch: 0
   description: Machine management for a container-centric world
   copyright:
     - license: Apache-2.0
 
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(\d+)$'
+    replace: "-rancher$1"
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/rancher/machine
-      expected-commit: 99d2c8daa21d3e81eebb3cfcda46459473628126
-      branch: master
+      expected-commit: 9d46e6bb16f98d184afa83267ea28d3dcc898478
+      tag: v${{vars.mangled-package-version}}
 
   - uses: go/bump
     with:
@@ -39,11 +45,12 @@ update:
   enabled: true
   ignore-regex-patterns:
     - patch
-  github:
-    identifier: rancher/machine
+  version-transform:
+    - match: -rancher
+      replace: .
+  git:
+    tag-filter-prefix: v0.15.0-rancher
     strip-prefix: v
-    use-tag: true
-    tag-filter: v0.15.0-rancher
 
 test:
   pipeline:

--- a/rancher-machine.yaml
+++ b/rancher-machine.yaml
@@ -5,7 +5,7 @@ package:
   # tags, they are not newer releases than 0.15.0-rancherN. This is a forked version of
   # docker/machine and upstream also archieved and deprecated. So it's OK to use the
   # master branch here.
-  version: "0.15.0.126_git20250331"
+  version: "0.15.0.126_git20250401"
   epoch: 0
   description: Machine management for a container-centric world
   copyright:
@@ -37,15 +37,32 @@ pipeline:
 
 update:
   enabled: true
-  git: {}
-  schedule:
-    period: weekly
-    reason: Upstream only maintains 0.15.0 tag and there are newer tags exist, so we have to watch only master branch.
+  ignore-regex-patterns:
+    - patch
+  github:
+    identifier: rancher/machine
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v0.15.0-rancher
 
 test:
   pipeline:
-    - runs: |
+    - name: Smoke check - help and version
+      runs: |
         rancher-machine --help
         rancher-machine --version | grep ${{package.version}}
+    - name: Create a machine using the none driver
+      runs: |
         rancher-machine create --driver none --url localhost test-machine
         rancher-machine ls | grep test-machine
+    - name: Inspect the machine
+      runs: |
+        rancher-machine inspect test-machine | grep -qi '"DriverName": "none"'
+    - name: Run non-invasive subcommands
+      runs: |
+        rancher-machine url test-machine | grep -q "localhost"
+        rancher-machine ip test-machine
+    - name: Remove the machine
+      runs: |
+        rancher-machine rm -f test-machine
+        rancher-machine ls | grep -vq test-machine

--- a/rancher-machine.yaml
+++ b/rancher-machine.yaml
@@ -1,0 +1,51 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: rancher-machine
+  # Upstream doesn't follow proper symantic versioning, even though there are newer 0.16.x
+  # tags, they are not newer releases than 0.15.0-rancherN. This is a forked version of
+  # docker/machine and upstream also archieved and deprecated. So it's OK to use the
+  # master branch here.
+  version: "0.15.0.126_git20250331"
+  epoch: 0
+  description: Machine management for a container-centric world
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/machine
+      expected-commit: 99d2c8daa21d3e81eebb3cfcda46459473628126
+      branch: master
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/golang-jwt/jwt/v4@v4.5.2
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.36.0
+        golang.org/x/oauth2@v0.27.0
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/rancher-machine
+      output: rancher-machine
+      ldflags: |
+        -X github.com/rancher/machine/version.Version=${{package.version}}
+        -X github.com/rancher/machine/version.GitCommit=$(git rev-parse HEAD)
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: Upstream only maintains 0.15.0 tag and there are newer tags exist, so we have to watch only master branch.
+
+test:
+  pipeline:
+    - runs: |
+        rancher-machine --help
+        rancher-machine --version | grep ${{package.version}}
+        rancher-machine create --driver none --url localhost test-machine
+        rancher-machine ls | grep test-machine


### PR DESCRIPTION
Needed by Rancher package.

CVEs in moby/moby can't be properly mitigated, as upgrading to different versions results in compilation failures.


```
└── 📄 /usr/bin/rancher-machine
        📦 github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29 (go-module)
            High CVE-2024-36621 GHSA-2mj3-vfvx-fc43 fixed in 26.0.0
            Medium CVE-2022-24769 GHSA-2mm7-x5h6-5pvq fixed in 20.10.14
            Medium CVE-2021-41091 GHSA-3fwx-pjgw-3558 fixed in 20.10.9
            Medium CVE-2021-21285 GHSA-6fj5-m822-rqx8 fixed in 19.3.15
            Medium CVE-2020-27534 GHSA-6hwg-w5jg-9c6x fixed in 19.03.9
            Medium CVE-2021-21284 GHSA-7452-xqpj-6rpc fixed in 19.3.15
            High CVE-2024-36623 GHSA-gh5c-3h97-2f3q fixed in 26.0.0
            Medium GHSA-xmmx-7jpf-fx42 fixed in 20.10.11
            Medium CVE-2024-24557 GHSA-xw73-rw38-6vjc fixed in 24.0.9
```

Example:

```
go: github.com/rancher/machine/libmachine/mcndockerclient imports
2025/03/31 11:00:06 WARN     github.com/samalba/dockerclient tested by
2025/03/31 11:00:06 WARN     github.com/samalba/dockerclient.test imports
2025/03/31 11:00:06 WARN     github.com/docker/docker/pkg/jsonlog: module github.com/docker/docker@latest found (v28.0.4+incompatible, replaced by github.com/moby/moby@v20.10.14+incompatible), but does not contain package github.com/docker/docker/pkg/jsonlog
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
