### PR TITLE
exim: set BIN_DIRECTORY to usr/bin

### DIFF
--- a/exim.yaml
+++ b/exim.yaml
@@ -1,7 +1,7 @@
 package:
   name: exim
   version: "4.98.2"
-  epoch: 40
+  epoch: 41
   description: Message Transfer Agent
   copyright:
     - license: GPL-2.0-or-later
@@ -54,6 +54,7 @@ pipeline:
       uri: https://ftp.exim.org/pub/exim/exim4/exim-${{package.version}}.tar.xz
 
   - runs: |
+      sed -i -e 's|BIN_DIRECTORY=/usr/sbin|BIN_DIRECTORY=/usr/bin|' exim.Makefile
       cp exim.Makefile Local/Makefile
 
       sed -i -e 's/^HAVE_ICONV.*$//' OS/Makefile-Linux
@@ -66,9 +67,6 @@ pipeline:
       install -m750 -D -g mail -d "${{targets.destdir}}"/etc/mail
       make DESTDIR="${{targets.destdir}}" INSTALL_ARG="-no_symlink -no_chown exim" install
       install -D -m644 doc/exim.8 "${{targets.destdir}}"/usr/share/man/man8/exim.8
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv "${{targets.destdir}}"/usr/sbin/* "${{targets.destdir}}"/usr/bin
-      rmdir "${{targets.destdir}}"/usr/sbin
       cd "${{targets.destdir}}"/usr/bin
       mv exim-* exim
       chmod u+s exim


### PR DESCRIPTION
make install is called multiple times, thus it is best to set correct
destination for all invocations, instead of fixing them one by one.
