### PR TITLE
tests: add service file test pipeline and use it in in a few packages

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: 4.6.1
-  epoch: 40
+  epoch: 41
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -111,6 +111,7 @@ update:
 
 test:
   pipeline:
+    - uses: test/verify-service
     - name: "Check chrony version"
       runs: |
         chronyd --version

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "9.9_p2"
-  epoch: 40
+  epoch: 41
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -214,6 +214,15 @@ subpackages:
         - openssh-server
         - systemd
         - wolfi-baselayout
+    test:
+      environment:
+        contents:
+          packages:
+            - openssh-doc
+      pipeline:
+        - uses: test/verify-service
+          with:
+            man: 'true'
 
   - name: "openssh-server-config"
     description: "OpenSSH server configuration"

--- a/pipelines/test/verify-service.yaml
+++ b/pipelines/test/verify-service.yaml
@@ -1,0 +1,54 @@
+name: verify-service
+
+needs:
+  packages:
+    - apk-tools
+    - grep
+    - systemd
+
+inputs:
+  man:
+    description: Run verify without skipping doc tests
+    default: 'false'
+
+pipeline:
+  - name: Verify Service files
+    runs: |
+      set -xe
+
+      # If there's a templated service file systemd-analyze verify
+      # will fill in  test_instance for the template. If the
+      # test resource doesn't exist verify won't pass.
+      # The quaota service need a mountpoint to verify the quota service against.
+      # Which casued this but any service that depends on a template will probably
+      # need something.
+      cat << EOF > /usr/lib/systemd/system/test_instance.mount
+      [Unit]
+      Description=Test Mount
+      DefaultDependencies=no
+      Conflicts=umount.target
+      Before=local-fs.target umount.target
+
+      [Mount]
+      What=/dev/null
+      Where=/test_instance
+      EOF
+
+      # ${{package.name}} when run inside of a test pipeline is always the name of the top-level
+      # package. This seems like a bug to me.
+      package_name=$(basename ${{targets.contextdir}})
+
+      echo "Package name: ${package_name}"
+      service_files=$(mktemp)
+      apk -L info ${package_name} | grep 'usr/lib/systemd/system/.*.service$' > ${service_files} || true
+
+      if [ ! -s ${service_files} ]; then
+        echo "No service files found!"
+        exit 1
+      fi
+
+      for file in $(cat "${service_files}"); do
+        systemd-analyze verify --man=${{inputs.man}} "${file}"
+      done
+
+      rm "${service_files}"

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.4"
-  epoch: 40
+  epoch: 41
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -10,9 +10,13 @@ package:
     memory: 12Gi
   dependencies:
     runtime:
+      - dbus
       - kmod
       - merged-sbin
       - merged-usrsbin
+      - quota-tools
+      - systemd-boot
+      - wolfi-baselayout
       - wolfi-baselayout
 
 vars:
@@ -32,7 +36,6 @@ environment:
       - audit-dev
       - bpftool
       - build-base
-      - busybox-full
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
       - cmake
@@ -41,6 +44,7 @@ environment:
       - curl-dev
       - dbus-dev
       - findutils
+      - gnutar
       - gperf
       - iptables-dev
       - kmod
@@ -98,8 +102,77 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/lib
       mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.destdir}}/lib/
+      # We've never used init we don't intend to
+      rm ${{targets.destdir}}/usr/lib/systemd/system/rc-local.service
 
 subpackages:
+  - name: "systemd-test"
+    description: "Installable systemd-tests"
+    dependencies:
+      runtime:
+        - merged-sbin
+        - systemd
+        - systemd-container
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd
+          mv ${{targets.destdir}}/usr/lib/systemd/tests ${{targets.subpkgdir}}/usr/lib/systemd
+          cd ${{targets.destdir}}
+
+          find . -name '*test*' -print \
+          | tar --xattrs '--xattrs-include=*' -pcz '--files-from=-' -f - \
+          | tar --xattrs '--xattrs-include=*' -xzf - -C /home/build/melange-out/systemd-test
+
+          find . -name '*test*' -exec rm -f '{}' \;
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system/
+    test:
+      environment:
+        contents:
+          packages:
+            - bash
+            - coreutils
+            - findutils
+            - python3
+            - tzdata
+            - busybox
+            - tpm2-tss
+            - libidn2 # There's a lot of dlopen tests
+            - libbpf
+            - libzstd1
+            - libarchive
+            - kmod-libs
+      pipeline:
+        - runs: |
+            mkdir -p /var/tmp/
+            # Skipping tests:
+            # test-sd-device - but got the following error: No such device
+            # test-path-util - failed at src/test/test-path-util.c:385, function test_find_executable_full(). Aborting.
+            # test-label - Error occurred while opening directory =>: Read-only file system
+            # test-dns-domain - Assertion 'r >= expected' failed at src/test/test-dns-domain.c:782, function test_dns_name_apply_idna_one(). Aborting.
+            # test-compress-benchmark - failed at src/test/test-compress-benchmark.c:105, function test_compress_decompress(). Aborting.
+            # test-capability - but got error: Protocol error
+            # test-bcd - >= 0' failed at src/boot/test-bcd.c:19, function load_bcd().
+            # test-tpm2 - none setup in the test env.
+            # test-fd-util - Failed to fork off '(caf-noproc)': Operation not permitted
+            # test-fstab-generator - lots of set -x seems to fail messing with mounts?
+            # 2025/03/28 11:52:30 INFO Assertion 'mkdtemp_malloc("/tmp/test-rm-rf.XXXXXXX", &d) >= 0' failed at src/test/test-rm-rf.c:19, function test_rm_rf_chmod_inner(). Aborting.
+            # 2025/03/28 11:52:30 INFO (setresuid) terminated by signal ABRT.
+            # 2025/03/28 11:52:30 INFO Assertion 'r >= 0' failed at src/test/test-rm-rf.c:100, function test_rm_rf_chmod(). Aborting.
+            /usr/lib/systemd/tests/run-unit-tests.py -u \
+            -s test-sd-device \
+            -s test-path-util \
+            -s test-label \
+            -s test-dns-domain \
+            -s test-compress-benchmark \
+            -s test-capability \
+            -s test-bcd \
+            -s test-tpm2 \
+            -s test-fd-util \
+            -s test-fstab-generator.sh \
+            -s test-rm-rf
+
   - range: standalone-binaries
     name: ${{range.key}}-standalone
     description: Standalone version of ${{range.key}}
@@ -234,79 +307,27 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mkdir -p ${{targets.subpkgdir}}/usr/lib/kernel/
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system-generators/
           mv ${{targets.destdir}}/etc/kernel ${{targets.subpkgdir}}/etc/
           mv ${{targets.destdir}}/usr/bin/kernel-install ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/bootctl ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-boot-update.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
           mv ${{targets.destdir}}/usr/lib/kernel ${{targets.subpkgdir}}/usr/lib/
           mv ${{targets.destdir}}/usr/lib/systemd/boot ${{targets.subpkgdir}}/usr/lib/systemd/
           mv ${{targets.destdir}}/usr/lib/systemd/systemd-bless-boot ${{targets.subpkgdir}}/usr/lib/systemd/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-bless-boot.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
           mv ${{targets.destdir}}/usr/lib/systemd/system-generators/systemd-bless-boot-generator ${{targets.subpkgdir}}/usr/lib/systemd/system-generators/
     test:
       pipeline:
+        - uses: test/verify-service
         - runs: |
             bootctl --version
             bootctl --help
             kernel-install --version
             kernel-install --help
 
-  - name: "systemd-test"
-    description: "Installable systemd-tests"
-    dependencies:
-      runtime:
-        - merged-sbin
-        - merged-usrsbin
-        - systemd
-        - systemd-container
-        - wolfi-baselayout
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd
-          mv ${{targets.destdir}}/usr/lib/systemd/tests ${{targets.subpkgdir}}/usr/lib/systemd
-    test:
-      environment:
-        contents:
-          packages:
-            - bash
-            - coreutils
-            - findutils
-            - python3
-            - tzdata
-            - busybox
-            - tpm2-tss
-            - libidn2 # There's a lot of dlopen tests
-            - libbpf
-            - libzstd1
-            - libarchive
-            - kmod-libs
-      pipeline:
-        - runs: |
-            mkdir -p /var/tmp/
-            # Skipping tests:
-            # test-sd-device - but got the following error: No such device
-            # test-path-util - failed at src/test/test-path-util.c:385, function test_find_executable_full(). Aborting.
-            # test-label - Error occurred while opening directory =>: Read-only file system
-            # test-dns-domain - Assertion 'r >= expected' failed at src/test/test-dns-domain.c:782, function test_dns_name_apply_idna_one(). Aborting.
-            # test-compress-benchmark - failed at src/test/test-compress-benchmark.c:105, function test_compress_decompress(). Aborting.
-            # test-capability - but got error: Protocol error
-            # test-bcd - >= 0' failed at src/boot/test-bcd.c:19, function load_bcd().
-            # test-tpm2 - none setup in the test env.
-            # test-fd-util - Failed to fork off '(caf-noproc)': Operation not permitted
-            # test-fstab-generator - lots of set -x seems to fail messing with mounts?
-            /usr/lib/systemd/tests/run-unit-tests.py -u \
-            -s test-sd-device \
-            -s test-path-util \
-            -s test-label \
-            -s test-dns-domain \
-            -s test-compress-benchmark \
-            -s test-capability \
-            -s test-bcd \
-            -s test-tpm2 \
-            -s test-fd-util \
-            -s test-fstab-generator.sh
-
-  - name: "systemd-container"
+  - name: systemd-container
     description: "systemd container tools"
     dependencies:
       runtime:
@@ -324,22 +345,35 @@ subpackages:
           find . -name '*machine*' \
           -not -name 'systemd-machine-id*' \
           -not -name 'sysinit.target.wants' \
-          -not -name 'sysinit.target.wants/' \
+          -not -name 'sysinit.target.wants' \
           -not -name 'systemd-pcr*.service' \
-          -exec cp -l -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*nspawn*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*vmspawn*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*import*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*export*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*portable*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
+          find . -name '*nspawn*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
+          find . -name '*vmspawn*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
+          find . -name '*import*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
+          find . -name '*export*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
+          find . -name '*portable*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
 
           # Remove those files from the main package
           find . -name '*machine*' -not -name 'systemd-machine-id*' -exec rm -f '{}' \;
+
           find . -name '*nspawn*' -exec rm -f '{}' \;
           find . -name '*vmspawn*' -exec rm -f '{}' \;
           find . -name '*import*' -exec rm -f '{}' \;
           find . -name '*export*' -exec rm -f '{}' \;
-          find . -name '*portable*' -type f -exec rm -f '{}' \;
+          find . -name '*portable*' -exec rm -f '{}' \;
           find . -name '*portable*' -type d -exec rmdir '{}' \;
 
           # Misc utilties
@@ -353,6 +387,7 @@ subpackages:
             - curl
             - gnutar
       pipeline:
+        - uses: test/verify-service
         - runs: |
             machinectl --help
             machinectl --version
@@ -399,13 +434,16 @@ subpackages:
       - runs: |
           cd ${{targets.destdir}}/
           mkdir -p ${{targets.subpkgdir}}
-          find . -name '*udev*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
-          find . -name '*systemd-hwdb*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*udev*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+          find . -name '*systemd-hwdb*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=- -f - \
+          | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
 
-          find . -name '*udev*' -exec rm -f '{}' \;
-          find . -name '*systemd-hwdb*' -exec rm -f '{}' \;
+          find . -name '*udev*' -exec rm -f {} \;
+          find . -name '*systemd-hwdb*'  -exec rm -f {} \;
     test:
       pipeline:
+        - uses: test/verify-service
         - runs: |
             systemd-hwdb --version
             systemd-hwdb --help
@@ -476,6 +514,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system/
           mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-logind.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/dbus-org.freedesktop.login1.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-logind.service ${{targets.subpkgdir}}/usr/lib/systemd/system
+          mv ${{targets.destdir}}/usr/lib/systemd/systemd-logind ${{targets.destdir}}/usr/lib/systemd/system/
 
   - name: "systemd-logind-stub"
     description: "Fake login service to boot directly into a shell"
@@ -499,6 +540,7 @@ subpackages:
         - merged-sbin
         - merged-usrsbin
         - wolfi-baselayout
+        - systemd-homed # systemd-homed-firstboot
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
@@ -510,6 +552,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-homed-firstboot.service ${{targets.subpkgdir}}/usr/lib/systemd/system/systemd-homed-firstboot.service
     test:
       pipeline:
+        - uses: test/verify-service
         - name: "Check version"
           runs: |
             systemd-firstboot --version
@@ -542,10 +585,12 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/systemd
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
-          find . -name '*home*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*home*' -print | tar -pcz --files-from=-  -f - | tar --xattrs  --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
+
           find . -name '*home*' -exec rm -f '{}' \;
     test:
       pipeline:
+        - uses: test/verify-service
         - runs: |
             homectl --help
 
@@ -563,10 +608,11 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/systemd
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
-          find . -name '*userdb*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*userdb*' -print | tar --xattrs --xattrs-include='*' -pcz --files-from=-  -f - | tar --xattrs --xattrs-include='*' -xzf - -C ${{targets.subpkgdir}}
           find . -name '*userdb*' -exec rm -f '{}' \;
     test:
       pipeline:
+        - uses: test/verify-service
         - runs: |
             userdbctl --help
 
@@ -584,6 +630,7 @@ test:
         - systemd-dev
         - libsystemd
   pipeline:
+    - uses: test/verify-service
     - name: "Check systemctl version"
       runs: |
         systemctl --version


### PR DESCRIPTION
The tar lines, while I don't like fix an issues that systemd-analyze
verify found where symlinks are turned into real files. Test was moved
forward in the pipeline because we don't have install via file lists
and otherwise other packages will pickup the test files when they shoulnd't.
    
All the service files aren't 100% clean but they're not longer failing.

This should probably also have a warning linter like ldd or docs do.