### PR TITLE
py3-jupyterlab-server: update

### DIFF
--- a/py3-altair.yaml
+++ b/py3-altair.yaml
@@ -25,8 +25,8 @@ data:
 environment:
   contents:
     packages:
-      - py3-supported-hatchling
       - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -44,19 +44,48 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
+        - py${{range.key}}-jinja2
         - py${{range.key}}-jsonschema
+        - py${{range.key}}-narwhals
+        - py${{range.key}}-packaging
     pipeline:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
       - uses: strip
     test:
+      environment:
+        contents:
+          packages:
+            - jq
+            - py${{range.key}}-pandas
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+        - name: Test chart output to json
+          uses: py/one-python
+          with:
+            content: |
+              cat > test.py <<EOF
+              import pandas as pd
+              import altair as alt
+
+              data = pd.DataFrame(
+                {
+                  "a": list("CCCDDDEEE"),
+                  "b": [2, 7, 4, 1, 2, 6, 8, 4, 7]
+                }
+              )
+
+              chart = alt.Chart(data).mark_point().encode(x="a", y="b")
+
+              print(chart.to_json())
+              EOF
+
+              python3 test.py | jq -r '.encoding.x.field' | grep "a"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -66,13 +95,6 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-altair.yaml
+++ b/py3-altair.yaml
@@ -25,8 +25,8 @@ data:
 environment:
   contents:
     packages:
-      - py3-supported-build-base
       - py3-supported-hatchling
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -44,48 +44,19 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-jinja2
         - py${{range.key}}-jsonschema
-        - py${{range.key}}-narwhals
-        - py${{range.key}}-packaging
     pipeline:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
       - uses: strip
     test:
-      environment:
-        contents:
-          packages:
-            - jq
-            - py${{range.key}}-pandas
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
-        - name: Test chart output to json
-          uses: py/one-python
-          with:
-            content: |
-              cat > test.py <<EOF
-              import pandas as pd
-              import altair as alt
-
-              data = pd.DataFrame(
-                {
-                  "a": list("CCCDDDEEE"),
-                  "b": [2, 7, 4, 1, 2, 6, 8, 4, 7]
-                }
-              )
-
-              chart = alt.Chart(data).mark_point().encode(x="a", y="b")
-
-              print(chart.to_json())
-              EOF
-
-              python3 test.py | jq -r '.encoding.x.field' | grep "a"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -95,6 +66,13 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterlab-server.yaml
+++ b/py3-jupyterlab-server.yaml
@@ -6,30 +6,24 @@ package:
   description: A set of server components for JupyterLab and JupyterLab like applications.
   copyright:
     - license: BSD-3-Clause
-  dependencies:
-    runtime:
-      - py3-babel
-      - py3-importlib-metadata
-      - py3-jinja2
-      - py3-json5
-      - py3-jsonschema
-      - py3-jupyter-server
-      - py3-packaging
-      - py3-requests
-      - python-3
+
+vars:
+  pypi-package: jupyterlab-server
+  import: jupyterlab_server
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -38,10 +32,46 @@ pipeline:
       repository: https://github.com/jupyterlab/jupyterlab_server
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-babel
+        - py${{range.key}}-json5
+        - py${{range.key}}-jupyter-server
+        - py${{range.key}}-requests
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - python-${{range.key}}
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+        - name: Basic test to generate default config
+          runs: python -m jupyterlab_server --generate-config | grep "Writing default config to" | grep ".jupyter/jupyter_jupyterlab_server_config.py"
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-jupyterlab-server.yaml
+++ b/py3-jupyterlab-server.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyterlab-server
   version: 2.27.3
-  epoch: 0
+  epoch: 1
   description: A set of server components for JupyterLab and JupyterLab like applications.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Updating `py3-jupyterlab-server` for all python3 versions.

Related: https://github.com/chainguard-dev/image-requests/issues/5554