### PR TITLE
Adjust sed to match new `link` GCC spec

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.64.1"
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -111,7 +111,7 @@ pipeline:
   # Ensure that we don't run into nvidia GPU issues at runtime.
   - runs: |
       gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"
-      sed -r 's/,?-z,now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
+      sed -r 's/-z now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
 
   # Install `invoke` (build) dependencies. We ultimately package with venv so
   # these won't leak into the package.

--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-device-plugin
   version: "0.17.1"
-  epoch: 1
+  epoch: 2
   description: meta package providing all NVIDIA device plugins for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
 
   - runs: |
       gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"
-      sed -r 's/,?-z,now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
+      sed -r 's/-z now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
 
   - uses: go/bump
     with:


### PR DESCRIPTION
Adjust the `sed` command that gets rid of `-z now` on linker flags now that our spec file has a new `link` spec.

Relates: #48511
Relates: #48510 