### PR TITLE
util-linux: fix mount regression

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.41"
-  epoch: 40
+  epoch: 41
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -42,6 +42,11 @@ pipeline:
     with:
       expected-sha256: 81ee93b3cfdfeb7d7c4090cedeba1d7bbce9141fd0b501b686b3fe475ddca4c6
       uri: https://www.kernel.org/pub/linux/utils/util-linux/v${{vars.major-minor}}/util-linux-${{package.version}}.tar.xz
+
+  - uses: patch
+    with:
+      # Fix mount regression
+      patches: 42e34984709ce9c21640b8c2b7aa1cf84a40add0.patch
 
   - runs: |
       cp ttydefaults.h include/

--- a/util-linux/42e34984709ce9c21640b8c2b7aa1cf84a40add0.patch
+++ b/util-linux/42e34984709ce9c21640b8c2b7aa1cf84a40add0.patch
@@ -1,0 +1,40 @@
+From https://github.com/util-linux/util-linux/commit/42e34984709ce9c21640b8c2b7aa1cf84a40add0
+From 7dbfe31a83f45d5aef2b508697e9511c569ffbc8 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Mon, 24 Mar 2025 14:31:05 +0100
+Subject: [PATCH] libmount: fix --no-canonicalize regression
+
+Fixes: https://github.com/util-linux/util-linux/issues/3474
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/context.c | 3 ---
+ sys-utils/mount.8.adoc | 2 +-
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/libmount/src/context.c b/libmount/src/context.c
+index 0323cb23d34..15a8ad3bbd0 100644
+--- a/libmount/src/context.c
++++ b/libmount/src/context.c
+@@ -530,9 +530,6 @@ int mnt_context_is_xnocanonicalize(
+ 	assert(cxt);
+ 	assert(type);
+ 
+-	if (mnt_context_is_nocanonicalize(cxt))
+-		return 1;
+-
+ 	ol = mnt_context_get_optlist(cxt);
+ 	if (!ol)
+ 		return 0;
+diff --git a/sys-utils/mount.8.adoc b/sys-utils/mount.8.adoc
+index 4f23f8d1f0e..5103b91c578 100644
+--- a/sys-utils/mount.8.adoc
++++ b/sys-utils/mount.8.adoc
+@@ -756,7 +756,7 @@ Allow to make a target directory (mountpoint) if it does not exist yet. The opti
+ *X-mount.nocanonicalize*[**=**_type_]::
+ Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when binding a mount over a symlink, or a symlink over a directory or another symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
+ +
+-The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but it does not modify flags for open_tree syscalls.
++The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify open_tree syscall flags and does not allow the bind-mount over a symlink use case.
+ +
+ Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
+ 


### PR DESCRIPTION
Which causes many helm chart deployment failures.

Thanks to @kranurag7 for report

Related:
- https://github.com/util-linux/util-linux/issues/3474
- https://github.com/k3s-io/k3s/issues/12006
