### PR TITLE
avahi - fix installation to /usr/bin rather than /bin

### DIFF
--- a/avahi.yaml
+++ b/avahi.yaml
@@ -1,7 +1,7 @@
 package:
   name: avahi
   version: 0.9_rc1
-  epoch: 40
+  epoch: 41
   description: A multicast/unicast DNS-SD framework
   copyright:
     - license: LGPL-2.1
@@ -55,7 +55,7 @@ pipeline:
     with:
       opts: |
         --prefix=/usr \
-        --sbindir=/bin \
+        --sbindir=/usr/bin \
         --localstatedir=/var \
         --with-distro=none \
         --disable-qt3 \


### PR DESCRIPTION
avahi was landing files in /bin rather than /usr/bin.
