### PR TITLE
revert temp hack

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -24,6 +24,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - py3-supported-python
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
We bundled a build, and we are happy, put the dep back in.

See: https://github.com/wolfi-dev/os/pull/48788
