### PR TITLE
feat: new package for clickhouse-operator

### DIFF
--- a/clickhouse-operator.yaml
+++ b/clickhouse-operator.yaml
@@ -36,10 +36,8 @@ update:
 test:
   # Despite using KWOK or specifying a kubeconfig (e.g. `clickhouse-operator -kubeconfig "/root/.kube/config"`),
   # we still encounter this error:
-  # {"error": "failed to get API group resources: unable to retrieve the complete list of server APIs:
-  #  clickhouse-keeper.altinity.com/v1:
-  #  Get \"https://127.0.0.1:32764/apis/clickhouse-keeper.altinity.com/v1\": dial tcp 127.0.0.1:32764:
-  #  connect: connection refused"}
+  # Err: Get "https://127.0.0.1:32764/apis/clickhouse.altinity.com/v1/clickhouseoperatorconfigurations":
+  # dial tcp 127.0.0.1:32764: connect: connection refused
   pipeline:
     - uses: test/tw/ldd-check
     - name: Basic tests

--- a/clickhouse-operator.yaml
+++ b/clickhouse-operator.yaml
@@ -1,0 +1,48 @@
+package:
+  name: clickhouse-operator
+  version: "0.24.5"
+  epoch: 0
+  description: Altinity Kubernetes Operator for ClickHouse creates, configures and manages ClickHouse® clusters running on Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Altinity/clickhouse-operator
+      tag: release-${{package.version}}
+      expected-commit: 2a4b0f2fa3e8a325cbc5b4739d9f74dc4854a9c7
+
+  - uses: go/build
+    with:
+      packages: ./cmd/operator
+      ldflags: "-w -X github.com/altinity/clickhouse-operator/pkg/version.Version=v${{package.version}} -extldflags"
+      output: clickhouse-operator
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binary in the location expected by clickhouse-operator"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}
+          ln -sf /usr/bin/clickhouse-operator ${{targets.contextdir}}/clickhouse-operator
+
+update:
+  enabled: true
+  github:
+    identifier: Altinity/clickhouse-operator
+    strip-prefix: release-
+
+test:
+  # Despite using KWOK or specifying a kubeconfig (e.g. `clickhouse-operator -kubeconfig "/root/.kube/config"`),
+  # we still encounter this error:
+  # {"error": "failed to get API group resources: unable to retrieve the complete list of server APIs:
+  #  clickhouse-keeper.altinity.com/v1:
+  #  Get \"https://127.0.0.1:32764/apis/clickhouse-keeper.altinity.com/v1\": dial tcp 127.0.0.1:32764:
+  #  connect: connection refused"}
+  pipeline:
+    - uses: test/tw/ldd-check
+    - name: Basic tests
+      runs: |
+        clickhouse-operator -version
+        clickhouse-operator -help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
