### PR TITLE
thingsboard: bump spring-security.version

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "3.9.1"
-  epoch: 4
+  epoch: 5
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -26,6 +26,3 @@ patches:
     - groupId: org.apache.tomcat.embed
       artifactId: tomcat-embed-core
       version: 10.1.35
-    - groupId: org.springframework.security
-      artifactId: spring-security-crypto
-      version: 6.3.8

--- a/thingsboard/pombump-properties.yaml
+++ b/thingsboard/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "1.5.13"
   - property: jgit.version
     value: "7.2.0.202503040940-r"
+  - property: spring-security.version
+    value: "6.3.8"


### PR DESCRIPTION
CVE remediation in https://github.com/wolfi-dev/os/pull/47625 bumped the `spring-security-crypto` version.  This seems to have caused a problem with other `spring-security` components that remained on a previous version.

With that specific pombump in place, the build WARNs like this:
```
2025/03/27 05:06:27 WARN 2025/03/27 10:06:27 INFO Have patch: org.springframework.security.spring-security-crypto:6.3.8
2025/03/27 05:06:27 WARN 2025/03/27 10:06:27 INFO Adding missing dependency: org.springframework.security.spring-security-crypto:6.3.8
2025/03/27 05:06:27 WARN 2025/03/27 10:06:27 INFO Have patch: org.springframework.security.spring-security-crypto:6.3.8
2025/03/27 05:06:27 WARN 2025/03/27 10:06:27 INFO Patching DM dep org.springframework.security.spring-security-crypto from 6.3.8 to 6.3.8 with scope: import
2025/03/27 05:06:32 INFO [WARNING] 'dependencyManagement.dependencies.dependency.type' for org.springframework.security:spring-security-crypto:jar must be 'pom' to import the managed dependencies. @ org.thingsboard:thingsboard:3.9.1, /home/build/pom.xml, line 1563, column 23
2025/03/27 05:06:32 INFO [WARNING] 'dependencyManagement.dependencies.dependency.type' for org.springframework.security:spring-security-crypto:jar must be 'pom' to import the managed dependencies. @ line 1563, column 23
```

And worse, no `spring-security-crypto-6.3.8.jar` is provided in our main `thingsboard.jar`. This causes tb-node to fail like this:
```
Caused by: java.lang.ClassNotFoundException: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
	at java.base/java.net.URLClassLoader.findClass(Unknown Source)
```

Instead of forcing the specific `-crypto` version, this PR bumps the parent `spring-security` version leaving maven to figure out the deps.  That gets our missing jar in place:
```
$ find . -name spring-security-crypto*
./usr/share/thingsboard/BOOT-INF/lib/spring-security-crypto-6.3.8.jar
```

Manual cve scan on resultant apks:
```
$ for i in `ls *.apk`; do wolfictl scan ./$i; done
🔎 Scanning "./thingsboard-3.9.1-r5.apk"
✅ No vulnerabilities found
🔎 Scanning "./thingsboard-tb-js-executor-3.9.1-r5.apk"
✅ No vulnerabilities found
🔎 Scanning "./thingsboard-tb-mqtt-transport-3.9.1-r5.apk"
✅ No vulnerabilities found
2025/04/01 17:06:29 WARN unable to discover java packages from opener: unable to process nested java archive (BOOT-INF/lib/js-beautify-1.14.7.jar): usr/share/thingsboard/bin/thingsboard.jar: no package identified in archive location=usr/share/thingsboard/bin/thingsboard.jar
🔎 Scanning "./thingsboard-tb-node-3.9.1-r5.apk"
✅ No vulnerabilities found
🔎 Scanning "./thingsboard-tb-web-ui-3.9.1-r5.apk"
✅ No vulnerabilities found
```
