### PR TITLE
Bump vitess-21 epoch to remediate CVE-2025-31125

### DIFF
--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -192,7 +192,6 @@ subpackages:
             mysqlctl --help
             mysqlctld --version
             mysqlctld --help
-            rulesctl --version
             rulesctl --help
             topo2topo --version
             topo2topo --help

--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.3"
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump the package to force a rebuild and pull in the new 'vite' npm package.

Fixes GHSA-4r4m-qw57-chr8