### PR TITLE
py3-aioitertools: new package

### DIFF
--- a/py3-aioitertools.yaml
+++ b/py3-aioitertools.yaml
@@ -1,0 +1,101 @@
+package:
+  name: py3-aioitertools
+  version: 0.12.0
+  epoch: 0
+  description: itertools and builtins for AsyncIO and mixed iterables
+  copyright:
+    - license: MIT
+  annotations:
+    cgr.dev/ecosystem: python
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: aioitertools
+  import: aioitertools
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-flit-core
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: eeaef4806a23370d0c8685d1ff5c06b9e47d9d3e
+      repository: https://github.com/omnilib/aioitertools
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - python-${{range.key}}
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+        - name: Test a functional import
+          runs: python${{range.key}} -c "from ${{vars.import}} import chain, iter, islice, map, next, zip"
+        - name: Run a test async iterator
+          runs: |
+            cat >> test.py <<EOF
+            import asyncio
+
+            from aioitertools import iter, next
+            from typing import Iterable
+
+            test_iter = iter(["foo", "bar", "baz"])
+
+            async def get_first_item(iterable: Iterable[str]) -> str:
+                item = await next(iterable)
+                return item
+
+            assert asyncio.run(get_first_item(test_iter)) == "foo"
+
+            EOF
+
+            python${{range.key}} test.py
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - "[a-z][0-9]*$"
+  github:
+    identifier: omnilib/aioitertools
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

New `py3-aioitertools` package

Related: https://github.com/chainguard-dev/image-requests/issues/5554

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)