### PR TITLE
py3-jupyter-lsp: update package for all python versions

### DIFF
--- a/py3-jupyter-lsp.yaml
+++ b/py3-jupyter-lsp.yaml
@@ -1,39 +1,69 @@
-# Generated from https://pypi.org/project/jupyter-lsp/
 package:
   name: py3-jupyter-lsp
   version: 2.2.5
-  epoch: 1
+  epoch: 2
   description: Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server
+  annotations:
+    cgr.dev/ecosystem: python
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyter-server
-      - py3-importlib-metadata
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyter-lsp
+  import: jupyter_lsp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 793147a05ad446f809fd53ef1cd19a9f5256fd0a2d6b7ce943a982cb4f545001
-      uri: https://files.pythonhosted.org/packages/source/j/jupyter-lsp/jupyter-lsp-${{package.version}}.tar.gz
+      expected-commit: b159ae2736b26463d8cc8f0ef78f4b2ce9913370
+      repository: https://github.com/jupyter-lsp/jupyterlab-lsp
+      tag: jupyter-lsp-${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyter-core
+        - py${{range.key}}-jupyter-server
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+        working-directory: python_packages/jupyter_lsp
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 33411
+  ignore-regex-patterns:
+    - "[a-z][0-9]*$"
+  github:
+    identifier: jupyter-lsp/jupyterlab-lsp
+    tag-filter: jupyter-lsp-
+    strip-prefix: jupyter-lsp-


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Updates the `py3-jupyter-lsp` package to track the source code repo and expand it to all supported versions of Python.