### PR TITLE
Disable DNSSEC by default in systemd-resolved

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.4"
-  epoch: 41
+  epoch: 42
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -16,7 +16,6 @@ package:
       - merged-usrsbin
       - quota-tools
       - systemd-boot
-      - wolfi-baselayout
       - wolfi-baselayout
 
 vars:
@@ -93,7 +92,8 @@ pipeline:
         -Dvmspawn=enabled \
         -Dinstall-tests=true \
         -Dstandalone-binaries=true \
-        -Dsplit-bin=false
+        -Dsplit-bin=false \
+        -Ddefault-dnssec=no
 
   - uses: meson/compile
 


### PR DESCRIPTION
In some systems, having systemd-resolved use DNSSEC by default fails all DNS resolution. Many distros disable DNSSEC by default when using systemd-resolved.