### PR TITLE
add missing scripts to whereabouts package

### DIFF
--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: whereabouts
   version: "0.9.0"
-  epoch: 0
+  epoch: 1
   description: A CNI IPAM plugin that assigns IP addresses cluster-wide
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,8 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.contextdir}}"/
       install -Dm755 script/install-cni.sh "${{targets.contextdir}}"/install-cni.sh
+      install -Dm755 script/lib.sh "${{targets.contextdir}}"/lib.sh
+      install -Dm755 script/token-watcher.sh "${{targets.contextdir}}"/token-watcher.sh
 
 subpackages:
   - name: "${{package.name}}-compat"


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Upstream added two new scripts to the image so we have to do the same for package:
- https://github.com/k8snetworkplumbingwg/whereabouts/blame/d33f526057a47746ce345eec938a5bc3f0414e85/Dockerfile#L14