### PR TITLE
Pin Rust to 1.85 for yara-x

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -16,7 +16,7 @@ environment:
       - cargo-c
       - openssl-dev
       - perl
-      - rust
+      - rust-1.85
       - wolfi-base
   environment:
     RUSTFLAGS: "-C opt-level=3"


### PR DESCRIPTION
Rust 1.86 causes the yara-x build to fail. This PR preemptively pins Rust to `rust-1.85` to avoid disruptions while fixes are made upstream.