### PR TITLE
use go/build for php-fpm_exporter

### DIFF
--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,20 +1,10 @@
 package:
   name: php-fpm_exporter
   version: 2.2.0
-  epoch: 12
+  epoch: 13
   description: A prometheus exporter for PHP-FPM.
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -27,9 +17,10 @@ pipeline:
     with:
       deps: google.golang.org/protobuf@v1.33.0 golang.org/x/text@v0.3.8
 
-  - uses: goreleaser/build
+  - uses: go/build
     with:
-      skip: "docker,ko,publish,validate"
+      packages: .
+      output: php-fpm_exporter
 
 update:
   enabled: true


### PR DESCRIPTION
this was a single binary package and we are now moving to using go/build for this package.

```bash
/ # apk add php-fpm_exporter
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/1) Installing php-fpm_exporter (2.2.0-r12)
Executing busybox-1.37.0-r40.trigger
OK: 25 MiB in 16 packages
/ # apk info -L php-fpm_exporter
php-fpm_exporter-2.2.0-r12 contains:
usr/bin/php-fpm_exporter
var/lib/db/sbom/php-fpm_exporter-2.2.0-r12.spdx.json
```