### PR TITLE
 druid/GHSA-2c59-37c4-qrx5/GHSA-55g7-9cwv-5qfv/GHSA-fjpj-2g6w-x25r/GHSA-pqr6-cmr2-h8hf/GHSA-qcwq-55hx-v3vh/fixes

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: "32.0.1"
-  epoch: 1
+  epoch: 2
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,10 @@ pipeline:
       expected-commit: a0420265af08e285527893a3c26dbfdf85d87784
 
   - uses: maven/pombump
+
+  - uses: patch
+    with:
+      patches: GHSA-2c59-37c4-qrx5-fix.patch
 
   - runs: |
       mvn -B -ff -q \

--- a/druid/GHSA-2c59-37c4-qrx5-fix.patch
+++ b/druid/GHSA-2c59-37c4-qrx5-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/extensions-core/parquet-extensions/pom.xml b/extensions-core/parquet-extensions/pom.xml
+index c6aaf4c6f7..3211604ac9 100644
+--- a/extensions-core/parquet-extensions/pom.xml
++++ b/extensions-core/parquet-extensions/pom.xml
+@@ -33,7 +33,7 @@
+   <modelVersion>4.0.0</modelVersion>
+ 
+   <properties>
+-    <parquet.version>1.13.1</parquet.version>
++    <parquet.version>1.15.1</parquet.version>
+   </properties>
+   <dependencies>
+     <dependency>
+@@ -201,7 +201,7 @@
+         </dependency>
+       </dependencies>
+       <properties>
+-        <parquet.version>1.13.0</parquet.version>
++        <parquet.version>1.15.1</parquet.version>
+       </properties>
+     </profile>
+   </profiles>

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -17,9 +17,6 @@ patches:
     - groupId: org.apache.thrift
       artifactId: libthrift
       version: 0.9.3-1
-    - groupId: org.xerial.snappy
-      artifactId: snappy-java
-      version: 1.1.10.1
     - groupId: com.microsoft.azure
       artifactId: msal4j
       version: 1.15.1


### PR DESCRIPTION
GHSA-2c59-37c4-qrx5: Requires a patch as maven/pombump could not handle two property definitions in the same file
GHSA-55g7-9cwv-5qfv/GHSA-fjpj-2g6w-x25r/GHSA-pqr6-cmr2-h8hf/GHSA-qcwq-55hx-v3vh: Removing outdated version pin resolves these CVEs