### PR TITLE
py3-pdm-backend: new package

### DIFF
--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -1,0 +1,65 @@
+package:
+  name: py3-pdm-backend
+  version: 2.4.3
+  epoch: 0
+  description: The build backend used by PDM that supports latest packaging standards.
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pdm-backend
+  import: pdm_backend
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d5d5c23eac4c81535b37ed2cdbe9a53a6c35ed69
+      repository: https://github.com/pdm-project/pdm-backend
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - "[a-z][0-9]*$"
+  github:
+    identifier: pdm-project/pdm-backend
+    use-tag: true

--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -12,7 +12,7 @@ package:
 
 vars:
   pypi-package: pdm-backend
-  import: pdm_backend
+  import: pdm.backend
 
 data:
   - name: py-versions

--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -55,7 +55,7 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
-  
+
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:

--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -55,6 +55,15 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+  
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding the `py3-pdm-backend` package, pre-req for the `pdm` build system.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)