### PR TITLE
Add build deps and extra-library-paths so ldd-checks pass

### DIFF
--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -121,15 +121,15 @@ subpackages:
     description: "OpenJDK 12 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-12-jre-base
     pipeline:
       - runs: |

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-only
@@ -121,8 +121,15 @@ subpackages:
     description: "OpenJDK 12 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-12-jre-base
     pipeline:
       - runs: |
@@ -139,9 +146,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-12-openjdk/lib/server/"
 
   - name: "openjdk-12-jre-base"
     description: "OpenJDK 12 Java Runtime Environment (headless)"
@@ -188,6 +195,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-12-openjdk/lib/server/"
 
   - name: "openjdk-12-jmods"
     description: "OpenJDK 12 jmods"

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-13
   version: 13.0.14.5
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only
@@ -116,8 +116,15 @@ subpackages:
     description: "OpenJDK 13 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-13-jre-base
     pipeline:
       - runs: |
@@ -134,9 +141,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-13-openjdk/lib/server/"
 
   - name: "openjdk-13-jre-base"
     description: "OpenJDK 13 Java Runtime Environment (headless)"
@@ -182,6 +189,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-13-openjdk/lib/server/"
 
   - name: "openjdk-13-jmods"
     description: "OpenJDK 13 jmods"

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -116,15 +116,15 @@ subpackages:
     description: "OpenJDK 13 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-13-jre-base
     pipeline:
       - runs: |

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only
@@ -114,8 +114,15 @@ subpackages:
     description: "OpenJDK 14 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-14-jre-base
     pipeline:
       - runs: |
@@ -132,9 +139,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-14-openjdk/lib/server/"
 
   - name: "openjdk-14-jre-base"
     description: "OpenJDK 14 Java Runtime Environment (headless)"
@@ -142,6 +149,7 @@ subpackages:
       runtime:
         - java-common
         - java-cacerts
+        - libstdc++
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-14-openjdk"
@@ -178,6 +186,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-14-openjdk/lib/server/"
 
   - name: "openjdk-14-jmods"
     description: "OpenJDK 14 jmods"

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -114,15 +114,15 @@ subpackages:
     description: "OpenJDK 14 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-14-jre-base
     pipeline:
       - runs: |

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -119,8 +119,15 @@ subpackages:
     description: "OpenJDK 15 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-15-jre-base
     pipeline:
       - runs: |
@@ -137,9 +144,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-15-openjdk/lib/server/"
 
   - name: "openjdk-15-jre-base"
     description: "OpenJDK 15 Java Runtime Environment (headless)"
@@ -147,6 +154,7 @@ subpackages:
       runtime:
         - java-common
         - java-cacerts
+        - libstdc++
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-15-openjdk"
@@ -182,6 +190,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-15-openjdk/lib/server/"
 
   - name: "openjdk-15-jmods"
     description: "OpenJDK 15 jmods"

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -119,15 +119,15 @@ subpackages:
     description: "OpenJDK 15 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-15-jre-base
     pipeline:
       - runs: |

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -122,15 +122,15 @@ subpackages:
     description: "OpenJDK 16 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-16-jre-base
     pipeline:
       - runs: |

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only
@@ -122,8 +122,15 @@ subpackages:
     description: "OpenJDK 16 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-16-jre-base
     pipeline:
       - runs: |
@@ -140,9 +147,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-16-openjdk/lib/server/"
 
   - name: "openjdk-16-jre-base"
     description: "OpenJDK 16 Java Runtime Environment (headless)"
@@ -150,6 +157,7 @@ subpackages:
       runtime:
         - java-common
         - java-cacerts
+        - libstdc++
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-16-openjdk"
@@ -185,6 +193,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-16-openjdk/lib/server/"
 
   - name: "openjdk-16-jmods"
     description: "OpenJDK 16 jmods"

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: "17.0.14" # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only
@@ -171,6 +171,11 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-17-openjdk/lib/server/"
 
   - name: "openjdk-17-jmods"
     description: "OpenJDK 17 jmods"

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 6
+  epoch: 7
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -128,8 +128,15 @@ subpackages:
     description: "OpenJDK 18 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-18-jre-base
     pipeline:
       - runs: |
@@ -146,9 +153,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-18-openjdk/lib/server/"
 
   - name: "openjdk-18-jre-base"
     description: "OpenJDK 18 Java Runtime Environment (headless)"
@@ -189,6 +196,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-18-openjdk/lib/server/"
 
   - name: "openjdk-18-jmods"
     description: "OpenJDK 18 jmods"

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -125,15 +125,15 @@ subpackages:
     description: "OpenJDK 19 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-19-jre-base
     pipeline:
       - runs: |

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 6
+  epoch: 7
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -125,8 +125,15 @@ subpackages:
     description: "OpenJDK 19 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-19-jre-base
     pipeline:
       - runs: |
@@ -143,9 +150,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-19-openjdk/lib/server/"
 
   - name: "openjdk-19-jre-base"
     description: "OpenJDK 19 Java Runtime Environment (headless)"
@@ -186,6 +193,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-19-openjdk/lib/server/"
 
   - name: "openjdk-19-jmods"
     description: "OpenJDK 19 jmods"

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -131,15 +131,15 @@ subpackages:
     description: "OpenJDK 20 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib-dev
+        - alsa-lib
         - freetype
-        - giflib-dev
-        - lcms2-dev
+        - giflib
+        - lcms2
         - libfontconfig1
-        - libjpeg-turbo-dev
-        - libxext-dev
-        - libxrender-dev
-        - libxtst-dev
+        - libjpeg-turbo
+        - libxext
+        - libxrender
+        - libxtst
         - openjdk-20-jre-base
     pipeline:
       - runs: |

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -131,8 +131,15 @@ subpackages:
     description: "OpenJDK 20 Java Runtime Environment"
     dependencies:
       runtime:
+        - alsa-lib-dev
         - freetype
+        - giflib-dev
+        - lcms2-dev
         - libfontconfig1
+        - libjpeg-turbo-dev
+        - libxext-dev
+        - libxrender-dev
+        - libxtst-dev
         - openjdk-20-jre-base
     pipeline:
       - runs: |
@@ -149,9 +156,9 @@ subpackages:
               "${{targets.subpkgdir}}"/$_java_home/lib
     test:
       pipeline:
-        - uses: test/ldd-check
+        - uses: test/tw/ldd-check
           with:
-            packages: $(basename ${{targets.contextdir}})
+            extra-library-paths: "/usr/lib/jvm/java-20-openjdk/lib/server/"
 
   - name: "openjdk-20-jre-base"
     description: "OpenJDK 20 Java Runtime Environment (headless)"
@@ -192,6 +199,11 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            extra-library-paths: "/usr/lib/jvm/java-20-openjdk/lib/server/"
 
   - name: "openjdk-20-jmods"
     description: "OpenJDK 20 jmods"


### PR DESCRIPTION
The ldd-check testing of all these openjdk packages was failing until I made these changes.