### PR TITLE
py3-jsonpointer: split binary from library - add functional testing

### DIFF
--- a/py3-jsonpointer.yaml
+++ b/py3-jsonpointer.yaml
@@ -75,7 +75,7 @@ subpackages:
             EOF
 
             python${{range.key}} test.py
-  
+
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
     description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}

--- a/py3-jsonpointer.yaml
+++ b/py3-jsonpointer.yaml
@@ -1,22 +1,29 @@
-# Generated from https://pypi.org/project/jsonpointer/
 package:
   name: py3-jsonpointer
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: Identify specific nodes in a JSON document (RFC 6901)
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provider-priority: "0"
 
+vars:
+  import: jsonpointer
+  pypi-package: jsonpointer
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-supported-build-base-dev
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,30 +35,81 @@ pipeline:
 subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
-    pipeline:
-      - name: Python Build
-        uses: py/pip-build-install
-        with:
-          python: python${{range.key}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
+      provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - python-${{range.key}}
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+        - name: Test basic module functionality
+          runs: |
+            cat >> test.py <<EOF
+            from jsonpointer import JsonPointer, set_pointer, resolve_pointer
+
+            test_obj = {"foo": {"array": [{"bar": 42}], "baz": {"derp": "string"}}}
+            assert resolve_pointer(test_obj, "/foo/array/0") == test_obj["foo"]["array"][0]
+
+            set_pointer(test_obj, "/foo/array/0", 24)
+            assert test_obj["foo"]["array"][0] == 24
+
+            pointer = JsonPointer("/foo/array/0")
+            assert pointer.resolve(test_obj) == 24
+            EOF
+
+            python${{range.key}} test.py
+  
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
       provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
     test:
       pipeline:
-        - name: Import Test
-          uses: python/import
-          with:
-            import: ${{vars.module_name}}
-            python: python${{range.key}}
+        - name: Test all binaries are executable
+          runs: |
+            jsonpointer --version
 
-data:
-  - name: py-versions
-    items:
-      "3.10": "310"
-      "3.11": "311"
-      "3.12": "312"
-      "3.13": "313"
+            echo '{"a": [1, 2, 3]}' > a.json
+            echo '{"a": {"b": [4, 5, 6]}}' > b.json
+
+            jsonpointer "/a" a.json | grep "[1, 2, 3]"
+            jsonpointer "/a/b" b.json | grep "[4, 5, 6]"
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -61,14 +119,3 @@ update:
     identifier: stefankoegl/python-json-pointer
     strip-prefix: v
     use-tag: true
-
-vars:
-  module_name: jsonpointer
-  pypi-package: jsonpointer
-
-test:
-  pipeline:
-    - name: Import Test
-      uses: python/import
-      with:
-        import: ${{vars.module_name}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Updating the `py3-jsonpointer` package - splits binary from the library.

This is a dependency of:
- `py3-jsonpatch` - does not use the binary