### PR TITLE
pipelines/test/verify-service: test sockets, allow skipping files

### DIFF
--- a/pipelines/test/verify-service.yaml
+++ b/pipelines/test/verify-service.yaml
@@ -7,6 +7,9 @@ needs:
     - systemd
 
 inputs:
+  skip-files:
+    description: Files to skip testing
+    default: ''
   man:
     description: Run verify without skipping doc tests
     default: 'false'
@@ -38,12 +41,23 @@ pipeline:
       # package. This seems like a bug to me.
       package_name=$(basename ${{targets.contextdir}})
 
+      skip_expr=""
+      for skip in ${{inputs.skip-files}}; do
+        if [ -z ${skip_expr} ]; then
+          skip_expr="${skip}"
+        else
+          skip_expr="${skip_expr}|${skip}"
+        fi
+      done
+      skip_expr="(${skip_expr})"
+
       echo "Package name: ${package_name}"
+      echo "Skipping files: ${skip_expr}"
       service_files=$(mktemp)
-      apk -L info ${package_name} | grep 'usr/lib/systemd/system/.*.service$' > ${service_files} || true
+      apk -L info ${package_name} | grep -E 'usr/lib/systemd/system/.*.(service|socket)$' | grep -vE "/${skip_expr}$" > ${service_files}
 
       if [ ! -s ${service_files} ]; then
-        echo "No service files found!"
+        echo "No service or socket files found!"
         exit 1
       fi
 

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -631,6 +631,8 @@ test:
         - libsystemd
   pipeline:
     - uses: test/verify-service
+      with:
+        skip-files: syslog.socket # intentionally shiped without a corresponding service
     - name: "Check systemctl version"
       runs: |
         systemctl --version


### PR DESCRIPTION
```
amelia-crate@amelia-crate-16 ~/w/os (test-analyze-socket)> for pkg in (grep -ls "uses: test/verify-service" *); make test/(echo $pkg | sed s/.yaml//) >/dev/null 2>&1 || echo "Broke $pkg's tests!"; end
Broke openssh.yaml's tests!
Broke systemd.yaml's tests!
amelia-crate@amelia-crate-16 ~/w/os (test-analyze-socket)>
```