### PR TITLE
Revert "curl,curl-rusttls: Establish libcurl-abi virtual package"

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: "8.12.1"
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -67,8 +67,6 @@ subpackages:
     description: "curl library (rustls backend)"
     dependencies:
       provider-priority: 10
-      provides:
-        - libcurl-abi=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,16 +1,10 @@
 package:
   name: curl
   version: "8.12.1"
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      # Allow only libcurl libraries built from the same upstream
-      # source version instead of only relying on SONAMEs.
-      # https://github.com/chainguard-dev/internal-dev/issues/10381
-      - libcurl-abi=${{package.version}}
 
 environment:
   contents:
@@ -97,8 +91,6 @@ subpackages:
       # raise the priority here so this beats rustls
       # TODO: revert this to "5" once rustls is fixed.
       provider-priority: 15
-      provides:
-        - libcurl-abi=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib


### PR DESCRIPTION
Drop libcurl-abi requires/provides; this works fine with apk but causes an issue with the package resolver in apko:

```
resolving apk packages: for arch "arm64": solving "curl=8.12.1-r1"
constraint: resolving "curl-8.12.1-r1.apk" deps:
we already selected "libcurl-openssl4=8.12.1-r1" which conflicts with "libcurl-abi=8.12.1"
```

This reverts commit 3ed2939d650cbc4073af56bed18656ab0d81c242.
