### PR TITLE
add docker-machine-driver-harvester and docker-machine-driver-linode

### DIFF
--- a/docker-machine-driver-harvester.yaml
+++ b/docker-machine-driver-harvester.yaml
@@ -13,6 +13,15 @@ pipeline:
       repository: https://github.com/harvester/docker-machine-driver-harvester
       tag: v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.36.0
+        k8s.io/kubernetes@v1.30.10
+        github.com/golang/glog@v1.2.4
+
   - uses: go/build
     with:
       ldflags: -X main.VERSION={{package.version}}

--- a/docker-machine-driver-harvester.yaml
+++ b/docker-machine-driver-harvester.yaml
@@ -1,0 +1,40 @@
+package:
+  name: docker-machine-driver-harvester
+  version: 1.0.2
+  epoch: 0
+  description: The Harvester machine driver for Docker.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 833f7f6c8b63c7f1ed8c41688fd3736fcdcc18b6
+      repository: https://github.com/harvester/docker-machine-driver-harvester
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -X main.VERSION={{package.version}}
+      output: docker-machine-driver-harvester
+      packages: .
+
+test:
+  environment:
+    contents:
+      packages:
+        - rancher-machine
+  pipeline:
+    - runs: |
+        # Binary doesn't provide --version or --help flags so we have the negative test here.
+        docker-machine-driver-harvester 2>&1 | grep -q "This is a Docker Machine plugin binary."
+        # This is another negative test to check if the driver is working. We can't have proper test
+        # because the driver requires a harvesterhci.io cluster to be up and running.
+        rancher-machine create --driver harvester --harvester-image-name=rancher/harvester:latest --harvester-disk-size=1 --harvester-network-name=test TEST 2>&1 | grep -q "connect: connection refused"
+
+update:
+  enabled: true
+  github:
+    identifier: harvester/docker-machine-driver-harvester
+    strip-prefix: v
+    use-tag: true

--- a/docker-machine-driver-linode.yaml
+++ b/docker-machine-driver-linode.yaml
@@ -38,6 +38,6 @@ test:
 update:
   enabled: true
   github:
-    identifier: harvester/docker-machine-driver-harvester
+    identifier: linode/docker-machine-driver-linode
     strip-prefix: v
     use-tag: true

--- a/docker-machine-driver-linode.yaml
+++ b/docker-machine-driver-linode.yaml
@@ -1,0 +1,43 @@
+package:
+  name: docker-machine-driver-linode
+  version: 0.1.15
+  epoch: 0
+  description: Linode Driver Plugin for Docker Machine using Linode APIv4
+  copyright:
+    - license: MIT
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d5fe1adaaf54dc42ac5d9846844ea01ffd5f7de3
+      repository: https://github.com/linode/docker-machine-driver-linode
+      tag: v${{package.version}}
+
+  - name: Fix wrong go.sum
+    runs: go mod tidy
+
+  - uses: go/build
+    with:
+      ldflags: -X github.com/linode/docker-machine-driver-linode/pkg/drivers/linode.VERSION={{package.version}}
+      output: docker-machine-driver-linode
+      packages: .
+
+test:
+  environment:
+    contents:
+      packages:
+        - rancher-machine
+  pipeline:
+    - runs: |
+        # Binary doesn't provide --version or --help flags so we have the negative test here.
+        docker-machine-driver-linode 2>&1 | grep -q "This is a Docker Machine plugin binary."
+        # This is another negative test to check if the driver is working. We can't have proper test
+        # because the driver requires a real Linode account to be up and running.
+        rancher-machine create --driver linode --linode-image=linode/ubuntu18.04 --linode-token=test TEST 2>&1 | grep -q "Invalid Token"
+
+update:
+  enabled: true
+  github:
+    identifier: harvester/docker-machine-driver-harvester
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Add rancher dependencies. We can't mitigate the following dependencies as resulting build failures:

```
🔎 Scanning "packages/aarch64/docker-machine-driver-harvester-1.0.2-r0.apk"
└── 📄 /usr/bin/docker-machine-driver-harvester
        📦 github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29 (go-module)
            High CVE-2024-36621 GHSA-2mj3-vfvx-fc43 fixed in 26.0.0
            Medium CVE-2022-24769 GHSA-2mm7-x5h6-5pvq fixed in 20.10.14
            Medium CVE-2021-41091 GHSA-3fwx-pjgw-3558 fixed in 20.10.9
            Medium CVE-2021-21285 GHSA-6fj5-m822-rqx8 fixed in 19.3.15
            Medium CVE-2020-27534 GHSA-6hwg-w5jg-9c6x fixed in 19.03.9
            Medium CVE-2021-21284 GHSA-7452-xqpj-6rpc fixed in 19.3.15
            High CVE-2024-36623 GHSA-gh5c-3h97-2f3q fixed in 26.0.0
            Medium GHSA-xmmx-7jpf-fx42 fixed in 20.10.11
            Medium CVE-2024-24557 GHSA-xw73-rw38-6vjc fixed in 24.0.9
        📦 k8s.io/kubernetes v1.30.10 (go-module)
            Medium CVE-2025-1767 GHSA-3wgm-2gw2-vh5m
```

https://github.com/harvester/docker-machine-driver-harvester/blob/2180e88035d773520cfbf0f76843d705f501e6bd/go.mod#L6

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
