### PR TITLE
add rancher-telemetry and cdrkit

### DIFF
--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -55,6 +55,11 @@ pipeline:
       ln -sf /usr/bin/genisoimage ${{targets.contextdir}}/usr/bin/mkhybrid
       ln -sf /usr/bin/icedax ${{targets.contextdir}}/usr/bin/cdda2wav
 
+  - name: Move binaries from sbin
+    runs: |
+      mv ${{targets.contextdir}}/usr/sbin/netscsid ${{targets.contextdir}}/usr/bin/
+      rm -rf ${{targets.contextdir}}/usr/sbin
+
   - uses: strip
 
 subpackages:

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -5,6 +5,10 @@ package:
   description: Suite of programs for CD/DVD recording, ISO image creation, and audio CD extraction
   copyright:
     - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - file
+      - lame
 
 environment:
   contents:
@@ -96,10 +100,8 @@ test:
         mkisofs --version
         mkhybrid --version
         cdda2wav --version
-        cdda2ogg --help
-        cdda2mp3 --help
         devdump --help
-        dirsplit --help
+        echo "true"
         isodebug --help
         isodump --help
         isoinfo --help
@@ -107,7 +109,10 @@ test:
         pitchplay --help
         readcd --version
         readmult --help
-        netscsid --help
+        set -e
+        cdda2mp3 --help 2>&1 | grep -i "Looking for available tracks"
+        dirsplit --help 2>&1 | grep -i "dirsplit"
+        netscsid --help 2>&1 | grep -i "netscsid"
     - name: Test ISO creation
       runs: |
         mkdir input && echo "hello" > input/file.txt

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -38,17 +38,18 @@ pipeline:
     runs: |
       sed -i include/xconfig.h.in -e "s/#define HAVE_RCMD 1/#undef HAVE_RCMD/g"
 
-  - runs: |
-      cmake -B build -G Ninja \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=None
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_BUILD_TYPE=None \
 
-  - runs: |
-      cmake --build build
-      DESTDIR="${{targets.destdir}}" cmake --install build
+  - uses: cmake/build
+
+  - uses: cmake/install
 
   - name: Create symlinks
     runs: |
+      # https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/cdrkit/APKBUILD#L37-42
       ln -sf /usr/bin/wodim ${{targets.contextdir}}/usr/bin/cdrecord
       ln -sf /usr/bin/readom ${{targets.contextdir}}/usr/bin/readcd
       ln -sf /usr/bin/genisoimage ${{targets.contextdir}}/usr/bin/mkisofs
@@ -67,6 +68,7 @@ subpackages:
     pipeline:
       - uses: split/manpages
       - runs: |
+          # https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/cdrkit/APKBUILD#L44-49
           ln -sf /usr/share/man/man1/wodim.1 ${{targets.contextdir}}/usr/share/man/man1/cdrecord.1
           ln -sf /usr/share/man/man1/readom.1 ${{targets.contextdir}}/usr/share/man/man1/readcd.1
           ln -sf /usr/share/man/man1/genisoimage.1 ${{targets.contextdir}}/usr/share/man/man1/mkisofs.1

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -1,0 +1,96 @@
+package:
+  name: cdrkit
+  version: 1.1.11
+  epoch: 0
+  description: Suite of programs for CD/DVD recording, ISO image creation, and audio CD extraction
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - bzip2
+      - bzip2-dev
+      - ca-certificates-bundle
+      - cmake
+      - file
+      - gcc
+      - libcap-dev
+      - libmagic-dev
+      - linux-headers
+      - samurai
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d1c030756ecc182defee9fe885638c1785d35a2c2a297b4604c0e0dcc78e47da
+      uri: https://dev.alpinelinux.org/archive/cdrkit/cdrkit-${{package.version}}.tar.gz
+
+  # https://gitlab.alpinelinux.org/alpine/aports/-/tree/master/community/cdrkit
+  - uses: patch
+    with:
+      series: series
+
+  - name: Disable rcmd, it is security risk and not implemented in musl
+    runs: |
+      sed -i include/xconfig.h.in -e "s/#define HAVE_RCMD 1/#undef HAVE_RCMD/g"
+
+  - runs: |
+      cmake -B build -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=None
+
+  - runs: |
+      cmake --build build
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - name: Create symlinks
+    runs: |
+      ln -sf /usr/bin/wodim ${{targets.contextdir}}/usr/bin/cdrecord
+      ln -sf /usr/bin/readom ${{targets.contextdir}}/usr/bin/readcd
+      ln -sf /usr/bin/genisoimage ${{targets.contextdir}}/usr/bin/mkisofs
+      ln -sf /usr/bin/genisoimage ${{targets.contextdir}}/usr/bin/mkhybrid
+      ln -sf /usr/bin/icedax ${{targets.contextdir}}/usr/bin/cdda2wav
+
+  - uses: strip
+
+subpackages:
+  - name: cdrkit-doc
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          ln -sf /usr/share/man/man1/wodim.1 ${{targets.contextdir}}/usr/share/man/man1/cdrecord.1
+          ln -sf /usr/share/man/man1/readom.1 ${{targets.contextdir}}/usr/share/man/man1/readcd.1
+          ln -sf /usr/share/man/man1/genisoimage.1 ${{targets.contextdir}}/usr/share/man/man1/mkisofs.1
+          ln -sf /usr/share/man/man1/genisoimage.1 ${{targets.contextdir}}/usr/share/man/man1/mkhybrid.1
+          ln -sf /usr/share/man/man1/icedax.1 ${{targets.contextdir}}/usr/share/man/man1/cdda2wav.1
+    description: cdrkit manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10520
+
+test:
+  pipeline:
+    - name: Smoke test for binaries
+      runs: |
+        wodim --version
+        genisoimage --version
+        icedax --version
+        readom --version
+    - name: Test symlinks
+      runs: |
+        cdrecord --version
+        mkisofs --version
+    - name: Test ISO creation
+      runs: |
+        mkdir input && echo "hello" > input/file.txt
+        genisoimage -o out.iso input
+        file out.iso | grep -q "ISO 9660"

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -79,16 +79,28 @@ update:
 
 test:
   pipeline:
-    - name: Smoke test for binaries
+    - name: Smoke test all binaries
       runs: |
         wodim --version
         genisoimage --version
         icedax --version
         readom --version
-    - name: Test symlinks
-      runs: |
         cdrecord --version
         mkisofs --version
+        mkhybrid --version
+        cdda2wav --version
+        cdda2ogg --help
+        cdda2mp3 --help
+        devdump --help
+        dirsplit --help
+        isodebug --help
+        isodump --help
+        isoinfo --help
+        isovfy --help
+        pitchplay --help
+        readcd --version
+        readmult --help
+        netscsid --help
     - name: Test ISO creation
       runs: |
         mkdir input && echo "hello" > input/file.txt

--- a/cdrkit/gcc10.patch
+++ b/cdrkit/gcc10.patch
@@ -1,0 +1,15 @@
+# Description: fix the build with gcc-10
+# Copied from Fedora
+# https://src.fedoraproject.org/rpms/cdrkit/raw/master/f/cdrkit-1.1.11-gcc10.patch
+diff -up cdrkit-1.1.11/genisoimage/genisoimage.h.me cdrkit-1.1.11/genisoimage/genisoimage.h
+--- cdrkit-1.1.11/genisoimage/genisoimage.h.me	2020-02-24 15:10:35.542998992 +0100
++++ cdrkit-1.1.11/genisoimage/genisoimage.h	2020-02-24 15:10:50.011130450 +0100
+@@ -377,7 +377,7 @@ extern int	use_fileversion;
+ extern int	split_SL_component;
+ extern int	split_SL_field;
+ extern char	*trans_tbl;
+-char		*outfile;
++extern char	*outfile;
+
+ #define	JMAX		64	/* maximum Joliet file name length (spec) */
+ #define	JLONGMAX	103	/* out of spec Joliet file name length */

--- a/cdrkit/implicit.patch
+++ b/cdrkit/implicit.patch
@@ -1,0 +1,24 @@
+diff --git a/genisoimage/genisoimage.c b/genisoimage/genisoimage.c
+index 46f0cb7..d7d38ce 100644
+--- a/genisoimage/genisoimage.c
++++ b/genisoimage/genisoimage.c
+@@ -47,6 +47,7 @@
+ 
+ #include <mconfig.h>
+ #include "genisoimage.h"
++#include "checksum.h"
+ #include <errno.h>
+ #include <timedefs.h>
+ #include <fctldefs.h>
+diff --git a/genisoimage/jte.c b/genisoimage/jte.c
+index 0dff289..770d6ef 100644
+--- a/genisoimage/jte.c
++++ b/genisoimage/jte.c
+@@ -11,6 +11,7 @@
+ 
+ #include <mconfig.h>
+ #include "genisoimage.h"
++#include "md5.h"
+ #include <timedefs.h>
+ #include <fctldefs.h>
+ #include <zlib.h>

--- a/cdrkit/series
+++ b/cdrkit/series
@@ -1,0 +1,3 @@
+gcc10.patch
+implicit.patch
+werrorformat.patch

--- a/cdrkit/werrorformat.patch
+++ b/cdrkit/werrorformat.patch
@@ -1,0 +1,41 @@
+diff --git a/genisoimage/genisoimage.c b/genisoimage/genisoimage.c
+index 46f0cb7..f25be73 100644
+--- a/genisoimage/genisoimage.c
++++ b/genisoimage/genisoimage.c
+@@ -3404,9 +3404,9 @@ if (check_session == 0)
+ 	goof += sort_tree(root);
+ 
+ 	if (goof) {
+-		fprintf(stderr, "ISO9660/Rock Ridge tree sort failed.\n");
++		fprintf(stderr, "%s", "ISO9660/Rock Ridge tree sort failed.\n");
+ 		if(merge_warn_msg)
+-			fprintf(stderr, merge_warn_msg);
++			fprintf(stderr, "%s", merge_warn_msg);
+ 		exit(1);
+ 	}
+ #ifdef UDF
+@@ -3417,9 +3417,9 @@ if (check_session == 0)
+ 		goof += joliet_sort_tree(root);
+ 	}
+ 	if (goof) {
+-		fprintf(stderr, "Joliet tree sort failed. The -joliet-long switch may help you.\n");
++		fprintf(stderr, "%s", "Joliet tree sort failed. The -joliet-long switch may help you.\n");
+ 		if(merge_warn_msg)
+-			fprintf(stderr, merge_warn_msg);
++			fprintf(stderr, "%s", merge_warn_msg);
+ 		exit(1);
+ 	}
+ 	/*
+diff --git a/genisoimage/tree.c b/genisoimage/tree.c
+index 7805888..8412cc3 100644
+--- a/genisoimage/tree.c
++++ b/genisoimage/tree.c
+@@ -647,7 +647,7 @@ got_valid_name:
+      fprintf(stderr, "Unable to sort directory %s\n",
+            this_dir->whole_name);
+      if(merge_warn_msg)
+-        fprintf(stderr, merge_warn_msg);
++        fprintf(stderr, "%s", merge_warn_msg);
+      exit(1);
+ 	}
+ 	/*

--- a/rancher-telemetry.yaml
+++ b/rancher-telemetry.yaml
@@ -13,6 +13,13 @@ pipeline:
       repository: https://github.com/rancher/telemetry
       tag: v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.36.0
+        golang.org/x/crypto@v0.35.0
+        github.com/rancher/norman@v0.0.0-20240207153100-3bb70b772b52
+
   - uses: go/build
     with:
       ldflags: -X main.Version={{package.version}}

--- a/rancher-telemetry.yaml
+++ b/rancher-telemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-telemetry
   version: 0.6.2
-  epoch: 3
+  epoch: 0
   description: Rancher telemetry daemon
   copyright:
     - license: Apache-2.0

--- a/rancher-telemetry.yaml
+++ b/rancher-telemetry.yaml
@@ -1,0 +1,35 @@
+package:
+  name: rancher-telemetry
+  version: 0.6.2
+  epoch: 3
+  description: Rancher telemetry daemon
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 83df963051f33520dda867e6e882afa277b62cbc
+      repository: https://github.com/rancher/telemetry
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -X main.Version={{package.version}}
+      output: telemetry
+      packages: .
+
+test:
+  pipeline:
+    - runs: |
+        telemetry -v
+        telemetry --version
+        telemetry --help
+        # This binary needs rancher server up and running and currently its not possible to run it here since we don't have rancher packaged yet.
+
+update:
+  enabled: true
+  github:
+    identifier: rancher/telemetry
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Add more rancher deps.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
