### PR TITLE
add rancher-helm-3

### DIFF
--- a/rancher-helm-3.yaml
+++ b/rancher-helm-3.yaml
@@ -1,0 +1,72 @@
+package:
+  name: rancher-helm-3
+  version: 3.17.0
+  epoch: 0
+  description: The Kubernetes Package Manager
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - rancher-helm=${{package.full-version}}
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 259981a18a6ce2f326171f75d8e8b7bf397d598c
+      repository: https://github.com/rancher/helm
+      tag: v${{package.version}}-rancher1
+
+  - name: Extract Kubernetes version
+    runs: |
+      # https://github.com/rancher/helm/blob/259981a18a6ce2f326171f75d8e8b7bf397d598c/Makefile#L61-L69
+      #!/bin/sh
+      set -e
+      K8S_FULL_VERSION=$(go list -f '{{.Version}}' -m k8s.io/client-go)
+      K8S_VERSION_STRIPPED="${K8S_FULL_VERSION#v}"
+      IFS='.' read -r MAJOR MINOR PATCH <<EOF
+      $K8S_VERSION_STRIPPED
+      EOF
+      MAJOR=$(expr "$MAJOR" + 1)
+      echo "$MAJOR" > k8s_major
+      echo "$MINOR" > k8s_minor
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.36.0
+        golang.org/x/oauth2@v0.27.0
+        github.com/docker/docker@v26.1.5+incompatible
+        github.com/containerd/containerd@v1.7.27
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X helm.sh/helm/v3/internal/version.version=${{package.version}}
+        -X helm.sh/helm/v3/internal/version.metadata=""
+        -X helm.sh/helm/v3/internal/version.gitCommit=$(git rev-parse HEAD)
+        -X helm.sh/helm/v3/internal/version.gitTreeState=$(test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
+        -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=$(cat k8s_major)
+        -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=$(cat k8s_minor)
+        -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=$(cat k8s_major)
+        -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=$(cat k8s_minor)
+      output: rancher-helm
+      packages: ./cmd/helm
+
+test:
+  pipeline:
+    - runs: |
+        rancher-helm version | grep -i "${{package.version}}"
+        rancher-helm --help
+    - runs: |
+        rancher-helm create test
+
+update:
+  enabled: true
+  github:
+    identifier: rancher/helm
+    strip-prefix: v
+    strip-suffix: -rancher1
+    use-tag: true
+    tag-filter-contains: -rancher
+    tag-filter: v3.


### PR DESCRIPTION
Rancher dependency. https://github.com/rancher/helm

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
