### PR TITLE
Patch GHSA-3wgm-2gw2-vh5m in our k8s package by disabling git repo pl…

### DIFF
--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.32
   version: "1.32.3"
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,8 @@ pipeline:
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
       expected-commit: 32cc146f75aad04beaaa245a7157eb35063a9f99
+      cherry-picks: |
+        master/282e1490d4357e66a4de9a212dfd43acc158044d: Disable git_repo volume driver by default.
 
   - uses: go/bump
     with:
@@ -374,7 +376,7 @@ test:
         # See if the version that returns, matches our melange package version.
         # This command fails if there is a mis-match, and likewise if there
         # is any issues with kubeconfig setup and auth (above).
-        kubectl version --output=json | jq -e '.serverVersion.gitVersion=="v${{package.version}}"'
+        kubectl version --output=json | jq -e '.serverVersion.gitVersion' | grep "v${{package.version}}"
         kubectl api-resources
 
         # Validate we can add some resources


### PR DESCRIPTION
…ugin.

This has been deprecated for 6 years and the vulnerability isn't getting fixed. It's due to be disabled by default in 1.33, this forwards that up.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
