### PR TITLE
jitsucom-jitsu: bump nextjs to 15.2.4 to fix CVE-2025-30218

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.9.0"
-  epoch: 0
+  epoch: 1
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -47,8 +47,8 @@ pipeline:
       patches: GHSA-c76h-2ccp-4975.patch CVE-2025-27152.patch CVE-2025-27789.patch
 
   - runs: |
-      # CVE-2025-29927
-      (cd webapps/console && npm pkg set dependencies.next=^15.2.3)
+      # CVE-2025-30218
+      (cd webapps/console && npm pkg set dependencies.next=^15.2.4)
       pnpm install -r --unsafe-perm
       export NEXTJS_STANDALONE_BUILD=1
 


### PR DESCRIPTION
Fixes GHSA-223j-4rm8-mrmf
