### PR TITLE
rustup: bump openssl to 0.10.72 to fix GHSA-4fcv-w3qc-ppgg

### DIFF
--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: "1.28.1"
-  epoch: 1
+  epoch: 2
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT

--- a/rustup/cargobump-deps.yaml
+++ b/rustup/cargobump-deps.yaml
@@ -4,6 +4,6 @@ packages:
     - name: curl
       version: 0.4.47
     - name: openssl
-      version: 0.10.70
+      version: 0.10.72
     - name: ring
       version: 0.17.12


### PR DESCRIPTION
Fixes GHSA-4fcv-w3qc-ppgg