### PR TITLE
Chart-testing package addition

### DIFF
--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -11,7 +11,7 @@ package:
       - helm
       - kubectl
       - openssh-client
-      - yamale
+      - py3.11-yamale-bin
       - yamllint
 
 pipeline:

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -11,7 +11,7 @@ package:
       - helm
       - kubectl
       - openssh-client
-      - py3.11-yamale-bin
+      - py3-yamale
       - yamllint
 
 pipeline:

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -7,12 +7,12 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - helm
       - git
-      - yamllint
-      - yamale
+      - helm
       - kubectl
       - openssh-client
+      - yamale
+      - yamllint
 
 pipeline:
   - uses: git-checkout
@@ -27,7 +27,7 @@ pipeline:
       packages: ./ct
       output: ct
       ldflags: "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
-  
+
   - runs: |
       mkdir -p ${{targets.destdir}}/etc/ct
       install -Dm755 ./etc/chart_schema.yaml ${{targets.destdir}}/etc/ct/chart_schema.yaml

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -113,4 +113,3 @@ test:
         cd helm-charts
         ct list-changed --target-branch main > changed.txt 2>&1
         grep -q "grafana" changed.txt
-        yamale --version

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -26,7 +26,10 @@ pipeline:
       modroot: .
       packages: ./ct
       output: ct
-      ldflags: "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
+      ldflags: |
+        -X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} 
+        -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+        -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
 
   - runs: |
       mkdir -p ${{targets.destdir}}/etc/ct

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -11,7 +11,7 @@ package:
       - helm
       - kubectl
       - openssh-client
-      - py3-yamale
+      - py3-yamale-bin
       - yamllint
 
 pipeline:

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,0 +1,32 @@
+package:
+  name: chart-testing
+  version: "3.12.0"
+  epoch: 13
+  description: Tool for testing Helm charts, used for linting and testing pull requests.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/helm/chart-testing
+      tag: v${{package.version}}
+      expected-commit: d6991035017d7ac0e3dec3d1b5ad2e5f18674b32
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./ct
+      output: ct
+      ldflags: "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
+
+update:
+  enabled: true
+  github:
+    identifier: helm/chart-testing
+    strip-prefix: v
+test:
+  pipeline:
+    - name: "Version test"
+      runs: |
+        ct version

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -29,7 +29,7 @@ pipeline:
       ldflags: |
         -X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}}
         -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
-        -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
+        -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)
 
   - runs: |
       mkdir -p ${{targets.destdir}}/etc/ct

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,7 +1,7 @@
 package:
   name: chart-testing
   version: "3.12.0"
-  epoch: 0
+  epoch: 14
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
@@ -9,10 +9,10 @@ package:
     runtime:
       - helm
       - git
-      - yamllit
+      - yamllint
       - yamale
       - kubectl
-
+      - openssh-client
 pipeline:
   - uses: git-checkout
     with:
@@ -26,6 +26,11 @@ pipeline:
       packages: ./ct
       output: ct
       ldflags: "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
+  
+  - runs: |
+      mkdir -p ${{targets.destdir}}/etc/ct
+      install -Dm755 ./etc/chart_schema.yaml ${{targets.destdir}}/etc/ct/chart_schema.yaml
+      install -Dm755 ./etc/lintconf.yaml ${{targets.destdir}}/etc/ct/lintconf.yaml
 
 update:
   enabled: true
@@ -34,12 +39,6 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - helm
-        - git
-        - yamllint
   pipeline:
     - name: "Version and help test"
       runs: |
@@ -53,11 +52,9 @@ test:
     - name: "Ct lint test"
       runs: |
         # Using grafana helm chart
-        git clone --depth=1 https://github.com/grafana/helm-charts.git
+        git clone https://github.com/grafana/helm-charts.git
         cd helm-charts
         git checkout caca81a241a207cc6dc0e84c3ab51f76bd800028
-        # Init git (required by ct)
-        git init
         git config user.email "test@example.com"
         git config user.name "Test User"
         echo "# test change" >> charts/grafana/Chart.yaml
@@ -70,7 +67,8 @@ test:
           - charts
         chart-repos:
           - "grafana=https://grafana.github.io/helm-charts"
-        target-branch: HEAD
+        target-branch: caca81a241a207cc6dc0e84c3ab51f76bd800028
+        skip-clone: true
         validate-chart-schema: false
         helm-extra-args: --dry-run
         EOF
@@ -79,8 +77,7 @@ test:
         strict: true
         EOF
         # Run ct lint
-        ct lint --config ct-config.yaml > lint_output.txt 2>&1
-        grep -q "All charts linted successfully" lint_output.txt
+        ct lint --config ct-config.yaml | grep -q "All charts linted successfully"
         # Ct lint error case, injecting errors:
         echo "bad: [unclosed" >> charts/grafana/values.yaml
         echo "# test change2" >> charts/grafana/Chart.yaml

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -27,7 +27,7 @@ pipeline:
       packages: ./ct
       output: ct
       ldflags: |
-        -X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}} 
+        -X github.com/helm/chart-testing/v3/ct/cmd.Version=${{package.version}}
         -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
         -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=$(git rev-parse --short HEAD)"
 

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -5,6 +5,13 @@ package:
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - helm
+      - git
+      - yamllit
+      - yamale
+      - kubectl
 
 pipeline:
   - uses: git-checkout

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,7 +1,7 @@
 package:
   name: chart-testing
   version: "3.12.0"
-  epoch: 13
+  epoch: 0
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
@@ -25,8 +25,80 @@ update:
   github:
     identifier: helm/chart-testing
     strip-prefix: v
+
 test:
+  environment:
+    contents:
+      packages:
+        - helm
+        - git
+        - yamllint
   pipeline:
-    - name: "Version test"
+    - name: "Version and help test"
       runs: |
-        ct version
+        ct version 2>&1 | grep ${{package.version}}
+        ct --help > help_output.txt 2>&1
+        grep -q "Lint and test" help_output.txt
+    - name: "Completion command test"
+      runs: |
+        ct completion bash > bash_completion.sh 2>&1
+        grep -q "bash completion V2 for ct" bash_completion.sh
+    - name: "Ct lint test"
+      runs: |
+        # Using grafana helm chart
+        git clone --depth=1 https://github.com/grafana/helm-charts.git
+        cd helm-charts
+        git checkout caca81a241a207cc6dc0e84c3ab51f76bd800028
+        # Init git (required by ct)
+        git init
+        git config user.email "test@example.com"
+        git config user.name "Test User"
+        echo "# test change" >> charts/grafana/Chart.yaml
+        sed -i 's/8.11.2/8.11.3/' charts/grafana/Chart.yaml
+        git add .
+        git commit -m "Trigger chart change"
+        # ct config file
+        cat > ct-config.yaml <<EOF
+        chart-dirs:
+          - charts
+        chart-repos:
+          - "grafana=https://grafana.github.io/helm-charts"
+        target-branch: HEAD
+        validate-chart-schema: false
+        helm-extra-args: --dry-run
+        EOF
+        # Helm lint config
+        cat > lintconf.yaml <<EOF
+        strict: true
+        EOF
+        # Run ct lint
+        ct lint --config ct-config.yaml > lint_output.txt 2>&1
+        grep -q "All charts linted successfully" lint_output.txt
+        # Ct lint error case, injecting errors:
+        echo "bad: [unclosed" >> charts/grafana/values.yaml
+        echo "# test change2" >> charts/grafana/Chart.yaml
+        sed -i 's/8.11.3/8.11.4/' charts/grafana/Chart.yaml
+        ct lint --config ct-config.yaml > lint_output.txt 2>&1 || true
+        grep -q "failed linting charts" lint_output.txt
+    - name: "Ct install test"
+      runs: |
+        cd helm-charts
+        sed -i '$d' charts/grafana/values.yaml
+        sed -i '$d' charts/grafana/values.yaml
+        # Install (dry-run mode)
+        ct install --config ct-config.yaml --helm-extra-args '--dry-run --debug' > install_output.txt 2>&1 || true
+        # Check that the install was attempted
+        grep -q "Installing chart" install_output.txt
+        # Note: Install chart deployment would fail because of unavailability of k8s cluster, but attempt was made, which comes under scope of ct's functionality
+    - name: "Ct lint-install test"
+      runs: |
+        cd helm-charts
+        ct lint-and-install --config ct-config.yaml --helm-extra-args='--dry-run --debug' > lint_install_output.txt 2>&1 || true
+        grep -q "Linting charts/grafana" lint_install_output.txt
+        grep -q "Installing chart with values" lint_install_output.txt
+    - name: "Ct list-changed test"
+      runs: |
+        cd helm-charts
+        ct list-changed --target-branch main > changed.txt 2>&1
+        grep -q "grafana" changed.txt
+        yamale --version

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,7 +1,7 @@
 package:
   name: chart-testing
   version: "3.12.0"
-  epoch: 14
+  epoch: 0
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,7 @@ package:
       - yamale
       - kubectl
       - openssh-client
+
 pipeline:
   - uses: git-checkout
     with:
@@ -54,11 +55,17 @@ test:
         # Using grafana helm chart
         git clone https://github.com/grafana/helm-charts.git
         cd helm-charts
-        git checkout caca81a241a207cc6dc0e84c3ab51f76bd800028
         git config user.email "test@example.com"
         git config user.name "Test User"
-        echo "# test change" >> charts/grafana/Chart.yaml
-        sed -i 's/8.11.2/8.11.3/' charts/grafana/Chart.yaml
+        CHART_FILE="charts/grafana/Chart.yaml"
+        # Increment chart version for test
+        current_version=$(grep '^version:' "$CHART_FILE" | awk '{ print $2 }')
+        major=$(echo "$current_version" | cut -d. -f1)
+        minor=$(echo "$current_version" | cut -d. -f2)
+        patch=$(echo "$current_version" | cut -d. -f3)
+        new_patch=$((patch + 1)) # Increment patch version
+        new_version="$major.$minor.$new_patch"
+        sed -i "s/^version: .*/version: $new_version/" "$CHART_FILE" # Replace version in Chart.yaml
         git add .
         git commit -m "Trigger chart change"
         # ct config file
@@ -67,10 +74,9 @@ test:
           - charts
         chart-repos:
           - "grafana=https://grafana.github.io/helm-charts"
-        target-branch: caca81a241a207cc6dc0e84c3ab51f76bd800028
+        target-branch: main
         skip-clone: true
         validate-chart-schema: false
-        helm-extra-args: --dry-run
         EOF
         # Helm lint config
         cat > lintconf.yaml <<EOF
@@ -81,7 +87,9 @@ test:
         # Ct lint error case, injecting errors:
         echo "bad: [unclosed" >> charts/grafana/values.yaml
         echo "# test change2" >> charts/grafana/Chart.yaml
-        sed -i 's/8.11.3/8.11.4/' charts/grafana/Chart.yaml
+        new_patch=$((patch + 2)) # Increment patch version
+        new_version="$major.$minor.$new_patch"
+        sed -i "s/^version: .*/version: $new_version/" "$CHART_FILE" # Updating version again for further testing errors
         ct lint --config ct-config.yaml > lint_output.txt 2>&1 || true
         grep -q "failed linting charts" lint_output.txt
     - name: "Ct install test"


### PR DESCRIPTION
**chart-testing** package `Current version: v.3.12.0`
- https://github.com/helm/chart-testing
- `ct` is the tool for testing Helm charts. It is meant to be used for linting and testing pull requests. It automatically detects charts changed against the target branch.

**Type:** Go
**Runtime dependencies:** [(Reference)](https://github.com/helm/chart-testing?tab=readme-ov-file#prerequisites)
- `git`
- `helm`
- `kubectl`
- `ssh`
- `yamale`
- `yamllint`

**Tests:**
- Complete CLI tests
- Python import tests