### PR TITLE
linkerd-extension-init: bump openssl to fix GHSA-4fcv-w3qc-ppgg

### DIFF
--- a/linkerd-extension-init.yaml
+++ b/linkerd-extension-init.yaml
@@ -48,21 +48,27 @@ test:
         - linkerd2-cli
         - yq
   pipeline:
+    - uses: test/kwok/cluster
+    - name: Run the linkerd-extension-init binary help command
     - runs: |
         /usr/bin/linkerd-extension-init --help
-    - uses: test/kwok/cluster
     - name: Install linkerd
       runs: |
+        # Starting linkerd 25.4.1, it now requires the gateway-api to be enabled by default
+        # Instructions to enable: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
+        # At some point in the future, the CRD URL might need to be updated to a newer version.
+        # The kwokctl cluster seems to stop in between runs, so we need to start it everytime.
+        kwokctl start cluster
+        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
         linkerd install --crds | kubectl apply -f -
         linkerd install | kubectl apply -f -
         linkerd check
     - name: "Integration test"
-      uses: test/daemon-check-output
-      with:
-        setup: kubectl create namespace linkerd-extension-init-test
-        start: linkerd-extension-init -n linkerd-extension-init-test --linkerd-namespace linkerd --extension extname --prometheus-url promurl
-        timeout: 30
-        expected_output: successfully patched namespace
-        post: |
-          kubectl get namespace linkerd-extension-init-test -o yaml | grep "viz.linkerd.io/external-prometheus: promurl"
-          kubectl get namespace linkerd-extension-init-test -o yaml | grep "linkerd.io/extension: extname"
+      runs: |
+        # The kwokctl cluster seems to stop in between runs, so we need to start it everytime.
+        kwokctl start cluster
+        kubectl create namespace linkerd-extension-init-test
+        linkerd_test_output=$(linkerd-extension-init -n linkerd-extension-init-test --linkerd-namespace linkerd --extension extname --prometheus-url promurl)
+        [[ "$linkerd_test_output" = *"linkerd_extension_init: successfully patched namespace" ]] || exit 1
+        kubectl get namespace linkerd-extension-init-test -o yaml | grep "viz.linkerd.io/external-prometheus: promurl"
+        kubectl get namespace linkerd-extension-init-test -o yaml | grep "linkerd.io/extension: extname"

--- a/linkerd-extension-init.yaml
+++ b/linkerd-extension-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd-extension-init
   version: "0.1.3"
-  epoch: 1
+  epoch: 2
   description: "A utility for initializing Linkerd extension namespaces after installation"
   copyright:
     - license: Apache-2.0

--- a/linkerd-extension-init/cargobump-deps.yaml
+++ b/linkerd-extension-init/cargobump-deps.yaml
@@ -1,5 +1,5 @@
 packages:
     - name: openssl
-      version: 0.10.70
+      version: 0.10.72
     - name: ring
       version: 0.17.12


### PR DESCRIPTION
Bump openssl to version 0.10.72 to fix GHSA-4fcv-w3qc-ppgg