### PR TITLE
hivemind: add patch to disable automatic env loading

### DIFF
--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -1,7 +1,7 @@
 package:
   name: hivemind
   version: 1.1.0
-  epoch: 6
+  epoch: 7
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT
@@ -17,6 +17,11 @@ pipeline:
       repository: https://github.com/DarthSim/hivemind
       tag: "v${{package.version}}"
       expected-commit: 580abe5b3faf585c450604227e40e960cdbb21bd
+
+  - uses: patch
+    with:
+      patches: |
+        allow-skipping-dotenv-load.patch
 
   - uses: go/bump
     with:

--- a/hivemind/allow-skipping-dotenv-load.patch
+++ b/hivemind/allow-skipping-dotenv-load.patch
@@ -1,0 +1,40 @@
+From c191cfe754de2c37602056bb90eb197b7e9762ed Mon Sep 17 00:00:00 2001
+From: Agis Anastasopoulos <a@xz0.org>
+Date: Fri, 22 Sep 2023 13:31:00 +0300
+Subject: [PATCH] Support skipping loading .env file
+
+This patch adds supports for skipping loading the `.env` file, by
+setting the HIVEMIND_SKIP_ENV environment variable. For example:
+
+    $ HIVEMIND_SKIP_ENV=1 hivemind
+
+Resolves #28.
+---
+ main.go | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/main.go b/main.go
+index 7c2bf58..7a9c8d7 100644
+--- a/main.go
++++ b/main.go
+@@ -6,7 +6,7 @@ import (
+ 
+ 	"github.com/urfave/cli"
+ 
+-	_ "github.com/DarthSim/godotenv/autoload"
++	"github.com/DarthSim/godotenv"
+ )
+ 
+ const version = "1.1.0"
+@@ -17,6 +17,11 @@ func main() {
+ 		err  error
+ 	)
+ 
++	_, skipEnv := os.LookupEnv("HIVEMIND_SKIP_ENV")
++	if !skipEnv {
++		godotenv.Load()
++	}
++
+ 	app := cli.NewApp()
+ 
+ 	app.Name = "Hivemind"


### PR DESCRIPTION
Fixes:

Adds https://github.com/DarthSim/hivemind/pull/34

to disable automatic env loading, that patch is pretty easy, would be nice if this could be integrated here, otherwise I need to do an overwrite in my own repo :(

The automatic env loading makes development container pretty bad as it's not possible to overwrite it again in userland


Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
