### PR TITLE
druid: CVE remediation

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: "32.0.1"
-  epoch: 2
+  epoch: 3
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0

--- a/druid.yaml
+++ b/druid.yaml
@@ -35,7 +35,9 @@ pipeline:
 
   - uses: patch
     with:
-      patches: GHSA-2c59-37c4-qrx5-fix.patch
+      patches: GHSA-2c59-37c4-qrx5-fix.patch GHSA-4g8c-wm8x-jfhw-fix.patch
+
+
 
   - runs: |
       mvn -B -ff -q \

--- a/druid.yaml
+++ b/druid.yaml
@@ -37,8 +37,6 @@ pipeline:
     with:
       patches: GHSA-2c59-37c4-qrx5-fix.patch GHSA-4g8c-wm8x-jfhw-fix.patch
 
-
-
   - runs: |
       mvn -B -ff -q \
       install \

--- a/druid/GHSA-4g8c-wm8x-jfhw-fix.patch
+++ b/druid/GHSA-4g8c-wm8x-jfhw-fix.patch
@@ -1,0 +1,21 @@
+diff --git a/extensions-contrib/druid-deltalake-extensions/pom.xml b/extensions-contrib/druid-deltalake-extensions/pom.xml
+index 59328a1d..933b4a27 100644
+--- a/extensions-contrib/druid-deltalake-extensions/pom.xml
++++ b/extensions-contrib/druid-deltalake-extensions/pom.xml
+@@ -112,8 +112,18 @@
+           <groupId>com.amazonaws</groupId>
+           <artifactId>aws-java-sdk-bundle</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>software.amazon.awssdk</groupId>
++          <artifactId>bundle</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
++    <dependency>
++       <groupId>software.amazon.awssdk</groupId>
++       <artifactId>bundle</artifactId>
++       <version>2.30.17</version>
++    </dependency>
++
+

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -23,3 +23,6 @@ patches:
     - groupId: com.azure
       artifactId: azure-identity
       version: 1.12.2
+    - groupId: org.xerial.snappy
+      artifactId: snappy-java
+      version: 1.1.10.4

--- a/druid/pombump-properties.yaml
+++ b/druid/pombump-properties.yaml
@@ -5,3 +5,5 @@ properties:
     value: "3.7.1"
   - property: netty4.version
     value: 4.1.118.Final
+  - property: hadoop.compile.version
+    value: "3.4.1"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
