### PR TITLE
add grpc_health_probe symlink with grpc-health-probe package

### DIFF
--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-health-probe
   version: "0.4.37"
-  epoch: 32
+  epoch: 33
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,8 @@ pipeline:
       packages: .
       output: grpc-health-probe
       ldflags: -X main.versionTag=v${{package.version}}
+
+  - runs: ln -s /usr/bin/grpc-health-probe ${{targets.contextdir}}/usr/bin/grpc_health_probe
 
   - uses: strip
 

--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -48,3 +48,4 @@ test:
   pipeline:
     - runs: |
         grpc-health-probe -version | grep ${{package.version}}
+        stat /usr/bin/grpc_health_probe


### PR DESCRIPTION
required by image and can also be consumed by other images.

