### PR TITLE
fixup libcurl abi

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: "8.12.1"
-  epoch: 1
+  epoch: 3
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -68,7 +68,7 @@ subpackages:
     dependencies:
       provider-priority: 10
       provides:
-        - libcurl-abi=${{package.version}}
+        - libcurl-abi=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: "8.12.1"
-  epoch: 2
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -67,6 +67,8 @@ subpackages:
     description: "curl library (rustls backend)"
     dependencies:
       provider-priority: 10
+      provides:
+        - libcurl-abi=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,10 +1,16 @@
 package:
   name: curl
   version: "8.12.1"
-  epoch: 2
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      # Allow only libcurl libraries built from the same upstream
+      # source version instead of only relying on SONAMEs.
+      # https://github.com/chainguard-dev/internal-dev/issues/10381
+      - libcurl-abi=${{package.version}}
 
 environment:
   contents:
@@ -91,6 +97,8 @@ subpackages:
       # raise the priority here so this beats rustls
       # TODO: revert this to "5" once rustls is fixed.
       provider-priority: 15
+      provides:
+        - libcurl-abi=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.12.1"
-  epoch: 1
+  epoch: 3
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ package:
       # Allow only libcurl libraries built from the same upstream
       # source version instead of only relying on SONAMEs.
       # https://github.com/chainguard-dev/internal-dev/issues/10381
-      - libcurl-abi=${{package.version}}
+      - libcurl-abi~${{package.version}}
 
 environment:
   contents:
@@ -98,7 +98,7 @@ subpackages:
       # TODO: revert this to "5" once rustls is fixed.
       provider-priority: 15
       provides:
-        - libcurl-abi=${{package.version}}
+        - libcurl-abi=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib


### PR DESCRIPTION
- **Reapply "curl,curl-rusttls: Establish libcurl-abi virtual package"**
  This reverts commit 0e1e5b757abf15e966f66686b6fc93f6f949bc9e.
  

- **Fixup libcurl-abi virtual**
  Also provide full version, but depend just on the major version
  (twiddle wakka operator).
  