### PR TITLE
linkerd-extension-init: use test/daemon-check-output pipeline

### DIFF
--- a/linkerd-extension-init.yaml
+++ b/linkerd-extension-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd-extension-init
   version: "0.1.3"
-  epoch: 2
+  epoch: 3
   description: "A utility for initializing Linkerd extension namespaces after installation"
   copyright:
     - license: Apache-2.0
@@ -48,27 +48,22 @@ test:
         - linkerd2-cli
         - yq
   pipeline:
-    - uses: test/kwok/cluster
-    - name: Run the linkerd-extension-init binary help command
     - runs: |
         /usr/bin/linkerd-extension-init --help
+    - uses: test/kwok/cluster
     - name: Install linkerd
       runs: |
-        # Starting linkerd 25.4.1, it now requires the gateway-api to be enabled by default
-        # Instructions to enable: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
-        # At some point in the future, the CRD URL might need to be updated to a newer version.
-        # The kwokctl cluster seems to stop in between runs, so we need to start it everytime.
-        kwokctl start cluster
-        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/latest/download/standard-install.yaml
         linkerd install --crds | kubectl apply -f -
         linkerd install | kubectl apply -f -
         linkerd check
     - name: "Integration test"
-      runs: |
-        # The kwokctl cluster seems to stop in between runs, so we need to start it everytime.
-        kwokctl start cluster
-        kubectl create namespace linkerd-extension-init-test
-        linkerd_test_output=$(linkerd-extension-init -n linkerd-extension-init-test --linkerd-namespace linkerd --extension extname --prometheus-url promurl)
-        [[ "$linkerd_test_output" = *"linkerd_extension_init: successfully patched namespace" ]] || exit 1
-        kubectl get namespace linkerd-extension-init-test -o yaml | grep "viz.linkerd.io/external-prometheus: promurl"
-        kubectl get namespace linkerd-extension-init-test -o yaml | grep "linkerd.io/extension: extname"
+      uses: test/daemon-check-output
+      with:
+        setup: kubectl create namespace linkerd-extension-init-test
+        start: linkerd-extension-init -n linkerd-extension-init-test --linkerd-namespace linkerd --extension extname --prometheus-url promurl
+        timeout: 30
+        expected_output: successfully patched namespace
+        post: |
+          kubectl get namespace linkerd-extension-init-test -o yaml | grep "viz.linkerd.io/external-prometheus: promurl"
+          kubectl get namespace linkerd-extension-init-test -o yaml | grep "linkerd.io/extension: extname"


### PR DESCRIPTION
passing with `make docker-test/linkerd-extension-init`