### PR TITLE
linkerd2: bump openssl and tokio

### DIFF
--- a/linkerd2.yaml
+++ b/linkerd2.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2
   version: "25.4.1"
-  epoch: 0
+  epoch: 1
   description: "meta linkerd package"
   copyright:
     - license: Apache-2.0

--- a/linkerd2/cargobump-deps.yaml
+++ b/linkerd2/cargobump-deps.yaml
@@ -1,3 +1,5 @@
 packages:
     - name: openssl
-      version: 0.10.70
+      version: 0.10.72
+    - name: tokio
+      version: 1.44.2


### PR DESCRIPTION
Bump openssl to 0.10.72 to fix GHSA-4fcv-w3qc-ppgg
Bump tokio to 1.44.2 to fix GHSA-rr8g-9fpq-6wmg
