### PR TITLE
Chart-testing package - Added bash as runtime dependency

### DIFF
--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,12 +1,13 @@
 package:
   name: chart-testing
   version: "3.12.0"
-  epoch: 0
+  epoch: 1
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - bash
       - git
       - helm
       - kubectl


### PR DESCRIPTION
`chart-testing` needs bash as per usage instructions