### PR TITLE
py3-jsonpatch: split jsonpatch binaries from jsonpatch lib / adding additional testing

### DIFF
--- a/py3-jsonpatch.yaml
+++ b/py3-jsonpatch.yaml
@@ -1,22 +1,28 @@
-# Generated from https://pypi.org/project/jsonpatch/
 package:
   name: py3-jsonpatch
-  version: "1.33"
-  epoch: 0
+  version: 1.33
+  epoch: 1
   description: Apply JSON-Patches (RFC 6902)
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provider-priority: "0"
 
+vars:
+  pypi-package: jsonpatch
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-supported-build-base-dev
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -33,27 +39,59 @@ subpackages:
         uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
     dependencies:
       runtime:
         - py${{range.key}}-jsonpointer
-      provides:
-        - py3-${{vars.pypi-package}}
-      provider-priority: ${{range.value}}
     test:
       pipeline:
         - name: Import Test
           uses: python/import
           with:
-            import: ${{vars.module_name}}
+            import: ${{vars.pypi-package}}
             python: python${{range.key}}
+  
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - jq
+      pipeline:
+        - name: Test binaries
+          runs: |
+            cat > a.json <<EOF
+            {"a": [1, 2], "b": 0}
+            EOF
 
-data:
-  - name: py-versions
-    items:
-      "3.10": "310"
-      "3.11": "311"
-      "3.12": "312"
-      "3.13": "313"
+            cat > b.json <<EOF
+            {"a": [1, 2, 3], "c": 100}
+            EOF
+
+            jsondiff a.json b.json | jq -r '.[] | select(.path=="/a/2" and .op=="add") | .value' | grep 3
+
+            # Create a patch
+            jsondiff a.json b.json > patch.json || true
+            # Test output of patching a.json
+            jsonpatch a.json patch.json | jq -r '.c' | grep 100
+            # Output patched json to new file
+            jsonpatch a.json patch.json --indent=2 > c.json
+            # Test that patched a.json == b.json (diff is nothing)
+            jsondiff b.json c.json > diff.json || true
+            [ ! -s diff.json ] || exit 1
 
 update:
   enabled: true
@@ -63,14 +101,3 @@ update:
     identifier: stefankoegl/python-json-patch
     strip-prefix: v
     use-tag: true
-
-vars:
-  module_name: jsonpatch
-  pypi-package: jsonpatch
-
-test:
-  pipeline:
-    - name: Import Test
-      uses: python/import
-      with:
-        import: ${{vars.module_name}}

--- a/py3-jsonpatch.yaml
+++ b/py3-jsonpatch.yaml
@@ -54,7 +54,7 @@ subpackages:
           with:
             import: ${{vars.pypi-package}}
             python: python${{range.key}}
-  
+
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
     description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Splitting `jsonpatch` binaries from the lib, deconflicts situations like these: https://github.com/wolfi-dev/os/pull/49326/checks?check_run_id=40176300241

Packages that depend on `jsonpatch`:
- `ceph` - lib only, doesn't use binaries
- `cloud-init` - lib only, doesn't use binaries