### PR TITLE
fix(postgresql): enable full feature set in Postgres 

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -10,6 +10,7 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
+      - tzdata
 
 environment:
   environment:
@@ -91,8 +92,7 @@ pipeline:
         --with-gssapi \
         --with-ldap \
         --with-llvm \
-        --enable-thread-safety \
-        --with-system-tzdata=/usr/share/zoneinfo
+        --enable-thread-safety
 
   - uses: autoconf/make
 

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.8"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -24,16 +24,28 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - clang-19
       - curl
       - execline-dev
       - flex
+      - gawk
+      - icu-data-full
       - icu-dev
+      - krb5-dev
       - libedit-dev
+      - libuuid
       - libxml2-dev
+      - libxslt-dev
+      - llvm-19-dev
+      - llvm-lld-19-dev
+      - lz4-dev
       - net-tools
+      - openldap-dev
       - openssl-dev
+      - tzdata
       - util-linux-dev
       - zlib-dev
+      - zstd-dev
 
 var-transforms:
   - from: ${{package.name}}
@@ -71,7 +83,16 @@ pipeline:
         --with-openssl \
         --with-libedit-preferred \
         --with-uuid=e2fs \
-        --with-libxml
+        --with-libxml \
+        --with-libxslt \
+        --with-icu \
+        --with-lz4 \
+        --with-zstd \
+        --with-gssapi \
+        --with-ldap \
+        --with-llvm \
+        --enable-thread-safety \
+        --with-system-tzdata=/usr/share/zoneinfo
 
   - uses: autoconf/make
 
@@ -347,3 +368,18 @@ test:
     - name: "Test server can run and respond to requests"
       runs: |
         psql -d testdb -c "\conninfo"
+    - name: "Test XML xpath support"
+      runs: |
+        psql -d testdb -c "SELECT xpath('/book/title', '<book><title>My Title</title></book>');" | grep "<title>My Title</title>"
+    - name: "Test ICU collation presence"
+      runs: |
+        psql -d testdb -c "SELECT collname FROM pg_collation WHERE collprovider = 'i';" | grep -E "unicode|und-x-icu|af-x-icu"
+    - name: "Test krb5 config parameter exists"
+      runs: |
+        psql -d testdb -c "SHOW krb_server_keyfile;" | grep "krb5"
+    - name: "Test JIT is enabled"
+      runs: |
+        psql -t -A -d testdb -c "SHOW jit;" | grep "on"
+    - name: "Test toast compression set to lz4"
+      runs: |
+        psql -t -A -d testdb -c "SET default_toast_compression = 'lz4'; SHOW default_toast_compression;" | grep "^lz4$"

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -10,6 +10,7 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
+      - tzdata
 
 environment:
   environment:
@@ -91,8 +92,7 @@ pipeline:
         --with-gssapi \
         --with-ldap \
         --with-llvm \
-        --enable-thread-safety \
-        --with-system-tzdata=/usr/share/zoneinfo
+        --enable-thread-safety
 
   - uses: autoconf/make
 

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.4"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -10,6 +10,19 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
+      - icu-data-full
+      - krb5
+      - libedit
+      - libuuid
+      - libxml2
+      - libxslt
+      - llvm-19
+      - lz4
+      - openldap
+      - openssl
+      - tzdata
+      - zlib
+      - zstd
 
 environment:
   environment:
@@ -24,16 +37,28 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - clang-19
       - curl
       - execline-dev
       - flex
+      - gawk
+      - icu-data-full
       - icu-dev
+      - krb5-dev
       - libedit-dev
+      - libuuid
       - libxml2-dev
+      - libxslt-dev
+      - llvm-19-dev
+      - llvm-lld-19-dev
+      - lz4-dev
       - net-tools
+      - openldap-dev
       - openssl-dev
+      - tzdata
       - util-linux-dev
       - zlib-dev
+      - zstd-dev
 
 var-transforms:
   - from: ${{package.name}}
@@ -71,7 +96,16 @@ pipeline:
         --with-openssl \
         --with-libedit-preferred \
         --with-uuid=e2fs \
-        --with-libxml
+        --with-libxml \
+        --with-libxslt \
+        --with-icu \
+        --with-lz4 \
+        --with-zstd \
+        --with-gssapi \
+        --with-ldap \
+        --with-llvm \
+        --enable-thread-safety \
+        --with-system-tzdata=/usr/share/zoneinfo
 
   - uses: autoconf/make
 

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -10,19 +10,6 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
-      - icu-data-full
-      - krb5
-      - libedit
-      - libuuid
-      - libxml2
-      - libxslt
-      - llvm-19
-      - lz4
-      - openldap
-      - openssl
-      - tzdata
-      - zlib
-      - zstd
 
 environment:
   environment:
@@ -387,3 +374,18 @@ test:
     - name: "Test server can run and respond to requests"
       runs: |
         psql -d testdb -c "\conninfo"
+    - name: "Test XML xpath support"
+      runs: |
+        psql -d testdb -c "SELECT xpath('/book/title', '<book><title>My Title</title></book>');" | grep "<title>My Title</title>"
+    - name: "Test ICU collation presence"
+      runs: |
+        psql -d testdb -c "SELECT collname FROM pg_collation WHERE collprovider = 'i';" | grep -E "unicode|und-x-icu|af-x-icu"
+    - name: "Test krb5 config parameter exists"
+      runs: |
+        psql -d testdb -c "SHOW krb_server_keyfile;" | grep "krb5"
+    - name: "Test JIT is enabled"
+      runs: |
+        psql -t -A -d testdb -c "SHOW jit;" | grep "on"
+    - name: "Test toast compression set to lz4"
+      runs: |
+        psql -t -A -d testdb -c "SET default_toast_compression = 'lz4'; SHOW default_toast_compression;" | grep "^lz4$"


### PR DESCRIPTION
- Enable additional PostgreSQL features: ICU, LZ4, ZSTD, XML, XSLT, OpenSSL, Kerberos, LDAP, and LLVM libs


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
