### PR TITLE
qdrant/GHSA-rr8g-9fpq-6wmg fix

### DIFF
--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: "1.13.6"
-  epoch: 0
+  epoch: 1
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ pipeline:
 
   - name: build-qdrant-binary
     runs: |
-      cargo auditable build --release --bin qdrant
+      cargo auditable build --release --bin qdrant --jobs $(nproc)
 
   - runs: |
       _qdrant_home="usr/lib/qdrant"

--- a/qdrant/cargobump-deps.yaml
+++ b/qdrant/cargobump-deps.yaml
@@ -1,5 +1,3 @@
 packages:
-    - name: quinn-proto
-      version: 0.11.8
-    - name: ring
-      version: 0.17.12
+    - name: tokio
+      version: 1.44.2


### PR DESCRIPTION
Pacakage changes:

-  added jobs flag to allow all cores to be used to build. Reduces build time.

Cargobump-deps changes:

- values here for both quinn-proto and ring are no longer bumping the version of the dependencies are quinn-proto has `0.11.8` in the project definition and ring is defined as `0.17.13` now.
- bumped tokio from 1.44.1 to 1.44.2 by defining it here.