### PR TITLE
softhsm: update fetch URL

### DIFF
--- a/softhsm.yaml
+++ b/softhsm.yaml
@@ -27,7 +27,10 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 61249473054bcd1811519ef9a989a880a7bdcc36d317c9c25457fc614df475f2
-      uri: https://dist.opendnssec.org/source/softhsm-${{package.version}}.tar.gz
+      # TODO: softhsm is now included in OpenDNSSEC releases with unrelated
+      # versioning, so this will require manual intervention for every new
+      # version
+      uri: https://github.com/opendnssec/opendnssec/releases/download/2.1.14/softhsm-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
https://www.opendnssec.org/en/latest/download/ now points at their GitHub Releases page, so use that URL.

Fixes: #48784 