### PR TITLE
yara-x/GHSA-rr8g-9fpq-6wmg fix

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "0.14.0"
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -27,6 +27,8 @@ pipeline:
       repository: https://github.com/VirusTotal/yara-x
       expected-commit: b9ade771e129eda2487083f0eea6a05234b6dbcc
       tag: v${{package.version}}
+
+  - uses: rust/cargobump
 
   - runs: |
       sed -i 's/\(protobuf-.* = \)"3.7.1"/\1"3.7.2"/' Cargo.toml

--- a/yara-x/cargobump-deps.yaml
+++ b/yara-x/cargobump-deps.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: tokio
+    version: 1.44.2


### PR DESCRIPTION
Package file changes:
- added cargobump block

Cargobump-deps changes:
- bumped tokio from 1.44.1 to 1.44.2 by defining it here.