### PR TITLE
bug: Do not keep approving already approved prs.

### DIFF
--- a/scripts/auto-approve-pr.sh
+++ b/scripts/auto-approve-pr.sh
@@ -7,7 +7,8 @@ set -o pipefail
 repo=$1
 
 get_prs() {
-    gh pr list --app "octo-sts" --label "auto-approver-bot/approve" --limit=50 --json number --jq '.[].number'
+    # Get PRs that are not approved by the bot (github-actions)
+    gh pr list --app "octo-sts" --label "auto-approver-bot/approve" --json number,reviews --limit 100 --jq '.[] | select(.reviews | map(.author.login == "github-actions") | all(. == false)) | .number'
 }
 
 readarray -t PRS < <(get_prs)


### PR DESCRIPTION
Currently the bot will keep auto approving the already approved PR over and over again, for example here:
https://github.com/wolfi-dev/os/pull/48819

So it's super noisy and annoying. This should filter out things that have been already approved by the bot. I have tested the query from the CLI against the repo, but since it runs in a GHA I really want more eyes on this.
