### PR TITLE
geckodriver: cve remediation

### DIFF
--- a/geckodriver.yaml
+++ b/geckodriver.yaml
@@ -1,7 +1,7 @@
 package:
   name: geckodriver
   version: "0.36.0"
-  epoch: 1
+  epoch: 2
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MPL-2.0

--- a/geckodriver/cargobump-deps.yaml
+++ b/geckodriver/cargobump-deps.yaml
@@ -3,3 +3,5 @@ packages:
       version: 2.5.4
     - name: zip
       version: 2.3.0
+    - tokio:
+      version: 10.38.2


### PR DESCRIPTION
Bump tokio dependency to 10.38.2
Fixes: GHSA-rr8g-9fpq-6wmg
