### PR TITLE
linkerd2-proxy: cve remediation

### DIFF
--- a/linkerd2-proxy.yaml
+++ b/linkerd2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-proxy
   version: "2.291.0"
-  epoch: 0
+  epoch: 1
   description: "A program that validates linkerd networks"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump the epoch to force a package rebuild and pull the latest tokio dependency.
Fixes: GHSA-rr8g-9fpq-6wmg