### PR TITLE
New package auditwheel

### DIFF
--- a/py3-auditwheel.yaml
+++ b/py3-auditwheel.yaml
@@ -1,0 +1,102 @@
+package:
+  name: py3-auditwheel
+  version: "6.3.0"
+  epoch: 1
+  description: auditing and relabeling of PEP 600 Linux wheels
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: auditwheel
+  import: auditwheel
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-flit-core
+      - py3-supported-pip
+      - py3-supported-python
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/auditwheel
+      tag: ${{package.version}}
+      expected-commit: ff5b63713a98182a5f4c97abb709f47bcc9e3bec
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - patchelf
+        - py${{range.key}}-packaging
+        - py${{range.key}}-pyelftools
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            auditwheel repair -h
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - a
+    - b
+    - rc
+    - post
+  github:
+    identifier: pypa/auditwheel


### PR DESCRIPTION
Dependencies are already packaged.

Not really needed, but could be useful soon:
- auditwheel repair can be used to fixup wheels during collect-wheels pipeline
- auditwheel show is a useful debugging / test pipeline tool to determine compat
