### PR TITLE
cve-remediation: octo sts issues: write, so that automation can create labels

### DIFF
--- a/.github/chainguard/lifecycle-cve-remediation.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-remediation.sts.yaml
@@ -9,3 +9,4 @@ permissions:
   pull_requests: write
   contents: write
   workflows: write
+  issues: write # needed to create labels on PRs


### PR DESCRIPTION
This was verified in a dev environment, seems something may have changed on the GitHub side, without this we get an error

```
failed to create pull request: failed to add labels to PR '3025': POST https://api.github.com/repos/foo/bar/issues/3025/labels: 403 You do not have permission to create labels on this repository. [{Resource:Repository Field:label Code:unauthorized Message:}]
```

