### PR TITLE
added subpackages readinessprobe and version-upgrade-hook to mongodb-kubernetes-operator

### DIFF
--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -7,8 +7,8 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - coreutils
       - bash-binsh
+      - coreutils
 
 pipeline:
   - uses: git-checkout

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongodb-kubernetes-operator
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes Operator which deploys MongoDB Community into Kubernetes clusters.
   copyright:
     - license: MIT
@@ -46,6 +46,10 @@ subpackages:
             stat /manager
             stat /usr/local/bin/entrypoint
 
+  # Note: Upstream uses different versioning for components (e.g., operator: 0.12.x, version hook: 1.0.x),
+  # but Chainguard images use a unified tag matching the main operator version due to Git-based automation.
+  # See upstream version mapping in release.json: https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/release/release.json
+  # All components are built from the same source, even if upstream lacks separate tags.
   - name: ${{package.name}}-version-upgrade-post-start-hook
     dependencies:
       runtime:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -94,6 +94,17 @@ subpackages:
         with:
           output: readinessprobe
           packages: ./cmd/readiness/main.go
+    test:
+      pipeline:
+        - name: "Verify readinessprobe"
+          uses: test/daemon-check-output
+          with:
+            start: |
+              readinessprobe
+            timeout: 60
+            expected_output: |
+              KUBERNETES_SERVICE_HOST
+              KUBERNETES_SERVICE_PORT
 
   - name: mongodb-kubernetes-readinessprobe-compat
     pipeline:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -48,6 +48,10 @@ subpackages:
             stat /usr/local/bin/entrypoint
 
   - name: ${{package.name}}-version-upgrade-post-start-hook
+    dependencies:
+      runtime:
+        - coreutils
+        - bash
     pipeline:
       - uses: go/build
         with:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -47,6 +47,17 @@ subpackages:
             stat /manager
             stat /usr/local/bin/entrypoint
 
+  - name: ${{package.name}}-version-upgrade-post-start-hook
+    pipeline:
+      - uses: go/build
+        with:
+          output: version-upgrade-hook
+          packages: ./cmd/versionhook/main.go
+    test:
+      pipeline:
+        - runs: |
+            ./version-upgrade-hook
+
 test:
   environment:
     environment:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -62,8 +62,14 @@ subpackages:
         environment:
           AGENT_STATUS_FILEPATH: "/var/log/mongodb-mms-automation/healthstatus/agent-health-status.json"
       pipeline:
-        - runs: |
-            version-upgrade-hook
+        - name: "Verify version-upgrade-hook"
+          uses: test/daemon-check-output
+          with:
+            start: |
+              version-upgrade-hook
+            timeout: 60
+            expected_output: |
+              Running version change post-start hook
   
   - name: ${{package.name}}-version-upgrade-post-start-hook-compat
     pipeline:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -80,6 +80,27 @@ subpackages:
       pipeline:
         - runs: |
             stat /version-upgrade-hook 
+  
+  - name: mongodb-kubernetes-readinessprobe
+    dependencies:
+      runtime:
+        - coreutils
+        - bash
+    pipeline:
+      - uses: go/build
+        with:
+          output: readinessprobe
+          packages: ./cmd/readiness/main.go
+  
+  - name: mongodb-kubernetes-readinessprobe-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/probes/
+          ln -sf /usr/bin/readinessprobe ${{targets.subpkgdir}}/probes/readinessprobe
+    test:
+      pipeline:
+        - runs: |
+            stat /probes/readinessprobe
 
 test:
   environment:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - bash-binsh
-      - coreutils
 
 pipeline:
   - uses: git-checkout

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -54,9 +54,22 @@ subpackages:
           output: version-upgrade-hook
           packages: ./cmd/versionhook/main.go
     test:
+      environment:
+        environment:
+          AGENT_STATUS_FILEPATH: "/var/log/mongodb-mms-automation/healthstatus/agent-health-status.json"
       pipeline:
         - runs: |
-            ./version-upgrade-hook
+            version-upgrade-hook
+  
+  - name: ${{package.name}}-version-upgrade-post-start-hook-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -sf /usr/bin/version-upgrade-hook ${{targets.subpkgdir}}/version-upgrade-hook 
+    test:
+      pipeline:
+        - runs: |
+            stat /version-upgrade-hook 
 
 test:
   environment:

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -52,7 +52,7 @@ subpackages:
   - name: ${{package.name}}-version-upgrade-post-start-hook
     dependencies:
       runtime:
-        - coreutils
+        - coreutils # for `cp`
         - bash
     pipeline:
       - uses: go/build
@@ -86,7 +86,7 @@ subpackages:
   - name: mongodb-kubernetes-readinessprobe
     dependencies:
       runtime:
-        - coreutils
+        - coreutils # for `cp`
         - bash
     pipeline:
       - uses: go/build

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -83,7 +83,7 @@ subpackages:
         - runs: |
             stat /version-upgrade-hook
 
-  - name: mongodb-kubernetes-readinessprobe
+  - name: ${{package.name}}-readinessprobe
     dependencies:
       runtime:
         - coreutils # for `cp`
@@ -105,7 +105,7 @@ subpackages:
               KUBERNETES_SERVICE_HOST
               KUBERNETES_SERVICE_PORT
 
-  - name: mongodb-kubernetes-readinessprobe-compat
+  - name: ${{package.name}}-readinessprobe-compat
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/probes/

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,4 +1,3 @@
-#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: mongodb-kubernetes-operator
   version: 0.12.0

--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -70,17 +70,17 @@ subpackages:
             timeout: 60
             expected_output: |
               Running version change post-start hook
-  
+
   - name: ${{package.name}}-version-upgrade-post-start-hook-compat
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/
-          ln -sf /usr/bin/version-upgrade-hook ${{targets.subpkgdir}}/version-upgrade-hook 
+          ln -sf /usr/bin/version-upgrade-hook ${{targets.subpkgdir}}/version-upgrade-hook
     test:
       pipeline:
         - runs: |
-            stat /version-upgrade-hook 
-  
+            stat /version-upgrade-hook
+
   - name: mongodb-kubernetes-readinessprobe
     dependencies:
       runtime:
@@ -91,7 +91,7 @@ subpackages:
         with:
           output: readinessprobe
           packages: ./cmd/readiness/main.go
-  
+
   - name: mongodb-kubernetes-readinessprobe-compat
     pipeline:
       - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
