### PR TITLE
cargobump-deps: cve remediation for GHSA-2frx-2596-x5r6

### DIFF
--- a/cargo-audit.yaml
+++ b/cargo-audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-audit
   version: "0.21.2"
-  epoch: 2
+  epoch: 3
   description: Audit your dependencies for crates with security vulnerabilities reported to the RustSec Advisory Database.
   copyright:
     - license: MIT OR Apache-2.0

--- a/cargo-audit/cargobump-deps.yaml
+++ b/cargo-audit/cargobump-deps.yaml
@@ -9,3 +9,41 @@ packages:
       version: 0.17.12
     - name: tokio
       version: 1.43.1
+    - name: gix
+      version: 0.71.0
+    - name: gix-commitgraph
+      version: 0.27.0
+    - name: gix-config
+      version: 0.44.0
+    - name: gix-diff
+      version: 0.51.0
+    - name: gix-discover
+      version: 0.39.0
+    - name: gix-features
+      version: 0.41.0
+    - name: gix-filter
+      version: 0.18.0
+    - name: gix-index
+      version: 0.39.0
+    - name: gix-negotiate
+      version: 0.19.0
+    - name: gix-object
+      version: 0.48.0
+    - name: gix-odb
+      version: 0.68.0
+    - name: gix-pack
+      version: 0.58.0
+    - name: gix-protocol
+      version: 0.49.0
+    - name: gix-ref
+      version: 0.51.0
+    - name: gix-revision
+      version: 0.33.0
+    - name: gix-revwalk
+      version: 0.19.0
+    - name: gix-traverse
+      version: 0.45.0
+    - name: gix-worktree
+      version: 0.40.0
+    - name: gix-worktree-state
+      version: 0.18.0


### PR DESCRIPTION
The GHSA-2frx-2596-x5r6 advisory has a lot of gix packages along with their fixes.
This PR remediates and bumps the following packages:
* gix bump to version: 0.71.0
* gix-commitgraph bump to version: 0.27.0
* gix-config bump to version: 0.44.0
* gix-diff bump to version: 0.51.0
* gix-discover bump to version: 0.39.0
* gix-features bump to version: 0.41.0
* gix-filter bump to version: 0.18.0
* gix-index bump to version: 0.39.0
* gix-negotiate bump to version: 0.19.0
* gix-object bump to version: 0.48.0
* gix-odb bump to version: 0.68.0
* gix-pack bump to version: 0.58.0
* gix-protocol bump to version: 0.49.0
* gix-ref bump to version: 0.51.0
* gix-revision bump to version: 0.33.0
* gix-revwalk bump to version: 0.19.0
* gix-traverse bump to version: 0.45.0
* gix-worktree bump to version: 0.40.0
* gix-worktree-state bump to version: 0.18.0
