### PR TITLE
fix(update): Bump yunikorn-k8shim to 1.6.2 and ignore pre-release tags and use tag to get the version

### DIFF
--- a/yunikorn-k8shim.yaml
+++ b/yunikorn-k8shim.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-k8shim
-  version: "1.6.1"
-  epoch: 4
+  version: "1.6.2"
+  epoch: 0
   description: Apache YuniKorn K8shim
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e4f21c7a31b495f393c2caac84259a54aaa1e293
+      expected-commit: 79a952d66ffe9c7109a8c218025cb7b8310e77f1
       repository: https://github.com/apache/yunikorn-k8shim
       tag: v${{package.version}}
 
@@ -17,8 +17,6 @@ pipeline:
     with:
       deps: |-
         k8s.io/kubernetes@v1.31.6
-        golang.org/x/oauth2@v0.27.0
-        golang.org/x/net@v0.36.0
       modroot: .
 
   - uses: go/build
@@ -46,7 +44,10 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - -\d+$ # Ignore pre-releases (e.g., 1.6.0-0, 1.6.0-1, 1.6.0-2) that precede proper releases (e.g., 1.6.0)
   github:
+    use-tag: true
     identifier: apache/yunikorn-k8shim
     strip-prefix: v
 


### PR DESCRIPTION


- Upstream has not created a formal release for version `1.6.2` but has tagged the commit.\
- Enabled tag-based updates with `use-tag: true` to correctly track future versions.
- Ignored pre-release versions (e.g., `1.6.0-1`) using regex to avoid picking unstable tags during automated updates.
