### PR TITLE
withdraw dotnet-bootstrap-9 9.0.200-r0

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -38,3 +38,4 @@ openjdk-24-jre-24_beta16-r4.apk
 openjdk-24-jre-24_beta16-r5.apk
 openjdk-24-jre-24_beta36-r0.apk
 openjdk-24-jre-24_beta36-r1.apk
+dotnet-bootstrap-9-9.0.200-r0.apk


### PR DESCRIPTION
This versioning should never have been used: the corresponding `dotnet-9` packages were withdrawn in
9b6678035dc4a93f1e03b26e806157c40c877832.