### PR TITLE
libnotify: fix gcc argument ordering in test, fixing build failure

### DIFF
--- a/libnotify.yaml
+++ b/libnotify.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnotify
   version: "0.8.6"
-  epoch: 0
+  epoch: 1
   description: "GNOME/libnotify mirror"
   copyright:
     - license: LGPL-2.1-or-later
@@ -97,7 +97,7 @@ test:
         }
         EOF
 
-        gcc $(pkg-config --cflags --libs libnotify) test.c -o test
+        gcc test.c $(pkg-config --cflags --libs libnotify) -o test
 
         # Verify the binary was created
         test -x test


### PR DESCRIPTION
Fixes: #48780