### PR TITLE
smarter-device-manager: remove unneeded go/bump

### DIFF
--- a/smarter-device-manager.yaml
+++ b/smarter-device-manager.yaml
@@ -5,7 +5,7 @@
 package:
   name: smarter-device-manager
   version: 1.20.11
-  epoch: 15
+  epoch: 16
   description: Device manager container that enables access to device drivers on containers for k8s
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,6 @@ pipeline:
     with:
       deps: |-
         github.com/golang/glog@v1.2.4
-        golang.org/x/net@v0.37.0
 
   - runs: |
       CGO_ENABLED=0 go build -trimpath -ldflags='-w -extldflags="-static"' .


### PR DESCRIPTION
The earlier `go mod` commands are pulling a newer version now.

Fixes: #48783