### PR TITLE
Update the gcsfuse package to the latest version

### DIFF
--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcsfuse
-  version: 1.4.2
-  epoch: 18
+  version: 2.11.1
+  epoch: 0
   description: A user-space file system for interacting with Google Cloud Storage
   copyright:
     - license: Apache-2.0
@@ -14,15 +14,15 @@ pipeline:
     with:
       repository: https://github.com/GoogleCloudPlatform/gcsfuse
       tag: v${{package.version}}
-      expected-commit: 342c39b1863fedeb3bd947aaad2d0188dd0737fa
+      expected-commit: 4f2ad4e2ba5f041b9628577a3bae0f3fa00a3e6c
 
   - uses: go/bump
     with:
       deps: |-
-        google.golang.org/protobuf@v1.33.0
-        golang.org/x/crypto@v0.35.0
-        golang.org/x/oauth2@v0.27.0
-        golang.org/x/net@v0.36.0
+        google.golang.org/protobuf@v1.36.5
+        golang.org/x/crypto@v0.36.0
+        golang.org/x/oauth2@v0.28.0
+        golang.org/x/net@v0.37.0
       modroot: .
 
   - uses: go/build
@@ -37,7 +37,7 @@ update:
   git:
     strip-prefix: v
     # There are some malformed tags (v@debian_11, etc.)
-    tag-filter-prefix: v1
+    tag-filter-prefix: v2
 
 test:
   pipeline:


### PR DESCRIPTION
We were pinned to a v1 version of gcsfuse and the last time v1 was updated was last year.