### PR TITLE
scripts/auto-approve-pr.sh: bump limit from 30->50 for open PRs.

### DIFF
--- a/scripts/auto-approve-pr.sh
+++ b/scripts/auto-approve-pr.sh
@@ -7,7 +7,7 @@ set -o pipefail
 repo=$1
 
 get_prs() {
-  gh search prs --repo wolfi-dev/os --app "octo-sts" --label "auto-approver-bot/approve" --review none --state open --json number --jq '.[].number'
+  gh search prs --repo wolfi-dev/os --app "octo-sts" --label "auto-approver-bot/approve" --limit=50 --review none --state open --json number --jq '.[].number'
 }
 
 readarray -t PRS < <(get_prs)


### PR DESCRIPTION
Restore the --limit=50 that was dropped here: https://github.com/wolfi-dev/os/pull/49562
