### PR TITLE
new: smartmontools

### DIFF
--- a/smartmontools.yaml
+++ b/smartmontools.yaml
@@ -61,6 +61,7 @@ test:
     - name: Verify smartmontools installation
       runs: |
         smartctl --version | grep "${{package.version}}"
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/smartmontools.yaml
+++ b/smartmontools.yaml
@@ -1,0 +1,77 @@
+package:
+  name: smartmontools
+  version: "7.4"
+  epoch: 0
+  description: Control and monitor S.M.A.R.T. enabled hard drives
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libcap-ng-dev
+      - linux-headers
+      - systemd-dev
+      - usrmerge-tool
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\.(\d+)$
+    replace: ${1}_${2}
+    to: smartmontools-tag-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/smartmontools/smartmontools
+      tag: RELEASE_${{vars.smartmontools-tag-version}}
+      expected-commit: 0c0bada5eedb759c9d7bb50ff54959cf0809c5a9
+
+  - working-directory: smartmontools
+    uses: autoconf/configure
+    with:
+      opts: |
+        --sbindir=/usr/bin
+
+  - working-directory: smartmontools
+    uses: autoconf/make
+
+  - working-directory: smartmontools
+    uses: autoconf/make-install
+
+      #- runs: |
+    #usrmerge-tool -usr-sbin ${{targets.destdir}}
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share/doc
+          mv ${{targets.destdir}}/usr/share/doc/smartmontools ${{targets.contextdir}}/usr/share/doc
+    description: ${{package.name}} manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  environment: {}
+  pipeline:
+    - name: Verify smartmontools installation
+      runs: |
+        smartctl --version | grep "${{package.version}}"
+
+update:
+  enabled: true
+  version-transform:
+    - match: ^(\d+)_(\d+)$
+      replace: ${1}.${2}
+  github:
+    identifier: smartmontools/smartmontools
+    strip-prefix: "RELEASE_"
+    use-tag: true

--- a/smartmontools.yaml
+++ b/smartmontools.yaml
@@ -18,8 +18,8 @@ environment:
 
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+)\.(\d+)$
-    replace: ${1}_${2}
+    match: \.
+    replace: _
     to: smartmontools-tag-version
 
 pipeline:
@@ -65,8 +65,8 @@ test:
 update:
   enabled: true
   version-transform:
-    - match: ^(\d+)_(\d+)$
-      replace: ${1}.${2}
+    - match: _
+      replace: .
   github:
     identifier: smartmontools/smartmontools
     strip-prefix: "RELEASE_"

--- a/smartmontools.yaml
+++ b/smartmontools.yaml
@@ -30,16 +30,13 @@ pipeline:
       expected-commit: 0c0bada5eedb759c9d7bb50ff54959cf0809c5a9
 
   - working-directory: smartmontools
-    uses: autoconf/configure
-    with:
-      opts: |
-        --sbindir=/usr/bin
-
-  - working-directory: smartmontools
-    uses: autoconf/make
-
-  - working-directory: smartmontools
-    uses: autoconf/make-install
+    pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            --sbindir=/usr/bin
+      - uses: autoconf/make
+      - uses: autoconf/make-install
 
   - uses: strip
 

--- a/smartmontools.yaml
+++ b/smartmontools.yaml
@@ -15,7 +15,6 @@ environment:
       - libcap-ng-dev
       - linux-headers
       - systemd-dev
-      - usrmerge-tool
 
 var-transforms:
   - from: ${{package.version}}
@@ -41,9 +40,6 @@ pipeline:
 
   - working-directory: smartmontools
     uses: autoconf/make-install
-
-      #- runs: |
-    #usrmerge-tool -usr-sbin ${{targets.destdir}}
 
   - uses: strip
 


### PR DESCRIPTION
Add smartmontools to wolfi; enhances the ceph package with regards to interacting with drive control (think flashing lights for DC ops to swap disks).

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
