### PR TITLE
downgrade npm to 11.2.0

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,8 @@
+# downgraded to 11.2.0 until https://github.com/npm/cli/issues/8216 is resolved
 package:
   name: npm
-  version: "11.3.0"
-  epoch: 0
+  version: "11.2.0"
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -17,7 +18,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://registry.npmjs.org/npm/-/npm-${{package.version}}.tgz
-      expected-sha512: 96eb611483f49c55f7fa74df61b588de9e213f80a256728e6798ddc67176c7b07e4a1cfc7de8922422cbce02543714367037536955221fa451b0c4fefaf20c66
+      expected-sha512: 3dc9c50ba813a3d54393155a435fe66404b72685ab0e3008f9ae9ed8d81f6104860f07ed2656dd5748c1322d95f3140fa9b19c59a6bba7750fd12285f81866da
       delete: true
 
   - runs: |
@@ -87,7 +88,7 @@ subpackages:
         - uses: test/docs
 
 update:
-  enabled: true
+  enabled: false
   ignore-regex-patterns:
     - -v # ignore versions that start contain a -v, e.g. arborist-v7.2.1, libnpmfund-v4.2.0
   github:


### PR DESCRIPTION
Related: https://github.com/npm/cli/issues/8216

Downgrade npm to 11.2.0 until the linked issue is resolved or there's a default setting to workaround it.