### PR TITLE
withdraw npm 11.3.0-r0 packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -39,3 +39,5 @@ openjdk-24-jre-24_beta16-r5.apk
 openjdk-24-jre-24_beta36-r0.apk
 openjdk-24-jre-24_beta36-r1.apk
 dotnet-bootstrap-9-9.0.200-r0.apk
+npm-11.3.0-r0.apk
+npm-doc-11.3.0-r0.apk


### PR DESCRIPTION
Following https://github.com/wolfi-dev/os/pull/49670, 11.3.0 is affected by https://github.com/npm/cli/issues/8216 and we believe the potential impact on our users to be substantial.