### PR TITLE
npm: add test for issue that should block updates, re-enable updates

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -2,7 +2,7 @@
 package:
   name: npm
   version: "11.2.0"
-  epoch: 1
+  epoch: 2
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -88,7 +88,6 @@ subpackages:
         - uses: test/docs
 
 update:
-  enabled: false
   ignore-regex-patterns:
     - -v # ignore versions that start contain a -v, e.g. arborist-v7.2.1, libnpmfund-v4.2.0
   github:
@@ -102,6 +101,7 @@ test:
     contents:
       packages:
         - nodejs
+        - python3
     environment:
       HOME: /home/build
   pipeline:
@@ -112,3 +112,59 @@ test:
         npm help
         npx --version
         npx --help
+    - runs: |
+        # Reproduce https://github.com/npm/cli/issues/8216: create a
+        # package-lock.json and then attempt to use a registry at a non-/
+        # prefix with `npm install`
+
+        cat << EOF > proxy.py
+        import http.server
+        import socketserver
+        import urllib.request
+
+        class MyProxy(http.server.SimpleHTTPRequestHandler):
+
+            def do_GET(self):
+                if not self.path.startswith("/prefix"):
+                  self.send_response(404)
+                  self.end_headers()
+                  self.wfile.write(b"Unprefixed!\n")
+                  return
+                path = self.path.replace("/prefix", "")
+                url = f"https://registry.npmjs.org/{path}"
+                self.send_response(200)
+                self.end_headers()
+                self.copyfile(urllib.request.urlopen(url), self.wfile)
+
+        PORT = 7777
+
+        httpd = None
+
+        try:
+            httpd = socketserver.TCPServer(('', PORT), MyProxy)
+            print(f"Proxy at: http://localhost:{PORT}")
+            httpd.serve_forever()
+        finally:
+            if httpd:
+                httpd.shutdown()
+        EOF
+
+        # Run a proxy which strips "prefix/" from URLs, which should work as an
+        # NPM registry rooted at /prefix
+        python3 proxy.py &
+        sleep 1
+
+        # Create a package-lock.json
+        npm install rightpad
+        # Ensure npm will find something to do
+        rm -rf node_modules .npm
+
+        # Set our registry
+        npm config set registry http://localhost:7777/prefix/
+
+        # npm will use the scheme of `resolved` regardless of registry setting,
+        # so avoid the need to terminate SSL in our proxy
+        sed -i 's/https/http/' package-lock.json
+
+        # Attempt an install
+        npm install --loglevel silly


### PR DESCRIPTION
Specifically https://github.com/npm/cli/issues/8216 breaks using `npm`
against a registry hosted at any path but `/`.  The test added here
passes on 11.2.0, but fails on a (locally-built) 11.3.0.
    
As this will result in package updates failing until upstream release a
fix for the issue, we can re-enable automated updates.  We won't have
to come back later and re-enable them manually, and the first fixed
version should land automatically.
