### PR TITLE
py3-zict: new package

### DIFF
--- a/py3-zict.yaml
+++ b/py3-zict.yaml
@@ -1,0 +1,88 @@
+package:
+  name: py3-zict
+  version: 3.0.0
+  epoch: 0
+  description: Useful Mutable Mappings
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: zict
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: bb17ff367d788a9430eeafff36126d8db0499ad0
+      repository: https://github.com/dask/zict
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - python-${{range.key}}
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - name: Test basic functionality
+          runs: |
+            cat > test.py <<EOF
+            import pickle
+            import zlib
+
+            from ${{vars.pypi-package}} import File, Func, LRU
+
+            a = File("mydir/")
+            b = Func(zlib.compress, zlib.decompress, a)
+            c = Func(pickle.dumps, pickle.loads, b)
+            d = LRU(100, c)
+
+            d["x"] = [1, 2, 3]
+
+            assert d["x"] == [1, 2, 3]
+            EOF
+
+            python${{range.key}} test.py
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: dask/zict
+    use-tag: true


### PR DESCRIPTION
Adding `py3-zict` package: dependency of `py3-distributed` -> `py3-dask` -> `py3-jupyter-ai`

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)