### PR TITLE
Fix the python shbang for oscap-docker which has /usr/sbin/python3

### DIFF
--- a/openscap.yaml
+++ b/openscap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openscap
   version: "1.4.2"
-  epoch: 0
+  epoch: 1
   description: NIST Certified SCAP 1.2 toolkit
   copyright:
     - license: LGPL-2.1-or-later
@@ -78,6 +78,7 @@ pipeline:
       for f in ${{targets.destdir}}/usr/bin/*; do
         [ -f "$f" ] || continue
         sed -i '1s,^#!/usr/bin/python3$,#!/usr/bin/python${{vars.py-version}},' "$f"
+        sed -i '1s,^#!/usr/sbin/python3$,#!/usr/sbin/python${{vars.py-version}},' "$f"
       done
 
   - uses: strip
@@ -99,7 +100,6 @@ subpackages:
               import openscap_py
               import oscap_docker_python
         - runs: |
-            ln -s /usr/bin/python3.13 /usr/bin/python3
             oscap-docker --help
 
 # TODO: Requires some additional graphviz/xml packages


### PR DESCRIPTION
The oscap-docker python script has `/usr/sbin/python3` in its shbang line so the fix shbang step needs to be expanded to include sbin. I opted to do this as a second line to ease readability.

The symlink was only causing the test to pass so drop that.