### PR TITLE
iptables - split iptables-apply out to a subpackage.

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 21
+  epoch: 22
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -92,6 +92,19 @@ subpackages:
       runtime:
         - merged-sbin
         - wolfi-baselayout
+
+  - name: iptables-apply
+    description: iptables-apply program
+    pipeline:
+      - runs: |
+          spd=${{targets.contextdir}}
+          mkdir -p "$spd/usr/bin"
+          mv ${{targets.destdir}}/usr/bin/iptables-apply "$spd/usr/bin"
+    test:
+      pipeline:
+        - runs: |
+            iptables-apply --help
+            iptables-apply --version
 
   - name: iptables-doc
     description: iptables documentation


### PR DESCRIPTION
iptables-apply is a bash script (per its #!).

As an unintended side effect of usrmerge, melange began noticing this recently and now correctly added the dependency on bash to iptables.

Many users will not use iptables-apply and would rather not have the unused depends on bash.  Evidence for this is the fact that melange previously did not identify the dependency and no one screamed.

The solution here is to just split out iptables into its own package. If a user needs it, they can get it there.
