### PR TITLE
Fix subversion builds in QEMU

### DIFF
--- a/subversion.yaml
+++ b/subversion.yaml
@@ -1,7 +1,7 @@
 package:
   name: subversion
   version: 1.14.5
-  epoch: 2
+  epoch: 3
   description: Replacement for CVS, another versioning system (svn)
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND HPND-Markus-Kuhn AND MIT AND Unicode-DFS-2015 AND FSFAP
@@ -35,6 +35,10 @@ pipeline:
   - runs: ./autogen.sh
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --with-apr=/usr/bin/apr-1-config \
+        --with-apr-util=/usr/bin/apu-1-config
 
   - uses: autoconf/make
 


### PR DESCRIPTION
I noticed subversion [failing](https://github.com/chainguard-dev/melange/actions/runs/14388582517/job/40352545990?pr=1909#step:16:860) to build in QEMU:
```
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/branch.lo] Error 1
2025/04/10 19:25:19 WARN make: *** Waiting for unfinished jobs....
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/branch_repos.lo] Error 1
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/branch_migrate.lo] Error 1
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/compat.lo] Error 1
2025/04/10 19:25:19 WARN cc1: error: /usr/sbin/apr-1-config//usr/include/apr-1: Not a directory
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/cancel.lo] Error 1
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/compose_delta.lo] Error 1
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/branch_nested.lo] Error 1
2025/04/10 19:25:19 WARN make: *** [Makefile:809: subversion/libsvn_delta/branch_compat.lo] Error 1
```

This PR adds two configure options which fix the build in QEMU. That said, I'm not sure why the QEMU runner is combining `/usr/sbin/apr-1-config/` and `/usr/include/apr-1` into a single string/path.