### PR TITLE
add missing provides for subpkgs of knative-operator

### DIFF
--- a/knative-operator-1.17.yaml
+++ b/knative-operator-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-operator-1.17
   version: 1.17.5
-  epoch: 2
+  epoch: 3
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,9 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     description: Compat package for ${{package.name}}
+    dependencies:
+      provides:
+        - knative-operator-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/ko-app
@@ -58,6 +61,9 @@ subpackages:
 
   - name: ${{package.name}}-webhook-compat
     description: Compat package for ${{package.name}}-webhook
+    dependencies:
+      provides:
+        - knative-operator-webhook-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/ko-app
@@ -67,6 +73,9 @@ subpackages:
         - runs: stat /ko-app/webhook
 
   - name: ${{package.name}}-webhook
+    dependencies:
+      provides:
+        - knative-operator-webhook=${{package.full-version}}
     pipeline:
       - name: build the webhook binary
         uses: go/build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [x] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions
