### PR TITLE
new: gptfdisk

### DIFF
--- a/gptfdisk.yaml
+++ b/gptfdisk.yaml
@@ -1,0 +1,84 @@
+package:
+  name: gptfdisk
+  version: 1.0.10
+  epoch: 0
+  description: Text-mode partitioning tool that works on Globally Unique Identifier (GUID) Partition Table (GPT) disks
+  copyright:
+    - license: LGPL-2.0-or-later
+  dependencies:
+    runtime:
+      - sgdisk
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - e2fsprogs-dev
+      - ncurses-dev
+      - popt-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2abed61bc6d2b9ec498973c0440b8b804b7a72d7144069b5a9209b2ad693a282
+      uri: https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/${{package.version}}/gptfdisk-${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: fix-wrong-include.patch fix-cgdisk-linking.patch
+
+  - uses: autoconf/make
+
+  - runs: |
+      env
+      # Makefile has no install target so install manually
+      set -x
+      for bin in gdisk sgdisk cgdisk fixparts; do
+        install -Dm755 $bin ${{targets.destdir}}/usr/bin/$bin
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: sgdisk
+    description: Script friendly partitioning tool for Globally Unique Identifier (GUID) Partition Table (GPT) disks
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/sgdisk ${{targets.contextdir}}/usr/bin/sgdisk
+          rm -f ${{targets.destdir}}/usr/bin/sgdisk
+    test:
+      pipeline:
+        - name: Check sgdisk binary
+          runs: |
+            sgdisk --version | grep ${{package.version}}
+        - uses: test/tw/ldd-check
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - bash-binsh
+  pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: 2abed61bc6d2b9ec498973c0440b8b804b7a72d7144069b5a9209b2ad693a282
+        uri: https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/${{package.version}}/gptfdisk-${{package.version}}.tar.gz
+    - name: Execute gdisk test script
+      runs: |
+        # Massage test script to use installed binaries.
+        sed -i "s/BIN=\./BIN=\/usr\/bin\//g" gdisk_test.sh
+        ./gdisk_test.sh
+    - name: Verify gptfdisk installation basic - binary check only (all interactive).
+      runs: |
+        for bin in gdisk cgdisk fixparts; do
+          [ -x /usr/bin/$bin ] || exit 1
+        done
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 885

--- a/gptfdisk.yaml
+++ b/gptfdisk.yaml
@@ -59,7 +59,6 @@ test:
   environment:
     contents:
       packages:
-        - busybox
         - bash-binsh
   pipeline:
     - uses: fetch

--- a/gptfdisk/fix-cgdisk-linking.patch
+++ b/gptfdisk/fix-cgdisk-linking.patch
@@ -1,0 +1,16 @@
+Description: Add tinfo to LDLIB for cgdisk command
+Author: James Page <james.page@chainguard.dev>
+
+diff --git a/Makefile b/Makefile
+index af9701c..87021cd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -72,7 +72,7 @@ LDLIBS+=-luuid #-licuio -licuuc
+ FATBINFLAGS=
+ THINBINFLAGS=
+ SGDISK_LDLIBS=-lpopt
+-CGDISK_LDLIBS=-lncursesw
++CGDISK_LDLIBS=-lncursesw -ltinfo
+ LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
+ MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
+ ALL=gdisk cgdisk sgdisk fixparts

--- a/gptfdisk/fix-wrong-include.patch
+++ b/gptfdisk/fix-wrong-include.patch
@@ -1,0 +1,19 @@
+Description: Correct include path for ncurses.h
+Origin: https://git.alpinelinux.org/aports/plain/main/gptfdisk/
+
+diff --git a/gptcurses.cc b/gptcurses.cc
+index 1b18cf2..4ebfde1 100644
+--- a/gptcurses.cc
++++ b/gptcurses.cc
+@@ -23,11 +23,7 @@
+ #include <iostream>
+ #include <string>
+ #include <sstream>
+-#if defined (__APPLE__) || (__FreeBSD__)
+ #include <ncurses.h>
+-#else
+-#include <ncursesw/ncurses.h>
+-#endif
+ #include "gptcurses.h"
+ #include "support.h"
+ 


### PR DESCRIPTION
GPT fdisk provides partitioning tools for GPT block devices; used by ceph via the sgdisk binary which is great for script usage.

Includes a patch from Alpine for include paths and a linking issue seen in Wolfi; package lacks any configure command and the upstream Makefile is primitive.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
