### PR TITLE
nfs-ganesha: enable ceph support

### DIFF
--- a/nfs-ganesha.yaml
+++ b/nfs-ganesha.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-ganesha
   version: "6.5"
-  epoch: 2
+  epoch: 3
   description: NFS-Ganesha is an NFSv3,v4,v4.1 fileserver that runs in user mode on most UNIX/Linux systems
   copyright:
     - license: GPL-3.0-or-later
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - ceph-dev
       - flex
       - gcc-12-default
       - krb5-dev


### PR DESCRIPTION
Enable support for use of CephFS and RADOS as a backend for NFS
shares.
