### PR TITLE
py3-pyyaml: depend on all cypthons

### DIFF
--- a/py3-pyyaml.yaml
+++ b/py3-pyyaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyyaml
   version: 6.0.2
-  epoch: 2
+  epoch: 3
   description: Python3 bindings for YAML
   copyright:
     - license: MIT
@@ -24,7 +24,7 @@ environment:
     packages:
       - build-base
       - busybox
-      - py3-cython
+      - py3-supported-cython
       - py3-supported-pip
       - py3-supported-python-dev
       - py3-supported-wheel


### PR DESCRIPTION
Although any cython can build any wheel, it is not getting detected
and used in the 3.10 and 3.11 builds.

    # for i in *.apk; do echo $i; tar tf $i | grep _yaml.cpython; done
    py3.10-pyyaml-6.0.2-r2.apk
    py3.11-pyyaml-6.0.2-r2.apk
    py3.12-pyyaml-6.0.2-r2.apk
    usr/lib/python3.12/site-packages/yaml/_yaml.cpython-312-x86_64-linux-gnu.so
    py3.13-pyyaml-6.0.2-r2.apk
    usr/lib/python3.13/site-packages/yaml/_yaml.cpython-313-x86_64-linux-gnu.so

Hopefully with this change all python versions will have the compiled
extension.
