### PR TITLE
fix(kubernetes-1.32): add ip6tables to kube-proxy runtime dependencies

### DIFF
--- a/kubernetes-1.32.yaml
+++ b/kubernetes-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.32
   version: "1.32.3"
-  epoch: 4
+  epoch: 5
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -155,6 +155,7 @@ subpackages:
     dependencies:
       runtime:
         - iptables
+        - ip6tables
         - nftables
         - kmod
         - conntrack-tools


### PR DESCRIPTION
Fixes: Adds ip6tables alongside iptables to ensure kube-proxy has access to required networking tools during runtime. This prevents log warnings related to missing iptables binaries when running the kube-proxy component.

