### PR TITLE
mono-6.14.0: new package

### DIFF
--- a/mono.yaml
+++ b/mono.yaml
@@ -13,7 +13,7 @@ package:
 
 environment:
   environment:
-    CFLAGS: "-Wno-int-conversion"
+    CFLAGS: "-Wno-int-conversion -DMONO_ARCH_NOMAP32BIT"
   contents:
     packages:
       - autoconf
@@ -40,18 +40,21 @@ pipeline:
   - working-directory: /home/build/src
     pipeline:
       - runs: |
-          PATH=/usr/local/bin:$PATH
-          mkdir -p /usr/local
-          chown -R $(whoami) /usr/local
-          ./autogen.sh --prefix=/usr/local
+          PATH=/usr/lib/mono/bin:$PATH
+          mkdir -p /usr/lib/mono
+          chown -R $(whoami) /usr/lib/mono
+          ./autogen.sh --prefix=/usr/lib/mono
           make
           make install
 
-  - working-directory: /usr/local
+  - working-directory: /usr/lib/mono
     pipeline:
       - runs: |
-          mkdir -p "${{targets.destdir}}"/usr/local
-          mv ./* "${{targets.destdir}}"/usr/local
+          mkdir -p "${{targets.destdir}}"/usr/lib/mono
+          mv ./* "${{targets.destdir}}"/usr/lib/mono/
+          mkdir -p "${{targets.destdir}}"/usr/bin
+          ln -s /usr/lib/mono/bin/mcs "${{targets.destdir}}"/usr/bin/
+          ln -s /usr/lib/mono/bin/mono "${{targets.destdir}}"/usr/bin/
 
 update:
   enabled: true

--- a/mono.yaml
+++ b/mono.yaml
@@ -7,8 +7,9 @@ package:
     - license: Apache-2.0
     - license: MIT
     - license: BSD-3-Clause
-  runtime:
-    - python3
+  dependencies:
+    runtime:
+      - python3
 
 environment:
   environment:

--- a/mono.yaml
+++ b/mono.yaml
@@ -1,0 +1,95 @@
+package:
+  name: mono
+  version: 6.14.0
+  epoch: 0
+  description: The mono framework.
+  copyright:
+    - license: Apache-2.0
+    - license: MIT
+    - license: BSD-3-Clause
+  runtime:
+    - python3
+
+environment:
+  environment:
+    CFLAGS: "-Wno-int-conversion"
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - cmake
+      - gdb
+      - gettext
+      - krb5
+      - libtool
+      - python3
+      - wget
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.winehq.org/mono/mono.git
+      tag: mono-${{package.version}}
+      expected-commit: 3d1eb55c535487d608ef4b57aca330803a6e002d
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          PATH=/usr/local/bin:$PATH
+          mkdir -p /usr/local
+          chown -R $(whoami) /usr/local
+          ./autogen.sh --prefix=/usr/local
+          make
+          make install
+
+  - working-directory: /usr/local
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/local
+          mv ./* "${{targets.destdir}}"/usr/local
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 6360
+
+test:
+  pipeline:
+    - name: Basic mono command test
+      runs: |
+        mono --version
+    - name: Compile and run a simple .NET application
+      runs: |
+        cat <<'EOF' > HelloWorld.cs
+        using System;
+
+        class Program
+        {
+            static void Main()
+            {
+                Console.WriteLine("Hello, World!");
+            }
+        }
+        EOF
+        mcs HelloWorld.cs
+        mono HelloWorld.exe
+    - name: Compile and run a .NET application with arguments
+      runs: |
+        cat <<'EOF' > ArgumentEcho.cs
+        using System;
+
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                Console.WriteLine("Arguments: " + String.Join(", ", args));
+            }
+        }
+        EOF
+        mcs ArgumentEcho.cs
+        mono ArgumentEcho.exe arg1 arg2 arg3
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
