### PR TITLE
py3-distributed: re-enable runtime dependency / package tests

### DIFF
--- a/py3-distributed.yaml
+++ b/py3-distributed.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distributed
   version: 2025.3.0
-  epoch: 0
+  epoch: 1
   description: A distributed task scheduler for Dask
   annotations:
     cgr.dev/ecosystem: python
@@ -42,7 +42,7 @@ subpackages:
       runtime:
         - py${{range.key}}-click
         - py${{range.key}}-cloudpickle
-        # - py${{range.key}}-dask
+        - py${{range.key}}-dask
         - py${{range.key}}-jinja2
         - py${{range.key}}-locket
         - py${{range.key}}-msgpack
@@ -64,6 +64,20 @@ subpackages:
           mkdir -p ./cleanup/${{range.key}}/
           mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - name: Test importing key modules
+          runs: |
+            cat > test.py <<EOF
+            from ${{vars.pypi-package}} import Client
+            from ${{vars.pypi-package}}.diagnostics.progressbar import progress
+            EOF
+
+            python${{range.key}} test.py
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
@@ -75,6 +89,13 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/
           mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - name: Test all binaries
+          runs: |
+            dask-ssh --version
+            dask-scheduler --version
+            dask-worker --version
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding the `dask` runtime dep back in