### PR TITLE
php-*-zstd: ignore -pie$ tags

### DIFF
--- a/php-8.1-zstd.yaml
+++ b/php-8.1-zstd.yaml
@@ -54,6 +54,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - pie$
   github:
     identifier: kjdev/php-ext-zstd
     use-tag: true

--- a/php-8.2-zstd.yaml
+++ b/php-8.2-zstd.yaml
@@ -54,6 +54,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - pie$
   github:
     identifier: kjdev/php-ext-zstd
     use-tag: true

--- a/php-8.3-zstd.yaml
+++ b/php-8.3-zstd.yaml
@@ -54,6 +54,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - pie$
   github:
     identifier: kjdev/php-ext-zstd
     use-tag: true

--- a/php-8.4-zstd.yaml
+++ b/php-8.4-zstd.yaml
@@ -54,6 +54,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - pie$
   github:
     identifier: kjdev/php-ext-zstd
     use-tag: true


### PR DESCRIPTION
This was prompted by
https://github.com/kjdev/php-ext-zstd/tree/0.14.0%2Bpie, which has only `.github` and metadata changes compared to 0.14.0.  As one of those changes was the addition of `composer.json`, I believe this tag was created to make the existing 0.14.0 code available to the PHP Installer for Extensions (https://github.com/php/pie).

Closes: #49830
Closes: #49815
Closes: #49832
Closes: #49831 