### PR TITLE
kserve/update: refactor poetry install; omit cuda related deps

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,19 +1,22 @@
 package:
   name: kserve
   version: "0.15.0"
-  epoch: 0
+  epoch: 1
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
+
+vars:
+  py-version: 3.11 # Upstream https://github.com/kserve/kserve/blob/release-0.15/python/storage-initializer.Dockerfile uses python-3.11
 
 environment:
   contents:
     packages:
       - go
-      - py3.11-pip
-      - py3.11-poetry
-      - py3.11-poetry-bin
-      - python-3.11-dev # Upstream https://github.com/kserve/kserve/blob/master/python/storage-initializer.Dockerfile uses python-3.11
+      - py${{vars.py-version}}-pip
+      - py${{vars.py-version}}-poetry
+      - py${{vars.py-version}}-poetry-bin
+      - python-${{vars.py-version}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -90,22 +93,19 @@ subpackages:
           # Due to bump-python-version.patch, we need to re-lock dependencies
           poetry lock
 
-          # aiohttp: CVE-2024-52304 GHSA-8495-4g3g-x7pr
-          # setuptools: CVE-2024-6345 GHSA-cx63-2mw6-8hw5
+          # Install dependencies and build the package using poetry
+          # NB: exclude 'ray' extras since that brings unwanted cuda/nv deps
+          poetry install --no-interaction --no-root --extras "storage"
+
+          # cryptography: CVE-2024-12797 GHSA-79v4-65xg-pq4g
           poetry add \
-            "aiohttp=^3.10.11" \
-            "setuptools=^74.1.1" \
-            "certifi" \
-            "idna" \
-            "packaging" \
-            "google.cloud" \
             "cryptography=^44.0.1"
 
           poetry run pip freeze | grep -v kserve > requirements.txt
-
           poetry build
-          # Install the wheel file with the root directory set to ${{targets.contextdir}}
-          pip install --root ${{targets.contextdir}} -I -r requirements.txt --no-compile
+
+          # Install runtime deps and wheel with the root directory set to ${{targets.contextdir}}
+          python3 -m pip install --root ${{targets.contextdir}} -I -r requirements.txt --no-compile
           python3 -m pip install --verbose --prefix=/usr --root=${{targets.contextdir}} dist/*.whl
       - name: install storage-initializer entrypoint
         working-directory: ./python/storage-initializer
@@ -117,7 +117,7 @@ subpackages:
 
           cd ${{targets.contextdir}}/storage-initializer/scripts/
           # update shbang to point to the python used rather than '/usr/bin/env python'
-          sed -i.dist "1s,#!/usr/bin/env python[^ ]*,#!$(which python3.11)," initializer-entrypoint
+          sed -i.dist "1s,#!/usr/bin/env python[^ ]*,#!$(which python${{vars.py-version}})," initializer-entrypoint
           # exit fail if it did not change anything
           diff -u initializer-entrypoint.dist initializer-entrypoint && exit 1
           rm initializer-entrypoint.dist


### PR DESCRIPTION
As part of the kserve 0.15.0 upstream release, new llm changes bring in additional cuda/nv related dependencies by default.  To avoid these, we removed `poetry install ... ray` from the storage-controller subpackage during our [package update](https://github.com/wolfi-dev/os/pull/48626).

Unfortunately, that also removed kserve cloud storage capabilities which led to [image failures](https://github.com/chainguard-dev/image-release-stats/issues/4999). This PR reinstates our storage functionality while continuing to exclude the new llm-related dependencies:

- remove `poetry adds` where upstream already includes current or newer versions
- only install [storage](https://github.com/kserve/kserve/blob/d20d4228a8b2956b800ad5a3e62c0578b5a5b97f/python/kserve/pyproject.toml#L76-L83) extras (omitting 'ray')
