### PR TITLE
add rancher-ui-driver-linode

### DIFF
--- a/docker-machine-driver-linode.yaml
+++ b/docker-machine-driver-linode.yaml
@@ -1,10 +1,13 @@
 package:
   name: docker-machine-driver-linode
   version: 0.1.15
-  epoch: 0
+  epoch: 1
   description: Linode Driver Plugin for Docker Machine using Linode APIv4
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - rancher-ui-driver-linode
 
 pipeline:
   - uses: git-checkout

--- a/rancher-ui-driver-linode.yaml
+++ b/rancher-ui-driver-linode.yaml
@@ -47,6 +47,6 @@ test:
   pipeline:
     - name: Ensure files existance
       runs: |
-        for f in linode.svg component.js component.css linode.svg; do
+        for f in component.js component.css linode.svg; do
           test -f /usr/share/rancher/ui/assets/rancher-ui-driver-linode/$(basename $f)
         done

--- a/rancher-ui-driver-linode.yaml
+++ b/rancher-ui-driver-linode.yaml
@@ -1,0 +1,52 @@
+package:
+  name: rancher-ui-driver-linode
+  version: "0.7.0"
+  epoch: 0
+  description: UI for Linode options when used as a Rancher Node Template
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - nodejs
+      - npm
+      - nvm
+      - yarn
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/linode/rancher-ui-driver-linode
+      tag: v${{package.version}}
+      expected-commit: b5a9fd67a069081a7c66f52b0d7870b4f9748661
+
+  - runs: |
+      npm install
+      npm run build
+
+  - name: Install files
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/rancher/ui/assets/rancher-ui-driver-linode
+      cp -r assets/* ${{targets.destdir}}/usr/share/rancher/ui/assets/rancher-ui-driver-linode
+      cp -r dist/* ${{targets.destdir}}/usr/share/rancher/ui/assets/rancher-ui-driver-linode
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: linode/rancher-ui-driver-linode
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Ensure files existance
+      runs: |
+        for f in linode.svg component.js component.css linode.svg; do
+          test -f /usr/share/rancher/ui/assets/rancher-ui-driver-linode/$(basename $f)
+        done


### PR DESCRIPTION
Adds https://github.com/linode/rancher-ui-driver-linode/tree/main to Rancher.

https://github.com/rancher/rancher/blob/3fdfa8c24361429803baa3fc4be739cfd4e0263a/package/Dockerfile#L241

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
