### PR TITLE
rebuild rancher and retry for export-images

### DIFF
--- a/rancher-2.10.yaml
+++ b/rancher-2.10.yaml
@@ -165,11 +165,17 @@ pipeline:
   - name: Export k3s images
     runs: |
       CATTLE_K3S_VERSION="$(
-        curl -fsSL "https://github.com/rancher/rancher/raw/refs/tags/v${{package.version}}/package/Dockerfile" \
+        curl -fsSL --retry 5 --retry-connrefused "https://github.com/rancher/rancher/raw/refs/tags/v${{package.version}}/package/Dockerfile" \
           | grep -m1 '^ENV CATTLE_K3S_VERSION' \
           | sed 's/ENV CATTLE_K3S_VERSION //'
       )"
-      ${{targets.contextdir}}/usr/bin/export-images -k3s-version $CATTLE_K3S_VERSION -output ${{targets.contextdir}}/var/lib/rancher/k3s/agent/images/k3s-airgap-images.tar
+      # Tools doesn't have a retry mechanism, and it results CI flakes if the network is slow. (context cancelled)
+      for i in $(seq 1 20); do
+        if ${{targets.contextdir}}/usr/bin/export-images -k3s-version $CATTLE_K3S_VERSION -output ${{targets.contextdir}}/var/lib/rancher/k3s/agent/images/k3s-airgap-images.tar; then
+          break
+        fi
+        sleep 10
+      done
       rm -rf ${{targets.contextdir}}/usr/bin/export-images # We don't need this binary in the final image
 
   - runs: |

--- a/rancher-2.10.yaml
+++ b/rancher-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.10
   version: "2.10.4"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Adds retry to export-images since it fails on the CI sometimes. Also rebuild to include `rancher-ui-driver-linode`.