### PR TITLE
shardowsocks-rust-1.23.0-r2/cve remediation

### DIFF
--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: shadowsocks-rust
   version: "1.23.0"
-  epoch: 1
+  epoch: 2
   description: A Rust port of shadowsocks
   copyright:
     - license: MIT

--- a/shadowsocks-rust/cargobump-deps.yaml
+++ b/shadowsocks-rust/cargobump-deps.yaml
@@ -3,3 +3,5 @@ packages:
       version: 0.17.12
     - name: tokio
       version: 1.44.2
+    - name: crossbeam-channel
+      version: 0.5.15


### PR DESCRIPTION
fixed GHSA-pg9f-39pc-qf8g