### PR TITLE
openjdk-8: dynamically link with zlib

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.442.06 # this corresponds to same release as jdk8u442-ga / jdk8u442-b06
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -112,7 +112,8 @@ pipeline:
         --with-hotspot-src-zip=/home/build/icedtea-drops/hotspot.tar.xz \
         --with-jdk-home=/usr/lib/jvm/java-1.7-openjdk \
         --with-curves="nist+" \
-        --with-pkgversion="Wolfi ${{package.version}}-r${{package.epoch}}"
+        --with-pkgversion="Wolfi ${{package.version}}-r${{package.epoch}}" \
+        --with-zlib=system
 
       make icedtea-boot SHELL=/bin/bash
       make


### PR DESCRIPTION
Switch to dynamic linking with zlib to improve security
posture.

Signed-off-by: James Page <james.page@chainguard.dev>
