### PR TITLE
Withdraw keda-2.16-2.16.1-r10 and mysql-9.1-9.1.0-r40

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -8,3 +8,13 @@ py3.12-numpy-2.2.4-r0.apk
 py3.12-numpy-bin-2.2.4-r0.apk
 py3.13-numpy-2.2.4-r0.apk
 py3.13-numpy-bin-2.2.4-r0.apk
+
+keda-2.16-2.16.1-r10.apk
+keda-2.16-admission-webhooks-2.16.1-r10.apk
+keda-2.16-metrics-apiserver-2.16.1-r10.apk
+mysql-9.1-9.1.0-r40.apk
+mysql-9.1-bitnami-compat-9.1.0-r40.apk
+mysql-9.1-client-9.1.0-r40.apk
+mysql-9.1-dev-9.1.0-r40.apk
+mysql-9.1-oci-entrypoint-9.1.0-r40.apk
+mysql-9.1-oci-entrypoint-compat-9.1.0-r40.apk


### PR DESCRIPTION
See https://github.com/chainguard-dev/internal-dev/issues/11219