### PR TITLE
build gdal with numpy bindings

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -54,8 +54,8 @@ environment:
       - openssl-dev
       - pcre2-dev
       - proj-dev
-      - py3-supported-python
       - py3-supported-numpy
+      - py3-supported-python
       - py3-supported-python-dev
       - py3-supported-setuptools
       - qhull-dev

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -18,6 +18,7 @@ data:
 
 environment:
   environment:
+    # IMPORTANT NOTE: WE WANT TO BUILD WITH PYTHON NUMPY BINDINGS. GDAL_PYTHON_BINDINGS_WITHOUT_NUMPY ENV VARIABLE SHOULD ALWAYS BE SET TO "NO".
     GDAL_PYTHON_BINDINGS_WITHOUT_NUMPY: "NO"
   contents:
     packages:
@@ -54,6 +55,7 @@ environment:
       - pcre2-dev
       - proj-dev
       - py3-supported-python
+      - py3-supported-numpy
       - py3-supported-python-dev
       - py3-supported-setuptools
       - qhull-dev
@@ -131,6 +133,14 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.outdir}}/gdal-py${{range.key}}/usr/lib/python3* ${{targets.contextdir}}/usr/lib/
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-numpy
+      pipeline:
+        - runs: |
+            python${{range.key}} -c "from osgeo import gdal_array"
 
   - name: py3-supported-gdal
     description: Meta package providing ${{package.name}} for supported Python versions.

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.10.3"
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
 
 environment:
   environment:
-    GDAL_PYTHON_BINDINGS_WITHOUT_NUMPY: "YES"
+    GDAL_PYTHON_BINDINGS_WITHOUT_NUMPY: "NO"
   contents:
     packages:
       - armadillo-dev


### PR DESCRIPTION
we always want to build using numpy bindings else we run into errors like following:

```bash
ImportError: cannot import name ‘gdal_array’ from ‘osgeo’
```