### PR TITLE
xfsprogs: fix missing python3 dep for xfs_protofile, misc tests

### DIFF
--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,13 +1,14 @@
 package:
   name: xfsprogs
   version: "6.14.0"
-  epoch: 0
+  epoch: 1
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:
     runtime:
       - merged-usrsbin
+      - python3
       - wolfi-baselayout
 
 environment:
@@ -120,17 +121,22 @@ test:
     - name: "Check xfs_repair version"
       runs: |
         xfs_repair -V
-        xfs_admin version
+        xfs_admin -V
         xfs_admin help
-        xfs_bmap -v
-        xfs_estimate version
+        xfs_bmap -V
+        xfs_estimate -V
         xfs_estimate help
-        xfs_fsr version
+        xfs_fsr -V
         xfs_fsr help
-        xfs_mkfile version
+        xfs_mkfile -V
         xfs_mkfile help
-        xfs_quota version
+        xfs_quota -V
         xfs_quota help
+        xfs_property -V
+        xfs_protofile --help
+        xfs_protofile -V
+        xfs_spaceman -V
+        fsck.xfs
     - name: "Check mkfs.xfs version"
       runs: |
         mkfs.xfs -V
@@ -156,4 +162,9 @@ test:
         mkfs.xfs xfs.img
         xfs_admin -L "TestXFS" xfs.img
         xfs_admin -l xfs.img | grep 'TestXFS'
+    - name: "Test xfs_repair functionality"
+      runs: |
+        dd if=/dev/zero of=xfs.img bs=1M count=300
+        mkfs.xfs xfs.img
+        xfs_repair -f xfs.img 2>&1 | grep '^done$'
     - uses: test/tw/ldd-check


### PR DESCRIPTION
The xfsprogs package was missing a runtime dependency on python3 that prevented the `xfs_protofile` script from being runnable:

```
c49d114c0896:/work/packages# /usr/bin/xfs_protofile
/bin/sh: /usr/bin/xfs_protofile: not found
c49d114c0896:/work/packages# head -1 /usr/bin/xfs_protofile
#!/usr/bin/python3
```

- fix this by adding the dependency,
- add a test to ensure that xfs_protofile is runnable,
- fix and add other tests to pass the right version flag (-V)
- add a test for xfs_repair basic functionality

