### PR TITLE
httpie: use python/build-wheel pipeline to build httpie

### DIFF
--- a/httpie.yaml
+++ b/httpie.yaml
@@ -1,7 +1,7 @@
 package:
   name: httpie
   version: 3.2.4
-  epoch: 0
+  epoch: 1
   description: "HTTPie for Terminal — modern, user-friendly command-line HTTP client for the API era. JSON support, colors, sessions, downloads, plugins & more."
   copyright:
     - license: BSD-3-Clause
@@ -31,11 +31,8 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 2105caa49bae87c5809c274e407619a0de2639d1
 
-  - runs: |
-      python3 setup.py build
-
-  - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
+  - name: Python Build
+    uses: python/build-wheel
 
   - uses: strip
 


### PR DESCRIPTION
this package was failing for a while now. the tests are comprehensive but we never catched this. 

with this commit we use python/build-wheel pipeline to build the package and now httpie binary works. 