### PR TITLE
add more defaults to test/kwok/cluster pipeline

### DIFF
--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -8,6 +8,12 @@ needs:
     - kubernetes # has a runtime dependency on kubectl
     - etcd
 
+inputs:
+  namespace:
+    description: namespace in which we want to run the operator/controller/manager
+    required: true
+    default: default
+
 pipeline:
   - runs: |
       # ensure we can create a cluster using our own components instead of
@@ -45,3 +51,11 @@ pipeline:
 
       kubectl wait --for=condition=Ready nodes --all
       kubectl cluster-info
+      export KUBERNETES_SERVICE_HOST="127.0.0.1"
+      export KUBERNETES_SERVICE_PORT="32764"
+      mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
+      CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+      cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      echo ${{inputs.namespace}} > /var/run/secrets/kubernetes.io/serviceaccount/namespace
+      kubectl create sa ${{inputs.namespace}}
+      kubectl create token ${{inputs.namespace}} > /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -51,11 +51,7 @@ pipeline:
 
       kubectl wait --for=condition=Ready nodes --all
       kubectl cluster-info
-      export KUBERNETES_SERVICE_HOST="127.0.0.1"
-      export KUBERNETES_SERVICE_PORT="32764"
       mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
       CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
       cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       echo ${{inputs.namespace}} > /var/run/secrets/kubernetes.io/serviceaccount/namespace
-      kubectl create sa ${{inputs.namespace}}
-      kubectl create token ${{inputs.namespace}} > /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
we duplicate these parameters over and over again in package tests. Adding these here given these are good defaults which always remains the same.

some packages where these are getting repeated are:
```bash
$ rg 'KUBERNETES_SERVICE_PORT' -l
mongodb-kubernetes-operator.yaml
kube-state-metrics.yaml
cluster-proportional-autoscaler.yaml
sealed-secrets.yaml
kyverno-1.13.yaml
flux-source-controller.yaml
lvm-driver.yaml
ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
kubernetes-event-exporter.yaml
ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
redis-operator.yaml
ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
metrics-server.yaml
```