### PR TITLE
vitess-21.0: bump epoch to remediate CVE-2025-32395

### DIFF
--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.4"
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump epoch to pull in latest version of 'vite' dependency.
Fixes: GHSA-356w-63v5-8wf4
