### PR TITLE
Update runtime dependencies for Chart-testing package

### DIFF
--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,13 +1,13 @@
 package:
   name: chart-testing
   version: "3.12.0"
-  epoch: 1
+  epoch: 2
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - bash
+      - busybox
       - git
       - helm
       - kubectl


### PR DESCRIPTION
- Replace `bash` with `busybox` as upstream image uses `/bin/sh`