### PR TITLE
openssf-compiler-options: make it easier to integrate with oldglibc

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 17
+  epoch: 18
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/etc/clang/common.cfg
+++ b/openssf-compiler-options/etc/clang/common.cfg
@@ -30,3 +30,5 @@
 
 # enable stack pointers for profiling
 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+
+@oldglibc.cfg

--- a/openssf-compiler-options/etc/clang/oldglibc.cfg
+++ b/openssf-compiler-options/etc/clang/oldglibc.cfg
@@ -1,0 +1,2 @@
+# must exist, as llvm @ is a required include
+# when needed this file will be replaced by oldglibc

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
@@ -4,4 +4,5 @@
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
 
+%include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
@@ -4,4 +4,5 @@
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
 
+%include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
Sometimes binaries need to build against older glibc. Currently it is
achieved via build-depends on oldglibc and environment/buildsystem
specific settings. But those at times fail to propagate to the
toolchain. Instead of relying on the environment/buildsystem settings
create integration point in openssf-compiler-options to allow oldglibc
package to inject the relevant linker & include flags. Note that lots
of software is starting to omit glibc libraries that got merged into
libc.so, and thus oldglibc can also specify linking with old split-out
dl, pthread libraries to resolve a class of failures to build from
source. These builds can also then make different hardening choices,
and optimisations in terms of march/mtune.

This has been end to end tested in:
- https://github.com/chainguard-dev/enterprise-packages/pull/20345

But will be cleaned up and split out into individual pull
requests. This is one of them.
