### PR TITLE
nvidia-container-toolkit: undo incorrect removal of tools packages, update set of tools packages for 1.17.5

### DIFF
--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-container-toolkit
   version: "1.17.5"
-  epoch: 1
+  epoch: 2
   description: Build and run containers leveraging NVIDIA GPUs
   copyright:
     - license: Apache-2.0
@@ -36,15 +36,6 @@ data:
       nvidia-cdi-hook: nvidia-cdi-hook
       nvidia-ctk: nvidia-ctk
 
-  - name: tools
-    items:
-      containerd: containerd
-      crio: crio
-      docker: docker
-      nvidia-toolkit: nvidia-toolkit
-      operator: operator
-      toolkit: toolkit
-
 subpackages:
   - range: commands
     name: "${{package.name}}-${{range.key}}"
@@ -62,30 +53,23 @@ subpackages:
             apk add runc # runc is just a placeholder, the actual runtime binary is TBD by the user
             ${{range.value}} --help
 
-  - range: tools
-    name: "${{package.name}}-${{range.key}}"
+  - name: "${{package.name}}-nvidia-toolkit"
     pipeline:
       - uses: go/build
         with:
           modroot: .
-          packages: ./tools/container/${{range.key}}
+          packages: ./tools/container/nvidia-toolkit
           ldflags: -s -w -X main.Version=${{package.version}}
-          output: ${{range.key}}
+          output: nvidia-toolkit
           vendor: true
       - runs: |
           # Ref: https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.15.0/deployments/container/Dockerfile.ubi8#L74
           mkdir -p ${{targets.contextdir}}/work
-          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/work/${{range.key}}
+          ln -sf /usr/bin/nvidia-toolkit ${{targets.contextdir}}/work/nvidia-toolkit
     test:
       pipeline:
         - runs: |
-            # Operator requires root privileges to run
-            if [ "${{range.key}}" = "operator" ]; then
-              set +e
-              /work/${{range.key}} 2>&1 | grep -q "Permission denied"
-              exit $?
-            fi
-            /work/${{range.key}} --version
+            /work/nvidia-toolkit --version
 
 update:
   enabled: true

--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -36,6 +36,15 @@ data:
       nvidia-cdi-hook: nvidia-cdi-hook
       nvidia-ctk: nvidia-ctk
 
+  - name: tools
+    items:
+      containerd: containerd
+      crio: crio
+      docker: docker
+      nvidia-toolkit: nvidia-toolkit
+      operator: operator
+      toolkit: toolkit
+
 subpackages:
   - range: commands
     name: "${{package.name}}-${{range.key}}"
@@ -52,6 +61,31 @@ subpackages:
         - runs: |
             apk add runc # runc is just a placeholder, the actual runtime binary is TBD by the user
             ${{range.value}} --help
+
+  - range: tools
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./tools/container/${{range.key}}
+          ldflags: -s -w -X main.Version=${{package.version}}
+          output: ${{range.key}}
+          vendor: true
+      - runs: |
+          # Ref: https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.15.0/deployments/container/Dockerfile.ubi8#L74
+          mkdir -p ${{targets.contextdir}}/work
+          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/work/${{range.key}}
+    test:
+      pipeline:
+        - runs: |
+            # Operator requires root privileges to run
+            if [ "${{range.key}}" = "operator" ]; then
+              set +e
+              /work/${{range.key}} 2>&1 | grep -q "Permission denied"
+              exit $?
+            fi
+            /work/${{range.key}} --version
 
 update:
   enabled: true


### PR DESCRIPTION
I mistakenly removed all `tools` packages as they were all removed in upstream's `main` in January, well before the release of 1.17.5 in March. However, there is a separate long-lived 1.17 branch in which they have _not_ all been removed: this restores the building of the `tools` packages, and updates the set we build to match upstream.