### PR TITLE
spin: build with Rust 1.85 until next update

### DIFF
--- a/spin.yaml
+++ b/spin.yaml
@@ -1,7 +1,7 @@
 package:
   name: spin
   version: "3.2.0"
-  epoch: 0
+  epoch: 1
   description: "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
   copyright:
     - license: Apache-2.0
@@ -36,13 +36,17 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      # This build requires the stable version of rust, managed by rustup, because it requires a few other toolchains too.
-      rustup install stable
+      # This build requires other toolchains so we use rustup.
+      #
+      # TODO: We're pinned at 1.85.0 because certain WASM dependencies don't
+      # compile with 1.86.0. Revert to `rustup install stable' when upstream
+      # release (they've already fixed this upstream)
+      rustup install 1.85.0
       rustup target add wasm32-wasip1
       rustup target add wasm32-unknown-unknown
 
-      # This is a bit of a hack, but it's the easiest way to get the right version of rustc and cargo in the path.
-      export PATH="$HOME/.rustup/toolchains/stable-${{build.arch}}-unknown-linux-gnu/bin:$PATH"
+      # Put our rustup-installed toolchains into $PATH
+      export PATH="$(dirname "$(rustup which cargo)"):$PATH"
 
       if [ "${{build.arch}}" = "aarch64" ]; then
           echo '[build]' >> .cargo/config
@@ -58,6 +62,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: true # See TODO in "Configure and build" above
   github:
     identifier: fermyon/spin
     strip-prefix: v


### PR DESCRIPTION
This fixes a FTBFS: upstream have already fixed it, but it's more than
just a dependency bump so we'll wait for the next release to undo this.
To ensure we actually _do_ undo it, set package updates to manual.

Fixes: https://github.com/wolfi-dev/os/issues/50363