### PR TITLE
py3-pycrdt | py3-pycrdt-websocket | py3-sqlite-anyio: new packages

### DIFF
--- a/py3-pycrdt-websocket.yaml
+++ b/py3-pycrdt-websocket.yaml
@@ -1,0 +1,81 @@
+package:
+  name: py3-pycrdt-websocket
+  version: 0.15.5
+  epoch: 0
+  description: pycrdt-websocket is an async WebSocket connector for pycrdt.
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  import: pycrdt_websocket
+  pypi-package: pycrdt-websocket
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7daeef9d0135f712dda5c7af742cc47610b95eae
+      repository: https://github.com/jupyter-server/pycrdt-websocket
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-anyio
+        - py${{range.key}}-pycrdt
+        - py${{range.key}}-sqlite-anyio
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+        - name: Test importing key components
+          uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              from ${{vars.import}} import ASGIServer, WebsocketServer
+              from ${{vars.import}} import WebsocketProvider
+              from ${{vars.import}}.websocket import HttpxWebsocket
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: jupyter-server/pycrdt-websocket
+    tag-filter: v
+    strip-prefix: v

--- a/py3-pycrdt.yaml
+++ b/py3-pycrdt.yaml
@@ -25,9 +25,9 @@ environment:
   contents:
     packages:
       - build-base
+      - maturin
       - py3-supported-build-base
       - py3-supported-maturin
-      - maturin
       - rust
 
 pipeline:

--- a/py3-pycrdt.yaml
+++ b/py3-pycrdt.yaml
@@ -1,0 +1,75 @@
+package:
+  name: py3-pycrdt
+  version: 0.12.13
+  epoch: 0
+  description: CRDTs based on Yrs.
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pycrdt
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - py3-supported-build-base
+      - py3-supported-maturin
+      - maturin
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5b5f9251b95504ae3283db526ab2bb5729f2f254
+      repository: https://github.com/jupyter-server/pycrdt
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-anyio
+        - py${{range.key}}-importlib-metadata
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - name: Test basic functionality
+          runs: python${{range.key}} test-pycrdt.py
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: jupyter-server/pycrdt
+    use-tag: true

--- a/py3-pycrdt/test-pycrdt.py
+++ b/py3-pycrdt/test-pycrdt.py
@@ -1,0 +1,23 @@
+from pycrdt import Array, Doc, Map, Text
+
+text0 = Text("Hello")
+array0 = Array([0, "foo"])
+map0 = Map({"key0": "value0"})
+
+doc = Doc()
+doc["text0"] = text0
+doc["array0"] = array0
+doc["map0"] = map0
+
+assert str(doc["text0"]) == "Hello"
+assert doc["array0"][0] == 0
+assert doc["map0"]["key0"] == "value0"
+
+with doc.transaction():
+    text0 += ", World!"
+    array0.append("bar")
+    map0["key1"] = "value1"
+
+assert str(doc.get("text0", type=Text)) == "Hello, World!"
+assert doc.get("array0", type=Array)[2] == "bar"
+assert doc.get("map0", type=Map)["key1"] == "value1"

--- a/py3-sqlite-anyio.yaml
+++ b/py3-sqlite-anyio.yaml
@@ -1,0 +1,71 @@
+package:
+  name: py3-sqlite-anyio
+  version: 0.2.3
+  epoch: 0
+  description: Asynchronous client for SQLite using AnyIO
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  import: sqlite_anyio
+  pypi-package: sqlite-anyio
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ee1ebd99fc8062c874b119995f838244094f45a4
+      repository: https://github.com/davidbrochart/sqlite-anyio
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-anyio
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: davidbrochart/sqlite-anyio
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding packages:
- `py3-pycrdt`
- `py3-pycrdt-websocket`
- `py3-sqlite-anyio`

Dependencies of `py3-jupyter-server-ydoc` -> `py3-jupyter-collaboration` -> `py3-jupyterlab-chat` -> `py3-jupyter-ai`

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
