### PR TITLE
fix(node-problem-detector-0.8): Epoch bump node-problem-detector-0.8 and sub packages explicitly to work around incorrect provides statements in previous package versions

### DIFF
--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.20
-  epoch: 11
+  epoch: 12
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
The previous version node-problem-detector which is being installed (0.8.20-r5)in our node-problem-detector image had a hardcoded provides node-problem-detector=0.8.999
which sorts higher than the current provides of node-problem-detector=0.8.20-r11.

So every version of node-problem-detector from 0.8.14-r0 to 0.8.20-r5 will get precedence over the latest node-problem-detector package version.

The solution is either package withdrawals or explicitly install node-problem-detector-0.8 which doesn't rely on a provides statement and the latest version
will always sort higher and be installed.

This commit bumps the epoch of node-problem-detector-0.8 to force a rebuild of the node-problem-detector image with a new tag.

Signed-off-by: philroche <phil.roche@chainguard.dev>
