### PR TITLE
xfsprogs - split into xfsprogs-core and xfsprogs-extra

### DIFF
--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,15 +1,15 @@
 package:
   name: xfsprogs
   version: "6.14.0"
-  epoch: 1
+  epoch: 2
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:
     runtime:
       - merged-usrsbin
-      - python3
       - wolfi-baselayout
+      - xfsprogs-core
 
 environment:
   contents:
@@ -57,12 +57,27 @@ pipeline:
 subpackages:
   - name: xfsprogs-dev
     description: "headers for xfsprogs"
-    pipeline:
-      - uses: split/dev
     dependencies:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+        - xfsprogs-libs
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib64
+          mv ${{targets.destdir}}/usr/lib64/libhandle.so ${{targets.subpkgdir}}/usr/lib64
+
+  - name: xfsprogs-doc
+    description: xfsprogs docs
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/doc
+          mv ${{targets.destdir}}/usr/share/doc/xfsprogs ${{targets.subpkgdir}}/usr/share/doc
+    test:
+      pipeline:
+        - uses: test/docs
 
   - name: xfsprogs-libs
     description: "libraries for xfsprogs"
@@ -78,17 +93,47 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: xfsprogs-doc
-    description: "xfsprogs manpages"
+  - name: xfsprogs-core
+    description: "core xfs use utilities - mkfs and fsck"
     pipeline:
-      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv ${{targets.destdir}}/usr/bin/mkfs.xfs "${{targets.subpkgdir}}/usr/bin"
+
+          # bring mkfs.conf files with mkfs (like usr/share/xfsprogs/mkfs/lts_4.19.conf)
+          mkdir -p ${{targets.subpkgdir}}/usr/share/xfsprogs/mkfs
+          mv ${{targets.destdir}}/usr/share/xfsprogs/mkfs ${{targets.subpkgdir}}/usr/share/xfsprogs
+
+          # fsck.xfs is what systemd or many other things would expect to execute.
+          # fsck.xfs is a shell script wrapper around xfs_repair.
+          mv ${{targets.destdir}}/usr/bin/xfs_repair "${{targets.subpkgdir}}/usr/bin"
+          mv ${{targets.destdir}}/usr/bin/fsck.xfs "${{targets.subpkgdir}}/usr/bin"
     test:
+      environment:
+        contents:
+          packages:
+            - busybox
       pipeline:
-        - uses: test/docs
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
+        - name: "Check -V for programs"
+          runs: |
+            fail() { echo "FATAL:" "$@" 1>&2; exit 1; }
+            vercheck() {
+              local p="$1" out="" ver="${{package.version}}"
+              out=$($p -V) || fail "$p -V exited $?"
+              echo "$out" | grep -F "$ver" ||
+                fail "output of '$p -V' did not contain '$ver'"
+            }
+
+            vercheck mkfs.xfs
+            vercheck xfs_repair
+        - name: "Check fsck.xfs executes"
+          runs: |
+            fsck.xfs || fail "fsck.xfs exited $?"
+        - name: "Test xfs_repair functionality"
+          runs: |
+            dd if=/dev/zero of=xfs.img bs=1M count=300
+            mkfs.xfs xfs.img
+            xfs_repair -f xfs.img 2>&1 | grep '^done$'
 
   - name: xfs-scrub
     description: "xfs-scrub attempts to check and repair all metadata in a mounted XFS filesystem"
@@ -106,65 +151,74 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/xfs_scrub* "${{targets.subpkgdir}}"/usr/bin/
 
+  - name: xfsprogs-extra
+    description: "extra xfsprogs"
+    dependencies:
+      runtime:
+        - python3
+        - xfsprogs-core
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv ${{targets.destdir}}/usr/bin/* ${{targets.subpkgdir}}/usr/bin
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+            - file
+      pipeline:
+        - uses: test/tw/ldd-check
+        - name: "Check -V(version) output of binaries"
+          runs: |
+            fail() { echo "FATAL:" "$@" 1>&2; exit 1; }
+
+            vercheck() {
+              local p="$1" out="" ver="${{package.version}}"
+              out=$($p -V) || fail "$p -V exited $?"
+              echo "$out" | grep -F "$ver" ||
+                fail "output of '$p -V' did not contain '$ver'"
+            }
+
+            vercheck xfs_admin
+            vercheck xfs_bmap
+            vercheck xfs_estimate
+            vercheck xfs_fsr
+            vercheck xfs_mkfile
+            vercheck xfs_quota
+            vercheck xfs_property
+            vercheck xfs_spaceman
+        - name: "Check help output for programs"
+          runs: |
+            xfs_admin help
+            xfs_estimate help
+            xfs_fsr help
+            xfs_mkfile help
+            xfs_quota help
+        - name: "Test basic xfs_db functionality"
+          runs: |
+            dd if=/dev/zero of=xfs.img bs=1M count=300
+            mkfs.xfs xfs.img
+            xfs_db -c 'sb 0' -c 'p' xfs.img | grep 'magicnum'
+        - name: "Test xfs_info functionality"
+          runs: |
+            dd if=/dev/zero of=xfs.img bs=1M count=300
+            mkfs.xfs xfs.img
+            xfs_info xfs.img | grep -E 'naming\s*=\s*version\s*2'
+        - name: "Test xfs_metadump functionality"
+          runs: |
+            dd if=/dev/zero of=xfs.img bs=1M count=300
+            mkfs.xfs xfs.img
+            xfs_metadump xfs.img xfs_metadata.img
+            file xfs_metadata.img | grep 'XFS filesystem'
+        - name: "Test xfs_admin functionality"
+          runs: |
+            dd if=/dev/zero of=xfs.img bs=1M count=300
+            mkfs.xfs xfs.img
+            xfs_admin -L "TestXFS" xfs.img
+            xfs_admin -l xfs.img | grep 'TestXFS'
+
 update:
   enabled: true
   release-monitor:
     identifier: 5188
-
-test:
-  environment:
-    contents:
-      packages:
-        - util-linux
-        - file
-  pipeline:
-    - name: "Check xfs_repair version"
-      runs: |
-        xfs_repair -V
-        xfs_admin -V
-        xfs_admin help
-        xfs_bmap -V
-        xfs_estimate -V
-        xfs_estimate help
-        xfs_fsr -V
-        xfs_fsr help
-        xfs_mkfile -V
-        xfs_mkfile help
-        xfs_quota -V
-        xfs_quota help
-        xfs_property -V
-        xfs_protofile --help
-        xfs_protofile -V
-        xfs_spaceman -V
-        fsck.xfs
-    - name: "Check mkfs.xfs version"
-      runs: |
-        mkfs.xfs -V
-    - name: "Test basic xfs_db functionality"
-      runs: |
-        dd if=/dev/zero of=xfs.img bs=1M count=300
-        mkfs.xfs xfs.img
-        xfs_db -c 'sb 0' -c 'p' xfs.img | grep 'magicnum'
-    - name: "Test xfs_info functionality"
-      runs: |
-        dd if=/dev/zero of=xfs.img bs=1M count=300
-        mkfs.xfs xfs.img
-        xfs_info xfs.img | grep -E 'naming\s*=\s*version\s*2'
-    - name: "Test xfs_metadump functionality"
-      runs: |
-        dd if=/dev/zero of=xfs.img bs=1M count=300
-        mkfs.xfs xfs.img
-        xfs_metadump xfs.img xfs_metadata.img
-        file xfs_metadata.img | grep 'XFS filesystem'
-    - name: "Test xfs_admin functionality"
-      runs: |
-        dd if=/dev/zero of=xfs.img bs=1M count=300
-        mkfs.xfs xfs.img
-        xfs_admin -L "TestXFS" xfs.img
-        xfs_admin -l xfs.img | grep 'TestXFS'
-    - name: "Test xfs_repair functionality"
-      runs: |
-        dd if=/dev/zero of=xfs.img bs=1M count=300
-        mkfs.xfs xfs.img
-        xfs_repair -f xfs.img 2>&1 | grep '^done$'
-    - uses: test/tw/ldd-check


### PR DESCRIPTION
The vast majority of filesystem use is covered with 'fsck' and 'mkfs'.
The other tools provided by xfs are largely debug or recovery tools.

This splits out that core functionality into its own package in
order to reduce the dependency footprint of xfsprogs.

The -extra package is added for all other xfsprogs function.

Things to note here:
 * systemd-fsck (and probably other tools that run fsck)
   will invoke xfs.fsck.
 * xfs.fsck is a shell script wrapper around
   xfs_repair, thus incuring a /bin/sh dependency.

   Unfortunately, the /bin/sh dependency is not recorded here
   and will not be found by SCA in melange.
   See https://github.com/chainguard-dev/go-apk/issues/264 for more
   info.

 * Runtime use of xfs does not imply filesystem creation, so
   so mkfs.xfs could be further split out here into its own package.

   The current reverse dependencies of xfsprogs are
    aws-ebs-csi-driver
    azuredisk-csi
    docker-dind
    gcp-compute-persistent-disk-csi-driver-fips
    lvm-driver

   In the interest of caution, and the fact that mkfs does not incur
   any additional dependencies I have left mkfs.xfs as part of xfs-core
   so that those packages will have access to it.
