### PR TITLE
py3-jupyter-server-fileid | py3-jupyter-ydoc: new packages

### DIFF
--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -1,0 +1,80 @@
+package:
+  name: py3-jupyter-server-fileid
+  version: 0.9.3
+  epoch: 0
+  description: An extension that maintains file IDs for documents in a running Jupyter Server
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  import: jupyter_server_fileid
+  pypi-package: jupyter-server-fileid
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4538e7b447061a00371e12d45a88d23001fbc290
+      repository: https://github.com/jupyter-server/jupyter_server_fileid
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-jupyter-events
+        - py${{range.key}}-jupyter-server-bin
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-jupyter-core-bin
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+        - name: Test Jupyter extension is installed
+          runs: |
+            jupyter server extension list 2>&1 >> test.log
+            cat test.log | grep jupyter_server_fileid
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: jupyter-server/jupyter_server_fileid
+    strip-prefix: v
+    tag-filter: v

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -42,7 +42,7 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-jupyter-events
-        - py${{range.key}}-jupyter-server-bin
+        - py${{range.key}}-jupyter-server
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -67,7 +67,7 @@ subpackages:
           runs: |
             jupyter server extension list 2>&1 >> test.log
             cat test.log | grep jupyter_server_fileid
-  
+
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
     description: python${{range.key}} version of ${{vars.pypi-package}}

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -47,6 +47,10 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
     test:
       environment:
@@ -63,6 +67,22 @@ subpackages:
           runs: |
             jupyter server extension list 2>&1 >> test.log
             cat test.log | grep jupyter_server_fileid
+  
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - py${{range.key}}-click
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - name: Test binary is executable
+          runs: jupyter-fileid --version
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -53,6 +53,7 @@ subpackages:
         contents:
           packages:
             - py${{range.key}}-jupyter-core-bin
+            - py${{range.key}}-jupyter-server-bin
       pipeline:
         - uses: python/import
           with:

--- a/py3-jupyter-ydoc.yaml
+++ b/py3-jupyter-ydoc.yaml
@@ -1,0 +1,80 @@
+package:
+  name: py3-jupyter-ydoc
+  version: 3.0.3
+  epoch: 0
+  description: Jupyter document structures for collaborative editing using Yjs/pycrdt
+  annotations:
+    cgr.dev/ecosystem: python
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  import: jupyter_ydoc
+  pypi-package: jupyter-ydoc
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatch-nodejs-version
+      - py3-supported-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 08d4330e1e91fe6477715bb3a1d0e42938c19a1e
+      repository: https://github.com/jupyter-server/jupyter_ydoc
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-importlib-metadata
+        - py${{range.key}}-pycrdt
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-jupyter-core-bin
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+              from ${{vars.import}} import ydocs
+              from ${{vars.import}} import YBlob, YUnicode, YNotebook
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: jupyter-server/jupyter_ydoc
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding:
- `py3-jupyter-server-fileid`
- `py3-jupyter-ydoc`

Dependencies of `py3-jupyter-server-ydoc` -> `py3-jupyter-collaboration` -> `py3-jupyter-ai`

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)