### PR TITLE
sudo: Update to 1.9.16p2

### DIFF
--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
-  version: 1.9.16
-  epoch: 40
+  version: 1.9.16_p2
+  epoch: 0
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: ISC
@@ -22,11 +22,17 @@ environment:
       - busybox
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+(?:\.\d+(?:\.\d+)?)?)(_(p\d+))?$
+    replace: "${1}${3}"
+    to: mangled-package-version
+
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 558d10b9a1991fb3b9fa7fa7b07ec4405b7aefb5b3cb0b0871dbc81e3a88e558
-      uri: https://www.sudo.ws/dist/sudo-1.9.15p5.tar.gz
+      expected-sha256: 976aa56d3e3b2a75593307864288addb748c9c136e25d95a9cc699aafa77239c
+      uri: https://www.sudo.ws/dist/sudo-${{vars.mangled-package-version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
sudo is not using `${{package.version}}` in its `fetch` pipeline, which causes the automatic update to actually *not* update anything.