### PR TITLE
package update: Bump libmspack to 1.11 and switch to git-based updates

### DIFF
--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/community/libmspack/APKBUILD
 package:
   name: libmspack
-  version: 0.11_alpha
-  epoch: 3
+  version: 1.11
+  epoch: 0
   description: Library for Microsoft CAB compression formats
   copyright:
     - license: LGPL-2.1-only
@@ -15,18 +15,30 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 70dd1fb2f0aecc36791b71a1e1840e62173079eadaa081192d1c323a0eeea21b
-      uri: https://www.cabextract.org.uk/libmspack/libmspack-0.11alpha.tar.gz
+      repository: https://github.com/kyz/libmspack.git
+      tag: v${{package.version}}
+      expected-commit: 305907723a4e7ab2018e58040059ffb5e77db837
 
-  - uses: autoconf/configure
+  - working-directory: libmspack
+    runs: |
+      ./autogen.sh
 
-  - uses: autoconf/make
+  - working-directory: libmspack
+    uses: autoconf/configure
+    with:
+      opts: |
+        --disable-static
 
-  - uses: autoconf/make-install
+  - working-directory: libmspack
+    uses: autoconf/make
+
+  - working-directory: libmspack
+    uses: autoconf/make-install
 
   - uses: strip
 
@@ -45,9 +57,9 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # latest version doesn't seem to match what's reported at https://www.cabextract.org.uk/libmspack
-  release-monitor:
-    identifier: 16827
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v
 
 test:
   pipeline:


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/internal-dev/issues/11237

- Updated `libmspack` version from `0.11_alpha` to `1.11`.
- Switched from `release-monitor` to `git` backend for version tracking.
- The release monitor was already referencing the GitHub repo: https://github.com/kyz/libmspack.git
- This repo hosts both `libmspack` and `cabextract` and follows a unified versioning scheme.
- Replaced `fetch` with `git-checkout` to track upstream tags directly.

Even though their [official website](https://www.cabextract.org.uk/libmspack/) says:
> "The latest release of libmspack is [libmspack 0.11alpha](https://www.cabextract.org.uk/libmspack/libmspack-0.11alpha.tar.gz), released on 5 February 2023. In-development code can be obtained from the [libmspack Git repository](https://github.com/kyz/libmspack/tree/master/libmspack)."

Since both `libmspack` and `cabextract` are closely tied and live in the same repository, this update improves maintainability and allows for automated updates going forward.

Arch Linux uses the same version format ref: https://gitlab.archlinux.org/archlinux/packaging/packages/libmspack/-/blob/main/PKGBUILD