### PR TITLE
fix(test): add tests to ferretdb

### DIFF
--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ferretdb
   version: "2.1.0"
-  epoch: 0
+  epoch: 1
   description: "A truly Open Source MongoDB alternative"
   copyright:
     - license: Apache-2.0

--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -27,6 +27,38 @@ pipeline:
       output: ferretdb
       tags: ferretdb_tigris
 
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-17
+        - postgresql-17-client
+        - shadow
+        - sudo-rs
+        - wait-for-it
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "test if ferretdb binary is runnable"
+      runs: |
+        ferretdb --version
+    - name: "start ferretdb with postgresql backend"
+      runs: |
+        # start a postgres instance and create a database
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb ferretdb
+        psql -lqt | cut -d \| -f 1 | grep -qw ferretdb
+
+        # connect ferret db to postgres instance and listen on 127.0.0.1:27002
+        ferretdb --postgresql-url="postgres://localhost:5432/ferretdb" --listen-addr="localhost:27002" >/dev/null 2>&1 &
+        wait-for-it localhost:27002 --timeout=60
+
+        # verify that ferretdb is listening on 127.0.0.1:27002
+        netstat -tuplen | grep -qE "tcp.*127.0.0.1:27002.*LISTEN.*ferretdb"
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

This PR adds tests to ferret db package.

New tests:
- Check if binary runs
- Connect fenneldb to a postgres backend.  
     - FerretDB can work as a proxy that converts MongoDB queries to SQL and use PostgreSQL as a database engine. Since MongoDB has a restricted license. FennelDB package cannot be tested with `mongosh` client, which is used for read and writes. 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
