### PR TITLE
fix(calico-3.29.yaml): To force an image rebuild - bumping epoch

### DIFF
--- a/calico-3.29.yaml
+++ b/calico-3.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.29
   version: "3.29.3"
-  epoch: 41
+  epoch: 42
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
There were tagging issues with calico-key-cert-provisioner image using the subpackage of calico-3.29 so bumping the epoch will force rebuild with a new tag.

The tagging issues have been resolved in images definitions.

Signed-off-by: philroche <phil.roche@chainguard.dev>
