### PR TITLE
openjdk-24: reduce jdk-dev image by 34% by enabling linkable runtime modules

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.1"
-  epoch: 1
+  epoch: 2
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -10,7 +10,6 @@ package:
       - alsa-lib
       - freetype
       - giflib
-      - java-cacerts
       - lcms2
       - libfontconfig1
       - libjpeg-turbo
@@ -21,6 +20,8 @@ package:
       - libxtst
       - ttf-dejavu
       - zlib
+    provides:
+      - ${{package.name}}-jmods
 
 environment:
   contents:
@@ -37,6 +38,7 @@ environment:
       - fontconfig-dev
       - freetype-dev
       - giflib-dev
+      - java-cacerts
       - lcms2-dev
       - libffi-dev
       - libjpeg-turbo-dev
@@ -69,15 +71,9 @@ pipeline:
 
   - runs: chmod +x configure
 
-  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
-  # --with-extra-ldflags, the configure still produces warnings like:
-  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
-        --with-extra-cflags="$CFLAGS" \
-        --with-extra-cxxflags="$CXXFLAGS" \
-        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-23-openjdk \
         --prefix=/usr/lib/jvm/java-24-openjdk \
         --with-vendor-name=wolfi \
@@ -89,7 +85,9 @@ pipeline:
         --enable-dtrace=no \
         --with-zlib=system \
         --with-debug-level=release \
-        --with-native-debug-symbols=internal \
+        --with-native-debug-symbols=none \
+        --with-external-symbols-in-bundles=none \
+        --with-cacerts-file=/etc/ssl/certs/java/cacerts \
         --with-jvm-variants=server \
         --with-jtreg=no  \
         --with-libpng=system \
@@ -97,6 +95,7 @@ pipeline:
         --with-libjpeg=system \
         --with-giflib=system \
         --with-lcms=system \
+        --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
         --with-version-string=""
@@ -121,24 +120,10 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
-      # symlink to shared java cacerts store
-      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
-      ln -sf /etc/ssl/certs/java/cacerts \
-        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
       # symlink for `java-common` to work (which expects jre in $_java_home/jre)
       ln -sf . "${{targets.contextdir}}/$_java_home/jre"
 
-  - uses: strip
-
 subpackages:
-  - name: "${{package.name}}-dbg"
-    description: "OpenJDK 24 Java Debug Symbols"
-    pipeline:
-      - uses: split/debug
-    dependencies:
-      runtime:
-        - ${{package.name}}
-
   - name: "${{package.name}}-jre"
     description: "OpenJDK 24 Java Runtime Environment"
     dependencies:
@@ -146,7 +131,6 @@ subpackages:
         - alsa-lib
         - freetype
         - giflib
-        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -169,18 +153,6 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
-      - uses: strip
-
-  - name: "${{package.name}}-jmods"
-    description: "OpenJDK 24 jmods"
-    dependencies:
-      provides:
-        - openjdk-jmods=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-24-openjdk/jmods \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
 
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.
@@ -241,7 +213,6 @@ test:
     contents:
       packages:
         - openjdk-24-default-jdk
-        - openjdk-24-jmods
     environment:
       JAVA_HOME: /usr/lib/jvm/java-24-openjdk
   pipeline:
@@ -272,7 +243,7 @@ test:
         java -jar app.jar
 
         # Test jlink
-        jlink --verbose --module-path "app.jar:$JAVA_HOME/jmods" \
+        jlink --verbose --module-path "app.jar" \
           --add-modules test.modules \
           --output test-project-jre
 


### PR DESCRIPTION
Build OpenJDK 24 with [JEP 493](https://openjdk.org/jeps/493): Linking Run-Time Images without JMODs.

This new jdk feature enables use of jlink feature, without need to have a separate copy of jmods. This reduces jdk:24-dev tag size significantly, without compromising on features.

This does change packaging in following ways:

- one cannot modify the builds, as otherwise jlink detects changes to
  JAVA_HOME and refuses to perform jlink
- this means no debug build, no stripping, no splitting dbg build
- all debug symbols are turned off, but relocations are still present,
  thus there is binary size increase of ~0.01% for jre, and ~1% for jdk without jmods.
- But the jdk-dev image which usually ships with jmods becomes 34% smaller at 164M instead of 473M 
- java-cacerts is no longer a symlink, but a vendored copy of our build of it.
- it means when java-cacerts are upgraded, openjdk-24+ must be
  rebuilt, to revendor change. This might be actually a good thing, as
  certificate changes have caused connectivity issues in the past, and
  with this change java epoch will change, which may be easier to spot
  and debug (separate version tag too).

Also cleaned build which was setting empty variables, since the move to implicit spec files.