### PR TITLE
fix(nvidia-container-toolkit.yaml): To force an image rebuild - bumping epoch

### DIFF
--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-container-toolkit
   version: "1.17.5"
-  epoch: 2
+  epoch: 3
   description: Build and run containers leveraging NVIDIA GPUs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
There were extra packages changes made to the nvidia-container-toolkit image so bumping the epoch will force rebuild with a new tag.

Signed-off-by: philroche <phil.roche@chainguard.dev>
