### PR TITLE
temporal-ui-server: remediate CVE-2025-30204

### DIFF
--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-ui-server
   version: "2.37.1"
-  epoch: 0
+  epoch: 1
   description: Golang Server for https://github.com/temporalio/ui
   copyright:
     - license: MIT
@@ -25,6 +25,7 @@ pipeline:
     with:
       deps: |-
         golang.org/x/oauth2@v0.27.0
+        github.com/golang-jwt/jwt/v4@v4.5.2
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump jwt package to 4.5.2 in order to remediate CVE-2025-30204