### PR TITLE
azurefile-csi-1.32: new package

### DIFF
--- a/azurefile-csi-1.32.yaml
+++ b/azurefile-csi-1.32.yaml
@@ -1,0 +1,58 @@
+package:
+  name: azurefile-csi-1.32
+  version: 1.32.1
+  epoch: 0
+  description: Azure File CSI Driver
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - azurefile-csi=${{package.full-version}}
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c15fb97b5efdca5e573d732ec7f558566cd105bb
+      repository: https://github.com/kubernetes-sigs/azurefile-csi-driver
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.driverVersion=v${{package.version}}
+        -X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.buildDate=$(TZ="UTC" date +"%Y-%m-%dT%H:%M:%SZ")
+      output: azurefileplugin
+      packages: ./pkg/azurefileplugin
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/azurefileplugin ${{targets.subpkgdir}}/azurefileplugin
+    dependencies:
+      provides:
+        - azurefile-csi-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/azurefile-csi-driver
+    strip-prefix: v
+    tag-filter: v1.32.
+
+test:
+  pipeline:
+    - runs: azurefileplugin --version | grep ${{package.version}}
+    # Run the azurefileplugin binary and verify its startup
+    - name: Run and test `azurefileplugin`
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/azurefileplugin
+        timeout: 30
+        expected_output: |
+          Driver Version: v${{package.version}}
+          Enabling controller service capability: CREATE_DELETE_VOLUME
+          Enabling volume access mode: SINGLE_NODE_WRITER


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding the latest `azurefile-csi` package, other versions to be built.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)