### PR TITLE
docker-compose/GHSA-mh63-6h87-95cp fix

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-compose
   version: "2.35.0"
-  epoch: 0
+  epoch: 1
   description: Define and run multi-container applications with Docker
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,9 @@ pipeline:
         golang.org/x/crypto@v0.35.0
         golang.org/x/oauth2@v0.27.0
         golang.org/x/net@v0.36.0
+        github.com/DefangLabs/secret-detector@v0.0.0-20250403165618-22662109213e
+        github.com/golang-jwt/jwt/v5@v5.2.2
+        gopkg.in/ini.v1@v1.67.0
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
GHSA-mh63-6h87-95cp: remediate GHSA-mh63-6h87-95cp by following the dependency bumps [found in this commit](https://github.com/docker/compose/pull/12707/files), unable to cherry pick so a go/bump was used.