### PR TITLE
ld linux lib64

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -44,11 +44,10 @@ environment:
       - texinfo
       - wolfi-baselayout
       - zlib
-  # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
-    CPPFLAGS: ""
     # https://github.com/chainguard-dev/internal-dev/issues/7756
-    GCC_SPEC_FILE: /dev/null
+    # Use at least package elf notes
+    GCC_SPEC_FILE: /home/build/.melange.gcc.spec
 
 pipeline:
   - uses: git-checkout

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: "2.41"
-  epoch: 1
+  epoch: 2
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -374,11 +374,12 @@ subpackages:
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib
               mv "${{targets.destdir}}"/lib/ld-linux-aarch64.so.1 "${{targets.subpkgdir}}"/lib/
-          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`.
+          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`
+          # Note that /lib64 is always a symlink in wolfi-baselayout
           - if: ${{build.arch}} == 'x86_64'
             runs: |
-              mkdir -p "${{targets.subpkgdir}}"/lib64
-              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
+              mkdir -p "${{targets.subpkgdir}}"/lib
+              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib/
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/


### PR DESCRIPTION
- **glibc: install ld-linux to real /lib, instead of symlink location /lib64**
  

- **glibc: drop CXXFLAGS and use package elf notes**
  Full openssf hardening is not possible, but at least add package ELF notes.
  
  Also CXXFLAGS are unset since completed implementation of openssf
  specf file, thus remove obsolete comment and empty override of an
  unset variable.
  