### PR TITLE
airflow: pin apache-airflow-providers-celery to 3.10.0

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: "2.10.5"
-  epoch: 40
+  epoch: 41
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -95,7 +95,10 @@ pipeline:
       #GHSA-8w49-h785-mj3c/GHSA-8495-4g3g-x7pr/GHSA-27mf-ghqm-j3j8 fixes
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
-        aiohttp>=3.10.11 tornado>=6.4.2 statsd packaging pyparsing
+        aiohttp>=3.10.11 tornado>=6.4.2 apache-airflow-providers-celery==3.10.0 statsd packaging pyparsing
+      # NOTE: apache-airflow-providers-celery is pinned to 3.10.0 because 3.10.3 introduced a regresssion.
+      # https://github.com/apache/airflow/issues/47781 details more about it.
+      # before removing the pinning, please check if the images are coming good with helm charts.
 
   - runs: find . -name '__pycache__' -exec rm -rf {} +
 


### PR DESCRIPTION
3.10.3 introduced a regression via https://github.com/apache/airflow/issues/47781 so we need to pin apache-airflow-providers-celery to 3.10.0 as of now. 