### PR TITLE
glibc: install ld-linux to real /lib, instead of symlink location /lib64

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -54,7 +54,9 @@ pipeline:
   - uses: git-checkout
     with:
       expected-commit: 74f59e9271cbb4071671e5a474e7d4f1622b186f
-      repository: https://sourceware.org/git/glibc.git
+      # sourceware.org often has clone issues, switch to mirror
+      # recommended at https://sourceware.org/glibc/wiki/GlibcGit
+      repository: https://repo.or.cz/glibc.git
       tag: glibc-${{package.version}}
 
   - uses: patch

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: "2.41"
-  epoch: 1
+  epoch: 2
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -374,11 +374,12 @@ subpackages:
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib
               mv "${{targets.destdir}}"/lib/ld-linux-aarch64.so.1 "${{targets.subpkgdir}}"/lib/
-          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`.
+          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`
+          # Note that /lib64 is always a symlink in wolfi-baselayout
           - if: ${{build.arch}} == 'x86_64'
             runs: |
-              mkdir -p "${{targets.subpkgdir}}"/lib64
-              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
+              mkdir -p "${{targets.subpkgdir}}"/lib
+              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib/
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/
@@ -396,6 +397,10 @@ subpackages:
             - gcc
             - glibc-dev
       pipeline:
+        - name: Check lib64 and apk audit locations of ld-linux
+          runs: |
+            [ -e /lib64/ld-linux-* ]
+            [ -z "$(apk audit --full | grep ld-linux)" ]
         - name: Test usage of /etc/ld.so.conf.d/ snippets
           runs: |
             tmpdir="$(mktemp -d)"


### PR DESCRIPTION
Note that currently apk audit fails on ld-linux, because it installs
ld-linux into /lib64 on x86_64, which is a symlinked location as per
wolfi-baselayout.

Make the .apk ship it in "/lib" on x86_64, which remains LSB
compliant, but helps with unpacking, as now ld-linux can be unpacked
either before or after wolfi-baselayout.
