### PR TITLE
feat: Add tag filter to influxd to constrain to 2.x.x

### DIFF
--- a/influxd.yaml
+++ b/influxd.yaml
@@ -154,6 +154,7 @@ update:
   github:
     identifier: influxdata/influxdb
     strip-prefix: v
+    tag-filter: v2.
 
 test:
   pipeline:


### PR DESCRIPTION
InfluxDB 3 [went GA](https://www.influxdata.com/blog/influxdb-3-oss-ga/) yesterday.

As a result, automation tried to bump versions (https://github.com/wolfi-dev/os/pull/50652), however InfluxDB 3 is written in Rust, not Go and so needs different build steps.

This PR adds a tag filter to `update` so that we don't try and automatically update to version 3.

Version streaming will then be worked on to add build support for 3.


