### PR TITLE
Revert "glibc: install ld-linux to real /lib, instead of symlink location /lib64"

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: "2.41"
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -376,12 +376,11 @@ subpackages:
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib
               mv "${{targets.destdir}}"/lib/ld-linux-aarch64.so.1 "${{targets.subpkgdir}}"/lib/
-          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`
-          # Note that /lib64 is always a symlink in wolfi-baselayout
+          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`.
           - if: ${{build.arch}} == 'x86_64'
             runs: |
-              mkdir -p "${{targets.subpkgdir}}"/lib
-              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib/
+              mkdir -p "${{targets.subpkgdir}}"/lib64
+              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/
@@ -399,10 +398,6 @@ subpackages:
             - gcc
             - glibc-dev
       pipeline:
-        - name: Check lib64 and apk audit locations of ld-linux
-          runs: |
-            [ -e /lib64/ld-linux-* ]
-            [ -z "$(apk audit --full | grep ld-linux)" ]
         - name: Test usage of /etc/ld.so.conf.d/ snippets
           runs: |
             tmpdir="$(mktemp -d)"


### PR DESCRIPTION
This reverts commit 8d11fc241aa785ca4250ed696077dbdba815357f.

We believe this is causing apko resolution problems:

```
$ git log --oneline HEAD^.. --no-decorate 
0110eeec8 rtmpdump/2.6_git20250417 package update (#50727)

$ melange version | grep ^[A-Z]
GitVersion:    v0.23.7
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.24.2
Compiler:      gc
Platform:      linux/amd64

$ make debug/dash
@SOURCE_DATE_EPOCH=1741138794 /home/smoser/go/bin/melange build dash.yaml \
   ... ./dash
Building package dash with version dash-0.5.12-r30 from file dash.yaml
2025/04/17 10:28:33 INFO melange v0.23.7 is building:
2025/04/17 10:28:33 INFO populating workspace /tmp/melange-workspace-2612591557 from ./dash/
2025/04/17 10:28:33 INFO building workspace in '/tmp/melange-guest-3581609353' with apko
2025/04/17 10:28:34 ERRO failed to build package: unable to build guest: unable to lock image configuration: resolving apk packages: for arch "amd64": solving "apk-tools" constraint: resolving "apk-tools-2.14.10-r2.apk" deps:
solving "so:libz.so.1" constraint: resolving "zlib-1.3.1-r6.apk" deps:
solving "so:libc.so.6" constraint: resolving "glibc-2.41-r1.apk" deps:
solving "libgcc" constraint: resolving "libgcc-14.2.0-r12.apk" deps:
solving "so:ld-linux-x86-64.so.2" constraint: resolving "ld-linux-2.41-r2.apk" deps:
we already selected "glibc=2.41-r1" which conflicts with "glibc=2.41-r2"
make: *** [Makefile:115: debug/dash] Error 1
```

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
