### PR TITLE
fix: added runtime dependencies to package k6

### DIFF
--- a/k6.yaml
+++ b/k6.yaml
@@ -9,8 +9,8 @@ package:
     runtime:
       - bash-binsh
       - coreutils
-      - grep
       - curl
+      - grep
 
 environment:
   contents:

--- a/k6.yaml
+++ b/k6.yaml
@@ -27,7 +27,7 @@ pipeline:
       repository: https://github.com/grafana/k6
       tag: v${{package.version}}
       expected-commit: 02fdc80b36f3e74ac127a3ef63db2b10e1f89f90
-  
+
   - uses: go/bump
     with:
       deps: |-

--- a/k6.yaml
+++ b/k6.yaml
@@ -1,10 +1,16 @@
 package:
   name: k6
   version: "0.58.0"
-  epoch: 1
+  epoch: 2
   description: A modern load testing tool, using Go and JavaScript
   copyright:
     - license: AGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - bash-binsh
+      - coreutils
+      - grep
+      - curl
 
 environment:
   contents:

--- a/k6.yaml
+++ b/k6.yaml
@@ -27,6 +27,11 @@ pipeline:
       repository: https://github.com/grafana/k6
       tag: v${{package.version}}
       expected-commit: 02fdc80b36f3e74ac127a3ef63db2b10e1f89f90
+  
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.38.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: added runtime dependencies to package k6 since they are needed at image level (when configuring k6 scripts to run using the k6 Operator)

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
