### PR TITLE
quality: extend multus-cni package tests

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
   version: "4.2.0"
-  epoch: 2
+  epoch: 3
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -98,3 +98,54 @@ test:
         /usr/src/multus-cni/bin/multus-shim -version
         /usr/src/multus-cni/bin/multus-daemon -help
         /thin_entrypoint --multus-log-level info
+    - name: "Run multus with dummy config"
+      runs: |
+        echo '{"cniVersion": "0.3.1", "name": "test", "type": "multus"}' > /tmp/netconf.json
+        output=$(multus < /tmp/netconf.json 2>&1)
+        echo "$output"
+
+        if echo "$output" | grep -qi "CNI protocol versions supported"; then
+          echo "Multus responded correctly to dummy config."
+        else
+          echo "Multus output did not match expected output."
+          exit 1
+        fi
+    - name: "Run thin_entrypoint and validate logs"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          mkdir -p /host/etc/cni/net.d
+          mkdir -p /host/opt/cni/bin
+
+          cat <<EOF > /host/etc/cni/net.d/10-flannel.conflist
+          {
+            "cniVersion": "0.3.1",
+            "name": "cbr0",
+            "plugins": [
+              {
+                "type": "flannel",
+                  "delegate": {
+                  "hairpinMode": true,
+                  "isDefaultGateway": true
+                }
+              },
+              {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+              }
+            ]
+          }
+          EOF
+          mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
+          echo "FAKE_CA_CERT" > /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          echo "fake-token" > /var/run/secrets/kubernetes.io/serviceaccount/token
+          echo "default" > /var/run/secrets/kubernetes.io/serviceaccount/namespace
+        start: |
+          thin_entrypoint --multus-log-level=debug 2>&1
+        timeout: 10
+        expected_output: |
+          kubeconfig file is created
+          multus config file is created
+        post: |
+          echo "thin_entrypoint ran successfully with mocked environment"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
