### PR TITLE
haproxy-3.1: convert to git-checkout and git update backend

### DIFF
--- a/haproxy-3.1.yaml
+++ b/haproxy-3.1.yaml
@@ -37,6 +37,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c3f40894532072afb380f1779bce1ef85974df2f
       repository: https://git.haproxy.org/git/haproxy-3.1.git
+
   - uses: autoconf/make
     with:
       opts: |
@@ -52,13 +53,16 @@ pipeline:
         LUA_INC=/usr/include/lua5.3 \
         USE_GETADDRINFO=1 \
         SBINDIR=/usr/bin
+
   - runs: |
       make install DESTDIR="${{targets.destdir}}" PREFIX=/usr DOCDIR=/usr/share/doc/haproxy
       install -d "${{targets.destdir}}"/var/lib/haproxy
       mkdir -p "${{targets.destdir}}"/usr/bin
       mv "${{targets.destdir}}"/usr/sbin/* "${{targets.destdir}}"/usr/bin
       rmdir "${{targets.destdir}}"/usr/sbin
+
   - uses: strip
+
   # This MUST run after strip, which strips capabilities too!
   - runs: setcap cap_net_bind_service=+eip "${{targets.destdir}}/usr/bin/haproxy"
 

--- a/haproxy-3.1.yaml
+++ b/haproxy-3.1.yaml
@@ -31,13 +31,12 @@ environment:
       - openssl-dev
       - pcre2-dev
 
-# We have to use fetch, as there are issues cloning from: 'https://git.haproxy.org/git/haproxy-3.0.git'.
-# Namely: 'failed to validate pipeline git-checkout: failed to list refs for https://git.haproxy.org/git/haproxy-3.0.git/: pkt-line 1: invalid hash text: encoding/hex: invalid byte'
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.haproxy.org/download/${{vars.major-minor-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: a3952644ef939b36260d91d81a335636aa9b44572b4cb8b6001272f88545c666
+      tag: v${{package.version}}
+      expected-commit: c3f40894532072afb380f1779bce1ef85974df2f
+      repository: https://git.haproxy.org/git/haproxy-3.1.git
   - uses: autoconf/make
     with:
       opts: |
@@ -96,8 +95,9 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1298
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v3.1
 
 test:
   environment:


### PR DESCRIPTION
This avoids using release-monitoring.org which, as it doesn't distinguish between version streams of HAProxy, could result in us publishing, e.g., 3.2.x versions to the haproxy-3.1 package.

I've compared the release tarball and the tagged tree, and this is the only difference between the two:

```diff
diff --color -r -u haproxy-3.1/SUBVERS haproxy-3.1.7/SUBVERS
--- haproxy-3.1/SUBVERS	2025-04-21 09:51:58.634952910 -0400
+++ haproxy-3.1.7/SUBVERS	2025-04-17 12:14:57.000000000 -0400
@@ -1,2 +1,2 @@
--$Format:%h$
+-c3f4089

diff --color -r -u haproxy-3.1/VERDATE haproxy-3.1.7/VERDATE
--- haproxy-3.1/VERDATE	2025-04-21 09:51:58.634952910 -0400
+++ haproxy-3.1.7/VERDATE	2025-04-17 12:14:57.000000000 -0400
@@ -1,2 +1,2 @@
-$Format:%ci$
+2025-04-17 18:14:57 +0200
 2025/04/17
```