### PR TITLE
Refactor victoriametrics-compat

### DIFF
--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics
   version: "1.115.0"
-  epoch: 0
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0

--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -57,7 +57,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/
-          ln -sf /usr/bin/victoria-metrics ${{targets.contextdir}}/victoria-metrics
+          ln -sf /usr/bin/victoria-metrics ${{targets.contextdir}}/victoria-metrics-prod
 
 update:
   enabled: true


### PR DESCRIPTION
Upstream Dockerfile- https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/victoria-metrics/multiarch/Dockerfile
entrypoint is victoria-metrics-prod not victoria-metrics. I have verified that in the image as well. 

This package is not used by any other pkg/image. So this change should be safe
