### PR TITLE
feat: new packages for blobfuse2 & blob-csi

### DIFF
--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -51,11 +51,12 @@ pipeline:
       packages: ./pkg/blobfuse-proxy
 
   - runs: |
-      mkdir -p ${{targets.contextdir}}/blobfuse-proxy
-      cp ./pkg/blobfuse-proxy/init.sh ${{targets.contextdir}}/blobfuse-proxy/
-      cp ./pkg/blobfuse-proxy/install-proxy.sh ${{targets.contextdir}}/blobfuse-proxy/
-      cp ./pkg/blobfuse-proxy/install-proxy-rhcos.sh ${{targets.contextdir}}/blobfuse-proxy/
-      cp ./pkg/blobfuse-proxy/blobfuse-proxy.service ${{targets.contextdir}}/blobfuse-proxy/
+      mkdir -p ${{targets.contextdir}}/usr/lib/blobfuse-proxy
+      mkdir -p ${{targets.contextdir}}/lib/systemd/system
+      cp ./pkg/blobfuse-proxy/init.sh ${{targets.contextdir}}/usr/lib/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/install-proxy.sh ${{targets.contextdir}}/usr/lib/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/install-proxy-rhcos.sh ${{targets.contextdir}}//usr/lib/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/blobfuse-proxy.service ${{targets.contextdir}}/lib/systemd/system/
 
 subpackages:
   - name: "${{package.name}}-compat"
@@ -63,8 +64,13 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
+          mkdir -p ${{targets.subpkgdir}}/blobfuse-proxy
           ln -sf /usr/bin/blobplugin ${{targets.subpkgdir}}/blobplugin
-          ln -sf /usr/bin/blobfuse-proxy ${{targets.destdir}}/blobfuse-proxy/blobfuse-proxy
+          ln -sf /usr/bin/blobfuse-proxy ${{targets.subpkgdir}}/blobfuse-proxy/blobfuse-proxy
+          ln -sf /usr/lib/blobfuse-proxy/init.sh ${{targets.subpkgdir}}/blobfuse-proxy/init.sh
+          ln -sf /usr/lib/blobfuse-proxy/install-proxy.sh ${{targets.subpkgdir}}/blobfuse-proxy/install-proxy.sh
+          ln -sf /usr/lib/blobfuse-proxy/install-proxy-rhcos.sh ${{targets.subpkgdir}}/blobfuse-proxy/install-proxy-rhcos.sh
+          ln -sf /lib/systemd/system/blobfuse-proxy.service ${{targets.subpkgdir}}/blobfuse-proxy/blobfuse-proxy.service
     dependencies:
       provides:
         - blob-csi-compat=${{package.full-version}}

--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -62,9 +62,9 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"
+          mkdir -p ${{targets.subpkgdir}}
           ln -sf /usr/bin/blobplugin ${{targets.subpkgdir}}/blobplugin
-          ln -sf /usr/bin/blobfuse-proxy ${{targets.contextdir}}/blobfuse-proxy/blobfuse-proxy
+          ln -sf /usr/bin/blobfuse-proxy ${{targets.destdir}}/blobfuse-proxy/blobfuse-proxy
     dependencies:
       provides:
         - blob-csi-compat=${{package.full-version}}

--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -56,7 +56,6 @@ pipeline:
       cp ./pkg/blobfuse-proxy/install-proxy.sh ${{targets.contextdir}}/blobfuse-proxy/
       cp ./pkg/blobfuse-proxy/install-proxy-rhcos.sh ${{targets.contextdir}}/blobfuse-proxy/
       cp ./pkg/blobfuse-proxy/blobfuse-proxy.service ${{targets.contextdir}}/blobfuse-proxy/
-      ln -sf /usr/bin/blobfuse-proxy ${{targets.contextdir}}/blobfuse-proxy/blobfuse-proxy
 
 subpackages:
   - name: "${{package.name}}-compat"
@@ -65,6 +64,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/blobplugin ${{targets.subpkgdir}}/blobplugin
+          ln -sf /usr/bin/blobfuse-proxy ${{targets.contextdir}}/blobfuse-proxy/blobfuse-proxy
     dependencies:
       provides:
         - blob-csi-compat=${{package.full-version}}

--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -12,9 +12,18 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - blobfuse2
       - blobfuse2-health-monitor
+      - ca-certificates
+      - conntrack-tools
+      - curl
       - fuse3
+      - iproute2
+      - iptables
+      - kmod
+      - procps
+      - util-linux
 
 pipeline:
   - uses: git-checkout

--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -1,0 +1,101 @@
+package:
+  name: blob-csi-1.26
+  version: 1.26.2
+  epoch: 0
+  description: Azure Blob Storage CSI driver
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - blob-csi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - blobfuse2
+      - blobfuse2-health-monitor
+      - fuse3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4f9a396d340c0e625883eedc1d1d85ae4b7d86f7
+      repository: https://github.com/kubernetes-sigs/blob-csi-driver
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.driverVersion=v${{package.version}}
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.buildDate=$(TZ="UTC" date +"%Y-%m-%dT%H:%M:%SZ")
+      output: blobplugin
+      packages: ./pkg/blobplugin
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.driverVersion=v${{package.version}}
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/blob-csi-driver/pkg/blob.buildDate=$(TZ="UTC" date +"%Y-%m-%dT%H:%M:%SZ")
+      output: blobfuse-proxy
+      packages: ./pkg/blobfuse-proxy
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/blobfuse-proxy
+      cp ./pkg/blobfuse-proxy/init.sh ${{targets.contextdir}}/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/install-proxy.sh ${{targets.contextdir}}/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/install-proxy-rhcos.sh ${{targets.contextdir}}/blobfuse-proxy/
+      cp ./pkg/blobfuse-proxy/blobfuse-proxy.service ${{targets.contextdir}}/blobfuse-proxy/
+      ln -sf /usr/bin/blobfuse-proxy ${{targets.contextdir}}/blobfuse-proxy/blobfuse-proxy
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/blobplugin ${{targets.subpkgdir}}/blobplugin
+    dependencies:
+      provides:
+        - blob-csi-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/blob-csi-driver
+    strip-prefix: v
+    tag-filter: v1.26.
+
+test:
+  pipeline:
+    - uses: test/kwok/cluster
+    - runs: blobplugin --version | grep ${{package.version}}
+    - runs: |
+        mkdir -p /etc/kubernetes
+        cat <<EOF > /etc/kubernetes/azure.json
+        {
+          "cloud":"AzurePublicCloud",
+          "tenantId": "xxxx-xxxx-xxxx-xxxx-xxxx",
+          "subscriptionId": "xxxx-xxxx-xxxx-xxxx-xxxx",
+          "resourceGroup": "resource-group-name",
+          "location": "eastus2",
+          "aadClientId": "xxxx-xxxx-xxxx-xxxx-xxxx",
+          "aadClientSecret": "xxxx-xxxx-xxxx-xxxx-xxxx",
+          "useManagedIdentityExtension": false,
+          "userAssignedIdentityID": "",
+          "useInstanceMetadata": true
+        }
+        EOF
+    # Run the binary and verify its startup
+    - name: Run and test `blobplugin`
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/blobplugin -kubeconfig=/root/.kube/config -v=5
+        timeout: 30
+        expected_output: |
+          Driver Version: v${{package.version}}
+          Driver Name: blob.csi.azure.com
+          Enabling controller service capability: CREATE_DELETE_VOLUME
+          Enabling controller service capability: CLONE_VOLUME
+          Enabling volume access mode: MULTI_NODE_MULTI_WRITER

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -9,6 +9,7 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - fuse3-dev
 
 pipeline:
@@ -40,13 +41,13 @@ subpackages:
         # requires blobfuse2 process running in background.
         - uses: test/daemon-check-output
           with:
-            start: /usr/bin/bfusemon -no-cpu-profiler -no-memory-profiler -no-network-profiler -pid 12345 &
+            start: /usr/bin/bfusemon -no-cpu-profiler -no-memory-profiler -no-network-profiler -pid 12345
             timeout: 30
             expected_output: |
-              Transfer Pipe: 12345 
-              Polling Pipe: /tmp/transferPipe_12345 
-              Blobfuse2 Stats poll interval: /tmp/pollPipe_12345 
-              Health Stats poll interval: 10 
+              Polling Pipe: /tmp/transferPipe_12345
+              Blobfuse2 Stats poll interval: /tmp/pollPipe_12345
+              Health Stats poll interval: 10
+
 update:
   enabled: true
   github:
@@ -64,41 +65,39 @@ test:
         # Check basic help and version
         blobfuse2 --help | grep "Blobfuse2 is an open source project"
         blobfuse2 --version | grep ${{package.version}}
-    # Requires Azure credentials
-    # Fails with "Error: failed to initialize new pipeline [config error in azstorage [account name not provided]]"
-    # - runs: |
-    #     #!/bin/bash
-    #     set -e
+    - runs: |
+        mkdir -p /tmp/bfuse_test_mnt
+        cat > "/tmp/config.yaml" <<EOF
+          allow-other: true
 
-    #     cat > "/tmp/config.yaml" <<EOF
-    #       allow-other: true
+          logging:
+            type: syslog
 
-    #       logging:
-    #         type: syslog
+          components:
+            - libfuse
+            - file_cache
+            - attr_cache
+            - azstorage
 
-    #       components:
-    #         - libfuse
-    #         - file_cache
-    #         - attr_cache
-    #         - azstorage
+          libfuse:
+            attribute-expiration-sec: 120
+            entry-expiration-sec: 120
+            negative-entry-expiration-sec: 240
 
-    #       libfuse:
-    #         attribute-expiration-sec: 120
-    #         entry-expiration-sec: 120
-    #         negative-entry-expiration-sec: 240
+          file_cache:
+            path: /tmp/blobfuse_temp
+            timeout-sec: 0
+            allow-non-empty-temp: true
+            cleanup-on-start: true
 
-    #       file_cache:
-    #         path: /tmp/blobfuse_temp
-    #         timeout-sec: 0 
-    #         allow-non-empty-temp: true
-    #         cleanup-on-start: true
-
-    #       attr_cache:
-    #         timeout-sec: 7200
-    #     EOF
-
-    #     mkdir -p /tmp/bfuse_test_mnt
-
-    #     blobfuse2 mount /tmp/bfuse_test_mnt --config-file="/tmp/config.yaml" &
-    #     sleep 5
-    #     umount /tmp/bfuse_test_mnt
+          attr_cache:
+            timeout-sec: 7200
+        EOF
+    # Requires Azure Storage setup
+    # Error: failed to initialize new pipeline [config error in azstorage [account name not provided]]
+    - uses: test/daemon-check-output
+      with:
+        start: blobfuse2 mount /tmp/bfuse_test_mnt --config-file="/tmp/config.yaml"
+        timeout: 30
+        expected_output: |
+          initializePlugins: No plugins to load.

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -35,8 +35,8 @@ subpackages:
       pipeline:
         - runs: |
             # Check basic help and version
-            bfusemon --help | grep "Usage of bfusemon:"
-            bfusemon --version | grep ${{package.version}}
+            bfusemon --help
+            bfusemon -version
 
 update:
   enabled: true

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -1,0 +1,53 @@
+package:
+  name: blobfuse2
+  version: 2.4.2
+  epoch: 0
+  description: A virtual file system adapter for Azure Blob storage
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - fuse3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 25d91613a14bc3847d4443188340cc7e4c65a43f
+      repository: https://github.com/Azure/azure-storage-fuse
+      tag: ${{package.name}}-${{package.version}}
+
+  - uses: go/build
+    with:
+      output: blobfuse2
+      packages: .
+
+subpackages:
+  - name: "${{package.name}}-health-monitor"
+    description: "Health monitor for blobfuse2"
+    pipeline:
+      - uses: go/build
+        with:
+          output: bfusemon
+          packages: ./tools/health-monitor
+    test:
+      pipeline:
+        - runs: |
+            # Check basic help and version
+            bfusemon --help | grep "Blobfuse2 is an open source project"
+            bfusemon --version | grep ${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: Azure/azure-storage-fuse
+    strip-prefix: blobfuse2-
+    tag-filter: blobfuse2-2.4.
+
+test:
+  pipeline:
+    - runs: |
+        # Check basic help and version
+        blobfuse2 --help | grep "Blobfuse2 is an open source project"
+        blobfuse2 --version | grep ${{package.version}}

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -37,7 +37,16 @@ subpackages:
             # Check basic help and version
             bfusemon --help
             bfusemon -version
-
+        # requires blobfuse2 process running in background.
+        - uses: test/daemon-check-output
+          with:
+            start: /usr/bin/bfusemon -no-cpu-profiler -no-memory-profiler -no-network-profiler -pid 12345 &
+            timeout: 30
+            expected_output: |
+              Transfer Pipe: 12345 
+              Polling Pipe: /tmp/transferPipe_12345 
+              Blobfuse2 Stats poll interval: /tmp/pollPipe_12345 
+              Health Stats poll interval: 10 
 update:
   enabled: true
   github:
@@ -46,8 +55,50 @@ update:
     tag-filter: blobfuse2-2.4.
 
 test:
+  environment:
+    contents:
+      packages:
+        - umount
   pipeline:
     - runs: |
         # Check basic help and version
         blobfuse2 --help | grep "Blobfuse2 is an open source project"
         blobfuse2 --version | grep ${{package.version}}
+    # Requires Azure credentials
+    # Fails with "Error: failed to initialize new pipeline [config error in azstorage [account name not provided]]"
+    # - runs: |
+    #     #!/bin/bash
+    #     set -e
+
+    #     cat > "/tmp/config.yaml" <<EOF
+    #       allow-other: true
+
+    #       logging:
+    #         type: syslog
+
+    #       components:
+    #         - libfuse
+    #         - file_cache
+    #         - attr_cache
+    #         - azstorage
+
+    #       libfuse:
+    #         attribute-expiration-sec: 120
+    #         entry-expiration-sec: 120
+    #         negative-entry-expiration-sec: 240
+
+    #       file_cache:
+    #         path: /tmp/blobfuse_temp
+    #         timeout-sec: 0 
+    #         allow-non-empty-temp: true
+    #         cleanup-on-start: true
+
+    #       attr_cache:
+    #         timeout-sec: 7200
+    #     EOF
+
+    #     mkdir -p /tmp/bfuse_test_mnt
+
+    #     blobfuse2 mount /tmp/bfuse_test_mnt --config-file="/tmp/config.yaml" &
+    #     sleep 5
+    #     umount /tmp/bfuse_test_mnt

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -35,7 +35,7 @@ subpackages:
       pipeline:
         - runs: |
             # Check basic help and version
-            bfusemon --help | grep "Blobfuse2 is an open source project"
+            bfusemon --help | grep "Usage of bfusemon:"
             bfusemon --version | grep ${{package.version}}
 
 update:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
