### PR TITLE
kubeflow-jupyter-web-app: replace guincorn runtime dep

### DIFF
--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,14 +1,14 @@
 package:
   name: kubeflow-jupyter-web-app
   version: "1.10.0"
-  epoch: 0
+  epoch: 1
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - py${{vars.py-version}}-gunicorn
+      - py${{vars.py-version}}-gunicorn-bin
 
 vars:
   py-version: 3.13


### PR DESCRIPTION
we should be using -bin one because that pulls in both site-packages and binaries.