### PR TITLE
Synchronize CODEOWNERS with other repos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,16 +1,21 @@
+# Each line is a file pattern followed by one or more owners.
+
+# The foundations-squad includes members of the of the former Foundations
+# team and the Guarded OS team and the larger team provides more around the
+# clock coverage so should not change in the near future.
+
 # Require review by repo owners of changes to CODEOWNERS
 CODEOWNERS @wolfi-dev/foundations-squad
 
 # Important CI and Repo configuration
-.github/ @wolfi-dev/foundations-squad
-scripts/ @wolfi-dev/foundations-squad
+.github/                @wolfi-dev/foundations-squad
+.pre-commit-config.yaml @wolfi-dev/foundations-squad
 
-# Makefile and pipeline changes require approval of the Guarded OS squad.
+# Makefile and pipeline changes require approval of the Foundations squad.
 Makefile   @wolfi-dev/foundations-squad
 pipelines/ @wolfi-dev/foundations-squad
 
 # These packages require approval from the Foundations squad.
-abseil-cpp.yaml      @wolfi-dev/foundations-squad
 ca-certificates.yaml @wolfi-dev/foundations-squad
 clang-*.yaml         @wolfi-dev/foundations-squad
 curl.yaml            @wolfi-dev/foundations-squad


### PR DESCRIPTION
- Add a comment regarding Foundations team
- Drop scripts directory as that's more for automation
- Add Foundations team as a codeowner for pre-commit-config.yaml
- Drop abseil-cpp as the bug in apko was fixed
- Reformat the file
