### PR TITLE
Improve Trino package

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
-  version: "474"
-  epoch: 2
+  version: "475"
+  epoch: 3
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -10,8 +10,7 @@ package:
     memory: 64Gi
   dependencies:
     runtime:
-      - openjdk-23-default-jvm
-      - python3 # required by trino launcher script
+      - openjdk-24-default-jvm
       - trino-config
 
 environment:
@@ -26,7 +25,7 @@ environment:
       - go
       - jvmkill
       - maven
-      - openjdk-23
+      - openjdk-24-default-jdk
       - upx
       - wolfi-base
 
@@ -35,26 +34,26 @@ pipeline:
     working-directory: ./airlift/launcher
     with:
       repository: https://github.com/airlift/launcher.git
-      tag: 301
-      expected-commit: 2f521fa3de65a458c2d7879bc57841dd195b33df
+      tag: 303
+      expected-commit: 82aded83e695f028e906f129f05400f503fe3031
 
   - working-directory: ./airlift/launcher
     runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-23-openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
       ./mvnw package
 
   - uses: git-checkout
     with:
       repository: https://github.com/trinodb/trino.git
       tag: ${{package.version}}
-      expected-commit: 2d747e0e722d5127b5c25706194944bcb7a7a2f1
+      expected-commit: fd2b81e86ba1c288684746d0842c0ffc3a709598
 
   - uses: maven/pombump
 
   - runs: |
       set -x
 
-      export JAVA_HOME=/usr/lib/jvm/java-23-openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
 
       ./mvnw package -q -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all -T 8  -pl '!:trino-docs,!:trino-tests,!:trino-product-tests,!:trino-product-tests-launcher,!:trino-web-ui' -am
 
@@ -99,7 +98,6 @@ data:
       jmx: jmx
       kafka: kafka
       kafka-event-listener: kafka-event-listener
-      # kudu: kudu # kudu has an unfixable CVE (GHSA-735f-pc8j-v9w8), so we're not incuding it.
       mariadb: mariadb
       memory: memory
       ml: ml
@@ -111,7 +109,6 @@ data:
       opensearch: opensearch
       oracle: oracle
       password-authenticators: password-authenticators
-      # phoenix5: phoenix5 # phoenix5 is riddled with CVEs, so we're not including it.
       pinot: pinot
       postgresql: postgresql
       prometheus: prometheus
@@ -195,7 +192,7 @@ test:
         - ${{package.name}}-oci-entrypoint # need to setup basic
         - bash
     environment:
-      JAVA_HOME: /usr/lib/jvm/java-23-openjdk
+      JAVA_HOME: /usr/lib/jvm/default-jvm
   pipeline:
     - name: "test trino version"
     - runs: |


### PR DESCRIPTION
Trino package update. Trino 474 uses Java 24 in the container so our package should do so as well.

Also removed the need for python since the Trino launcher has been using a Go-based binary for a while and Python is no longer needed.

Also remove the Kudu and Phoenix connector plugin comment lines since we remove the connectors in upstream.

Fyi .. I am a Trino maintainer but not a wolfi expert.. ping me on Chainguard or Trino slack for discussion or comment in review.
