### PR TITLE
thanos/GHSA-vvgc-356p-c3xw fix

### DIFF
--- a/thanos.yaml
+++ b/thanos.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos
   version: "0.38.0"
-  epoch: 1
+  epoch: 2
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
         github.com/golang-jwt/jwt/v5@v5.2.2
+        golang.org/x/net@v0.39.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
An epoch bump and net version bump remediates this CVE