### PR TITLE
ruby3.4-logstash-core-9.0.0-r0 add to withdrawn packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -156,3 +156,5 @@ node-problem-detector-0.8-compat-0.8.20-r2.apk
 node-problem-detector-0.8-compat-0.8.20-r3.apk
 node-problem-detector-0.8-compat-0.8.20-r4.apk
 node-problem-detector-0.8-compat-0.8.20-r5.apk
+
+ruby3.4-logstash-core-9.0.0-r0.apk


### PR DESCRIPTION
adding ruby3.4-logstash-core-9.0.0-r0 to withdrawn packages