### PR TITLE
dive: cve remediation

### DIFF
--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: "0.13.1"
-  epoch: 1
+  epoch: 2
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT
@@ -24,6 +24,8 @@ pipeline:
 
   - uses: go/bump
     with:
+      deps: |-
+        golang.org/x/net@v0.38.0
       replaces: google.golang.org/genproto=google.golang.org/genproto@v0.0.0-20240730163845-b1a4ccb954bf
 
   - uses: go/build


### PR DESCRIPTION
bump x/net to v0.38.0
Fixes GHSA-vvgc-356p-c3xw
