### PR TITLE
Lddcheck mysql 9.3

### DIFF
--- a/mysql-9.3.yaml
+++ b/mysql-9.3.yaml
@@ -264,6 +264,9 @@ test:
         - make
         - glibc-dev
   pipeline:
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/private"
     - name: Check versions
       runs: |
         mysql --version |grep "${{package.version}}"

--- a/mysql-9.3.yaml
+++ b/mysql-9.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-9.3
   version: "9.3.0"
-  epoch: 0
+  epoch: 1
   description: "The MySQL open source relational database"
   copyright:
     - license: GPL-2.0-only # https://downloads.mysql.com/docs/licenses/mysqld-9.0-gpl-en.pdf


### PR DESCRIPTION
Now that we have extra-library-paths we can add the ldd-check test to mysql-9.3.

https://github.com/wolfi-dev/os/issues/40834