### PR TITLE
makefile kernel improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,10 @@ fetch-kernel:
 kernel/APKINDEX.tar.gz:
 	$(MAKE) apk-token
 	mkdir -p kernel
-	curl -LS --silent -o $@ \
+	curl -LS --silent -o $@.tmp \
 	  --user user:$$(chainctl auth token --audience apk.cgr.dev) \
 	  https://apk.cgr.dev/chainguard-private/$(ARCH)/APKINDEX.tar.gz
+	mv $@.tmp $@
 
 kernel/APKINDEX: kernel/APKINDEX.tar.gz
 	tar -x -C kernel -f $< $(notdir $@)

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,11 @@ ${CACHEDIR}/.libraries_token.txt: cache
 .PHONY: lib-token
 lib-token: ${CACHEDIR}/.libraries_token.txt
 
-.PHONY: fetch-kernel
+.PHONY: apk-token
 apk-token:
 	chainctl auth login --audience apk.cgr.dev
 
+.PHONY: fetch-kernel
 fetch-kernel: apk-token
 	$(eval KERNEL_PKG := $(shell curl -L --silent --output - --user user:$$(chainctl auth token --audience apk.cgr.dev) https://apk.cgr.dev/chainguard-private/$(ARCH)/APKINDEX.tar.gz | \
 		zcat | \

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,10 @@ kernel/chosen: kernel/APKINDEX
 	grep -e '^P:' -e '^V:' $< | sed -n '/^P:linux$$/{n;p}' > \
 	  kernel/available
 	grep '^V:' kernel/available | sed 's/V://' | \
-	  sort -V | tail -n1 > kernel/chosen
+	  sort -V | tail -n1 > $@.tmp
+	# Sanity check that this looks like an apk version
+	grep -E '^([0-9]+\.)+[0-9]+-r[0-9]+$' $@.tmp
+	mv $@.tmp $@
 
 kernel/linux.apk: kernel/chosen
 	@$(call authget,apk.cgr.dev,$@,$(QEMU_KERNEL_REPO)/$(ARCH)/linux-$(file < kernel/chosen).apk)


### PR DESCRIPTION
- Avoid using predictable paths in `/tmp`
- Split up the target into multiple chunks to ease debugging
- Add kernel dep to targets that call melange build when using qemu runner
- Fix `QEMU_KERNEL_IMAGE` being set in melange's environment
- Cleanup kernel w/ `clean` target
