### PR TITLE
argo-events/GHSA-vvgc-356p-c3xw fix

### DIFF
--- a/argo-events.yaml
+++ b/argo-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-events
   version: "1.9.6"
-  epoch: 0
+  epoch: 1
   description: Event-driven Automation Framework for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,8 @@ pipeline:
 
   - uses: go/bump
     with:
+      deps: |-
+        golang.org/x/net@v0.38.0
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v1.0.2
 
   - uses: go/build


### PR DESCRIPTION
Epoch bump and adding golang.org/x/net to go/bump block remediates the CVE