### PR TITLE
openjdk-24: restore update-ca-certificates support

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.1"
-  epoch: 2
+  epoch: 3
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -146,11 +146,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # symlink to shared java cacerts store
-          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
-            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
 
@@ -176,12 +171,20 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-cacerts
         - java-common-jre
         - ${{package.name}}-jre
       provides:
         - default-jvm=1.24
+      replaces:
+        - java-cacerts
     pipeline:
       - runs: |
+          # inverse symlink to cacerts store, to keep update-ca-certificates working
+          # note that updating certs breaks jlink support, todo open upstream bug
+          mkdir -p ${{targets.subpkgdir}}/etc/ssl/certs/java
+          ln -sf /usr/lib/jvm/java-24-openjdk/lib/security/cacerts ${{targets.subpkgdir}}/etc/ssl/certs/java/cacerts
+
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-24-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
@@ -189,12 +192,20 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
+        - java-cacerts
         - java-common
         - ${{package.name}}
       provides:
         - default-jdk=1.24
+      replaces:
+        - java-cacerts
     pipeline:
       - runs: |
+          # inverse symlink to cacerts store, to keep update-ca-certificates working
+          # note that updating certs breaks jlink support, todo open upstream bug
+          mkdir -p ${{targets.subpkgdir}}/etc/ssl/certs/java
+          ln -sf /usr/lib/jvm/java-24-openjdk/lib/security/cacerts ${{targets.subpkgdir}}/etc/ssl/certs/java/cacerts
+
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-24-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 


### PR DESCRIPTION
Landing support for 'JEP 493: Linking Run-Time Images without JMODs' in:
- https://github.com/wolfi-dev/os/pull/50581

Broke support for cacerts, as their location has changed, and so did
the symlink direction.

Restore the symlink, albeit in the other direction, such taht
update-ca-certificates continues to work.

Better integration is needed, as updating ca certificate breaks jlink
support, as it will detect file change and refuse to jlink things.
