### PR TITLE
readline: fix ncurses linking

### DIFF
--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: 8.2.13
-  epoch: 1
+  epoch: 2
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later
@@ -32,8 +32,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Needed to ensure ncurses linked
-      export LDFLAGS=$(echo $LDFLAGS | sed 's/,--as-needed//g')
       ./configure \
          --host=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \

--- a/readline/fix-ncurses-underlinking.patch
+++ b/readline/fix-ncurses-underlinking.patch
@@ -1,3 +1,7 @@
+Description: Force linking with ncurses
+  Ensure that readline is always linked with ncurses by disabling
+  --as-needed for this lib during linking.
+
 --- shlib/Makefile.in.orig
 +++ shlib/Makefile.in
 @@ -86,7 +86,7 @@
@@ -5,7 +9,7 @@
  
  SHLIB_XLDFLAGS = @LDFLAGS@ @SHLIB_XLDFLAGS@
 -SHLIB_LIBS = @SHLIB_LIBS@
-+SHLIB_LIBS = @SHLIB_LIBS@ -lncursesw
++SHLIB_LIBS = @SHLIB_LIBS@ -Wl,--no-as-needed -lncursesw -Wl,--as-needed
  
  SHLIB_DOT = @SHLIB_DOT@
  SHLIB_LIBPREF = @SHLIB_LIBPREF@


### PR DESCRIPTION
Ensure that --as-needed is disabled during linking of ncurses otherwise
the resulting readline so is underlinked and causes issues further
downstream with missing symbols.

Signed-off-by: James Page <james.page@chainguard.dev>
