### PR TITLE
New package crosstool-ng

### DIFF
--- a/crosstool-ng.yaml
+++ b/crosstool-ng.yaml
@@ -1,0 +1,83 @@
+package:
+  name: crosstool-ng
+  version: 1.27.0
+  epoch: 0
+  description: build toolchains
+  copyright:
+    - license: GPL-2.0
+  dependencies:
+    # The dependencies detected at crosstool build time affected
+    # available runtime options and are needed to build toolchains
+    # hence the list of environment & dependencies is unusally similar
+    runtime:
+      - autoconf
+      - automake
+      - bash
+      - bison
+      - build-base
+      - busybox
+      - coreutils
+      - curl
+      - file
+      - flex
+      - gawk
+      - git
+      - gnutar
+      - help2man
+      - libtool
+      - meson
+      - ncurses-dev
+      - patch
+      - py3.13-build-base-dev
+      - texinfo
+      - xz
+
+environment:
+  contents:
+    packages:
+      - bash
+      - bison
+      - build-base
+      - busybox
+      - coreutils
+      - curl
+      - file
+      - flex
+      - gawk
+      - gnutar
+      - help2man
+      - libtool
+      - meson
+      - ncurses-dev
+      - patch
+      - py3.13-build-base-dev
+      - texinfo
+      - xz
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 70c2b00ad79a0a21a48e5a0eedc9f91c374af21d
+      repository: https://github.com/crosstool-ng/crosstool-ng
+      tag: crosstool-ng-${{package.version}}
+
+  - runs: |
+      ./bootstrap
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: crosstool-ng/crosstool-ng
+    strip-prefix: crosstool-ng-
+
+test:
+  pipeline:
+    - runs: ct-ng help


### PR DESCRIPTION
Add a new package that is able to build toolchains. This will help
packaging native & cross toolchains, with a declarative config without
need to use out of date boostrap-stageN archives.
