### PR TITLE
openjdk-24 fix update-ca-certificates integration

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: "20241121"
-  epoch: 2
+  epoch: 40
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
@@ -34,6 +34,27 @@ pipeline:
         --purpose server-auth /etc/ssl/certs/java/cacerts
       EOF
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
+
+subpackages:
+  - name: java-cacerts-default
+    description: symlink to default jvm cacerts with JEP-493
+    dependencies:
+      runtime:
+        - ca-certificates
+        - p11-kit-trust
+    pipeline:
+      - runs: |
+          # Note that symlink replaces currently doesn't work in apko,
+          # hence duplicating the update.d hook for now. Stop gap to
+          # make update-ca-certificates still work.
+          mkdir -p "${{targets.contextdir}}"/etc/ssl/certs/java
+          ln -s /usr/lib/jvm/default-jvm/lib/security/cacerts "${{targets.contextdir}}"/etc/ssl/certs/java/cacerts
+          mkdir -p "${{targets.destdir}}"/etc/ca-certificates/update.d
+          cat > "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts <<EOF
+          exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors \
+            --purpose server-auth /etc/ssl/certs/java/cacerts
+          EOF
+          chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
 
 update:
   enabled: true

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.1"
-  epoch: 2
+  epoch: 3
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -146,11 +146,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # symlink to shared java cacerts store
-          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
-            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
 
@@ -176,6 +171,7 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-cacerts-default
         - java-common-jre
         - ${{package.name}}-jre
       provides:
@@ -189,6 +185,7 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
+        - java-cacerts-default
         - java-common
         - ${{package.name}}
       provides:


### PR DESCRIPTION
Removal of /etc/ssl/certs/java/cacerts is causing integration failure with update-ca-certificates and previous ways of updating cacerts.

It was done to support jlink without jmods for java 24 only in:
- https://github.com/wolfi-dev/os/pull/50581

Create inverse symlink for the time being, and also correct incorrect symlink override in the jre packaging.

This should keep jlink working, if cacerts are not modified.

This should also restore support for adding custom cacerts to the keystore, using the same paths as on previous jdk versions and other distributions.
