### PR TITLE
blobfuse2: add syslogs subpkg

### DIFF
--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -64,10 +64,6 @@ update:
     tag-filter: blobfuse2-2.4.
 
 test:
-  environment:
-    contents:
-      packages:
-        - umount
   pipeline:
     - runs: |
         # Check basic help and version

--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -1,7 +1,7 @@
 package:
   name: blobfuse2
   version: 2.4.2
-  epoch: 0
+  epoch: 1
   description: A virtual file system adapter for Azure Blob storage
   copyright:
     - license: MIT
@@ -47,6 +47,14 @@ subpackages:
               Polling Pipe: /tmp/transferPipe_12345
               Blobfuse2 Stats poll interval: /tmp/pollPipe_12345
               Health Stats poll interval: 10
+
+  - name: "${{package.name}}-syslog"
+    description: "Syslog configuration for blobfuse2"
+    pipeline:
+      - runs: |
+          install -Dm0644 setup/baseConfig.yaml sample*Config.yaml -t ${{targets.destdir}}/usr/share/blobfuse2
+          install -Dm0644 setup/11-blobfuse2.conf -t ${{targets.destdir}}/etc/rsyslog.d
+          install -Dm0644 setup/blobfuse2-logrotate ${{targets.destdir}}/etc/logrotate.d/blobfuse2
 
 update:
   enabled: true


### PR DESCRIPTION
Context:
We have a `blobfuse2` package in enterprise repo as well. Refactor handles the missing syslog files before withdrawing blobfuse2 from enterprise
https://github.com/chainguard-dev/enterprise-packages/blob/main/blobfuse2.yaml