### PR TITLE
newrelic-nri-statsd: bump epoch to bump gostatsd

### DIFF
--- a/newrelic-nri-statsd.yaml
+++ b/newrelic-nri-statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-statsd
   version: "2.11.0"
-  epoch: 2
+  epoch: 3
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Fixes: GHSA-vvgc-356p-c3xw