### PR TITLE
chore(gofumpt): remove unneeded build time deps explicit

### DIFF
--- a/gofumpt.yaml
+++ b/gofumpt.yaml
@@ -1,16 +1,10 @@
 package:
   name: gofumpt
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: Enforce a stricter format than gofmt, while being backwards compatible.
   copyright:
     - license: BSD-3-Clause
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
This PR just removes unneeded build time deps explicit
