### PR TITLE
quality: extend node-feature-discovery package tests

### DIFF
--- a/node-feature-discovery-0.17.yaml
+++ b/node-feature-discovery-0.17.yaml
@@ -128,10 +128,6 @@ test:
           configuration file parsed
           configuration successfully updated
           starting the nfd api controller
-        error_strings: |
-          panic
-          fatal
-          FATAL
     - name: Validation test
       runs: |
         test -f /etc/kubernetes/node-feature-discovery/nfd-worker.conf || (echo "Config file missing"; exit 1)

--- a/node-feature-discovery-0.17.yaml
+++ b/node-feature-discovery-0.17.yaml
@@ -8,16 +8,6 @@ package:
   dependencies:
     provides:
       - node-feature-discovery=${{package.full-version}}
-      - node-feature-discovery-0.17-master=${{package.full-version}}
-      - node-feature-discovery-0.17-worker=${{package.full-version}}
-      - node-feature-discovery-0.17-gc=${{package.full-version}}
-      - node-feature-discovery-0.17-topology-updater=${{package.full-version}}
-      - node-feature-discovery-0.17-kubectl-nfd=${{package.full-version}}
-
-environment:
-  contents:
-    packages:
-      - protoc
 
 pipeline:
   - uses: git-checkout
@@ -39,50 +29,49 @@ pipeline:
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/kubectl-nfd
       output: kubectl-nfd
-      tags: osusergo,netgo
-      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      ldflags: |
+        -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/nfd-gc
       output: nfd-gc
-      tags: osusergo,netgo
-      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      ldflags: |
+        -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/nfd-master
       output: nfd-master
-      tags: osusergo,netgo
-      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      ldflags: |
+        -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/nfd-topology-updater
       output: nfd-topology-updater
-      tags: osusergo,netgo
-      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      ldflags: |
+        -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/nfd-worker
       output: nfd-worker
-      tags: osusergo,netgo
-      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      ldflags: |
+        -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
-  - uses: strip
 
 update:
   enabled: true
@@ -93,15 +82,22 @@ update:
     tag-filter: v0.17.
 
 test:
-  environment:
-    contents:
-      packages:
-        - ${{package.name}}-master
-        - ${{package.name}}-worker
-        - ${{package.name}}-gc
-        - ${{package.name}}-topology-updater
-        - ${{package.name}}-kubectl-nfd
   pipeline:
+    - runs: |
+        kubectl-nfd -h
+        nfd-gc -version
+        nfd-master -version
+        nfd-topology-updater -version
+        nfd-worker -version
+        kubectl-nfd --help
+        nfd-gc --version
+        nfd-gc --help
+        nfd-master --version
+        nfd-master --help
+        nfd-topology-updater --version
+        nfd-topology-updater --help
+        nfd-worker --version
+        nfd-worker --help
     - uses: test/kwok/cluster
     - name: "Test nfd-master startup"
       uses: test/daemon-check-output
@@ -137,9 +133,6 @@ test:
           panic
           fatal
           FATAL
-        post: |
-          # Verify clean shutdown
-          ps aux | grep nfd-master | grep -v grep || true
     - name: Validation test
       runs: |
         test -f /etc/kubernetes/node-feature-discovery/nfd-worker.conf || (echo "Config file missing"; exit 1)

--- a/node-feature-discovery-0.17.yaml
+++ b/node-feature-discovery-0.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-feature-discovery-0.17
   version: "0.17.3"
-  epoch: 0
+  epoch: 1
   description: Node feature discovery for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/node-feature-discovery-0.17.yaml
+++ b/node-feature-discovery-0.17.yaml
@@ -72,7 +72,6 @@ pipeline:
         -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-
       go-package: go
 
-
 update:
   enabled: true
   github:

--- a/node-feature-discovery-0.17.yaml
+++ b/node-feature-discovery-0.17.yaml
@@ -8,6 +8,11 @@ package:
   dependencies:
     provides:
       - node-feature-discovery=${{package.full-version}}
+      - node-feature-discovery-0.17-master=${{package.full-version}}
+      - node-feature-discovery-0.17-worker=${{package.full-version}}
+      - node-feature-discovery-0.17-gc=${{package.full-version}}
+      - node-feature-discovery-0.17-topology-updater=${{package.full-version}}
+      - node-feature-discovery-0.17-kubectl-nfd=${{package.full-version}}
 
 environment:
   contents:
@@ -88,19 +93,53 @@ update:
     tag-filter: v0.17.
 
 test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-master
+        - ${{package.name}}-worker
+        - ${{package.name}}-gc
+        - ${{package.name}}-topology-updater
+        - ${{package.name}}-kubectl-nfd
   pipeline:
-    - runs: |
-        kubectl-nfd -h
-        nfd-gc -version
-        nfd-master -version
-        nfd-topology-updater -version
-        nfd-worker -version
-        kubectl-nfd --help
-        nfd-gc --version
-        nfd-gc --help
-        nfd-master --version
-        nfd-master --help
-        nfd-topology-updater --version
-        nfd-topology-updater --help
-        nfd-worker --version
-        nfd-worker --help
+    - uses: test/kwok/cluster
+    - name: "Test nfd-master startup"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          # Create minimal config file
+          mkdir -p /etc/kubernetes/node-feature-discovery
+          cat > /etc/kubernetes/node-feature-discovery/nfd-master.conf <<EOF
+          {
+            "noPublish": true,
+            "instance": "test",
+            "enableLeaderElection": false,
+            "nfdApiParallelism": 1,
+            "resyncPeriod": "1s",
+            "inClusterConfig": true,
+            "verifyServiceAccount": false
+          }
+          EOF
+
+          # Create minimal service account directory
+          mkdir -p /var/run/secrets/kubernetes.io/serviceaccount/
+          echo "fake-token" > /var/run/secrets/kubernetes.io/serviceaccount/token
+          echo "fake-ca" > /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          echo "default" > /var/run/secrets/kubernetes.io/serviceaccount/namespace
+        start: env KUBERNETES_SERVICE_HOST=localhost KUBERNETES_SERVICE_PORT=8080 nfd-master --config=/etc/kubernetes/node-feature-discovery/nfd-master.conf
+        timeout: 30
+        expected_output: |
+          Node Feature Discovery Master
+          configuration file parsed
+          configuration successfully updated
+          starting the nfd api controller
+        error_strings: |
+          panic
+          fatal
+          FATAL
+        post: |
+          # Verify clean shutdown
+          ps aux | grep nfd-master | grep -v grep || true
+    - name: Validation test
+      runs: |
+        test -f /etc/kubernetes/node-feature-discovery/nfd-worker.conf || (echo "Config file missing"; exit 1)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
