### PR TITLE
fix: crossplane-provider-* repository path is under the crossplane-contrib org

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: "1.21.1"
-  epoch: 1
+  epoch: 2
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
   - uses: git-checkout
     with:
       expected-commit: 4a5398fcc050393b01d6ebb60683e56b9383b179
-      repository: https://github.com/upbound/provider-aws
+      repository: https://github.com/crossplane-contrib/provider-upjet-aws
       tag: v${{package.version}}
 
   - uses: patch

--- a/crossplane-provider-azure.yaml
+++ b/crossplane-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-azure
   version: "1.11.2"
-  epoch: 3
+  epoch: 4
   description: Official Azure Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/upbound/provider-azure
+      repository: https://github.com/crossplane-contrib/provider-upjet-azure
       tag: v${{package.version}}
       expected-commit: 1945b70b7c598a802f66d9f5a9c5a39f21d63968
       recurse-submodules: true

--- a/crossplane-provider-gcp.yaml
+++ b/crossplane-provider-gcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-gcp
   version: "1.12.1"
-  epoch: 1
+  epoch: 2
   description: Official GCP Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/upbound/provider-gcp
+      repository: https://github.com/crossplane-contrib/provider-upjet-gcp
       tag: v${{package.version}}
       expected-commit: 43b97ce3d26da2e3a6d37f72f1fafa6431715ef4
       recurse-submodules: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: The repository path of the crossplane provider repos are now under crossplane-contrib organization.


