### PR TITLE
grafana-agent-operator: remediate cve

### DIFF
--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -26,6 +26,7 @@ pipeline:
     with:
       deps: |-
         github.com/golang-jwt/jwt/v5@v5.2.2
+        golang.org/x/crypto@v0.35.0
 
   - uses: go/build
     with:

--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: "0.44.2"
-  epoch: 37
+  epoch: 38
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
bump x/crypto to v0.35.0 to remediate GHSA-hcg3-q754-cr77
