### PR TITLE
feat(CODEOWNERS): Add sustaining team as nats* package owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,4 +25,7 @@ glibc.yaml           @wolfi-dev/foundations-squad
 llvm*.yaml           @wolfi-dev/foundations-squad
 openssh.yaml         @wolfi-dev/foundations-squad
 openssl.yaml         @wolfi-dev/foundations-squad
+# Adding sustaining-team as codeowner of nats* packages blocking any 
+# non sustaining-team and automation from merging of nats* package changes. 
+# This is in lieue of a possible move to less open license for nats* packages. 
 nats*.yaml           @wolfi-dev/sustaining-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,3 +25,4 @@ glibc.yaml           @wolfi-dev/foundations-squad
 llvm*.yaml           @wolfi-dev/foundations-squad
 openssh.yaml         @wolfi-dev/foundations-squad
 openssl.yaml         @wolfi-dev/foundations-squad
+nats*.yaml           @wolfi-dev/sustaining-team


### PR DESCRIPTION
With the possible move in licensing for the nats* packages to a less open license this commit
add sustaining team as codeowner thus blocking any non sustaining team merges of nats* packages
and also blocks automation from any automated updates or merges of nats* package updates.

This change is likley temporary until we can establish that the move to less open license is not proceeding.

Signed-off-by: philroche <phil.roche@chainguard.dev>
