### PR TITLE
add nextcloud-server

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,12 +1,13 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 41
+  epoch: 42
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - ${{package.name}}-config
       - libgcc
       - lua5.4
       - merged-usrsbin
@@ -161,39 +162,39 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: ${{package.name}}-compat
-    description: "Config compatibility to upstream docker image"
-    dependencies:
-      runtime:
-        - ${{package.name}}
-        - busybox # the httpd-foreground script calls `rm`
-        - merged-usrsbin
-        - wolfi-baselayout
+  - name: ${{package.name}}-config
+    description: ${{package.name}} configuration files
     pipeline:
       - runs: |
-          set -x
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
+          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+          mv "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
+    test:
+      pipeline:
+        - runs: |
+            stat /etc/apache2/httpd.conf
+            stat /etc/apache2/extra/httpd-ssl.conf
 
-          # Create necessary folders
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+  # This subpackage is to keep the backwards compatibility with the compat image.
+  # By having this subpackage, it allows packages that depend on apache2 config files
+  # (i.e., httpd.conf, httpd-ssl.conf) to be installed without having conflict with
+  # the ${{package.name}}-config and ${{package.name}}-compat subpackages. Some packages
+  # needs particular config adjustments in the httpd.conf file, and this subpackage
+  # allows them to be installed without having to modify the ${{package.name}}-compat
+  # subpackage if the package has a runtime dependency on it.
+  - name: ${{package.name}}-config-compat
+    description: ${{package.name}} configuration files for compat
+    dependencies:
+      replaces:
+        - ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
 
-          # Install necessary config files
-          mkdir -p "${{targets.subpkgdir}}"/etc/apache2
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
-
-          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
-          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
-          # Create symlinks
-          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
 
           # Modify User/Group and verify changes are applied.
           sed -ri \
@@ -232,11 +233,45 @@ subpackages:
             -e 's|etc/|usr/local/apache2/conf/|g' \
             -e 's|/var/run/apache2/|usr/local/apache2/logs/|g' \
             "${{targets.subpkgdir}}"/etc/apache2/extra/httpd-ssl.conf;
+
+          ### Add Include directive for additional configs
+          echo "IncludeOptional /etc/apache2/conf.d/*.conf" >> "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
+
+  - name: ${{package.name}}-compat
+    description: "Config compatibility to upstream docker image"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - ${{package.name}}-config-compat
+        - busybox # the httpd-foreground script calls `rm`
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          set -x
+
+          # Create necessary folders
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+
+          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
+          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
+          # Create symlinks
+          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
     test:
       environment:
         contents:
           packages:
             - curl
+            - ${{package.name}}-config-compat
       pipeline:
         - runs: |
             # Verify config is as expected upstream docker instance

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,13 +1,12 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 42
+  epoch: 41
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ${{package.name}}-config
       - libgcc
       - lua5.4
       - merged-usrsbin
@@ -150,26 +149,29 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: ${{package.name}}-config
-    description: ${{package.name}} httpd.conf and httpd-ssl.conf configuration
+  - name: ${{package.name}}-data
+    description: "Apache HTTP Server (data files)"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/etc/apache2
-          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
-          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
-          mv "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
-
-  - name: ${{package.name}}-config-compat
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/apache2
+          mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
+          mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
     dependencies:
-      replaces:
-        - apache2-config
-      provides:
-        - apache2-config
-    description: ${{package.name}} httpd.conf and httpd-ssl.conf configuration for compat
+      runtime:
+        - merged-usrsbin
+        - wolfi-baselayout
+
+  - name: ${{package.name}}-compat
+    description: "Config compatibility to upstream docker image"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - busybox # the httpd-foreground script calls `rm`
+        - merged-usrsbin
+        - wolfi-baselayout
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/etc/apache2
-          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
+          set -x
 
   - name: ${{package.name}}-config
     description: ${{package.name}} configuration files
@@ -204,6 +206,17 @@ subpackages:
 
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
+
+          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
+          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
+          # Create symlinks
+          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
 
           # Modify User/Group and verify changes are applied.
           sed -ri \

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -173,37 +173,14 @@ subpackages:
       - runs: |
           set -x
 
-  - name: ${{package.name}}-config
-    description: ${{package.name}} configuration files
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/etc/apache2
-          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
-          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
-          mv "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
-    test:
-      pipeline:
-        - runs: |
-            stat /etc/apache2/httpd.conf
-            stat /etc/apache2/extra/httpd-ssl.conf
+          # Create necessary folders
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
 
-  # This subpackage is to keep the backwards compatibility with the compat image.
-  # By having this subpackage, it allows packages that depend on apache2 config files
-  # (i.e., httpd.conf, httpd-ssl.conf) to be installed without having conflict with
-  # the ${{package.name}}-config and ${{package.name}}-compat subpackages. Some packages
-  # needs particular config adjustments in the httpd.conf file, and this subpackage
-  # allows them to be installed without having to modify the ${{package.name}}-compat
-  # subpackage if the package has a runtime dependency on it.
-  - name: ${{package.name}}-config-compat
-    description: ${{package.name}} configuration files for compat
-    dependencies:
-      replaces:
-        - ${{package.name}}-config
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/etc/apache2
-          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
-
+          # Install necessary config files
+          mkdir -p "${{targets.subpkgdir}}"/etc/apache2
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
 
@@ -255,56 +232,11 @@ subpackages:
             -e 's|etc/|usr/local/apache2/conf/|g' \
             -e 's|/var/run/apache2/|usr/local/apache2/logs/|g' \
             "${{targets.subpkgdir}}"/etc/apache2/extra/httpd-ssl.conf;
-
-          ### Add Include directive for additional configs
-          echo "IncludeOptional /etc/apache2/conf.d/*.conf" >> "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
-  - name: ${{package.name}}-data
-    description: "Apache HTTP Server (data files)"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/apache2
-          mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
-          mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
-
-  - name: ${{package.name}}-compat
-    description: "Config compatibility to upstream docker image"
-    dependencies:
-      runtime:
-        - ${{package.name}}
-        - ${{package.name}}-config-compat
-        - busybox # the httpd-foreground script calls `rm`
-        - merged-usrsbin
-        - wolfi-baselayout
-    pipeline:
-      - runs: |
-          set -x
-
-          # Create necessary folders
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
-
-          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
-          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
-          # Create symlinks
-          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
     test:
       environment:
         contents:
           packages:
             - curl
-            - ${{package.name}}-config-compat
       pipeline:
         - runs: |
             # Verify config is as expected upstream docker instance

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -156,8 +156,8 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/etc/apache2
           mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
-          cp "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
-          cp "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
+          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+          mv "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
 
   - name: ${{package.name}}-config-compat
     dependencies:
@@ -275,11 +275,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
-
-          # Install necessary config files
-          mkdir -p "${{targets.subpkgdir}}"/etc/apache2
-          cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
-          cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
 
           # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
           install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -12,7 +12,6 @@ package:
       - lua5.4
       - merged-usrsbin
       - wolfi-baselayout
-      - ${{package.name}}-config
 
 environment:
   contents:
@@ -152,23 +151,25 @@ subpackages:
         - wolfi-baselayout
 
   - name: ${{package.name}}-config
-    description: ${{package.name}} httpd.conf configuration
+    description: ${{package.name}} httpd.conf and httpd-ssl.conf configuration
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/etc/apache2
-          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
+          cp "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+          cp "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
 
-  - name: ${{package.name}}-data
-    description: "Apache HTTP Server (data files)"
+  - name: ${{package.name}}-config-compat
+    dependencies:
+      replaces:
+        - apache2-config
+      provides:
+        - apache2-config
+    description: ${{package.name}} httpd.conf and httpd-ssl.conf configuration for compat
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/apache2
-          mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
-          mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
 
   - name: ${{package.name}}-config
     description: ${{package.name}} configuration files
@@ -244,6 +245,17 @@ subpackages:
 
           ### Add Include directive for additional configs
           echo "IncludeOptional /etc/apache2/conf.d/*.conf" >> "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
+  - name: ${{package.name}}-data
+    description: "Apache HTTP Server (data files)"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/apache2
+          mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
+          mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
+    dependencies:
+      runtime:
+        - merged-usrsbin
+        - wolfi-baselayout
 
   - name: ${{package.name}}-compat
     description: "Config compatibility to upstream docker image"
@@ -263,6 +275,11 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+
+          # Install necessary config files
+          mkdir -p "${{targets.subpkgdir}}"/etc/apache2
+          cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
+          cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
 
           # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
           install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -12,6 +12,7 @@ package:
       - lua5.4
       - merged-usrsbin
       - wolfi-baselayout
+      - ${{package.name}}-config
 
 environment:
   contents:
@@ -149,6 +150,13 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: ${{package.name}}-config
+    description: ${{package.name}} httpd.conf configuration
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
 
   - name: ${{package.name}}-data
     description: "Apache HTTP Server (data files)"

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: docker-library-php
-  version: 0_git20250515
+  version: 0_git20250517
   epoch: 0
   description: "Docker Official Image packaging for PHP"
   copyright:

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -33,6 +33,22 @@ pipeline:
       install -m755 apache2-foreground ${{targets.destdir}}/usr/bin/apache2-foreground
       install -m755 docker-php-* ${{targets.destdir}}/usr/bin/
 
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "upstream image have executable placed at /usr/local/bin"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          for f in apache2-foreground docker-php-entrypoint docker-php-ext-configure docker-php-ext-enable docker-php-ext-install docker-php-source; do
+            ln -s /usr/bin/$f "${{targets.contextdir}}"/usr/local/bin/$f
+          done
+    test:
+      pipeline:
+        - runs: |
+            for f in apache2-foreground docker-php-entrypoint docker-php-ext-configure docker-php-ext-enable docker-php-ext-install docker-php-source; do
+              test "$(readlink /usr/local/bin/$f)" = "/usr/bin/$f"
+            done
+
 update:
   enabled: true
   git: {}

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: docker-library-php
-  version: 0_git20250514
+  version: 0_git20250515
   epoch: 0
   description: "Docker Official Image packaging for PHP"
   copyright:

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: docker-library-php
-  version: 0_git20250426
+  version: 0_git20250510
   epoch: 0
   description: "Docker Official Image packaging for PHP"
   copyright:
@@ -25,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/docker-library/php
       branch: master
-      expected-commit: d21ab07e7f4014a5443f47c8ff8e292f9c703a58
+      expected-commit: f998dfe65a30aeefeaa3366db0d9cb2960ee888a
 
   - name: Install scripts
     runs: |

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: docker-library-php
-  version: 0_git20250510
+  version: 0_git20250514
   epoch: 0
   description: "Docker Official Image packaging for PHP"
   copyright:

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,0 +1,50 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: docker-library-php
+  version: 0_git20250426
+  epoch: 0
+  description: "Docker Official Image packaging for PHP"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - apache2
+      - bash # apache2-foreground
+      - dash-binsh # docker-php-*
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/docker-library/php
+      branch: master
+      expected-commit: d21ab07e7f4014a5443f47c8ff8e292f9c703a58
+
+  - name: Install scripts
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -m755 apache2-foreground ${{targets.destdir}}/usr/bin/apache2-foreground
+      install -m755 docker-php-* ${{targets.destdir}}/usr/bin/
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: Upstream does not maintain tags or releases
+
+test:
+  pipeline:
+    - name: Ensure installed scripts are executable
+      runs: |
+        for f in apache2-foreground docker-php-entrypoint docker-php-ext-configure docker-php-ext-enable docker-php-ext-install docker-php-source; do
+          command -v "$f"
+          [ -x "/usr/bin/$f" ]
+        done

--- a/docker-library-php.yaml
+++ b/docker-library-php.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: docker-library-php
-  version: 0_git20250517
+  version: 0_git20250522
   epoch: 0
   description: "Docker Official Image packaging for PHP"
   copyright:

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: nextcloud-server
-  version: 31.0.4
+  version: 31.0.5
   epoch: 0
   description: "Nextcloud server, a safe home for all your data"
   copyright:
@@ -118,7 +118,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://download.nextcloud.com/server/releases/nextcloud-${{package.version}}.tar.bz2
-      expected-sha256: a47541566d5c6ac6f63e4f617e27da295156da47daa2cd22eee3400fd2ad1251
+      expected-sha256: 2228b8f524dcd87f08a2a9281d41b04f5cb500b7624bc8c8e07b8e3039061503
       directory: ${{targets.destdir}}/usr/src/nextcloud
       delete: true
 

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -140,6 +140,7 @@ pipeline:
     runs: |
       # Upstream image uses /usr/bin/apache2, but we have /usr/bin/httpd instead, both are the same
       # https://github.com/docker-library/php/blob/d21ab07e7f4014a5443f47c8ff8e292f9c703a58/apache2-foreground#L40
+      mkdir -p ${{targets.destdir}}/usr/bin
       ln -sf /usr/bin/httpd ${{targets.destdir}}/usr/bin/apache2
 
 update:

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -34,6 +34,7 @@ package:
       - php-${{vars.php-version}}-bcmath
       - php-${{vars.php-version}}-exif
       - php-${{vars.php-version}}-ftp
+      - php-${{vars.php-version}}-fpm
       - php-${{vars.php-version}}-gd
       - php-${{vars.php-version}}-gmp
       - php-${{vars.php-version}}-intl
@@ -61,6 +62,7 @@ package:
       - php-${{vars.php-version}}-posix
       - php-${{vars.php-version}}-xmlwriter
       - rsync
+      - ${{package.name}}-apache2-config
   scriptlets:
     post-install: |
       #!/bin/sh
@@ -83,6 +85,7 @@ var-transforms:
 environment:
   contents:
     packages:
+      - apache2-config
       - bash
       - build-base
       - busybox
@@ -190,6 +193,70 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/local/etc/php
       ln -sf /${PHP_INI_DIR}/conf.d ${{targets.destdir}}/usr/local/etc/php/conf.d
 
+  - name: Activate Apache site + modules
+    runs: |
+      # IMPORTANT: The additional configuration files are need to be in the conf.d directory
+      # in order to be loaded by the Apache server. And since we use the `apache2-compat` package
+      # at runtime, the `ServerRoot` is set to `/usr/local/apache2`, so we need to
+      # create the `conf.d` directory in there. If we don't do this, the Apache server will not
+      # load the additional configuration files and the server will not work as expected. It would
+      # only print the default Apache page: "It works!".
+
+      mkdir -p ${{targets.destdir}}/etc/apache2/conf.d
+
+      cat > ${{targets.destdir}}/etc/apache2/conf.d/000-nextcloud.conf <<'EOF'
+      # ---- Nextcloud on Wolfi ----
+      # Extra modules not already enabled in stock httpd.conf
+      LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
+      LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
+      LoadModule rewrite_module     /usr/lib/apache2/modules/mod_rewrite.so
+      LoadModule remoteip_module    /usr/lib/apache2/modules/mod_remoteip.so
+      LoadModule php_module         /usr/lib/apache2/modules/libphp.so
+
+      ServerName localhost
+      DocumentRoot "/var/www/html"
+
+      <FilesMatch \.php$>
+        SetHandler application/x-httpd-php
+      </FilesMatch>
+
+      <Directory "/var/www/html">
+        Require all granted
+        AllowOverride All
+        Options Indexes FollowSymLinks
+        DirectoryIndex index.php index.html
+      </Directory>
+
+      IncludeOptional /etc/apache2/conf-available/remoteip.conf
+      IncludeOptional /etc/apache2/conf-available/apache-limits.conf
+      EOF
+
+subpackages:
+  - name: ${{package.name}}-apache2-config
+    description: ${{package.name}} Apache2 httpd.conf configuration
+    dependencies:
+      replaces:
+        - apache2-config
+      provides:
+        - apache2-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          # First, copy the default httpd.conf file from the apache2-config package
+          cp /etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+
+          # Comment out threaded MPMs and add prefork
+          sed -ri \
+            -e 's/^(\s*)LoadModule\s+mpm_event_module/#\1LoadModule mpm_event_module/' \
+            -e 's/^(\s*)LoadModule\s+mpm_worker_module/#\1LoadModule mpm_worker_module/' \
+            "${{targets.contextdir}}/etc/apache2/httpd.conf"
+
+          grep -q mpm_prefork_module "${{targets.contextdir}}"/etc/apache2/httpd.conf || \
+            sed -i '/mod_mime\.so/a LoadModule mpm_prefork_module modules/mod_mpm_prefork.so' "${{targets.contextdir}}"/etc/apache2/httpd.conf
+
+          echo 'ServerRoot "/etc/apache2"' >> "${{targets.contextdir}}/etc/apache2/httpd.conf"
+          echo 'IncludeOptional conf.d/*.conf' >> "${{targets.contextdir}}/etc/apache2/httpd.conf"
+
 update:
   enabled: true
   github:
@@ -216,6 +283,7 @@ test:
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
   pipeline:
+    # TODO: ensure enabled modules "httpd -M | grep -E 'php|rewrite|remoteip'"
     - name: Ensure installed files
       runs: |
         for f in /cron.sh /entrypoint.sh /upgrade.exclude; do
@@ -223,6 +291,12 @@ test:
           [ -x "$f" ]
         done
         find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
+    - name: Ensure all needed modules are enabled
+      runs: |
+        # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
+        apache2-foreground -M 2>/dev/null \
+        | grep -E '(access_compat|alias|auth_basic|authn_(core|file)|authz_(core|host|user)|autoindex|deflate|dir|env|filter|headers|mime|mpm_prefork|negotiation|php|remoteip|reqtimeout|rewrite|setenvif|status)_module'
+
     - working-directory: /var/www/html
       pipeline:
         - name: "start daemon on localhost"

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -290,14 +290,19 @@ test:
         /bin/bash -c '
         set -eo pipefail
 
-        required_modules=$(crane export nextcloud:${{package.version}} - | \
+        # Sometimes the tag is not available yet, so its ok to use the previous one
+        # e.g. 31.0.4 -> 31.0.3
+        tag=${{package.version}}
+        crane manifest nextcloud:$tag >/dev/null 2>&1 || tag=${tag%.*}.$(( ${tag##*.} - 1 ))
+
+        required_modules=$(crane export nextcloud:$tag - | \
           tar -tvf - | \
           grep "usr/local/lib/php/extensions/.*\.so$" | \
           awk -F"/" "{print \$NF}" | \
           sed "s/\.so\$//" | \
           sort -u)
 
-        echo "Modules required by nextcloud:${{package.version}}:"
+        echo "Modules required by nextcloud:$tag:"
         echo "$required_modules"
 
         loaded_modules=$(php -m | tr "[:upper:]" "[:lower:]" | sed "s/zend opcache/opcache/")

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -28,9 +28,11 @@ package:
       - php-${{vars.php-version}}-ldap
       - php-${{vars.php-version}}-opcache
       - php-${{vars.php-version}}-pcntl
+      - php-${{vars.php-version}}-pdo
       - php-${{vars.php-version}}-pdo_mysql
+      - php-${{vars.php-version}}-mysqlnd
       - php-${{vars.php-version}}-pdo_pgsql
-      #- php-${{vars.php-version}}-sysvsem
+      - php-${{vars.php-version}}-sysvsem
       - php-${{vars.php-version}}-zip
       - rsync
   scriptlets:
@@ -159,15 +161,8 @@ pipeline:
       # https://github.com/docker-library/php/blob/d21ab07e7f4014a5443f47c8ff8e292f9c703a58/apache2-foreground#L40
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -sf /usr/bin/httpd ${{targets.destdir}}/usr/bin/apache2
-
-subpackages:
-  - name: ${{package.name}}-frontend
-    description: "Nextcloud frontend"
-    pipeline:
-      - working-directory: ${{targets.destdir}}/usr/src/nextcloud
-        runs: |
-          npm install
-          npm run build
+      mkdir -p ${{targets.destdir}}/usr/local/etc/php
+      ln -sf /${PHP_INI_DIR}/conf.d ${{targets.destdir}}/usr/local/etc/php/conf.d
 
 update:
   enabled: true

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -18,6 +18,7 @@ package:
       - su-exec
       - diffutils
       - apache2-utils
+      - apache2-compat
       - procps
       - apache2
       - bash
@@ -62,7 +63,6 @@ package:
       - php-${{vars.php-version}}-posix
       - php-${{vars.php-version}}-xmlwriter
       - rsync
-      - ${{package.name}}-apache2-config
   scriptlets:
     post-install: |
       #!/bin/sh
@@ -85,7 +85,6 @@ var-transforms:
 environment:
   contents:
     packages:
-      - apache2-config
       - bash
       - build-base
       - busybox
@@ -207,10 +206,10 @@ pipeline:
       cat > ${{targets.destdir}}/etc/apache2/conf.d/000-nextcloud.conf <<'EOF'
       # ---- Nextcloud on Wolfi ----
       # Extra modules not already enabled in stock httpd.conf
-      LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
-      LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
-      LoadModule rewrite_module     /usr/lib/apache2/modules/mod_rewrite.so
-      LoadModule remoteip_module    /usr/lib/apache2/modules/mod_remoteip.so
+      # LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
+      # LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
+      # LoadModule rewrite_module     /usr/lib/apache2/modules/mod_rewrite.so
+      # LoadModule remoteip_module    /usr/lib/apache2/modules/mod_remoteip.so
       LoadModule php_module         /usr/lib/apache2/modules/libphp.so
 
       ServerName localhost
@@ -230,19 +229,6 @@ pipeline:
       IncludeOptional /etc/apache2/conf-available/remoteip.conf
       IncludeOptional /etc/apache2/conf-available/apache-limits.conf
       EOF
-
-subpackages:
-  - name: ${{package.name}}-apache2-config
-    description: ${{package.name}} Apache2 httpd.conf configuration
-    dependencies:
-      replaces:
-        - apache2-config
-      provides:
-        - apache2-config
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/etc/apache2
-          cp /etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
 
 update:
   enabled: true

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -31,6 +31,7 @@ package:
       - libmagic
       - imagemagick
       - php-${{vars.php-version}}
+      - php-${{vars.php-version}}-config
       - php-${{vars.php-version}}-apache
       - php-${{vars.php-version}}-bcmath
       - php-${{vars.php-version}}-exif
@@ -140,6 +141,10 @@ pipeline:
       mkdir -p ${{targets.destdir}}/${PHP_INI_DIR}/conf.d
       mkdir -p ${{targets.destdir}}/etc/apache2/conf-available
 
+  - name: Set permissions
+    runs: |
+      chmod +x ${{targets.destdir}}/usr/src/nextcloud/occ
+
   - working-directory: nextcloud-docker/${{vars.major-version}}/apache
     runs: |
       cp -a config/. "${{targets.destdir}}/usr/src/nextcloud/config/"
@@ -230,6 +235,12 @@ subpackages:
           sed -i 's|/usr/share/apache2/default-site/htdocs|/var/www/html|' "$TARGET"
           sed -i 's|/usr/local/apache2/htdocs|/var/www/html|' "$TARGET"
 
+          # Fix the error: `Apache is running a threaded MPM, but your PHP Module is not compiled to be threadsafe. You need to recompile PHP.`
+          sed -ri \
+            -e 's|^(\s*)LoadModule mpm_event_module|\1#LoadModule mpm_event_module|' \
+            -e 's|^(\s*)#*LoadModule mpm_prefork_module|\1LoadModule mpm_prefork_module|' \
+            "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
+
           cat <<EOF >> "$TARGET"
           LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
           LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
@@ -256,6 +267,8 @@ test:
       packages:
         - wait-for-it
         - curl
+        - crane
+        - gnutar
     accounts:
       groups:
         - groupname: www-data
@@ -269,7 +282,6 @@ test:
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
   pipeline:
-    # TODO: ensure enabled modules "httpd -M | grep -E 'php|rewrite|remoteip'"
     - name: Ensure installed files
       runs: |
         for f in /cron.sh /entrypoint.sh /upgrade.exclude; do
@@ -281,11 +293,55 @@ test:
       runs: |
         # Check if the httpd.conf file is valid
         cat /etc/apache2/httpd.conf | grep "ServerRoot"
-    # - name: Ensure all needed modules are enabled
-    #   runs: |
-    #     # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
-    #     apache2-foreground -M 2>/dev/null \
-    #     | grep -E '(access_compat|alias|auth_basic|authn_(core|file)|authz_(core|host|user)|autoindex|deflate|dir|env|filter|headers|mime|mpm_prefork|negotiation|php|remoteip|reqtimeout|rewrite|setenvif|status)_module'
+    - name: Ensure the PHP modules match Nextcloud image
+      runs: |
+        /bin/bash -c '
+        set -eo pipefail
+
+        required_modules=$(crane export nextcloud:${{package.version}} - | \
+          tar -tvf - | \
+          grep "usr/local/lib/php/extensions/.*\.so$" | \
+          awk -F"/" "{print \$NF}" | \
+          sed "s/\.so\$//" | \
+          sort -u)
+
+        echo "Modules required by nextcloud:${{package.version}}:"
+        echo "$required_modules"
+
+        loaded_modules=$(php -m | tr "[:upper:]" "[:lower:]" | sed "s/zend opcache/opcache/")
+
+        missing_modules=()
+        while read -r module; do
+          if ! grep -iq "^${module}$" <<< "$loaded_modules"; then
+            missing_modules+=("$module")
+          fi
+        done <<< "$required_modules"
+
+        if [ ${#missing_modules[@]} -ne 0 ]; then
+          echo "Missing PHP modules: ${missing_modules[*]}"
+          exit 1
+        else
+          echo "All required PHP modules are loaded!"
+        fi
+        '
+    - name: Ensure the apache2-foreground loads the modules
+      runs: |
+        # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
+        set -e
+        { apache2-foreground -e debug 2>&1 | tee /tmp/apache2-foreground.log; } &>/dev/null &
+        sleep 5 # Wait for apache to write the log, then it will exit anyway due to permissions
+        set +e
+        PID=$!
+        wait $PID
+        kill $PID 2>/dev/null || true
+        OUTPUT=$(cat /tmp/apache2-foreground.log)
+        for m in mpm_prefork authn_file authn_core authz_host authz_groupfile authz_user authz_core access_compat auth_basic reqtimeout filter mime log_config env headers setenvif version unixd status autoindex dir alias deflate negotiation rewrite remoteip php; do
+          if ! echo "$OUTPUT" | grep -qi "loaded module $m"; then
+            echo "Module $m is not enabled."
+            echo "Output: $OUTPUT"
+            exit 1
+          fi
+        done
     - working-directory: /var/www/html
       pipeline:
         - name: "start daemon on localhost"
@@ -296,6 +352,45 @@ test:
             expected_output: |
               Initializing nextcloud
               Initializing finished
+              resuming normal operations
+            # Override the default error strings to check for additional errors
+            error_strings: |
+              ERROR
+              FAIL
+              FATAL
+              Traceback.*most.recent.call
+              Exception in thread
+              java.lang.*Exception
+              command not found
+              No such file or directory
+              php:crit
+              PHP Module is not compiled to be threadsafe
+              Pre-configuration failed
             post: |
               wait-for-it -t 10 --strict localhost:80
-              curl -sSf --retry 3 http://localhost | grep -iq "It works!"
+              # If http://localhost:80 shows "It works!", that means Apache is running
+              # but wrongly configured, so we need to check if the Nextcloud page is actually shown.
+              # Ensure that the we dont get the default Apache page, "It works!".
+              set -e
+              OUTPUT=$(curl -sSfL --retry 3 http://localhost:80)
+              set +e
+              if echo "$OUTPUT" | grep -qi "It works"; then
+                echo "Apache is running but not configured correctly!"
+                echo "Output: $OUTPUT"
+                exit 1
+              fi
+              if echo "$OUTPUT" | grep -qi "not installed"; then
+                echo "One or more PHP modules are not installed!"
+                echo "Output: $OUTPUT"
+                exit 1
+              fi
+              if echo "$OUTPUT" | grep -qi "New nextcloud instance"; then
+                echo "Nextcloud is not properly configured!"
+                echo "Output: $OUTPUT"
+                exit 1
+              fi
+              if ! echo "$OUTPUT" | grep -qi "Initializing nextcloud ${{package.version}}"; then
+                echo "Nextcloud version is not set correctly!"
+                echo "Output: $OUTPUT"
+                exit 1
+              fi

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -206,10 +206,10 @@ subpackages:
     dependencies:
       replaces:
         - apache2-config
-        - apache2-compat
+        - apache2-config-compat
       provides:
         - apache2-config
-        - apache2-compat
+        - apache2-config-compat
     pipeline:
       - runs: |
           # IMPORTANT: The additional configuration files are need to be in the conf.d directory
@@ -277,6 +277,10 @@ test:
           [ -x "$f" ]
         done
         find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
+    - name: Check http.conf
+      runs: |
+        # Check if the httpd.conf file is valid
+        cat /etc/apache2/httpd.conf | grep "ServerRoot"
     # - name: Ensure all needed modules are enabled
     #   runs: |
     #     # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -242,20 +242,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/etc/apache2
-          # First, copy the default httpd.conf file from the apache2-config package
           cp /etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
-
-          # Comment out threaded MPMs and add prefork
-          sed -ri \
-            -e 's/^(\s*)LoadModule\s+mpm_event_module/#\1LoadModule mpm_event_module/' \
-            -e 's/^(\s*)LoadModule\s+mpm_worker_module/#\1LoadModule mpm_worker_module/' \
-            "${{targets.contextdir}}/etc/apache2/httpd.conf"
-
-          grep -q mpm_prefork_module "${{targets.contextdir}}"/etc/apache2/httpd.conf || \
-            sed -i '/mod_mime\.so/a LoadModule mpm_prefork_module modules/mod_mpm_prefork.so' "${{targets.contextdir}}"/etc/apache2/httpd.conf
-
-          echo 'ServerRoot "/etc/apache2"' >> "${{targets.contextdir}}/etc/apache2/httpd.conf"
-          echo 'IncludeOptional conf.d/*.conf' >> "${{targets.contextdir}}/etc/apache2/httpd.conf"
 
 update:
   enabled: true
@@ -291,12 +278,11 @@ test:
           [ -x "$f" ]
         done
         find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
-    - name: Ensure all needed modules are enabled
-      runs: |
-        # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
-        apache2-foreground -M 2>/dev/null \
-        | grep -E '(access_compat|alias|auth_basic|authn_(core|file)|authz_(core|host|user)|autoindex|deflate|dir|env|filter|headers|mime|mpm_prefork|negotiation|php|remoteip|reqtimeout|rewrite|setenvif|status)_module'
-
+    # - name: Ensure all needed modules are enabled
+    #   runs: |
+    #     # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
+    #     apache2-foreground -M 2>/dev/null \
+    #     | grep -E '(access_compat|alias|auth_basic|authn_(core|file)|authz_(core|host|user)|autoindex|deflate|dir|env|filter|headers|mime|mpm_prefork|negotiation|php|remoteip|reqtimeout|rewrite|setenvif|status)_module'
     - working-directory: /var/www/html
       pipeline:
         - name: "start daemon on localhost"

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -19,6 +19,19 @@ package:
       - libmagic
       - imagemagick
       - php-${{vars.php-version}}
+      - php-${{vars.php-version}}-bcmath
+      - php-${{vars.php-version}}-exif
+      - php-${{vars.php-version}}-ftp
+      - php-${{vars.php-version}}-gd
+      - php-${{vars.php-version}}-gmp
+      - php-${{vars.php-version}}-intl
+      - php-${{vars.php-version}}-ldap
+      - php-${{vars.php-version}}-opcache
+      - php-${{vars.php-version}}-pcntl
+      - php-${{vars.php-version}}-pdo_mysql
+      - php-${{vars.php-version}}-pdo_pgsql
+      #- php-${{vars.php-version}}-sysvsem
+      - php-${{vars.php-version}}-zip
       - rsync
   scriptlets:
     post-install: |

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -39,7 +39,12 @@ package:
       - php-${{vars.php-version}}-gd
       - php-${{vars.php-version}}-gmp
       - php-${{vars.php-version}}-intl
+      - php-${{vars.php-version}}-apcu
       - php-${{vars.php-version}}-ldap
+      - php-${{vars.php-version}}-igbinary
+      - php-${{vars.php-version}}-imagick
+      - php-${{vars.php-version}}-memcached
+      - php-${{vars.php-version}}-sodium
       - php-${{vars.php-version}}-opcache
       - php-${{vars.php-version}}-pcntl
       - php-${{vars.php-version}}-pdo
@@ -61,8 +66,10 @@ package:
       - php-${{vars.php-version}}-curl
       - php-${{vars.php-version}}-openssl
       - php-${{vars.php-version}}-posix
+      - php-${{vars.php-version}}-xmlreader
       - php-${{vars.php-version}}-xmlwriter
       - rsync
+      - ${{package.name}}-apache2-config
   scriptlets:
     post-install: |
       #!/bin/sh
@@ -85,6 +92,7 @@ var-transforms:
 environment:
   contents:
     packages:
+      - apache2-compat
       - bash
       - build-base
       - busybox
@@ -192,43 +200,48 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/local/etc/php
       ln -sf /${PHP_INI_DIR}/conf.d ${{targets.destdir}}/usr/local/etc/php/conf.d
 
-  - name: Activate Apache site + modules
-    runs: |
-      # IMPORTANT: The additional configuration files are need to be in the conf.d directory
-      # in order to be loaded by the Apache server. And since we use the `apache2-compat` package
-      # at runtime, the `ServerRoot` is set to `/usr/local/apache2`, so we need to
-      # create the `conf.d` directory in there. If we don't do this, the Apache server will not
-      # load the additional configuration files and the server will not work as expected. It would
-      # only print the default Apache page: "It works!".
+subpackages:
+  - name: ${{package.name}}-apache2-config
+    description: ${{package.name}} Apache2 httpd.conf configuration
+    dependencies:
+      replaces:
+        - apache2-config
+        - apache2-compat
+      provides:
+        - apache2-config
+        - apache2-compat
+    pipeline:
+      - runs: |
+          # IMPORTANT: The additional configuration files are need to be in the conf.d directory
+          # in order to be loaded by the Apache server. And since we use the `apache2-compat` package
+          # at runtime, the `ServerRoot` is set to `/usr/local/apache2`, so we need to
+          # create the `conf.d` directory in there. If we don't do this, the Apache server will not
+          # load the additional configuration files and the server will not work as expected. It would
+          # only print the default Apache page: "It works!".
 
-      mkdir -p ${{targets.destdir}}/etc/apache2/conf.d
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra/
 
-      cat > ${{targets.destdir}}/etc/apache2/conf.d/000-nextcloud.conf <<'EOF'
-      # ---- Nextcloud on Wolfi ----
-      # Extra modules not already enabled in stock httpd.conf
-      # LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
-      # LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
-      # LoadModule rewrite_module     /usr/lib/apache2/modules/mod_rewrite.so
-      # LoadModule remoteip_module    /usr/lib/apache2/modules/mod_remoteip.so
-      LoadModule php_module         /usr/lib/apache2/modules/libphp.so
+          TARGET="${{targets.contextdir}}"/etc/apache2/httpd.conf
 
-      ServerName localhost
-      DocumentRoot "/var/www/html"
+          cp /etc/apache2/httpd.conf "$TARGET"
+          cp /etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
 
-      <FilesMatch \.php$>
-        SetHandler application/x-httpd-php
-      </FilesMatch>
+          sed -i 's|/usr/share/apache2/default-site/htdocs|/var/www/html|' "$TARGET"
+          sed -i 's|/usr/local/apache2/htdocs|/var/www/html|' "$TARGET"
 
-      <Directory "/var/www/html">
-        Require all granted
-        AllowOverride All
-        Options Indexes FollowSymLinks
-        DirectoryIndex index.php index.html
-      </Directory>
-
-      IncludeOptional /etc/apache2/conf-available/remoteip.conf
-      IncludeOptional /etc/apache2/conf-available/apache-limits.conf
-      EOF
+          cat <<EOF >> "$TARGET"
+          LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
+          LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
+          LoadModule rewrite_module     /usr/lib/apache2/modules/mod_rewrite.so
+          LoadModule remoteip_module    /usr/lib/apache2/modules/mod_remoteip.so
+          LoadModule php_module         /usr/lib/apache2/modules/libphp.so
+          <FilesMatch \.php$>
+            SetHandler application/x-httpd-php
+          </FilesMatch>
+          IncludeOptional /etc/apache2/conf-available/remoteip.conf
+          IncludeOptional /etc/apache2/conf-available/apache-limits.conf
+          EOF
 
 update:
   enabled: true

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -270,6 +270,7 @@ test:
         - crane
         - gnutar
         - tini
+        - procps
     accounts:
       groups:
         - groupname: www-data
@@ -295,7 +296,6 @@ test:
         grep -i 'ServerRoot "/usr/local/apache2"' /etc/apache2/httpd.conf
         grep -i 'DocumentRoot "//var/www/html"' /etc/apache2/httpd.conf
         apachectl -S # Final sanity check to ensure the config files are valid
-        killall -9 httpd || true # Kill the httpd process, so it doesn't interfere with the next test
     - name: Ensure the PHP modules match Nextcloud image
       runs: |
         /bin/bash -c '
@@ -336,12 +336,13 @@ test:
       runs: |
         # Those modules are scraped from the upstream image `nextcloud:latest`: `apache2-foreground -e debug`
         set -e
-        { apache2-foreground -e debug 2>&1 | tee /tmp/apache2-foreground.log; } &>/dev/null &
-        sleep 5 # Wait for apache to write the log, then it will exit anyway due to permissions
-        set +e
+        apache2-foreground -e debug 2>&1 | tee /tmp/apache2-foreground.log &>/dev/null &
         PID=$!
-        wait $PID
+        sleep 5
+        set +e
+        wait $PID || true
         kill $PID 2>/dev/null || true
+        sleep 5
         OUTPUT=$(cat /tmp/apache2-foreground.log)
         for m in mpm_prefork authn_file authn_core authz_host authz_groupfile authz_user authz_core access_compat auth_basic reqtimeout filter mime log_config env headers setenvif version unixd status autoindex dir alias deflate negotiation rewrite remoteip php; do
           if ! echo "$OUTPUT" | grep -qi "loaded module $m"; then
@@ -350,6 +351,7 @@ test:
             exit 1
           fi
         done
+        kill -KILL $(pidof apache2 httpd) 2>/dev/null || true # Ensure that all of the subprocesses are killed
     - working-directory: /var/www/html
       pipeline:
         - name: "start daemon on localhost"

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -213,9 +213,6 @@ subpackages:
       replaces:
         - apache2-config
         - apache2-config-compat
-      provides:
-        - apache2-config
-        - apache2-config-compat
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/etc/apache2

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -30,6 +30,7 @@ package:
       - libldap
       - libmagic
       - imagemagick
+      - openssl
       - php-${{vars.php-version}}
       - php-${{vars.php-version}}-config
       - php-${{vars.php-version}}-apache

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -77,6 +77,8 @@ package:
       #!/bin/sh
       # As wolfi-baselayout does provide /var/spool/cron already, and we can not create this
       # directory in the package, we need to create the cron file in the post-install scriptlet.
+      # Since scriptlets don't run in apko, this is for the `apk add` command only.
+      mkdir -p /var/spool/cron/crontabs || true
       echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
 vars:
@@ -115,6 +117,10 @@ environment:
 pipeline:
   - runs: mkdir -p ${{targets.destdir}}/usr/src/nextcloud
 
+  # We are using the release tarball from Nextcloud, not the GitHub repo, because
+  # they release their source code by omitting other lots of unnecessary stuff (that we don't need on runtime and build-time)
+  # and also PHP is not a compiled lang. The tarball should be exactly same in the GitHub, so this is safe to use.
+  # We don't build anything at all, all we need to do is to copy the files around.
   - uses: fetch
     with:
       uri: https://download.nextcloud.com/server/releases/nextcloud-${{package.version}}.tar.bz2
@@ -134,6 +140,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/src/nextcloud/data
       mkdir -p ${{targets.destdir}}/usr/src/nextcloud/custom_apps
       mkdir -p ${{targets.destdir}}/var/www/data
+      mkdir -p ${{targets.destdir}}/var/www/html
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-installation
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/post-installation
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-upgrade
@@ -232,6 +239,8 @@ subpackages:
             -e 's|^(\s*)#*LoadModule mpm_prefork_module|\1LoadModule mpm_prefork_module|' \
             "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
 
+          # Load additional modules that upstream image loads by default
+          # Also include the config files for remoteip and apache-limits as upstream image does
           cat <<EOF >> "$TARGET"
           LoadModule deflate_module     /usr/lib/apache2/modules/mod_deflate.so
           LoadModule negotiation_module /usr/lib/apache2/modules/mod_negotiation.so
@@ -269,7 +278,7 @@ test:
         - username: www-data
           gid: 65532
           uid: 65532
-      run-as: 0 # to create /var directory for testing
+      run-as: 0 # to create /var directory for testing, it should also be working as 65532
     environment:
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
@@ -281,10 +290,12 @@ test:
           [ -x "$f" ]
         done
         find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
-    - name: Check http.conf
+    - name: Validate httpd.conf file
       runs: |
-        # Check if the httpd.conf file is valid
-        cat /etc/apache2/httpd.conf | grep "ServerRoot"
+        grep -i 'ServerRoot "/usr/local/apache2"' /etc/apache2/httpd.conf
+        grep -i 'DocumentRoot "//var/www/html"' /etc/apache2/httpd.conf
+        apachectl -S # Final sanity check to ensure the config files are valid
+        killall -9 httpd || true # Kill the httpd process, so it doesn't interfere with the next test
     - name: Ensure the PHP modules match Nextcloud image
       runs: |
         /bin/bash -c '

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -12,10 +12,12 @@ package:
       - bash
       - dash-binsh
       - docker-library-php
+      - docker-library-php-compat
       - busybox
       - bzip2
       - libldap
       - libmagic
+      - imagemagick
       - php-${{vars.php-version}}
       - rsync
   scriptlets:
@@ -47,6 +49,8 @@ environment:
       - composer
       - curl
       - git
+      - nodejs
+      - npm
       - php-${{vars.php-version}}
   environment:
     APACHE_BODY_LIMIT: "1073741824"
@@ -143,6 +147,15 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -sf /usr/bin/httpd ${{targets.destdir}}/usr/bin/apache2
 
+subpackages:
+  - name: ${{package.name}}-frontend
+    description: "Nextcloud frontend"
+    pipeline:
+      - working-directory: ${{targets.destdir}}/usr/src/nextcloud
+        runs: |
+          npm install
+          npm run build
+
 update:
   enabled: true
   github:
@@ -154,10 +167,17 @@ test:
   environment:
     contents:
       packages:
-        - apache2
-        - apache2-utils
-        - apache2-data
-        - apache2-compat
+        - wait-for-it
+        - curl
+    accounts:
+      groups:
+        - groupname: www-data
+          gid: 65532
+      users:
+        - username: www-data
+          gid: 65532
+          uid: 65532
+      run-as: 0 # to create /var directory for testing
     environment:
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
@@ -174,8 +194,11 @@ test:
         - name: "start daemon on localhost"
           uses: test/daemon-check-output
           with:
-            start: "bash -x /entrypoint.sh apache2-foreground"
+            start: "/entrypoint.sh apache2-foreground"
             timeout: 120
             expected_output: |
               Initializing nextcloud
               Initializing finished
+            post: |
+              wait-for-it -t 10 --strict localhost:80
+              curl -sSf --retry 3 http://localhost | grep -iq "It works!"

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -8,6 +8,17 @@ package:
     - license: AGPL-3.0-or-later
   dependencies:
     runtime:
+      - coreutils
+      - findutils
+      - grep
+      - sed
+      - flock
+      - redis
+      - rsync
+      - su-exec
+      - diffutils
+      - apache2-utils
+      - procps
       - apache2
       - bash
       - dash-binsh
@@ -34,6 +45,20 @@ package:
       - php-${{vars.php-version}}-pdo_pgsql
       - php-${{vars.php-version}}-sysvsem
       - php-${{vars.php-version}}-zip
+      - php-${{vars.php-version}}-redis
+      - php-${{vars.php-version}}-pdo_sqlite
+      - php-${{vars.php-version}}-iconv
+      - php-${{vars.php-version}}-ctype
+      - php-${{vars.php-version}}-dom
+      - php-${{vars.php-version}}-curl
+      - php-${{vars.php-version}}-xml
+      - php-${{vars.php-version}}-simplexml
+      - php-${{vars.php-version}}-fileinfo
+      - php-${{vars.php-version}}-mbstring
+      - php-${{vars.php-version}}-curl
+      - php-${{vars.php-version}}-openssl
+      - php-${{vars.php-version}}-posix
+      - php-${{vars.php-version}}-xmlwriter
       - rsync
   scriptlets:
     post-install: |

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -177,7 +177,7 @@ pipeline:
 
       # Set apache config LimitRequestBody
       {
-        echo 'LimitRequestBody ${APACHE_BODY_LIMIT}'
+        echo "LimitRequestBody ${APACHE_BODY_LIMIT}"
       } > ${{targets.destdir}}/etc/apache2/conf-available/apache-limits.conf
 
   - name: Configure symlinks

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -218,13 +218,6 @@ subpackages:
         - apache2-config-compat
     pipeline:
       - runs: |
-          # IMPORTANT: The additional configuration files are need to be in the conf.d directory
-          # in order to be loaded by the Apache server. And since we use the `apache2-compat` package
-          # at runtime, the `ServerRoot` is set to `/usr/local/apache2`, so we need to
-          # create the `conf.d` directory in there. If we don't do this, the Apache server will not
-          # load the additional configuration files and the server will not work as expected. It would
-          # only print the default Apache page: "It works!".
-
           mkdir -p "${{targets.contextdir}}"/etc/apache2
           mkdir -p "${{targets.contextdir}}"/etc/apache2/extra/
 

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -1,0 +1,153 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: nextcloud-server
+  version: 31.0.4
+  epoch: 0
+  description: "Nextcloud server, a safe home for all your data"
+  copyright:
+    - license: AGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - busybox
+      - bzip2
+      - libldap
+      - libmagic
+      - php-${{vars.php-version}}
+      - rsync
+  scriptlets:
+    post-install: |
+      #!/bin/sh
+      echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+vars:
+  php-version: 8.1
+
+# Create a new major-version variable that contains only the major version
+# to use in the `nextcloud/docker` repo to find out the correct folder for the image.
+# e.g. 31.0.4 will create a new var major-version=31
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - composer
+      - git
+      - php-${{vars.php-version}}
+  environment:
+    APACHE_BODY_LIMIT: "1073741824"
+    PHP_MEMORY_LIMIT: "512M"
+    PHP_UPLOAD_LIMIT: "512M"
+    PHP_OPCACHE_MEMORY_CONSUMPTION: "128"
+    PHP_INI_DIR: "etc/php"
+
+pipeline:
+  - runs: mkdir -p ${{targets.destdir}}/usr/src
+
+  - uses: fetch
+    with:
+      uri: https://download.nextcloud.com/server/releases/nextcloud-${{package.version}}.tar.bz2
+      expected-sha256: a47541566d5c6ac6f63e4f617e27da295156da47daa2cd22eee3400fd2ad1251
+      directory: ${{targets.destdir}}/usr/src
+      delete: true
+
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nextcloud/docker
+      branch: master # It's ok to use master branch here, as this is something is not build-able thing; we just copy files around.
+      expected-commit: af005991484e03918488bb6cdb75750598a121f5
+      destination: nextcloud-docker
+
+  - name: Create dirs
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/src/nextcloud/data
+      mkdir -p ${{targets.destdir}}/usr/src/nextcloud/custom_apps
+      mkdir -p ${{targets.destdir}}/var/www/data
+      mkdir -p ${{targets.destdir}}/usr/src/nextcloud/occ
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-installation
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/post-installation
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-upgrade
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/post-upgrade
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/before-starting
+      chmod +x ${{targets.destdir}}/usr/src/nextcloud/occ
+
+  - working-directory: nextcloud-docker/${{vars.major-version}}/apache
+    runs: |
+      install -m755 config/* ${{targets.destdir}}/usr/src/nextcloud/config
+      install -m755 *.sh ${{targets.destdir}}/
+      install -m755 upgrade.exclude ${{targets.destdir}}/
+
+  - name: Prepare configs
+    runs: |
+      # Write opcache recommended settings
+      {
+          echo 'opcache.enable=1'
+          echo 'opcache.interned_strings_buffer=32'
+          echo 'opcache.max_accelerated_files=10000'
+          echo "opcache.memory_consumption=${PHP_OPCACHE_MEMORY_CONSUMPTION}"
+          echo 'opcache.save_comments=1'
+          echo 'opcache.revalidate_freq=60'
+          echo 'opcache.jit=1255'
+          echo 'opcache.jit_buffer_size=8M'
+      } > ${{targets.destdir}}/${PHP_INI_DIR}/conf.d/opcache-recommended.ini
+
+      # Enable APCu for CLI
+      {
+        echo 'apc.enable_cli=1'
+      } > ${{targets.destdir}}/${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini
+
+      # Configure igbinary serializer
+      {
+          echo 'apc.serializer=igbinary'
+          echo 'session.serialize_handler=igbinary'
+      } >> ${{targets.destdir}}/${PHP_INI_DIR}/conf.d/docker-php-ext-igbinary.ini
+
+      # Set Nextcloud PHP limits
+      {
+          echo "memory_limit=${PHP_MEMORY_LIMIT}"
+          echo "upload_max_filesize=${PHP_UPLOAD_LIMIT}"
+          echo "post_max_size=${PHP_UPLOAD_LIMIT}"
+      } > ${{targets.destdir}}/${PHP_INI_DIR}/conf.d/nextcloud.ini
+
+      # Set apache config RemoteIPs
+      {
+        echo 'RemoteIPHeader X-Real-IP'
+        echo 'RemoteIPInternalProxy 10.0.0.0/8'
+        echo 'RemoteIPInternalProxy 172.16.0.0/12'
+        echo 'RemoteIPInternalProxy 192.168.0.0/16'
+      } > ${{targets.destdir}}/etc/apache2/conf-available/remoteip.conf
+
+      # Set apache config LimitRequestBody
+      {
+        echo 'LimitRequestBody ${APACHE_BODY_LIMIT}'
+      } > ${{targets.destdir}}/etc/apache2/conf-available/apache-limits.conf
+
+update:
+  enabled: true
+  github:
+    identifier: nextcloud/server
+    use-tag: true
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Ensure installed files
+      runs: |
+        stat /cron.sh /entrypoint.sh /upgrade.exclude
+        find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
+    - working-directory: /var/www/html
+      pipeline:
+        - name: "start daemon on localhost"
+          uses: test/daemon-check-output
+          with:
+            start: "/entrypoint.sh apache2-foreground"
+            timeout: 120
+            expected_output: |
+              Server Running

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -30,6 +30,7 @@ package:
       - libmagic
       - imagemagick
       - php-${{vars.php-version}}
+      - php-${{vars.php-version}}-apache
       - php-${{vars.php-version}}-bcmath
       - php-${{vars.php-version}}-exif
       - php-${{vars.php-version}}-ftp

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -8,6 +8,10 @@ package:
     - license: AGPL-3.0-or-later
   dependencies:
     runtime:
+      - apache2
+      - bash
+      - dash-binsh
+      - docker-library-php
       - busybox
       - bzip2
       - libldap
@@ -17,6 +21,8 @@ package:
   scriptlets:
     post-install: |
       #!/bin/sh
+      # As wolfi-baselayout does provide /var/spool/cron already, and we can not create this
+      # directory in the package, we need to create the cron file in the post-install scriptlet.
       echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
 vars:
@@ -39,6 +45,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - composer
+      - curl
       - git
       - php-${{vars.php-version}}
   environment:
@@ -49,13 +56,13 @@ environment:
     PHP_INI_DIR: "etc/php"
 
 pipeline:
-  - runs: mkdir -p ${{targets.destdir}}/usr/src
+  - runs: mkdir -p ${{targets.destdir}}/usr/src/nextcloud
 
   - uses: fetch
     with:
       uri: https://download.nextcloud.com/server/releases/nextcloud-${{package.version}}.tar.bz2
       expected-sha256: a47541566d5c6ac6f63e4f617e27da295156da47daa2cd22eee3400fd2ad1251
-      directory: ${{targets.destdir}}/usr/src
+      directory: ${{targets.destdir}}/usr/src/nextcloud
       delete: true
 
   - uses: git-checkout
@@ -70,17 +77,17 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/src/nextcloud/data
       mkdir -p ${{targets.destdir}}/usr/src/nextcloud/custom_apps
       mkdir -p ${{targets.destdir}}/var/www/data
-      mkdir -p ${{targets.destdir}}/usr/src/nextcloud/occ
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-installation
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/post-installation
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/pre-upgrade
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/post-upgrade
       mkdir -p ${{targets.destdir}}/docker-entrypoint-hooks.d/before-starting
-      chmod +x ${{targets.destdir}}/usr/src/nextcloud/occ
+      mkdir -p ${{targets.destdir}}/${PHP_INI_DIR}/conf.d
+      mkdir -p ${{targets.destdir}}/etc/apache2/conf-available
 
   - working-directory: nextcloud-docker/${{vars.major-version}}/apache
     runs: |
-      install -m755 config/* ${{targets.destdir}}/usr/src/nextcloud/config
+      cp -a config/. "${{targets.destdir}}/usr/src/nextcloud/config/"
       install -m755 *.sh ${{targets.destdir}}/
       install -m755 upgrade.exclude ${{targets.destdir}}/
 
@@ -129,6 +136,12 @@ pipeline:
         echo 'LimitRequestBody ${APACHE_BODY_LIMIT}'
       } > ${{targets.destdir}}/etc/apache2/conf-available/apache-limits.conf
 
+  - name: Configure symlinks
+    runs: |
+      # Upstream image uses /usr/bin/apache2, but we have /usr/bin/httpd instead, both are the same
+      # https://github.com/docker-library/php/blob/d21ab07e7f4014a5443f47c8ff8e292f9c703a58/apache2-foreground#L40
+      ln -sf /usr/bin/httpd ${{targets.destdir}}/usr/bin/apache2
+
 update:
   enabled: true
   github:
@@ -137,17 +150,31 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - apache2
+        - apache2-utils
+        - apache2-data
+        - apache2-compat
+    environment:
+      NEXTCLOUD_ADMIN_USER: admin
+      NEXTCLOUD_ADMIN_PASSWORD: admin
   pipeline:
     - name: Ensure installed files
       runs: |
-        stat /cron.sh /entrypoint.sh /upgrade.exclude
+        for f in /cron.sh /entrypoint.sh /upgrade.exclude; do
+          stat ${f}
+          [ -x "$f" ]
+        done
         find /usr/src/nextcloud/config/ -type f -name "*.php" | grep -q .
     - working-directory: /var/www/html
       pipeline:
         - name: "start daemon on localhost"
           uses: test/daemon-check-output
           with:
-            start: "/entrypoint.sh apache2-foreground"
+            start: "bash -x /entrypoint.sh apache2-foreground"
             timeout: 120
             expected_output: |
-              Server Running
+              Initializing nextcloud
+              Initializing finished

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -260,6 +260,7 @@ test:
         - curl
         - crane
         - gnutar
+        - tini
     accounts:
       groups:
         - groupname: www-data
@@ -338,7 +339,7 @@ test:
         - name: "start daemon on localhost"
           uses: test/daemon-check-output
           with:
-            start: "/entrypoint.sh apache2-foreground"
+            start: "tini -s -- /entrypoint.sh apache2-foreground" # Had to use tini to make sure the process is reaped correctly by the daemon-check-output script
             timeout: 120
             expected_output: |
               Initializing nextcloud
@@ -377,11 +378,6 @@ test:
               fi
               if echo "$OUTPUT" | grep -qi "New nextcloud instance"; then
                 echo "Nextcloud is not properly configured!"
-                echo "Output: $OUTPUT"
-                exit 1
-              fi
-              if ! echo "$OUTPUT" | grep -qi "Initializing nextcloud ${{package.version}}"; then
-                echo "Nextcloud version is not set correctly!"
                 echo "Output: $OUTPUT"
                 exit 1
               fi

--- a/nextcloud-server.yaml
+++ b/nextcloud-server.yaml
@@ -82,7 +82,7 @@ package:
       echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
 vars:
-  php-version: 8.1
+  php-version: 8.3
 
 # Create a new major-version variable that contains only the major version
 # to use in the `nextcloud/docker` repo to find out the correct folder for the image.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
