### PR TITLE
azure-service-operator: generate crds correctly

### DIFF
--- a/azure-service-operator.yaml
+++ b/azure-service-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-service-operator
   version: "2.13.0"
-  epoch: 0
+  epoch: 1
   description: Azure Service Operator to provision Azure resources and connect your applications to them from within Kubernetes.
   copyright:
     - license: MIT
@@ -10,9 +10,12 @@ environment:
   contents:
     packages:
       - controller-gen
+      - gettext
       - gofumpt
+      - kustomize
       - python3
       - task
+      - yq
 
 pipeline:
   - uses: git-checkout
@@ -33,9 +36,20 @@ pipeline:
       - name: Generate CRDs
         runs: |
           mkdir reports
-          task controller:generate-crds
-          mkdir -p ${{targets.contextdir}}/usr/share/${{package.name}}/crds
-          cp v2/config/crd/generated/bases/* ${{targets.contextdir}}/usr/share/${{package.name}}/crds/
+          # The following task is a dependency of the task controller:bundle-crds,
+          # but we need to patch the generated kustomization because it's generated in
+          # legacy form of field `patches`, which is no longer compatible with the
+          # current version of Kustomize.
+          # So we need to patch it before it's consumed by the controller:bundle-crds
+          # task.
+          task controller:generate-kustomize
+          cd v2/config/crd/generated && \
+            sed -i "s|patches:|patchesStrategicMerge:|g" kustomization.yaml && \
+            kustomize edit fix && \
+            cd -
+          task controller:bundle-crds
+          mkdir -p ${{targets.contextdir}}/usr/share/${{package.name}}
+          cp -R v2/out/crds ${{targets.contextdir}}/usr/share/${{package.name}}/
 
 subpackages:
   - name: ${{package.name}}-compat
@@ -87,7 +101,7 @@ test:
         timeout: 30
         expected_output: |
           "Launching with flags" flags="MetricsAddr: 0, SecureMetrics: true, ProfilingMetrics: false, HealthAddr: , WebhookPort: 9443, WebhookCertDir: , EnableLeaderElection: false, CRDManagementMode: auto, CRDPatterns: resources.azure.com
-          "Loaded CRD" logger="controllers" crdPath="crds/resources.azure.com_resourcegroups.yaml" name="resourcegroups.resources.azure.com"
+          "Loaded CRD" logger="controllers" crdPath="crds/apiextensions.k8s.io_v1_customresourcedefinition_resourcegroups.resources.azure.com.yaml" name="resourcegroups.resources.azure.com"
           "Will update CRD" logger="controllers" crd="resourcegroups.resources.azure.com"
           "Applying CRD" logger="controllers" progress="1/1" crd="resourcegroups.resources.azure.com"
           "Restarting operator pod after updating CRDs" logger="controllers"


### PR DESCRIPTION
This PR fixes the generation of the CRDs managed by the operator.
Previously, expected labels in particular were missing leading to an infinite restart loop of the controller manager, since the CRDs applied at the startup, during the check selected by label, were never found.