### PR TITLE
align debezium packages with epoch:3

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: "3.0.8"
-  epoch: 2
+  epoch: 3
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/51727 updated `debezium-connect-entrypoint-3.0` to `epoch: 3` and some downstream things fail unless all the debezium packages have the same package+version. So let's bump these all to align.