### PR TITLE
nrjmx: Fix build failure by updating to version 2.8.1

### DIFF
--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -1,6 +1,6 @@
 package:
   name: nrjmx
-  version: "2.8.0"
+  version: "2.8.1"
   epoch: 0
   description: Command line tool to connect to a JMX server and retrieve the MBeans it exposes
   copyright:
@@ -29,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/newrelic/nrjmx
       tag: v${{package.version}}
-      expected-commit: 46b7d38cb561b9288ce0bc8e541e5cb2afc08ade
+      expected-commit: ab725e41913d680b40fbdd0d5a734260ad84af41
 
   - uses: maven/configure-mirror
 


### PR DESCRIPTION
## Summary
- Fixed build failure in nrjmx package by updating to version 2.8.1
- The package was failing to build because it was trying to use version 2.8.0, but that tag doesn't exist in the repository
- Updated the expected commit hash to match the v2.8.1 tag

## Test plan
- Package builds successfully with the updated version
- Package tests pass successfully