### PR TITLE
libatomic_ops: Fix build failure and update to 7.8.2

### DIFF
--- a/libatomic_ops.yaml
+++ b/libatomic_ops.yaml
@@ -1,6 +1,6 @@
 package:
   name: libatomic_ops
-  version: 7.8.0
+  version: 7.8.2
   epoch: 0
   description: Semi-portable access to hardware provided atomic memory operations
   copyright:
@@ -14,12 +14,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31
-      uri: https://github.com/ivmai/libatomic_ops/releases/download/v${{package.version}}/libatomic_ops-${{package.version}}.tar.gz
+      repository: https://github.com/ivmai/libatomic_ops.git
+      tag: v${{package.version}}
+      expected-commit: 4c00f978cbafe4eb76929dace4ba8f456e800fec
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
## Summary
- Fixed build failure in libatomic_ops package by switching from fetch to git-checkout pipeline
- The original package was trying to fetch a source tarball that doesn't exist
- Added libtool as a build dependency to fix the automake error
- Updated to the latest version 7.8.2 (from 7.8.0)

## Test plan
- Package builds successfully using the git checkout approach
- All tests pass successfully
- Updated version provides the latest features and fixes