### PR TITLE
Build yara-x with native-code-serialization

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "0.14.0"
-  epoch: 2
+  epoch: 3
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -36,11 +36,11 @@ pipeline:
       output: yr
 
   - runs: |
-      cargo cinstall -p yara-x-capi --release --prefix=${{targets.destdir}}/usr --pkgconfigdir=${{targets.destdir}}/usr/lib/pkgconfig --includedir=${{targets.destdir}}/usr/include --libdir=${{targets.destdir}}/usr/lib --manifest-path capi/Cargo.toml
+      cargo cinstall -p yara-x-capi --features=native-code-serialization --release --prefix=${{targets.destdir}}/usr --pkgconfigdir=${{targets.destdir}}/usr/lib/pkgconfig --includedir=${{targets.destdir}}/usr/include --libdir=${{targets.destdir}}/usr/lib --manifest-path capi/Cargo.toml
 
       # this is required because the yara_x_capi.pc will end up with /home/build/melange-out/yara-x each of the paths
       # this causes an issue during install and when attempting to build using the library api.
-      # this just removes that path form the file
+      # this just removes that path from the file
       sed -i 's|/home/build/melange-out/yara-x||g' ${{targets.destdir}}/usr/lib/pkgconfig/yara_x_capi.pc
 
 update:


### PR DESCRIPTION
While digging around in the yara-x CAPI code, I noticed this feature which is off by default: https://github.com/VirusTotal/yara-x/blob/5ce90ffb2fefca68f8569732dc808fa1df44254d/capi/Cargo.toml#L18-L28

I tested this locally and it shaved off _minutes_ of runtime when scanning large packages with malcontent (Trino in this case). For smaller scans, this will likely have a smaller effect, but for larger packages like Trino we'll see a large uplift.