### PR TITLE
Libqcow package addition - Includes subpackage for python bindings

### DIFF
--- a/libqcow.yaml
+++ b/libqcow.yaml
@@ -36,7 +36,7 @@ pipeline:
   - uses: autoconf/configure
 
   - uses: autoconf/make
-  
+
   - uses: autoconf/make-install
 
   - uses: strip

--- a/libqcow.yaml
+++ b/libqcow.yaml
@@ -1,0 +1,91 @@
+package:
+  name: libqcow
+  version: "20240308"
+  epoch: 0
+  description: "Library to access the QEMU Copy-On-Write (QCOW) image file format"
+  copyright:
+    - license: LGPL-3.0 AND GPL-3.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gettext
+      - gettext-dev
+      - libtool
+      - pkgconf
+      - pkgconf-dev
+      - py3-supported-build-base-dev
+      - wolfi-base
+      - zlib-dev
+
+vars:
+  pypi-package: pyqcow
+  import: pyqcow
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/libyal/libqcow
+      tag: ${{package.version}}
+      expected-commit: b630c1c15e30027142b6fe8ba83f94bd34862ab1
+
+  - runs: |
+      ./synclibs.sh
+      ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: strip
+
+subpackages:
+  - name: libqcow-dev
+    pipeline:
+      - uses: split/dev
+    description: libqcow dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: "Python ${{range.key}} bindings for libqcow"
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+update:
+  enabled: true
+  github:
+    identifier: libyal/libqcow
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/libqcow.yaml
+++ b/libqcow.yaml
@@ -1,7 +1,7 @@
 package:
   name: libqcow
   version: "20240308"
-  epoch: 0
+  epoch: 1
   description: "Library to access the QEMU Copy-On-Write (QCOW) image file format"
   copyright:
     - license: LGPL-3.0 AND GPL-3.0
@@ -36,6 +36,8 @@ pipeline:
   - uses: autoconf/configure
 
   - uses: autoconf/make
+  
+  - uses: autoconf/make-install
 
   - uses: strip
 

--- a/libqcow.yaml
+++ b/libqcow.yaml
@@ -19,21 +19,8 @@ environment:
       - libtool
       - pkgconf
       - pkgconf-dev
-      - py3-supported-build-base-dev
       - wolfi-base
       - zlib-dev
-
-vars:
-  pypi-package: pyqcow
-  import: pyqcow
-
-data:
-  - name: py-versions
-    items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
 
 pipeline:
   - uses: git-checkout
@@ -61,24 +48,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - range: py-versions
-    name: py${{range.key}}-${{vars.pypi-package}}
-    description: "Python ${{range.key}} bindings for libqcow"
-    dependencies:
-      provider-priority: ${{range.value}}
-      provides:
-        - py3-${{vars.pypi-package}}
-    pipeline:
-      - uses: py/pip-build-install
-        with:
-          python: python${{range.key}}
-    test:
-      pipeline:
-        - uses: python/import
-          with:
-            python: python${{range.key}}
-            import: ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
**Libqcow package** `Current version: 20240308`
- Library to access the QEMU Copy-On-Write (QCOW) image file format

**Type**: C library
**REF**: https://github.com/libyal/libqcow

**Tests:**
- ldd-check