### PR TITLE
glibc: add comment about causing disruptions

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: "2.41"
-  epoch: 2
+  epoch: 2 # Every glibc update causes build disruption; always announce on #eng-psa
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later


### PR DESCRIPTION
No epoch bump needed for this. We just want the comment to be there from now on.