### PR TITLE
ceph: add jq to runtime dependencies

### DIFF
--- a/ceph.yaml
+++ b/ceph.yaml
@@ -5,6 +5,9 @@ package:
   epoch: 4
   copyright:
     - license: LGPL-2.1
+  resources:
+    cpu: 32
+    memory: 128Gi
   dependencies:
     runtime:
       - blkid

--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.2"
   description: Distributed object, block, and file storage
-  epoch: 3
+  epoch: 4
   copyright:
     - license: LGPL-2.1
   dependencies:
@@ -11,6 +11,7 @@ package:
       - cryptsetup
       - curl
       - device-mapper
+      - jq
       - libaio
       - libedit
       - libgcc


### PR DESCRIPTION
Aligns with upstream packages and use by rook for liveness
checks of the Ceph MDS daemon.

Signed-off-by: James Page <james.page@chainguard.dev>
