### PR TITLE
cluster-api-1.9: convert to git update backend

### DIFF
--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -112,8 +112,6 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: kubernetes-sigs/cluster-api
+  git:
     tag-filter-prefix: v1.9
     strip-prefix: v
-    tag-filter: v


### PR DESCRIPTION
Older version streams have started hitting the `github` backend's lookback limitations, so move this version stream over to avoid the problem in future.