### PR TITLE
consul-k8s-1.6: convert to git update backend

### DIFF
--- a/consul-k8s-1.6.yaml
+++ b/consul-k8s-1.6.yaml
@@ -63,8 +63,7 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: hashicorp/consul-k8s
+  git:
     strip-prefix: v
     tag-filter-prefix: v1.6.
 


### PR DESCRIPTION
Older version streams are hitting update failures due to the `github` backend's limitations: this will avoid hitting those for this version stream in future.