### PR TITLE
improve tests for `kubernetes-csi-external-provisioner`

### DIFF
--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -47,7 +47,7 @@ test:
         mkdir -p /csi
         hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" & sleep 5
         csi-provisioner --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" & sleep 10
-        code=$(curl -sf -o /dev/null -w '%{http_code}' localhost:8080/metrics)
+        code=$(curl -v --fail -o /dev/null -w '%{http_code}' localhost:8080/metrics)
         test "$code" -eq 200
 
 update:

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -47,7 +47,7 @@ test:
         mkdir -p /csi
         hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" & sleep 5
         csi-provisioner --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" & sleep 10
-        curl -vfLI localhost:8000/metrics
+        curl -vfLI localhost:8080/metrics
 
 update:
   enabled: true

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-provisioner
   version: "5.2.0"
-  epoch: 6
+  epoch: 7
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0
@@ -43,11 +43,12 @@ test:
   pipeline:
     - uses: test/kwok/cluster
     - runs: |
-        csi-provisioner --version
+        csi-provisioner --version | grep "v${{package.version}}"
         mkdir -p /csi
         hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" & sleep 5
         csi-provisioner --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" & sleep 10
-        curl -Lk localhost:8080/metrics
+        code=$(curl -sf -o /dev/null -w '%{http_code}' localhost:8080/metrics)
+        test "$code" -eq 200
 
 update:
   enabled: true

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -47,8 +47,7 @@ test:
         mkdir -p /csi
         hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" & sleep 5
         csi-provisioner --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" & sleep 10
-        code=$(curl -v --fail -o /dev/null -w '%{http_code}' localhost:8080/metrics)
-        test "$code" -eq 200
+        curl -vfLI localhost:8000/metrics
 
 update:
   enabled: true


### PR DESCRIPTION
This PR improves tests for `kubernetes-csi-external-provisioner`