### PR TITLE
zip: adding missing patches

### DIFF
--- a/zip.yaml
+++ b/zip.yaml
@@ -88,3 +88,44 @@ test:
         zipsplit -t comment.zip
     - name: Binary reliability checks
       uses: test/tw/ldd-check
+    - name: Long filename test
+      runs: |
+        # Create a file with a very long name (over 256 characters)
+        longname=$(printf '%*s' 300 | tr ' ' 'A')
+        echo "test content" > "$longname"
+        zip -q longname.zip "$longname"
+        rm "$longname"
+        ls -la longname.zip
+    - name: Unicode filename test
+      runs: |
+        # Create a file with a long unicode name
+        unicode_name=$(printf '世界レイ%.0s' {1..50})
+        echo "test content" > "$unicode_name"
+        zip -q unicode.zip "$unicode_name"
+        rm "$unicode_name"
+        ls -la unicode.zip
+    - name: Large file test
+      runs: |
+        # Create a large file (100MB) and try to zip it
+        dd if=/dev/zero of=largefile bs=1M count=100
+        zip -q large.zip largefile
+        rm largefile
+        ls -la large.zip
+    - name: Multiple files test
+      runs: |
+        # Create multiple files with long names
+        for i in {1..100}; do
+          longname=$(printf 'file_%*s.txt' 100 | tr ' ' 'A')
+          echo "test content $i" > "$longname"
+        done
+        zip -q multiple.zip file_*.txt
+        rm file_*.txt
+        ls -la multiple.zip
+    - name: Nested directory test
+      runs: |
+        # Create nested directory structure with long names
+        mkdir -p "a/$(printf '%*s' 100 | tr ' ' 'B')/c"
+        echo "test content" > "a/$(printf '%*s' 100 | tr ' ' 'B')/c/test.txt"
+        zip -r -q nested.zip a
+        rm -rf a
+        ls -la nested.zip

--- a/zip.yaml
+++ b/zip.yaml
@@ -23,7 +23,7 @@ pipeline:
   # with gcc-14
   - uses: patch
     with:
-      patches: 06-stack-markings-to-avoid-executable-stack.patch 07-fclose-in-file-not-fclose-x.patch 08-hardening-build-fix-1.patch 09-hardening-build-fix-2.patch 10-remove-build-date.patch 12-fix-build-with-gcc-14.patch
+      patches: 06-stack-markings-to-avoid-executable-stack.patch 07-fclose-in-file-not-fclose-x.patch 08-hardening-build-fix-1.patch 09-hardening-build-fix-2.patch 10-remove-build-date.patch 12-fix-build-with-gcc-14.patch 14-buffer-overflow-unicode-filename.patch 15-buffer-overflow-cve-2018-13410.patch 
 
   - runs: make -f unix/Makefile LOCAL_ZIP="${CFLAGS} ${CPPFLAGS}" prefix=/usr generic
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
As mentioned in Issue: https://github.com/wolfi-dev/os/issues/51890 ,
The current `zip.yaml` does not contain the relevant patches to mitigate overflows. This error shows up:
```
*** buffer overflow detected ***: terminated
zip error: Interrupted (aborting)
``` 
This could be due to unicode characters present in the code.

These were the added patches:
1) https://sources.debian.org/patches/zip/3.0-15/14-buffer-overflow-unicode-filename.patch/
2) https://sources.debian.org/patches/zip/3.0-15/15-buffer-overflow-cve-2018-13410.patch/ 

Tests added to pipeline:
* 300 char file test
* Using Unicode characters
* 100MB file test
* Multiple 100 character files test
* Nested directory test

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
