### PR TITLE
fix(airflow): pin python requirements for airflow 2.x

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: "2.10.5"
-  epoch: 42
+  epoch: 43
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -98,10 +98,13 @@ pipeline:
       #GHSA-8w49-h785-mj3c/GHSA-8495-4g3g-x7pr/GHSA-27mf-ghqm-j3j8 fixes
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
-        aiohttp>=3.10.11 tornado>=6.4.2 apache-airflow-providers-celery==3.10.0 statsd packaging pyparsing
+        aiohttp>=3.10.11 tornado>=6.4.2 statsd packaging pyparsing \
+        apache-airflow==${{package.version}} apache-airflow-providers-celery==3.10.0 "flask>=2.2.1,<2.3"
       # NOTE: apache-airflow-providers-celery is pinned to 3.10.0 because 3.10.3 introduced a regresssion.
       # https://github.com/apache/airflow/issues/47781 details more about it.
-      # before removing the pinning, please check if the images are coming good with helm charts.
+      # NOTE: flask is pinned to < 2.3 as required by apache-airflow-providers-fab:
+      # https://github.com/apache/airflow/blob/21b8621539a382c3382f869752651be99ba30421/providers/fab/pyproject.toml#L68
+      # Before removing these pins, please check if the airflow[-bitnami] image helm tests pass.
 
   - runs: find . -name '__pycache__' -exec rm -rf {} +
 

--- a/airflow.yaml
+++ b/airflow.yaml
@@ -163,6 +163,7 @@ subpackages:
         with:
           image: airflow
           version-path: 2/debian-12
+          commit: 2fe4a9e70c66f608d4c7669ca2b52009cc6f4663
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami
           ln -sf /opt/airflow ${{targets.subpkgdir}}/opt/bitnami


### PR DESCRIPTION
Pinning `apache-airflow-providers-celery` in #50678 inadvertently brought in airflow 3.x python dependencies that are incompatible with the `Flask-SQLAlchemy` required by airflow 2.x.

This PR pins additional runtime requirements to ensure airflow 2.x compatibility.

Related: https://github.com/chainguard-dev/image-release-stats/issues/5178