### PR TITLE
gcp-compute-persistent-disk-csi-driver-1.15: switch to git update backend

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver-1.15.yaml
+++ b/gcp-compute-persistent-disk-csi-driver-1.15.yaml
@@ -91,7 +91,6 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
+  git:
     strip-prefix: v
-    tag-filter: v1.15
+    tag-filter-prefix: v1.15


### PR DESCRIPTION
The `github` backend can't look back far enough to find releases.