### PR TITLE
matter-labs/external-node: add packages

### DIFF
--- a/external-node.yaml
+++ b/external-node.yaml
@@ -1,0 +1,81 @@
+package:
+  name: external-node # this name?
+  version: 27.4.0
+  epoch: 0
+  description: ZKsync External Node is a read-replica of the main (centralized) node that can be run by anyone.
+  copyright:
+    - license: Apache-2.0
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - gcc
+      - curl
+      - clang
+      - glibc-dev
+      - openssl-dev
+      - liburing-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/matter-labs/zksync-era
+      tag: core-v${{package.version}}
+      expected-commit: f9bf60a05366cee82213bed03daea2580c8de4cc
+      destination: zksync
+
+subpackages:
+  # only builds on rust nightly
+  - name: ${{package.name}}-external-node
+    description: External Node is a read replica that can sync from the main node and serve the state locally.
+    pipeline:
+      - name: Configure and Build
+        working-directory: ${{package.srcdir}}/zksync/core/bin/external_node
+        uses: cargo/build
+        with:
+          output: external-node
+      - uses: strip
+    dependencies:
+      provides:
+        - ${{package.name}}-external-node=${{package.full-version}}
+    # how do I test this?
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-block-reverter
+    description:
+    pipeline:
+      - name: Configure and Build
+        working-directory: ${{package.srcdir}}/zksync/core/bin/block_reverter
+        uses: cargo/build
+        with:
+          output: block-reverter
+      - uses: strip
+    dependencies:
+      provides:
+        - ${{package.name}}-block-reverter=${{package.full-version}}
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-oci-entrypoint
+    description: Entrypoint for using External Node in OCI containers
+    dependencies:
+      runtime:
+        - busybox
+      provides:
+        - ${{package.name}}-oci-entrypoint=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/lib/external-node/init
+          cp ${{package.srcdir}}/zksync/docker/external-node/entrypoint.sh ${{targets.subpkgdir}}/var/lib/external-node/init/entrypoint.sh
+          chmod +x ${{targets.subpkgdir}}/var/lib/external-node/init/entrypoint.sh
+
+update:
+  enabled: true
+  github:
+    identifier: matter-labs/zksync-era
+    strip-prefix: core-v
+    use-tag: true

--- a/external-node.yaml
+++ b/external-node.yaml
@@ -16,6 +16,9 @@ environment:
       - glibc-dev
       - openssl-dev
       - liburing-dev
+  environment:
+    # Allow unstable features with stable rust
+    RUSTC_BOOTSTRAP: 1
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Adds packages for zksync external-node image
1. external-node
2. block-retriever
3. zksync-oci-endpoint
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
