### PR TITLE
Update openjdk-8 license with GPL2.0+CE

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,10 +1,10 @@
 package:
   name: openjdk-8
   version: 8.442.06 # this corresponds to same release as jdk8u442-ga / jdk8u442-b06
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
-    - license: GPL-2.0-or-later
+    - license: GPL-2.0-with-classpath-exception
   dependencies:
     runtime:
       - java-cacerts


### PR DESCRIPTION
IcedTea is licensed with the Classpath linking exception, so update OpenJDK 8 package to also use that license: https://www.gnu.org/software/classpath/license.html