### PR TITLE
Remove extraneous setuid bits from man-db and sudo

### DIFF
--- a/man-db.yaml
+++ b/man-db.yaml
@@ -2,7 +2,7 @@
 package:
   name: man-db
   version: 2.13.0
-  epoch: 40
+  epoch: 41
   description: The man command and related utilities for examining on-line help files
   copyright:
     - license: GPL-3.0
@@ -36,7 +36,8 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --sbindir=/usr/bin
+        # By default, man will be installed as a setuid program
+        --sbindir=/usr/bin --disable-setuid
 
   - uses: autoconf/make
 
@@ -71,6 +72,11 @@ test:
       packages:
         - man-db-doc
   pipeline:
+    - name: Ensure that setuid bits are not set
+      runs: |
+        set -x
+        if [ -u /usr/bin/man ]; then exit 1; fi
+        if [ -u /bin/man ]; then exit 1; fi
     - runs: |
         find /usr/share/man/ -type f -name "*.[0-9]" | xargs -i man -Tdvi -l {} >/dev/null
         apropos --version

--- a/man-db.yaml
+++ b/man-db.yaml
@@ -36,7 +36,6 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        # By default, man will be installed as a setuid program
         --sbindir=/usr/bin --disable-setuid
 
   - uses: autoconf/make

--- a/man-db.yaml
+++ b/man-db.yaml
@@ -74,8 +74,9 @@ test:
     - name: Ensure that setuid bits are not set
       runs: |
         set -x
-        if [ -u /usr/bin/man ]; then exit 1; fi
-        if [ -u /bin/man ]; then exit 1; fi
+        for bin in "/bin/man" "/bin/mandb" "/usr/bin/man" "/usr/bin/mandb"; do
+          if [ -u "$bin" ]; then exit 1; fi
+        done
     - runs: |
         find /usr/share/man/ -type f -name "*.[0-9]" | xargs -i man -Tdvi -l {} >/dev/null
         apropos --version

--- a/sudo.yaml
+++ b/sudo.yaml
@@ -35,7 +35,6 @@ pipeline:
   #     repository: https://github.com/sudo-project/sudo.git
   #     tag: ${{vars.mangled-package-version}}
   #     expected-commit: 172cbd968e6fe5f64d3384896a90c0a1aa73238d
-
   - uses: fetch
     with:
       expected-sha256: 976aa56d3e3b2a75593307864288addb748c9c136e25d95a9cc699aafa77239c
@@ -140,10 +139,10 @@ test:
         visudo --help
 
 update:
-  manual
   # TODO: flip over to auto-updates when the above comments are addressed
   # enabled: true
   # github:
   #   identifier: sudo-project/sudo
   #   tag-filter-prefix: SUDO_
-  #   strip-prefix: SUDO_: true
+  #   strip-prefix: SUDO_
+  manual: true

--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
-  version: 1.9.16
-  epoch: 41
+  version: 1.9.16_p2
+  epoch: 0
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: ISC
@@ -13,6 +13,12 @@ package:
       - merged-usrsbin
       - wolfi-baselayout
 
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d{1,2})\.(\d{1,2})\.(\d{1,2})(_)(p(\d{1,2}))?$
+    replace: SUDO_${1}_${2}_${3}${5}
+    to: mangled-package-version
+
 environment:
   contents:
     packages:
@@ -23,10 +29,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 558d10b9a1991fb3b9fa7fa7b07ec4405b7aefb5b3cb0b0871dbc81e3a88e558
-      uri: https://www.sudo.ws/dist/sudo-1.9.15p5.tar.gz
+      repository: https://github.com/sudo-project/sudo.git
+      tag: ${{vars.mangled-package-version}}
+      expected-commit: 172cbd968e6fe5f64d3384896a90c0a1aa73238d
 
   - uses: autoconf/configure
     with:
@@ -133,5 +140,7 @@ update:
       replace: "."
     - match: "p"
       replace: "_p"
-  release-monitor:
-    identifier: 4906
+  github:
+    identifier: sudo-project/sudo
+    tag-filter-prefix: SUDO_
+    strip-prefix: SUDO_

--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
   version: 1.9.16
-  epoch: 40
+  epoch: 41
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: ISC
@@ -50,8 +50,8 @@ pipeline:
   - runs: |
       # sudo must be owned by root with setuid set
       chmod u+s ${{targets.contextdir}}/usr/bin/sudo
-      chmod u+s ${{targets.contextdir}}/etc/sudo.conf
-      chmod u+s ${{targets.contextdir}}/etc/sudoers
+      chmod 0644 ${{targets.contextdir}}/etc/sudo.conf
+      chmod 0440 ${{targets.contextdir}}/etc/sudoers
 
 subpackages:
   - name: sudo-doc
@@ -129,9 +129,9 @@ test:
 update:
   enabled: true
   version-transform:
-    - match: '_'
-      replace: '.'
-    - match: 'p'
-      replace: '_p'
+    - match: "_"
+      replace: "."
+    - match: "p"
+      replace: "_p"
   release-monitor:
     identifier: 4906

--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
-  version: 1.9.16_p2
-  epoch: 0
+  version: 1.9.16
+  epoch: 41
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: ISC
@@ -13,12 +13,12 @@ package:
       - merged-usrsbin
       - wolfi-baselayout
 
-var-transforms:
-  - from: ${{package.version}}
-    match: (\d{1,2})\.(\d{1,2})\.(\d{1,2})(_)(p(\d{1,2}))?$
-    replace: SUDO_${1}_${2}_${3}${5}
-    to: mangled-package-version
-
+# TODO: re-enable this when package version comparisons account for patch levels
+# var-transforms:
+#   - from: ${{package.version}}
+#     match: (\d{1,2})\.(\d{1,2})\.(\d{1,2})(_)(p(\d{1,2}))?$
+#     replace: SUDO_${1}_${2}_${3}${5}
+#     to: mangled-package-version
 environment:
   contents:
     packages:
@@ -29,11 +29,17 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: git-checkout
+  # TODO: flip over to git-checkout when the above comment is addressed
+  # - uses: git-checkout
+  #   with
+  #     repository: https://github.com/sudo-project/sudo.git
+  #     tag: ${{vars.mangled-package-version}}
+  #     expected-commit: 172cbd968e6fe5f64d3384896a90c0a1aa73238d
+
+  - uses: fetch
     with:
-      repository: https://github.com/sudo-project/sudo.git
-      tag: ${{vars.mangled-package-version}}
-      expected-commit: 172cbd968e6fe5f64d3384896a90c0a1aa73238d
+      expected-sha256: 976aa56d3e3b2a75593307864288addb748c9c136e25d95a9cc699aafa77239c
+      uri: https://www.sudo.ws/dist/sudo-1.9.16p2.tar.gz
 
   - uses: autoconf/configure
     with:
@@ -134,13 +140,10 @@ test:
         visudo --help
 
 update:
-  enabled: true
-  version-transform:
-    - match: "_"
-      replace: "."
-    - match: "p"
-      replace: "_p"
-  github:
-    identifier: sudo-project/sudo
-    tag-filter-prefix: SUDO_
-    strip-prefix: SUDO_
+  manual
+  # TODO: flip over to auto-updates when the above comments are addressed
+  # enabled: true
+  # github:
+  #   identifier: sudo-project/sudo
+  #   tag-filter-prefix: SUDO_
+  #   strip-prefix: SUDO_: true


### PR DESCRIPTION
Closes: #52036
Closes: #52037

`man-db` can be built without `setuid` and we can tweak the `/etc/sudo*` permissions.