### PR TITLE
py3-legacy-cgi: depend on python-3.X-base, not python-3.X

### DIFF
--- a/py3-legacy-cgi.yaml
+++ b/py3-legacy-cgi.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-legacy-cgi
   version: "2.6.3"
-  epoch: 0
+  epoch: 1
   description: Fork of the standard library cgi and cgitb modules, being deprecated in PEP-594
   copyright:
     - license: PSF-2.0
@@ -37,7 +37,7 @@ subpackages:
           python: python${{range.key}}
     dependencies:
       runtime:
-        - python-${{range.key}}
+        - python-${{range.key}}-base
       provides:
         - py3-${{vars.pypi-package}}
       provider-priority: ${{range.value}}


### PR DESCRIPTION
Depending on `python-3.X` means that the various packages aren't coinstallable: they all depend on a different package which installs `/usr/bin/python3`.  This particularly causes problems for downstream `py3-*-supported` packages.