### PR TITLE
config(cve-pr-closer): adding octosts policy for cve-pr-closer bot

### DIFF
--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://accounts.google.com
+
+# lc-cve-pr-closer-cron@prod-enforce-fabc.iam.gserviceaccount.com
+claim_pattern:
+  email: 'lc-cve-pr-closer-cron@prod-enforce-fabc\.iam\.gserviceaccount\.com'
+
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
Octosts policy for cve-pr-closer bot to close stale request-cve-remediation PRs.