### PR TITLE
crosstool-ng: add rsync support

### DIFF
--- a/crosstool-ng.yaml
+++ b/crosstool-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: crosstool-ng
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: build toolchains
   copyright:
     - license: GPL-2.0
@@ -29,6 +29,7 @@ package:
       - ncurses-dev
       - patch
       - py3.13-build-base-dev
+      - rsync
       - texinfo
       - xz
 
@@ -51,6 +52,7 @@ environment:
       - ncurses-dev
       - patch
       - py3.13-build-base-dev
+      - rsync
       - texinfo
       - xz
 


### PR DESCRIPTION
During build and runtime, rsync is needed to support using latest
kernel headers. Which toolchains need, to create headers, that are
usable to build openssl with all features turned on.
