### PR TITLE
crosstool-ng: fix automatic parallel builds

### DIFF
--- a/crosstool-ng.yaml
+++ b/crosstool-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: crosstool-ng
   version: 1.27.0
-  epoch: 1
+  epoch: 2
   description: build toolchains
   copyright:
     - license: GPL-2.0
@@ -28,6 +28,7 @@ package:
       - meson
       - ncurses-dev
       - patch
+      - posix-libc-utils
       - py3.13-build-base-dev
       - rsync
       - texinfo
@@ -51,6 +52,7 @@ environment:
       - meson
       - ncurses-dev
       - patch
+      - posix-libc-utils
       - py3.13-build-base-dev
       - rsync
       - texinfo


### PR DESCRIPTION
Automatic parallel builds are not currently working due to missing dependency on getconf. Add it at configure time for detection, and to use at runtime too.

See:

https://github.com/crosstool-ng/crosstool-ng/blob/b49e4c689c4dc8e9c8da5b8f56d7ddf59e485d3b/m4/ctng_cpu_count.m4#L5