### PR TITLE
fix(vector): add openssl fixes to Cargo.toml

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -36,10 +36,6 @@ pipeline:
   - runs: |
       sed -i '7s/deny/allow/' src/lib.rs
       export RUSTFLAGS="$RUSTFLAGS --cap-lints=warn"
-      # Needed for vector to load our own openssl properly w/ FIPS
-      # Vector was ignoring our openssl.cnf and fipsmodule.cnf
-      # even when configured with proper OPENSSL_CONF and OPENSSL_MODULE env variables
-      # REF: https://vector.dev/docs/reference/configuration/tls/#fips-provider-example
       # Force building with system provided openssl instead of vendored version
       sed -i -E 's|^(openssl)\s*=.*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+).*|openssl = { version = "0.10.72", default-features = false }|' Cargo.toml
       sed -i -E 's|^(openssl-src)\s*=.*version\s*=\s*"([0-9]+).*|openssl-src = { version = "300", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml

--- a/vector.yaml
+++ b/vector.yaml
@@ -14,7 +14,6 @@ environment:
     packages:
       - bash
       - build-base
-      - coreutils
       - cyrus-sasl-dev
       - librdkafka
       - librdkafka-dev
@@ -37,8 +36,8 @@ pipeline:
       sed -i '7s/deny/allow/' src/lib.rs
       export RUSTFLAGS="$RUSTFLAGS --cap-lints=warn"
       # Force building with system provided openssl instead of vendored version
-      sed -i -E 's|^(openssl)\s*=.*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+).*|openssl = { version = "0.10.72", default-features = false }|' Cargo.toml
-      sed -i -E 's|^(openssl-src)\s*=.*version\s*=\s*"([0-9]+).*|openssl-src = { version = "300", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml
+      sed -i -E 's|^(openssl)\s*=.*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+).*|openssl = { version = "\2", default-features = false }|' Cargo.toml
+      sed -i -E 's|^(openssl-src)\s*=.*version\s*=\s*"([0-9]+).*|openssl-src = { version = "\2", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml
       OPENSSL_NO_VENDOR=1 make build -j$(nproc)
 
   - runs: |

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.46.1"
-  epoch: 10
+  epoch: 1
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -40,8 +40,9 @@ pipeline:
       # Vector was ignoring our openssl.cnf and fipsmodule.cnf
       # even when configured with proper OPENSSL_CONF and OPENSSL_MODULE env variables
       # REF: https://vector.dev/docs/reference/configuration/tls/#fips-provider-example
-      sed -i 's|openssl = { version = "0.10.72", default-features = false, features = \["vendored"\] }|openssl = { version = "0.10.72", default-features = false }|' Cargo.toml
-      sed -i 's|openssl-src = { version = "300", default-features = false, features = \["force-engine", "legacy"\] }|openssl-src = { version = "300", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml
+      # Force building with system provided openssl instead of vendored version
+      sed -i -E 's|^(openssl)\s*=.*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+).*|openssl = { version = "0.10.72", default-features = false }|' Cargo.toml
+      sed -i -E 's|^(openssl-src)\s*=.*version\s*=\s*"([0-9]+).*|openssl-src = { version = "300", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml
       OPENSSL_NO_VENDOR=1 make build -j$(nproc)
 
   - runs: |

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.46.1"
-  epoch: 0
+  epoch: 10
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -14,6 +14,7 @@ environment:
     packages:
       - bash
       - build-base
+      - coreutils
       - cyrus-sasl-dev
       - librdkafka
       - librdkafka-dev
@@ -35,7 +36,13 @@ pipeline:
   - runs: |
       sed -i '7s/deny/allow/' src/lib.rs
       export RUSTFLAGS="$RUSTFLAGS --cap-lints=warn"
-      make build
+      # Needed for vector to load our own openssl properly w/ FIPS
+      # Vector was ignoring our openssl.cnf and fipsmodule.cnf
+      # even when configured with proper OPENSSL_CONF and OPENSSL_MODULE env variables
+      # REF: https://vector.dev/docs/reference/configuration/tls/#fips-provider-example
+      sed -i 's|openssl = { version = "0.10.72", default-features = false, features = \["vendored"\] }|openssl = { version = "0.10.72", default-features = false }|' Cargo.toml
+      sed -i 's|openssl-src = { version = "300", default-features = false, features = \["force-engine", "legacy"\] }|openssl-src = { version = "300", optional = true, default-features = false, features = ["force-engine", "legacy"] }|' Cargo.toml
+      OPENSSL_NO_VENDOR=1 make build -j$(nproc)
 
   - runs: |
       install -Dm755 target/release/vector "${{targets.destdir}}"/usr/bin/vector


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Some inline fixes are added via sed to the `Cargo.toml` file during package build, to allow vector to properly load the system provided openssl instead of vendored version.

