### PR TITLE
tileserver-gl-5.3.0-r0 CVE remediation

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.0"
-  epoch: 0
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -59,7 +59,7 @@ pipeline:
     pipeline:
       - uses: patch
         with:
-          patches: ../CVE-2024-12905.patch
+          patches: ../CVE-2024-12905.patch ../CVE-2025-46653.patch
 
   # install packages
   - working-directory: app

--- a/tileserver-gl/CVE-2025-46653.patch
+++ b/tileserver-gl/CVE-2025-46653.patch
@@ -1,0 +1,85 @@
+# From upstream remediation
+# https://github.com/maptiler/tileserver-gl/commit/37992818666c944f52493df65b13fb5266ac46b9
+
+diff --git a/package-lock.json b/package-lock.json
+index b33c47449..88a717eb3 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -1269,6 +1269,19 @@
+         "gl-style-validate": "dist/gl-style-validate.mjs"
+       }
+     },
++    "node_modules/@noble/hashes": {
++      "version": "1.8.0",
++      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
++      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
++      "dev": true,
++      "license": "MIT",
++      "engines": {
++        "node": "^14.21.3 || >=16"
++      },
++      "funding": {
++        "url": "https://paulmillr.com/funding/"
++      }
++    },
+     "node_modules/@nodelib/fs.scandir": {
+       "version": "2.1.5",
+       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+@@ -1465,6 +1478,16 @@
+         "@octokit/openapi-types": "^12.11.0"
+       }
+     },
++    "node_modules/@paralleldrive/cuid2": {
++      "version": "2.2.2",
++      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
++      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@noble/hashes": "^1.1.5"
++      }
++    },
+     "node_modules/@pkgjs/parseargs": {
+       "version": "0.11.0",
+       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+@@ -4517,16 +4540,19 @@
+       }
+     },
+     "node_modules/formidable": {
+-      "version": "3.5.2",
+-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+-      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
++      "version": "3.5.4",
++      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
++      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+       "dev": true,
+       "license": "MIT",
+       "dependencies": {
++        "@paralleldrive/cuid2": "^2.2.2",
+         "dezalgo": "^1.0.4",
+-        "hexoid": "^2.0.0",
+         "once": "^1.4.0"
+       },
++      "engines": {
++        "node": ">=14.0.0"
++      },
+       "funding": {
+         "url": "https://ko-fi.com/tunnckoCore/commissions"
+       }
+@@ -5151,16 +5177,6 @@
+         "he": "bin/he"
+       }
+     },
+-    "node_modules/hexoid": {
+-      "version": "2.0.0",
+-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+-      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+-      "dev": true,
+-      "license": "MIT",
+-      "engines": {
+-        "node": ">=8"
+-      }
+-    },
+     "node_modules/hosted-git-info": {
+       "version": "4.1.0",
+       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",


### PR DESCRIPTION
Update formidable to remediate CVE-2025-46653

This pulls and applies the upstream version bump at https://github.com/maptiler/tileserver-gl/commit/37992818666c944f52493df65b13fb5266ac46b9




#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For PRs that add patches

- [x] Patch source is documented
