### PR TITLE
ceph: remove apache-arrow dependencies

### DIFF
--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.2"
   description: Distributed object, block, and file storage
-  epoch: 4
+  epoch: 5
   copyright:
     - license: LGPL-2.1
   resources:
@@ -60,7 +60,6 @@ vars:
 environment:
   contents:
     packages:
-      - apache-arrow-dev
       - autoconf
       - automake
       - bash
@@ -81,7 +80,6 @@ environment:
       - jq
       - keyutils-dev
       - libaio-dev
-      - libarrow
       - libcap-dev
       - libcap-ng-dev
       - libedit-dev
@@ -154,7 +152,7 @@ pipeline:
         -DWITH_LTTNG=OFF \
         -DWITH_MANPAGE=ON \
         -DWITH_RADOSGW_AMQP_ENDPOINT=OFF \
-        -DWITH_RADOSGW_SELECT_PARQUET=ON \
+        -DWITH_RADOSGW_SELECT_PARQUET=OFF \
         -DWITH_RADOSGW_POSIX=OFF \
         -DWITH_RDMA=OFF \
         -DWITH_REENTRANT_STRSIGNAL=ON \
@@ -162,7 +160,7 @@ pipeline:
         -DWITH_SPDK=OFF \
         -DWITH_SYSTEMD=ON \
         -DWITH_CEPHFS_SHELL=ON \
-        -DWITH_SYSTEM_ARROW=ON \
+        -DWITH_SYSTEM_ARROW=OFF \
         -DWITH_SYSTEM_BOOST=OFF \
         -DWITH_SYSTEM_FMT=OFF \
         -DWITH_SYSTEM_LIBURING=ON \


### PR DESCRIPTION
A recent version bump to `apache-arrow` is incompatible as a build dependency for our current version of ceph.  This PR disables arrow related config in the ceph package.

Related:
- [arrow version bump](https://github.com/wolfi-dev/os/pull/51825)
- [airflow version bump](https://github.com/wolfi-dev/os/pull/51963)
- https://github.com/chainguard-dev/internal-dev/issues/12045