### PR TITLE
rebuild tileserver-gl with libpng's newer version

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -64,6 +64,8 @@ pipeline:
   # install packages
   - working-directory: app
     runs: |
+      # fix CVE-2025-46653 GHSA-75v8-2h7p-7m2m
+      npm install formidable@3.5.3
       npm install --omit=dev
 
   # remove test code for resolve module that is triggering a false positive CVE scan

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.0"
-  epoch: 0
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
This PR is going to fix this issue:

```bash
 what():  libpng version mismatch: headers report 1.6.47, but library reports 1.6.48
```