### PR TITLE
add pipeline to use CMake for building and installing libqrencode

### DIFF
--- a/libqrencode.yaml
+++ b/libqrencode.yaml
@@ -17,7 +17,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/fukuchi/libqrencode
-      tag: v${{package.version}}
+      tag: ${{package.version}}
       expected-commit: 715e29fd4cd71b6e452ae0f4e36d917b43122ce8
 
   - runs: |

--- a/libqrencode.yaml
+++ b/libqrencode.yaml
@@ -1,0 +1,64 @@
+package:
+  name: libqrencode
+  version: 4.1.1
+  epoch: 0
+  description: Library for encoding QR codes
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - cmake
+      - libpng-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/fukuchi/libqrencode
+      tag: v${{package.version}}
+      expected-commit: 715e29fd4cd71b6e452ae0f4e36d917b43122ce8
+
+  - runs: |
+      cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+      cmake --build build
+      cmake --install build --prefix=${{targets.destdir}}/usr
+
+  - uses: strip
+
+subpackages:
+  - name: libqrencode-dev
+    description: Development files for libqrencode
+    dependencies:
+       runtime:
+         - libyang
+    pipeline:
+      - uses: split/dev
+    test:
+       pipeline:
+         - uses: test/pkgconf
+
+  - name: libqrencode-doc
+    description: Documentation files for libqrencode
+    pipeline:
+      - uses: split/manpages
+
+  - name: libqrencode-tools
+    description: Command-line tools for libqrencode
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share
+          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
+
+update:
+  enabled: true
+  github:
+    identifier: fukuchi/libqrencode
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Verify libqrencode installation
+      runs: |
+        qrencode --version || exit 1


### PR DESCRIPTION
Fixes:
[#33188](https://github.com/wolfi-dev/os/issues/33188)

Related:
based of [#34086](https://github.com/wolfi-dev/os/pull/34086)

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X ] This PR is marked as fixing a pre-existing package request bug
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
