### PR TITLE
php: enable apache module for libphp

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 40
+  epoch: 41
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -112,6 +112,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - ${{package.name}}
         - apr-util-dev
         - merged-usrsbin
         - perl

--- a/apr-util.yaml
+++ b/apr-util.yaml
@@ -1,7 +1,7 @@
 package:
   name: apr-util
   version: 1.6.3
-  epoch: 5
+  epoch: 6
   description: The Apache Portable Runtime Utility Library
   copyright:
     # Some files also contain RSA-MD.
@@ -24,7 +24,7 @@ environment:
       - libtool
       - openldap-dev
       - openssl-dev
-      - postgresql-16-dev
+      - postgresql-dev
       - sqlite-dev
 
 pipeline:
@@ -57,7 +57,7 @@ subpackages:
         - expat-dev
         - gdbm-dev
         - libapr-dev
-        - postgresql-16-dev
+        - postgresql-dev
         - openldap-dev
         - openssl-dev
         - sqlite-dev

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.32"
-  epoch: 41
+  epoch: 42
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -19,6 +19,8 @@ environment:
   contents:
     packages:
       - aom-dev
+      - apache2-dev
+      - apache2-utils
       - autoconf
       - bison
       - build-base
@@ -138,9 +140,16 @@ pipeline:
         --with-pgsql=shared \
         --with-zip=shared \
         --enable-sysvsem=shared \
-        --enable-sysvshm=shared
+        --enable-sysvshm=shared \
+        --with-apxs2=/usr/bin/apxs \
+        --enable-phpdbg=shared
 
   - uses: autoconf/make
+
+  - name: Copy httpd.conf before install
+    runs: |
+      mkdir -p ${{targets.destdir}}/etc/apache2
+      cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
@@ -286,6 +295,25 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: "${{package.name}}-apache"
+    description: Apache SAPI for PHP ${{vars.phpMM}}
+    dependencies:
+      provides:
+        - php-apache=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/apache2/modules
+          mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
+          install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/apache2/modules/libphp.so
 
   - name: "${{package.name}}-cgi"
     description: PHP 8.1 CGI

--- a/php-8.1/apache.conf
+++ b/php-8.1/apache.conf
@@ -1,0 +1,13 @@
+# Required modules: dir_module, php_module
+
+<IfModule dir_module>
+	<IfModule php_module>
+		DirectoryIndex index.php index.html
+		<FilesMatch "\.php$">
+			SetHandler application/x-httpd-php
+		</FilesMatch>
+		<FilesMatch "\.phps$">
+			SetHandler application/x-httpd-php-source
+		</FilesMatch>
+	</IfModule>
+</IfModule>

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.28"
-  epoch: 41
+  epoch: 42
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -19,6 +19,8 @@ environment:
   contents:
     packages:
       - aom-dev
+      - apache2-dev
+      - apache2-utils
       - autoconf
       - bison
       - build-base
@@ -133,9 +135,16 @@ pipeline:
         --with-pgsql=shared \
         --with-zip=shared \
         --enable-sysvsem=shared \
-        --enable-sysvshm=shared
+        --enable-sysvshm=shared \
+        --with-apxs2=/usr/bin/apxs \
+        --enable-phpdbg=shared
 
   - uses: autoconf/make
+
+  - name: Copy httpd.conf before install
+    runs: |
+      mkdir -p ${{targets.destdir}}/etc/apache2
+      cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
@@ -281,6 +290,25 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: "${{package.name}}-apache"
+    description: Apache SAPI for PHP ${{vars.phpMM}}
+    dependencies:
+      provides:
+        - php-apache=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/apache2/modules
+          mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
+          install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/apache2/modules/libphp.so
 
   - name: "${{package.name}}-cgi"
     description: PHP 8.2 CGI

--- a/php-8.2/apache.conf
+++ b/php-8.2/apache.conf
@@ -1,0 +1,13 @@
+# Required modules: dir_module, php_module
+
+<IfModule dir_module>
+	<IfModule php_module>
+		DirectoryIndex index.php index.html
+		<FilesMatch "\.php$">
+			SetHandler application/x-httpd-php
+		</FilesMatch>
+		<FilesMatch "\.phps$">
+			SetHandler application/x-httpd-php-source
+		</FilesMatch>
+	</IfModule>
+</IfModule>

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.20"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -25,6 +25,8 @@ environment:
   contents:
     packages:
       - aom-dev
+      - apache2-dev
+      - apache2-utils
       - autoconf
       - bison
       - build-base
@@ -138,9 +140,16 @@ pipeline:
         --with-pgsql=shared \
         --with-zip=shared \
         --enable-sysvsem=shared \
-        --enable-sysvshm=shared
+        --enable-sysvshm=shared \
+        --with-apxs2=/usr/bin/apxs \
+        --enable-phpdbg=shared
 
   - uses: autoconf/make
+
+  - name: Copy httpd.conf before install
+    runs: |
+      mkdir -p ${{targets.destdir}}/etc/apache2
+      cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
@@ -286,6 +295,25 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: "${{package.name}}-apache"
+    description: Apache SAPI for PHP ${{vars.phpMM}}
+    dependencies:
+      provides:
+        - php-apache=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/apache2/modules
+          mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
+          install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/apache2/modules/libphp.so
 
   - name: "${{package.name}}-cgi"
     description: PHP ${{vars.phpMM}} CGI

--- a/php-8.3/apache.conf
+++ b/php-8.3/apache.conf
@@ -1,0 +1,13 @@
+# Required modules: dir_module, php_module
+
+<IfModule dir_module>
+	<IfModule php_module>
+		DirectoryIndex index.php index.html
+		<FilesMatch "\.php$">
+			SetHandler application/x-httpd-php
+		</FilesMatch>
+		<FilesMatch "\.phps$">
+			SetHandler application/x-httpd-php-source
+		</FilesMatch>
+	</IfModule>
+</IfModule>

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.6"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -25,6 +25,8 @@ environment:
   contents:
     packages:
       - aom-dev
+      - apache2-dev
+      - apache2-utils
       - autoconf
       - bison
       - build-base
@@ -138,9 +140,16 @@ pipeline:
         --with-pgsql=shared \
         --with-zip=shared \
         --enable-sysvsem=shared \
-        --enable-sysvshm=shared
+        --enable-sysvshm=shared \
+        --with-apxs2=/usr/bin/apxs \
+        --enable-phpdbg=shared
 
   - uses: autoconf/make
+
+  - name: Copy httpd.conf before install
+    runs: |
+      mkdir -p ${{targets.destdir}}/etc/apache2
+      cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
@@ -286,6 +295,25 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: "${{package.name}}-apache"
+    description: Apache SAPI for PHP ${{vars.phpMM}}
+    dependencies:
+      provides:
+        - php-apache=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/apache2/modules
+          mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
+          install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/apache2/modules/libphp.so
 
   - name: "${{package.name}}-cgi"
     description: PHP ${{vars.phpMM}} CGI

--- a/php-8.4/apache.conf
+++ b/php-8.4/apache.conf
@@ -1,0 +1,13 @@
+# Required modules: dir_module, php_module
+
+<IfModule dir_module>
+	<IfModule php_module>
+		DirectoryIndex index.php index.html
+		<FilesMatch "\.php$">
+			SetHandler application/x-httpd-php
+		</FilesMatch>
+		<FilesMatch "\.phps$">
+			SetHandler application/x-httpd-php-source
+		</FilesMatch>
+	</IfModule>
+</IfModule>


### PR DESCRIPTION
apache2-foreground was needed the `libphp.so` to run properly, so lets enable the needed module. Also needed by `nextcloud-server`. `apache.conf` is from: https://gitlab.archlinux.org/archlinux/packaging/packages/php/-/tree/main?ref_type=heads