### PR TITLE
opa-envoy: reorder var-transforms to fix update checks

### DIFF
--- a/opa-envoy.yaml
+++ b/opa-envoy.yaml
@@ -24,14 +24,14 @@ var-transforms:
   # for future updates, until
   # https://github.com/chainguard-dev/melange/issues/1774 is addressed
   - from: ${{package.version}}
-    # 1.0.0 -> 1.0.0-envoy
-    match: ^(\d+\.\d+\.\d+)$
-    replace: $1-envoy
-    to: mangled-package-version
-  - from: ${{package.version}}
     # 1.1.0_p1 -> 1.1.0-envoy-1
     match: ^([0-9]+.[0-9]+.[0-9]+)(_p(\d+))?$
     replace: $1-envoy-$3
+    to: mangled-package-version
+  - from: ${{package.version}}
+    # 1.0.0 -> 1.0.0-envoy
+    match: ^(\d+\.\d+\.\d+)$
+    replace: $1-envoy
     to: mangled-package-version
   - from: ${{package.version}}
     match: ^(\d+\.\d+\.\d+).*$


### PR DESCRIPTION
I'll let automation create the update PR, as builds are currently broken pending a production deployment.