### PR TITLE
tekton: fix binary names

### DIFF
--- a/tekton-pipelines-1.0.yaml
+++ b/tekton-pipelines-1.0.yaml
@@ -48,7 +48,7 @@ subpackages:
       - uses: go/build
         with:
           packages: ./cmd/${{range.key}}
-          output: ${{range.key}}
+          output: ${{vars.base-package-name}}-${{range.key}}
     test:
       pipeline:
         - runs: |
@@ -66,7 +66,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/ko-app
-          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/ko-app/${{range.key}}
+          ln -sf /usr/bin/${{vars.base-package-name}}-${{range.key}} ${{targets.contextdir}}/ko-app/${{range.key}}
     test:
       environment:
         contents:


### PR DESCRIPTION
Fixing binary names e.g. `/usr/bin/resolvers` -> `/usr/bin/tekton-pipelines-resolvers`