### PR TITLE
Drop the use of `$HOME` in php packages

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.32"
-  epoch: 41
+  epoch: 42
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -206,7 +206,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.28"
-  epoch: 41
+  epoch: 42
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -201,7 +201,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.20"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -206,7 +206,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.6"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -206,7 +206,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"


### PR DESCRIPTION
Under bubblewrap this is a no-op because `HOME` is `/home/build`, but with the QEMU runner this breaks.

With this change, things pass under QEMU.

