### PR TITLE
add `kubernetes-csi-external-attacher-compat` pkg

### DIFF
--- a/kubernetes-csi-external-attacher.yaml
+++ b/kubernetes-csi-external-attacher.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher
   version: "4.8.1"
-  epoch: 5
+  epoch: 6
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,19 @@ pipeline:
       packages: ./cmd/csi-attacher
       ldflags: "-w -X main.version=v${{package.version}} -extldflags '-static'"
       output: csi-attacher
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: compat pkg for upstream entrypoint
+    pipeline:
+      - runs: |
+          # Symlink the binary from /usr/bin to /
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/csi-attacher ${{targets.subpkgdir}}/csi-attacher
+    test:
+      pipeline:
+        - runs: |
+            stat /csi-attacher
 
 update:
   enabled: true


### PR DESCRIPTION
This PR adds a compat package for `kubernetes-csi-external-attacher` to match the upstream's entrypoint.