### PR TITLE
fix(kubeflow-pipelines-metadata-writer): Use Python 3.10

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.5.0"
-  epoch: 0
+  epoch: 1
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -9,29 +9,22 @@ package:
   copyright:
     - license: Apache-2.0
 
+vars:
+  py-version: '3.10'
+
 environment:
   contents:
     packages:
       - argo-cd
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - eslint
-      - git
-      - go
       - go-licenses
       - jq
       - kubectl
       - nodejs
       - npm
-      - py3-gpep517
-      - py3-pip
-      - py3-setuptools
-      - py3-urllib3
-      - py3-wheel
-      - python3-dev
-  environment:
-    GO111MODULE: "on"
+      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-gpep517
+      - py${{vars.py-version}}-urllib3
 
 data:
   - name: backends-go-builds
@@ -115,7 +108,7 @@ subpackages:
             # GHSA-79v4-65xg-pq4g
             echo "cryptography==44.0.1" >> requirements.txt
 
-            pip3 install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
+            pip${{vars.py-version}} install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
             cp -r ../samples/* ${{targets.subpkgdir}}/samples
             cp ./src/$path/config/sample_config.json ${{targets.subpkgdir}}/samples/sample_config.json
             mkdir -p ${{targets.subpkgdir}}/config
@@ -218,37 +211,37 @@ subpackages:
     description: "Kubeflow Pipelines metadata_writer"
     dependencies:
       runtime:
-        - python3
-        - py3-absl-py
-        - py3-attrs
-        - py3-cachetools
-        - py3-certifi
-        - py3-charset-normalizer
-        - py3-google-auth
-        - py3-grpcio
-        - py3-idna
-        - py3-kubernetes
-        - py3-lru-dict
-        - py3-ml-metadata
-        - py3-oauthlib
-        - py3-protobuf
-        - py3-pyasn1-modules
-        - py3-pyasn1
-        - py3-dateutil
-        - py3-pyyaml
-        - py3-requests-oauthlib
-        - py3-requests
-        - py3-rsa
-        - py3-six
-        - py3-urllib3
-        - py3-websocket-client
+        - python-${{vars.py-version}}
+        - py${{vars.py-version}}-absl-py
+        - py${{vars.py-version}}-attrs
+        - py${{vars.py-version}}-cachetools
+        - py${{vars.py-version}}-certifi
+        - py${{vars.py-version}}-charset-normalizer
+        - py${{vars.py-version}}-google-auth
+        - py${{vars.py-version}}-grpcio
+        - py${{vars.py-version}}-idna
+        - py${{vars.py-version}}-kubernetes
+        - py${{vars.py-version}}-lru-dict
+        - py${{vars.py-version}}-ml-metadata
+        - py${{vars.py-version}}-oauthlib
+        - py${{vars.py-version}}-protobuf
+        - py${{vars.py-version}}-pyasn1-modules
+        - py${{vars.py-version}}-pyasn1
+        - py${{vars.py-version}}-dateutil
+        - py${{vars.py-version}}-pyyaml
+        - py${{vars.py-version}}-requests-oauthlib
+        - py${{vars.py-version}}-requests
+        - py${{vars.py-version}}-rsa
+        - py${{vars.py-version}}-six
+        - py${{vars.py-version}}-urllib3
+        - py${{vars.py-version}}-websocket-client
     pipeline:
       - runs: |
           cd backend/metadata_writer
-          python3 -m gpep517 build-wheel \
+          python${{vars.py-version}} -m gpep517 build-wheel \
             --wheel-dir dist \
             --output-fd 3 3>&1 >&2
-          python3 -m installer -d "${{targets.subpkgdir}}" \
+          python${{vars.py-version}} -m installer -d "${{targets.subpkgdir}}" \
             dist/*.whl
           find ${{targets.subpkgdir}} -name "*.pyc" -exec rm -rf '{}' +
 
@@ -260,8 +253,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/kfp/metadata_writer
-          _py3ver=$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
-          ln -s /usr/lib/python"$_py3ver"/site-packages/metadata_writer.py "${{targets.subpkgdir}}"/kfp/metadata_writer/
+          ln -s /usr/lib/python${{vars.py-version}}/site-packages/metadata_writer.py "${{targets.subpkgdir}}"/kfp/metadata_writer/
 
   - name: kubeflow-pipelines-metadata-envoy-config
     description: Kubeflow Pipelines Metadata-Envoy Config


### PR DESCRIPTION
ml-metadata doesn't support anything newer