### PR TITLE
tekton-pipelines-1.0: update binary names

### DIFF
--- a/tekton-pipelines-1.0.yaml
+++ b/tekton-pipelines-1.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines-1.0
   version: "1.0.0"
-  epoch: 1
+  epoch: 2
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ subpackages:
       - uses: go/build
         with:
           packages: ./cmd/${{range.key}}
-          output: ${{vars.base-package-name}}-${{range.key}}
+          output: ${{range.key}}
     test:
       pipeline:
         - runs: |
@@ -66,7 +66,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/ko-app
-          ln -sf /usr/bin/${{vars.base-package-name}}-${{range.key}} ${{targets.contextdir}}/ko-app/${{range.key}}
+          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/ko-app/${{range.key}}
     test:
       environment:
         contents:


### PR DESCRIPTION
Revert changes to the binary names - image build updates will use `<subpackage-name>` rather than `tekton-pipelines-<subpackage-name>`