### PR TITLE
fix(cve-pr-closer): switching to subject pattern for octosts

### DIFF
--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -1,8 +1,7 @@
 issuer: https://accounts.google.com
 
 # lc-cve-pr-closer-cron@prod-enforce-fabc.iam.gserviceaccount.com
-claim_pattern:
-  email: 'lc-cve-pr-closer-cron@prod-enforce-fabc\.iam\.gserviceaccount\.com'
+subject_pattern: "(101045395775641394837)"
 
 permissions:
   contents: read

--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -6,3 +6,6 @@ subject: "101045395775641394837"
 permissions:
   contents: read
   pull_requests: write
+  issues: read
+  checks: read
+  actions: read

--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -1,7 +1,7 @@
 issuer: https://accounts.google.com
 
 # lc-cve-pr-closer-cron@prod-enforce-fabc.iam.gserviceaccount.com
-subject_pattern: "(101045395775641394837)"
+subject: "101045395775641394837"
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to this [comment](https://github.com/wolfi-dev/os/pull/52156#discussion_r2070350671), switching to subject pattern for consistency with octosts pattern. 