### PR TITLE
py3-graph-tool: add more runtime deps

### DIFF
--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -72,7 +72,6 @@ subpackages:
         - py${{range.key}}-gobject3
         - py${{range.key}}-numpy
         - py${{range.key}}-scipy
-        - gtk-3
         - glib-gir
     pipeline:
       - runs: ./autogen.sh
@@ -81,6 +80,8 @@ subpackages:
           opts: |
             --enable-openmp \
             --includedir=/usr/lib/cairomm-1.16 \
+            --disable-debug \
+            --disable-dependency-tracking \
             PYTHON=python${{range.key}}
       - runs: |
           make -C . -j$(nproc) V=1

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -168,6 +168,8 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
+        with:
+          package: py${{range.key}}-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/pkgconf

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -165,7 +165,8 @@ subpackages:
         # - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
 
-  - name: ${{package.name}}-dev
+  - range: py-versions
+    name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
         with:

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -86,9 +86,7 @@ subpackages:
       - runs: |
           make -C . -j$(nproc) V=1
       - uses: autoconf/make-install
-      - uses: strip
-        with:
-          opts: -s -g
+      - runs: find ${{targets.contextdir}} -name "*.so" -exec strip -g {} \;
     test:
       environment:
         contents:

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -87,6 +87,8 @@ subpackages:
           make -C . -j$(nproc) V=1
       - uses: autoconf/make-install
       - uses: strip
+        with:
+          opts: -s -g
     test:
       environment:
         contents:

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -66,8 +66,6 @@ subpackages:
     name: py${{range.key}}-${{vars.pypi-package}}
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
-      provides:
-        - graph-tool=${{package.full-version}}
       runtime:
         - py${{range.key}}-cairo
         - py${{range.key}}-matplotlib

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-graph-tool
   version: 2.97
-  epoch: 0
+  epoch: 1
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
@@ -39,7 +39,9 @@ environment:
       - eigen-dev
       - expat-dev
       - freetype-dev
+      - glib-gir
       - gmp-dev
+      - gtk-3-dev
       - libsigcplusplus-dev
       - libtool
       - mpfr-dev
@@ -72,6 +74,8 @@ subpackages:
         - py${{range.key}}-gobject3
         - py${{range.key}}-numpy
         - py${{range.key}}-scipy
+        - gtk-3
+        - glib-gir
     pipeline:
       - runs: ./autogen.sh
       - uses: autoconf/configure

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -6,8 +6,6 @@ package:
   resources:
     cpu: 65
     memory: 128Gi
-  target-architecture:
-    - x86_64
   copyright:
     - license: GPL-3.0-only
 

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -6,6 +6,8 @@ package:
   resources:
     cpu: 65
     memory: 128Gi
+  target-architecture:
+    - x86_64
   copyright:
     - license: GPL-3.0-only
 


### PR DESCRIPTION
this adds more runtime deps and we're stripping the .so files correctly now reducing the package size very drastically. 