### PR TITLE
melange: add tmpfs /dev/shm to melange-init for VMs

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.23.15"
-  epoch: 1
+  epoch: 2
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -8,6 +8,8 @@ mount -t proc proc -o nodev,nosuid,hidepid=2 /proc
 mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
 mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
+mkdir -p -m 0755 /dev/shm
+mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
 
 # Fix /dev/fd
 ln -s /proc/self/fd /dev/fd


### PR DESCRIPTION
Builds using bazel are failing with the qemu melange runner because it expects the presence of a tmpfs mounted at /dev/shm. Modify the init for melange VMs to create the mountpoint for it and populate it.