### PR TITLE
php: fix installation conflict along with apache2

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.32"
-  epoch: 42
+  epoch: 43
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -146,14 +146,22 @@ pipeline:
 
   - uses: autoconf/make
 
-  - name: Copy httpd.conf before install
+  - name: Copy httpd.conf before install for apxs
     runs: |
+      # httpd.conf needs to be in the /home/build/melange-out/php-<VERSION>/etc/apache2/ directory
+      # otherwise `make install` complains that it cannot find it.
       mkdir -p ${{targets.destdir}}/etc/apache2
       cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - name: Remove httpd.conf after install for apxs
+    runs: |
+      # After `make install` the httpd.conf file is not needed anymore,
+      # so remove it to avoid conflicts with the apache2 package, as it already provides.
+      rm -f ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - uses: strip
 
@@ -311,6 +319,12 @@ subpackages:
           mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
           install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - apache2 # Ensure that we properly install the subpackage along with the main package and apache2
+            - apache2-compat
       pipeline:
         - uses: test/tw/ldd-check
         - runs: stat /usr/lib/apache2/modules/libphp.so

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.28"
-  epoch: 42
+  epoch: 43
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -141,14 +141,22 @@ pipeline:
 
   - uses: autoconf/make
 
-  - name: Copy httpd.conf before install
+  - name: Copy httpd.conf before install for apxs
     runs: |
+      # httpd.conf needs to be in the /home/build/melange-out/php-<VERSION>/etc/apache2/ directory
+      # otherwise `make install` complains that it cannot find it.
       mkdir -p ${{targets.destdir}}/etc/apache2
       cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - name: Remove httpd.conf after install for apxs
+    runs: |
+      # After `make install` the httpd.conf file is not needed anymore,
+      # so remove it to avoid conflicts with the apache2 package, as it already provides.
+      rm -f ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - uses: strip
 
@@ -306,6 +314,12 @@ subpackages:
           mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
           install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - apache2 # Ensure that we properly install the subpackage along with the main package and apache2
+            - apache2-compat
       pipeline:
         - uses: test/tw/ldd-check
         - runs: stat /usr/lib/apache2/modules/libphp.so

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.20"
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -146,14 +146,22 @@ pipeline:
 
   - uses: autoconf/make
 
-  - name: Copy httpd.conf before install
+  - name: Copy httpd.conf before install for apxs
     runs: |
+      # httpd.conf needs to be in the /home/build/melange-out/php-<VERSION>/etc/apache2/ directory
+      # otherwise `make install` complains that it cannot find it.
       mkdir -p ${{targets.destdir}}/etc/apache2
       cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - name: Remove httpd.conf after install for apxs
+    runs: |
+      # After `make install` the httpd.conf file is not needed anymore,
+      # so remove it to avoid conflicts with the apache2 package, as it already provides.
+      rm -f ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - uses: strip
 
@@ -311,6 +319,12 @@ subpackages:
           mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
           install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - apache2 # Ensure that we properly install the subpackage along with the main package and apache2
+            - apache2-compat
       pipeline:
         - uses: test/tw/ldd-check
         - runs: stat /usr/lib/apache2/modules/libphp.so

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.6"
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -146,14 +146,22 @@ pipeline:
 
   - uses: autoconf/make
 
-  - name: Copy httpd.conf before install
+  - name: Copy httpd.conf before install for apxs
     runs: |
+      # httpd.conf needs to be in the /home/build/melange-out/php-<VERSION>/etc/apache2/ directory
+      # otherwise `make install` complains that it cannot find it.
       mkdir -p ${{targets.destdir}}/etc/apache2
       cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - name: Make Install
     runs: |
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - name: Remove httpd.conf after install for apxs
+    runs: |
+      # After `make install` the httpd.conf file is not needed anymore,
+      # so remove it to avoid conflicts with the apache2 package, as it already provides.
+      rm -f ${{targets.destdir}}/etc/apache2/httpd.conf
 
   - uses: strip
 
@@ -311,6 +319,12 @@ subpackages:
           mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
           install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - apache2 # Ensure that we properly install the subpackage along with the main package and apache2
+            - apache2-compat
       pipeline:
         - uses: test/tw/ldd-check
         - runs: stat /usr/lib/apache2/modules/libphp.so


### PR DESCRIPTION
Follow-up fix for: https://github.com/wolfi-dev/os/pull/52332

Fixes an issue where we can't have the `apache2` and `php-8.x` at the same time in the runtime.