### PR TITLE
trino: reorder git-checkout stanzas to avoid spurious updates

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "475"
-  epoch: 3
+  epoch: 4
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,12 @@ environment:
 
 pipeline:
   - uses: git-checkout
+    with:
+      repository: https://github.com/trinodb/trino.git
+      tag: ${{package.version}}
+      expected-commit: fd2b81e86ba1c288684746d0842c0ffc3a709598
+
+  - uses: git-checkout
     working-directory: ./airlift/launcher
     with:
       repository: https://github.com/airlift/launcher.git
@@ -41,12 +47,6 @@ pipeline:
     runs: |
       export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
       ./mvnw package
-
-  - uses: git-checkout
-    with:
-      repository: https://github.com/trinodb/trino.git
-      tag: ${{package.version}}
-      expected-commit: fd2b81e86ba1c288684746d0842c0ffc3a709598
 
   - uses: maven/pombump
 


### PR DESCRIPTION
The automation which generates new update PRs assumes that the first `git-checkout` stanza corresponds to the git repo described by the `update` configuration.  When that isn't true (as here), it will always find a mismatch in expected commits and so always generate a new update PR.

This commit reorders the `git-checkout`s to avoid this problem.

Closes: #52477