### PR TITLE
Add staticcheck package

### DIFF
--- a/staticcheck.yaml
+++ b/staticcheck.yaml
@@ -1,6 +1,6 @@
 package:
   name: staticcheck
-  version: 0.6.1
+  version: 2025.1.1
   epoch: 0
   description: Staticcheck is a state of the art linter for the Go programming language.
   copyright:
@@ -23,7 +23,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/dominikh/go-tools
-      tag: v0.6.1
+      tag: 2025.1.1
       expected-commit: b8ec13ce4d00445d75da053c47498e6f9ec5d7d6 # verify this is correct for v0.6.1
 
   - runs: |

--- a/staticcheck.yaml
+++ b/staticcheck.yaml
@@ -1,0 +1,47 @@
+package:
+  name: staticcheck
+  version: 0.6.1
+  epoch: 0
+  description: Staticcheck is a state of the art linter for the Go programming language.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - go
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GOFLAGS: "-mod=readonly"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dominikh/go-tools
+      tag: v0.6.1
+      expected-commit: b8ec13ce4d00445d75da053c47498e6f9ec5d7d6 # verify this is correct for v0.6.1
+
+  - runs: |
+      cd cmd/staticcheck
+      go build -trimpath -ldflags="-s -w" -o staticcheck
+      install -Dm755 staticcheck "${{targets.destdir}}/usr/bin/staticcheck"
+      install -Dm644 ../../LICENSE "${{targets.destdir}}/usr/share/staticcheck/LICENSE"
+
+subpackages:
+  - name: "staticcheck-doc"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/doc/staticcheck"
+          cp -a "${{targets.destdir}}/usr/share/staticcheck/LICENSE" "${{targets.subpkgdir}}/usr/share/doc/staticcheck/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: dominikh/go-tools
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
### staticcheck-0.6.1: new package

Adds `staticcheck` version 0.6.1 to Wolfi OS. Staticcheck is a widely used linter for Go, integrated into tools like `gopls` and VSCode. This addition makes it easier to build container images with linting capabilities included.

---

**Fixes:** [#52135](https://github.com/wolfi-dev/os/issues/52135)  
**Related:** [#52131](https://github.com/wolfi-dev/os/issues/52131)

---

### Pre-review Checklist

#### For new package PRs only
- [x] This PR is marked as fixing a pre-existing package request bug  
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency  
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license *(MIT)*  
- [x] REQUIRED - The version of the package is still receiving security updates  
- [ ] This PR links to the upstream project's support policy (e.g. endoflife.date)