### PR TITLE
vitess-21.0/GHSA-859w-5945-r5v3 fix

### DIFF
--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.4"
-  epoch: 2
+  epoch: 3
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -94,6 +94,8 @@ pipeline:
 
       # CVE GHSA-3xgq-45jj-v275
       npm install cross-spawn@7.0.6
+      # CVE GHSA-859w-5945-r5v3
+      npm install vite@4.5.14
 
       npm prune --production
       npm install vite --save-dev


### PR DESCRIPTION
bumping vite from 4.5.13 to 4.5.14 remediates this CVE