### PR TITLE
k3s/GHSA-v778-237x-gjrc/GHSA-hcg3-q754-cr77 fix

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.32.4.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -71,6 +71,7 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
       replaces: |-
         golang.org/x/net=golang.org/x/net@v0.39.0
+        golang.org/x/crypto=golang.org/x/crypto@v0.38.0
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054


### PR DESCRIPTION
Bumping crypto to the newest version resolves the following CVEs: GHSA-v778-237x-gjrc/GHSA-hcg3-q754-cr77 