### PR TITLE
fix: add missing /dev/fd symlink

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.23.15"
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -9,6 +9,9 @@ mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
 mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
 
+# Fix /dev/fd
+ln -s /proc/self/fd /dev/fd
+
 # Setup tty/pty
 mkdir /dev/pts
 mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /dev/pts/


### PR DESCRIPTION
Canonically /dev/fd is a symlink to /proc/self/fd, this is needed for some redirect inputs in shells