### PR TITLE
add openmp versions 18 and 19

### DIFF
--- a/openmp-18.yaml
+++ b/openmp-18.yaml
@@ -1,0 +1,81 @@
+package:
+  name: openmp-18
+  version: "18.1.8"
+  epoch: 0
+  description: "LLVM OpenMP library"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libLLVM-18
+
+environment:
+  contents:
+    packages:
+      - binutils-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - help2man
+      - libLLVM-18
+      - libffi-dev
+      - libxml2-dev
+      - llvm-cmake-18
+      - llvm-18
+      - llvm-18-dev
+      - pkgconf
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/openmp-${{package.version}}.src.tar.xz
+      expected-sha256: 60ed57245e73894e4a2a89b15889f367bd906abfe6d3f92e1718223d4b496150
+
+  - runs: |
+      cmake -B build -G Ninja -Wno-dev \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-18/share/cmake" \
+        -DCMAKE_MODULE_PATH="/usr/lib/llvm-18/share/cmake/Modules" \
+        -DLLVM_CONFIG=/usr/lib/llvm-18/bin/llvm-config \
+        -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm-18/include \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-18/include \
+        -DLIBOMP_CPPFLAGS="-I/usr/lib/llvm-18/include" \
+        -DLIBOMP_INSTALL_ALIASES=OFF
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: "openmp-18-dev"
+    description: "headers for openmp-18"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - openmp-18
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: llvm/llvm-project
+    strip-prefix: llvmorg-
+    tag-filter: llvmorg-18
+    use-tag: true

--- a/openmp-18.yaml
+++ b/openmp-18.yaml
@@ -21,9 +21,9 @@ environment:
       - libLLVM-18
       - libffi-dev
       - libxml2-dev
-      - llvm-cmake-18
       - llvm-18
       - llvm-18-dev
+      - llvm-cmake-18
       - pkgconf
       - python3
       - samurai

--- a/openmp-19.yaml
+++ b/openmp-19.yaml
@@ -21,9 +21,9 @@ environment:
       - libLLVM-19
       - libffi-dev
       - libxml2-dev
-      - llvm-cmake-19
       - llvm-19
       - llvm-19-dev
+      - llvm-cmake-19
       - pkgconf
       - python3
       - samurai

--- a/openmp-19.yaml
+++ b/openmp-19.yaml
@@ -1,0 +1,81 @@
+package:
+  name: openmp-19
+  version: "19.1.7"
+  epoch: 0
+  description: "LLVM OpenMP library"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libLLVM-19
+
+environment:
+  contents:
+    packages:
+      - binutils-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - help2man
+      - libLLVM-19
+      - libffi-dev
+      - libxml2-dev
+      - llvm-cmake-19
+      - llvm-19
+      - llvm-19-dev
+      - pkgconf
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/openmp-${{package.version}}.src.tar.xz
+      expected-sha256: bd7e6901ab086fd268750363017935fd4a717c153dad3c2aab86cb0140d9e3fe
+
+  - runs: |
+      cmake -B build -G Ninja -Wno-dev \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-19/share/cmake" \
+        -DCMAKE_MODULE_PATH="/usr/lib/llvm-19/share/cmake/Modules" \
+        -DLLVM_CONFIG=/usr/lib/llvm-19/bin/llvm-config \
+        -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm-19/include \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-19/include \
+        -DLIBOMP_CPPFLAGS="-I/usr/lib/llvm-19/include" \
+        -DLIBOMP_INSTALL_ALIASES=OFF
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: "openmp-19-dev"
+    description: "headers for openmp-19"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - openmp-19
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: llvm/llvm-project
+    strip-prefix: llvmorg-
+    tag-filter: llvmorg-19
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
