### PR TITLE
Update neuvector-dbgen to properly reflect go.mod location.

### DIFF
--- a/neuvector-dbgen.yaml
+++ b/neuvector-dbgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-dbgen
   version: 0_git20240423
-  epoch: 3
+  epoch: 4
   description: NeuVector vulnerability database generator for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0
@@ -42,8 +42,8 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          modroot: updater
-          packages: .
+          modroot: .
+          packages: ./updater
           output: updater
           prefix: usr/local
           vendor: true


### PR DESCRIPTION
Not sure how this passed before (maybe a pipeline change?), but the root go.mod covers this subpackage as well, so restructure things to work properly.
