### PR TITLE
chore(kafka-4.0): Bump to OpenJDK 21

### DIFF
--- a/kafka-4.0.yaml
+++ b/kafka-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-4.0
   version: "4.0.0"
-  epoch: 40
+  epoch: 41
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -11,8 +11,11 @@ package:
     runtime:
       - bash # some helper scripts use bash
       - merged-usrsbin
-      - openjdk-17-default-jvm
+      - openjdk-${{vars.java-version}}-default-jvm
       - wolfi-baselayout
+
+vars:
+  java-version: '21'
 
 var-transforms:
   - from: ${{package.version}}
@@ -27,10 +30,10 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
-      - openjdk-17-default-jdk
+      - openjdk-${{vars.java-version}}-default-jdk
   environment:
     LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_HOME: /usr/lib/jvm/default-jvm
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Migrate from OpenJDK 17 to 21, inline with upstream