### PR TITLE
kube-fluentd-operator: Remove bundle clean

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 36
+  epoch: 37
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -88,10 +88,8 @@ pipeline:
       echo "gem 'webrick', '1.8.2'" >> Gemfile
 
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
-      bundle update rack
       # bump net-imap to mitigate GHSA-j3g3-5qv5-52mj
-      bundle update net-imap --patch
-      bundle install
+      bundle update rack net-imap --patch
 
 
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin
@@ -117,7 +115,6 @@ pipeline:
       bundle install
 
       # remove cache to avoid including it in the package
-      bundle clean
       rm -rf ${{targets.destdir}}/$(ruby -e "puts File.join(Gem.default_dir, 'ruby', RbConfig::CONFIG['ruby_version'])")/cache
 
   - uses: strip


### PR DESCRIPTION
A recent commit added this call to bundle clean, which seems like an
obvious move to anyone seeking to reduce APK size.  An unfortunate
effect was that the kubernetes_metadata Gem was removed.  It is not 100%
clear to me why this happened.

I have consolidated the bundle update for rack and net-imap, when these
were separate the update would cause older vulnerable packages to be
installed, which necessitated the bundle clean.

Another change that would have benefited from image backpressure —
https://github.com/chainguard-dev/internal-dev/issues/6651

