### PR TITLE
From wolfi repo from openssl

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: "3.5.0"
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -21,8 +21,6 @@ environment:
     # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
     # any version of jitternetropy-library and get an ESV certificate
     # for it.
-    build_repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - build-base
       - busybox


### PR DESCRIPTION
`openssl` explicitly lists the Wolfi APK repository, and we're seeing failures due to the signing key being missing for it, so this lists that explicitly.
