### PR TITLE
abseil-cpp: epoch bump to build against latest gtest-dev

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -7,7 +7,7 @@
 package:
   name: abseil-cpp
   version: "20250127.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0

--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,9 +1,3 @@
-# BEFORE UPDATING: Adding a new build of abseil-cpp into the archive at this
-# time may cause installs of packages that depend on abseil-cpp packages to
-# time out:
-#   https://github.com/chainguard-dev/melange/issues/1651
-# Until this issue is resolved, please request a PR approval for changes
-# to this file from the OS team.
 package:
   name: abseil-cpp
   version: "20250127.1" # On update, please check if -fdelete-null-pointer-checks is still required


### PR DESCRIPTION
Packages which depend on both `abseil-cpp` and `gtest` packages to build can't current construct a package build environment due to `abseil-cpp`'s dependencies on `so:libgtest.so.1.16.0` and `so:libgmock.so.1.16.0`.