### PR TITLE
Use lp.net not edge.lp.net

### DIFF
--- a/intltool.yaml
+++ b/intltool.yaml
@@ -1,7 +1,7 @@
 package:
   name: intltool
   version: 0.51.0
-  epoch: 1
+  epoch: 2
   description: The internationalization tool collection
   copyright:
     - license: GPL-2.0-or-later
@@ -29,7 +29,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
-      uri: https://edge.launchpad.net/intltool/trunk/${{package.version}}/+download/intltool-${{package.version}}.tar.gz
+      uri: https://launchpad.net/intltool/trunk/${{package.version}}/+download/intltool-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
Fix this build failure by using launchpad:

```
2025-05-07 07:50:55.392590839 +0000 UTC running step "fetch"
2025-05-07 07:50:55.409316998 +0000 UTC --2025-05-07 07:50:55--  https://edge.launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
2025-05-07 07:50:55.479449811 +0000 UTC Resolving edge.launchpad.net... 162.213.35.17, 162.213.35.16, 162.213.35.15
2025-05-07 07:50:55.511812588 +0000 UTC Connecting to edge.launchpad.net|162.213.35.17|:443... connected.
2025-05-07 07:50:55.546967285 +0000 UTC ERROR: cannot verify edge.launchpad.net's certificate, issued by 'CN=Kubernetes Ingress Controller Fake Certificate,O=Acme Co':
2025-05-07 07:50:55.546999825 +0000 UTC   Self-signed certificate encountered.
2025-05-07 07:50:55.547006695 +0000 UTC ERROR: no certificate subject alternative name matches
2025-05-07 07:50:55.547011765 +0000 UTC         requested host name 'edge.launchpad.net'.
2025-05-07 07:50:55.547016775 +0000 UTC To connect to edge.launchpad.net insecurely, use `--no-check-certificate'.
```