### PR TITLE
Drop an unnecessary go bump

### DIFF
--- a/smarter-device-manager.yaml
+++ b/smarter-device-manager.yaml
@@ -5,7 +5,7 @@
 package:
   name: smarter-device-manager
   version: 1.20.11
-  epoch: 16
+  epoch: 17
   description: Device manager container that enables access to device drivers on containers for k8s
   copyright:
     - license: Apache-2.0
@@ -29,11 +29,6 @@ pipeline:
       go mod init arm.com/smarter-device-management
       go mod tidy
       go mod vendor
-
-  - uses: go/bump
-    with:
-      deps: |-
-        github.com/golang/glog@v1.2.4
 
   - runs: |
       CGO_ENABLED=0 go build -trimpath -ldflags='-w -extldflags="-static"' .


### PR DESCRIPTION
The package was failing to build because `Error: failed to run update. Error: package github.com/golang/glog wit    h version 'v1.2.4' is already at version v1.2.5`