### PR TITLE
chore(strimzi-kafka): Bump to OpenJDK 21

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.46.0"
-  epoch: 2
+  epoch: 3
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ environment:
       - helm
       - make
       - maven
-      - openjdk-17-default-jdk
+      - openjdk-${{vars.java-version}}-default-jdk
       - perl-utils
       - tini
       - tini-compat
@@ -41,6 +41,7 @@ environment:
     DEST_DIR: opt/strimzi
 
 vars:
+  java-version: '21'
   shellcheck_version: 0.10.0
   shellcheck_aarch64_shasum512: 77abeaa8bee293264ebfd94a2021bd490695ed5518f2da7c0f9ec4b402cd1e5da6642a0e9f953961510cef7351cc9afae7c7a528a597d1befd1867b8c69e15b1
   shellcheck_x86_64_shasum512: 31006830087c2b9ffe9fa36c1ab4a8b11c85078cac8203265d0cfd630c70a4a506e66dd9d7ccde964360ad95045894149de457db34f10cad76708c7a4aa544ca
@@ -63,7 +64,7 @@ pipeline:
       pom: docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
 
   - runs: |
-      export JAVA_HOME="/usr/lib/jvm/java-17-openjdk"
+      export JAVA_HOME="/usr/lib/jvm/default-jvm"
       # Download the shellcheck tarball
       wget -qO- "https://github.com/koalaman/shellcheck/releases/download/v${{vars.shellcheck_version}}/shellcheck-v${{vars.shellcheck_version}}.linux.${{build.arch}}.tar.xz" -O shellcheck.tar.xz
 
@@ -161,7 +162,6 @@ subpackages:
         - kafka-strimzi-compat
         - net-tools
         - nmap
-        - openjdk-17-default-jvm
         - openssl
         - sed
         - strimzi-kafka-operator-kafka-agent
@@ -169,7 +169,6 @@ subpackages:
         - strimzi-kafka-operator-kafka-thirdparty-libs
         - strimzi-kafka-operator-kafka-thirdparty-libs-cc
         - tini
-        - tini-compat
       provides:
         - strimzi-kafka=${{package.full-version}}
     pipeline:


### PR DESCRIPTION
Align with upstream. Also remove explicit dependency on OpenJDK as it is already pulled in by Kafka and tini-compat as it is useless after usr merge