### PR TITLE
sts-policy: add staging scrape comments bot, read only access

### DIFF
--- a/.github/chainguard/scrape-error-comments.sts.yaml
+++ b/.github/chainguard/scrape-error-comments.sts.yaml
@@ -1,7 +1,8 @@
 issuer: https://accounts.google.com
 
-# detect@jrawlings-chainguard.iam.gserviceaccount.com
-subject: "114294174394359664841"
+# 114294174394359664841: detect@jrawlings-chainguard.iam.gserviceaccount.com
+# 116281006810362224152: scrape-errors@staging-enforce-cd1e.iam.gserviceaccount.com
+subject_pattern: "(114294174394359664841|116281006810362224152)"
 
 permissions:
   metadata: read


### PR DESCRIPTION
This allows a staging bot read access to PR comments 