### PR TITLE
Add `.ssh/authorized_keys` to rat exclusions.

### DIFF
--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.41.0"
-  epoch: 0
+  epoch: 1
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0
@@ -56,6 +56,7 @@ subpackages:
     description: "Compatibility package to place binaries and symlinks in location expected by the container"
     pipeline:
       - runs: |
+          mkdir -p ${{targets.contextdir}}
           cp artemis-docker/docker-run.sh "${{targets.contextdir}}"/
           mkdir -p ${{targets.destdir}}/opt/java/
           ln -sf /usr/lib/jvm/default-jvm ${{targets.destdir}}/opt/java/openjdk

--- a/apache-activemq-artemis/rat-exclusions.txt
+++ b/apache-activemq-artemis/rat-exclusions.txt
@@ -9,3 +9,6 @@
 # Files from pombump
 pom.xml
 pombump-properties.yaml
+
+# Files from QEMU runner
+.ssh/authorized_keys


### PR DESCRIPTION
Otherwise this file (added by QEMU runner) is flagged by the RAT plugin for not having a license.
