### PR TITLE
melange: bump RLIMIT_NOFILE hardlimit to max value from kernel

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.23.15"
-  epoch: 3
+  epoch: 4
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -85,6 +85,19 @@ if grep -q build /etc/passwd; then
 	chown -R build:build /home/build
 fi
 
+# Set default hard limit of open file descriptors to match systemd init
+# behavior. The pam_limit module uses the settings in /proc/1/limit as
+# its default values.
+if [ -f /proc/sys/fs/nr_open ] ; then
+    nofile_limit=$(ulimit -H -n)
+    kernel_max_limit=$(cat /proc/sys/fs/nr_open)
+    # ensure that we are increasing the hard limit
+    if [[ "${kernel_max_limit}" =~ ^[0-9]+$ ]] &&
+       [ "${nofile_limit}" -lt "${kernel_max_limit}" ] ; then
+         ulimit -H -n "$kernel_max_limit"
+    fi
+fi
+
 # Setup default network
 interface_name="$(ip -o link show | grep 'BROADCAST,MULTICAST' | head -n 1 | cut -d':' -f2 | tr -d ' ')"
 ip link set lo up


### PR DESCRIPTION
Some builds (flink-2.0, dotnet-bootstrap-9) were failing in the QEMU runner due to hitting the open file descriptor hard limit (RLIMIT_NOFILE), but would succeed in the bubblewrap runner.

Fix this by setting the hardlimit for open file descriptors for the melange init to be what the kernel reports in the /proc/sys/fs/nr_open sysctl.

The reason for the difference in values is that the pam_limits module uses as the default rlimits for processes the values reported in /proc/1/limits [1] (init's rlimits). In a bubblewrap environment, this will be inherited from the host's environment, and when systemd is init, it bumps the open file descriptor limit to be the max reported by the kernel [2]. What we're doing here in melange's init is mimicking the behavior of systemd.

[1] https://github.com/linux-pam/linux-pam/blob//modules/pam_limits/pam_limits.c#L478
    parse_kernel_limits() function
[2] https://github.com/systemd/systemd/blob/main/src/core/main.c#L1323
    bump_rlimit_nofile() function
