### PR TITLE
jenkins-docker: move to version stream

### DIFF
--- a/jenkins-docker-2.509.yaml
+++ b/jenkins-docker-2.509.yaml
@@ -1,12 +1,14 @@
 package:
-  name: jenkins-docker
+  name: jenkins-docker-2.509
   version: "2.509"
-  epoch: 0
+  epoch: 1
   description: Docker compatbility scripts and tooling for Jenkins
   copyright:
     - license: MIT
   dependencies:
     # https://github.com/jenkinsci/docker/blob/5575a3c8fe959449570de9eb03e6cb3127d8f389/alpine/hotspot/Dockerfile#L42
+    provides:
+      - jenkins-docker=${{package.full-version}}
     runtime:
       - bash
       - coreutils
@@ -43,8 +45,8 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: jenkinsci/docker
+  git:
+    tag-filter-prefix: "2.509."
 
 test:
   pipeline:


### PR DESCRIPTION
this was not version streamed properly and we look for this name inside the image build. let's version stream this properly so that this gets handled by automation from here on. 

have a provides for backwards compatibility as well so this is not a breaking change. 