### PR TITLE
feat(wal-g.yaml): Bump epoch of wal-g and subpackages to trigger rebuild and CVE scan

### DIFF
--- a/wal-g.yaml
+++ b/wal-g.yaml
@@ -1,7 +1,7 @@
 package:
   name: wal-g
   version: "3.0.7"
-  epoch: 2
+  epoch: 3
   description: "Archival and Restoration for databases in the Cloud"
   copyright:
     - license: "Apache-2.0"


### PR DESCRIPTION
We are investigating missing CVE re-detections for wal-g @ https://github.com/wolfi-dev/advisories/blob/main/wal-g.advisories.yaml

Bumping epoch will force rebuild and CVE rescan to allow us to continue investigating.

This is being tracked internally to chainguard in private github issue 12184

Signed-off-by: philroche <phil.roche@chainguard.dev>
