### PR TITLE
gnutar: test improvements (qemu env failure, add ldd-test)

### DIFF
--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutar
   version: "1.35"
-  epoch: 2
+  epoch: 3
   description: "The GNU Tar program"
   copyright:
     - license: GPL-3.0-or-later
@@ -45,7 +45,8 @@ update:
 
 test:
   pipeline:
+    - uses: test/tw/ldd-check
     - runs: |
-        tar czf - $(dirname $(which tar)) | tar -tzv | grep tar
+        tar czf - $(realpath $(dirname $(which tar))) | tar -tzv | grep tar
         tar --version
         tar --help


### PR DESCRIPTION
The primary test of tar was failing in the QEMU environment, this is because `which tar` returns `/usr/sbin/tar` due to $PATH in the QEMU having /usr/sbin earlier than /usr/bin. The test then attempts to tar up the directory containing the tar binary, but because after usrmerge, /usr/sbin is a symlink to /usr/bin, the test fails because the generated tarball only contains the symlink and doesn't follow it.

Fix this by using realpath on the result of $(dirname $(which tar)) to get the non-symlinked directory.

Also add the ldd-check test, to cover dependencies.
