### PR TITLE
tshark-4.4: fix test / add ldd-check test

### DIFF
--- a/tshark-4.4.yaml
+++ b/tshark-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: tshark-4.4
   version: "4.4.6"
-  epoch: 0
+  epoch: 1
   description: "TShark is a network protocol analyzer to dump and analyze network traffic"
   copyright:
     - license: GPL-2.0-only
@@ -55,8 +55,9 @@ test:
       packages:
         - curl
   pipeline:
+    - uses: test/tw/ldd-check
     - name: dump some packets
       runs: |
-        tshark -w /tmp/out.pcap -c 10 host example.com&
+        tshark -w /tmp/out.pcap -c 100 -a duration:10 host example.com&
         sleep 1; curl -sI http://example.com; sleep 1
         tshark -r /tmp/out.pcap -Y "http" |grep '200 OK'


### PR DESCRIPTION
The tshark test attempting to capture an http response from example.com was failing in the qemu because tshark was limited to capturing 10 packets which was not enough to capture the response. Bump the max count of packets to capture and also limit the duration to 10 seconds, to ensure that enough time and packets are captured, while ensuring that tshark eventually quits in the face of network problems.

Also add ldd-check test.