### PR TITLE
Add missing build deps for pgaudit-17 fixing an FTBFS

### DIFF
--- a/pgaudit-17.yaml
+++ b/pgaudit-17.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-17
   version: "17.1"
-  epoch: 1
+  epoch: 2
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - clang
       - glibc-dev
+      - krb5-dev
       - postgresql-17-dev
 
 pipeline:


### PR DESCRIPTION
This was previously failing to build:

```
2025-05-08 06:47:06.574387328 +0000 UTC x86_64-pc-linux-gnu-gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -fPIC -fvisibility=hidden -I. -I./ -I/usr/include/postgresql/17/server -I/usr/include/postgresql/internal  -D_GNU_SOURCE -I/usr/include/libxml2   -c -o pgaudit.o pgaudit.c 
2025-05-08 06:47:06.988584647 +0000 UTC In file included from /usr/include/postgresql/17/server/libpq/auth.h:17,
2025-05-08 06:47:06.988667997 +0000 UTC                  from pgaudit.c:28:
2025-05-08 06:47:06.988682287 +0000 UTC /usr/include/postgresql/17/server/libpq/libpq-be.h:32:10: fatal error: gssapi/gssapi.h: No such file or directory 
2025-05-08 06:47:06.988689677 +0000 UTC    32 | #include <gssapi/gssapi.h>
2025-05-08 06:47:06.988697777 +0000 UTC       |          ^~~~~~~~~~~~~~~~~
2025-05-08 06:47:06.988707607 +0000 UTC compilation terminated.
2025-05-08 06:47:06.995895106 +0000 UTC make: *** [<builtin>: pgaudit.o] Error 1
2025-05-08 06:47:13.376580152 +0000 UTC failed to build package: unable to run package pgaudit-17 pipeline: unable to run pipeline: exit status 2
```