### PR TITLE
Add missing build deps for pg-failover-slots-16 fixing an FTBFS

### DIFF
--- a/pg-failover-slots-16.yaml
+++ b/pg-failover-slots-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg-failover-slots-16
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: PG Failover Slots extension for PostgreSQL 16
   copyright:
     - license: BSD-3-Clause
@@ -12,6 +12,8 @@ environment:
       - automake
       - build-base
       - busybox
+      - clang
+      - krb5-dev
       - postgresql-16-dev
 
 pipeline:


### PR DESCRIPTION
This was failing to build exactly like to https://github.com/wolfi-dev/os/pull/52869