### PR TITLE
glu: stop using osmesa gl_provider

### DIFF
--- a/glu.yaml
+++ b/glu.yaml
@@ -1,7 +1,7 @@
 package:
   name: glu
   version: 9.0.3
-  epoch: 1
+  epoch: 2
   description: "Mesa OpenGL Utility library"
   copyright:
     - license: SGI-B-1.1
@@ -13,7 +13,6 @@ environment:
     packages:
       - build-base
       - mesa-dev
-      - mesa-osmesa
       - meson
       - ninja
       - wolfi-base
@@ -29,7 +28,6 @@ pipeline:
       opts: |
         -Db_lto=true \
         -Ddefault_library=shared \
-        -Dgl_provider=osmesa
 
   - uses: meson/compile
 


### PR DESCRIPTION
mesa 25.1.0 dropped osmesa, so we no longer build a mesa-osmesa package.