### PR TITLE
Create expected cache directory

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -2,7 +2,7 @@
 package:
   name: squid
   version: "7.0.1"
-  epoch: 40
+  epoch: 41
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -61,6 +61,9 @@ pipeline:
 
   - runs: |
       install -d ${{targets.destdir}}/usr/libexec/
+
+      # Otherwise it logs errors on startup if this doesn't exist.
+      mkdir -p ${{targets.destdir}}/var/cache/squid
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
I see this when running tests with the QEMU runner:
```
2025/05/08 14:20:12 INFO > 2025/05/08 21:20:11| ERROR: cannot change current directory to /var/cache/squid: (2) No such file or directory
```