### PR TITLE
GLib-2.0.gir was missing from our -dev packaged (needed by another bu…

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: "1.84.0"
-  epoch: 1
+  epoch: 2
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -130,8 +130,9 @@ subpackages:
     pipeline:
       - uses: split/dev
       - runs: |
-          mkdir -p ${{targets.contextdir}}/usr/lib
+          mkdir -p ${{targets.contextdir}}/usr/lib ${{targets.contextdir}}/usr/share/gir-1.0
           mv ${{targets.destdir}}/usr/lib/girepository-1.0 ${{targets.contextdir}}/usr/lib
+          mv ./output/gir/GLib-2.0.gir ${{targets.contextdir}}/usr/share/gir-1.0/
     dependencies:
       runtime:
         - cairo-dev


### PR DESCRIPTION
This file is needed by another build, and it seems that we weren't installing it in our -dev package, as I would have expected.  This is present in the Debian and Ubuntu dev equivalents...