### PR TITLE
Redirect output for `cadvisor` test.

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: "0.52.1"
-  epoch: 5
+  epoch: 6
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -67,7 +67,7 @@ test:
     - runs: |
         cadvisor --version
         cadvisor --help
-        nohup cadvisor &
+        nohup cadvisor >/dev/null 2>&1 </dev/null &
         sleep 5 # wait for cadvisor to start
     # Test case 1: Verify cadvisor health check endpoint
     # This test ensures that the cadvisor service is up and running by checking its health endpoint.


### PR DESCRIPTION
In the busybox shell, if a background process (even with `nohup`) is holding onto stdin/stdout/stderr then the shell won't exit.

It appears that most of our other tests already redirect things, so this just matches those.

This was broken on the QEMU runner previously.
