### PR TITLE
Bash's brace expansion is not available

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -1,7 +1,7 @@
 package:
   name: jellyfin
   version: "10.10.7"
-  epoch: 0
+  epoch: 1
   description: The Free Software Media System
   copyright:
     - license: GPL-2.0-only
@@ -90,7 +90,7 @@ test:
     - name: "Verify Jellyfin HTTP service on port 8096"
       runs: |
         echo "Checking if Jellyfin is listening on port 8096..."
-        for i in {1..5}; do
+        for i in $(seq 1 5); do
           if netstat -tuln | grep -q ":8096"; then
             echo "Port 8096 is open for Jellyfin."
             exit 0


### PR DESCRIPTION
`{1..5}` doesn't expand in the test environment's shell, instead we need to use `seq` to actually have a for loop with multiple runs.