### PR TITLE
Add `cgroups` to the set of mounts melange init does.

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.23.15"
-  epoch: 4
+  epoch: 5
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -10,6 +10,7 @@ mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
 mkdir -p -m 0755 /dev/shm
 mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
+mount -t cgroup -o all cgroup /sys/fs/cgroup
 
 # Fix /dev/fd
 ln -s /proc/kcore /dev/core

--- a/melange/init
+++ b/melange/init
@@ -10,7 +10,7 @@ mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
 mkdir -p -m 0755 /dev/shm
 mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
-mount -t cgroup -o all cgroup /sys/fs/cgroup
+mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /sys/fs/cgroup
 
 # Fix /dev/fd
 ln -s /proc/kcore /dev/core


### PR DESCRIPTION
This is needed for the `cgroups` tests to pass under QEMU.
