### PR TITLE
Make sure Bazel installs a default JDK.

### DIFF
--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-6
   version: 6.5.0
-  epoch: 2
+  epoch: 3
   description: Bazel is an open-source build and test tool
   resources:
     cpu: 16
@@ -63,7 +63,7 @@ test:
         - git
         - python3
         - openjdk-21
-        - openjdk-21-default-jvm
+        - openjdk-21-default-jdk
         - gcc
   pipeline:
     - name: "Verify bazel version"


### PR DESCRIPTION
Today these tests fail because `javac` isn't on `PATH` and `JAVA_HOME` is not set.

This small change makes things pass for me locally (in the QEMU runner).
