### PR TITLE
gperftools/tests: ensure tcmalloc libs are linked to in tests

### DIFF
--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -2,7 +2,7 @@
 package:
   name: gperftools
   version: "2.17.2"
-  epoch: 0
+  epoch: 1
   description: Fast, multi-threaded malloc and nifty performance analysis tools
   copyright:
     - license: BSD-3-Clause
@@ -128,11 +128,10 @@ test:
         - binutils
         - coreutils
         - findutils
+        - posix-libc-utils
         - tcmalloc # Explicit tcmalloc dependency
         - tcmalloc-profiler # For profiling functionality
         - gperftools-dev # For headers and development files
-    environment:
-      GCC_SPEC_FILE: no-hardening.spec # Our spec file interferes with the tests
   pipeline:
     - name: "Test basic heap profiler functionality"
       runs: |
@@ -146,7 +145,9 @@ test:
           return 0;
         }
         EOF
-        g++ -O0 -o heap_test heap_test.cpp -ltcmalloc
+        g++ -O0 -Wl,--no-as-needed -o heap_test heap_test.cpp -ltcmalloc
+        # ensure g++/ld actually linked in libtcmalloc
+        ldd heap_test | grep libtcmalloc.so
         HEAPPROFILE=/tmp/test ./heap_test
         test -f /tmp/test.0001.heap
     - name: "Test CPU profiler functionality"
@@ -161,7 +162,9 @@ test:
           return 0;
         }
         EOF
-        g++ -O0 -o cpu_test cpu_test.cpp -ltcmalloc_and_profiler
+        g++ -O0 -Wl,--no-as-needed -o cpu_test cpu_test.cpp -ltcmalloc_and_profiler
+        # ensure g++/ld actually linked in libtcmalloc_and_profiler
+        ldd cpu_test | grep libtcmalloc_and_profiler.so
         CPUPROFILE=/tmp/cpu.prof ./cpu_test
         test -f /tmp/cpu.prof
     - name: "Test linking against tcmalloc"
@@ -175,8 +178,12 @@ test:
         }
         EOF
         g++ -O0 -o malloc_test malloc_test.cpp -ltcmalloc
+        # ensure g++/ld actually linked in libtcmalloc
+        ldd malloc_test | grep libtcmalloc.so
         ./malloc_test
     - name: "Test minimal TCMalloc compilation"
       runs: |
         g++ -O0 -o minimal_test malloc_test.cpp -ltcmalloc_minimal
+        # ensure g++/ld actually linked in libtcmalloc_minimal
+        ldd minimal_test | grep libtcmalloc_minimal.so
         ./minimal_test


### PR DESCRIPTION
Some of the gperftools tests for basic functionality were failing due the compiler linking with -Wl,--as-needed by default, which drops shared libraries on the list to be linked when no symbols need to be resolved from it at compile time.

Fix this by passing g++ the -Wl,--no-as-needed flag to turn off this behavior, and furthermore add ldd to the test environment and verify that the tcmalloc libraries get linked in to the built binaries properly.
