### PR TITLE
upgrade aws-sdk-core gem for kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 37
+  epoch: 38
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -86,6 +86,8 @@ pipeline:
       echo "gem 'google-protobuf', '3.25.5'" >> Gemfile
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'webrick', '1.8.2'" >> Gemfile
+      # to match with the upstream image
+      echo "gem 'aws-sdk-core', '~> 3.223'" >> Gemfile
 
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       # bump net-imap to mitigate GHSA-j3g3-5qv5-52mj


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

