### PR TITLE
grafana-11.6: add -buildvcs=false to upstream build system

### DIFF
--- a/grafana-11.6.yaml
+++ b/grafana-11.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.6
   version: "11.6.1"
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -37,6 +37,10 @@ pipeline:
       expected-commit: ae23ead4d959aa73a5a0ffada60e4147d679523c
       repository: https://github.com/grafana/grafana
       tag: v${{vars.upstream-package-version}}
+
+  - uses: patch
+    with:
+      patches: append-buildvcs-false-to-go-build.patch
 
   - uses: go/bump
     with:

--- a/grafana-11.6/append-buildvcs-false-to-go-build.patch
+++ b/grafana-11.6/append-buildvcs-false-to-go-build.patch
@@ -1,0 +1,34 @@
+From 801181cfaf2bc1b650184aa1278de5badbecc8cc Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Fri, 9 May 2025 08:17:45 +0000
+Subject: [PATCH] append -buildvcs=false to go build
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since go1.24, the go build command now sets the main module’s version
+in the compiled binary based on the version control system tag and/or
+commit. A +dirty suffix will be appended if there are uncommitted
+changes.
+Use the -buildvcs=false flag to omit version control information from
+the binary.
+Reference from: https://tip.golang.org/doc/go1.24#go-command
+---
+ pkg/build/cmd.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/build/cmd.go b/pkg/build/cmd.go
+index 9796a1428da..4d3ff170627 100644
+--- a/pkg/build/cmd.go
++++ b/pkg/build/cmd.go
+@@ -199,6 +199,7 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
+ 	}
+ 
+ 	args = append(args, "-o", binary)
++	args = append(args, "-buildvcs=false")
+ 	args = append(args, pkg)
+ 
+ 	runPrint("go", args...)
+-- 
+2.47.2
+


### PR DESCRIPTION
Since go1.24, the go build command now sets the main module’s version in the compiled binary based on the version control system tag and/or commit. A +dirty suffix will be appended if there are uncommitted changes.
Use the -buildvcs=false flag to omit version control information from the binary.
