### PR TITLE
etcd-3.5: add -buildvcs=false flag

### DIFF
--- a/etcd-3.5.yaml
+++ b/etcd-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: etcd-3.5
   version: "3.5.21"
-  epoch: 42
+  epoch: 43
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0
@@ -35,21 +35,24 @@ pipeline:
       packages: .
       modroot: ./etcdctl
       output: etcdctl
-      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD)"
+      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD) -X go.etcd.io/etcd/etcdctl/v3/version.Version=${{package.version}}"
+      extra-args: "-buildvcs=false"
 
   - uses: go/build
     with:
       packages: .
       modroot: ./etcdctl
       output: etcdutl
-      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD)"
+      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD) -X go.etcd.io/etcd/etcdctl/v3/version.Version=${{package.version}}"
+      extra-args: "-buildvcs=false"
 
   - uses: go/build
     with:
       packages: .
       modroot: ./server
       output: etcd
-      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD)"
+      ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD) -X go.etcd.io/etcd/server/v3/version.Version=${{package.version}}"
+      extra-args: "-buildvcs=false"
 
   - runs: |
       mkdir -p "${{targets.contextdir}}"/var/lib/${{package.name}}


### PR DESCRIPTION
Starting from go1.24  the go build command now sets the main module’s version in the compiled binary based on the version control system tag and/or commit. A +dirty suffix will be appended if there are uncommitted changes. Use the -buildvcs=false flag to omit version control information from the binary.
Reference: https://tip.golang.org/doc/go1.24#go-command
