### PR TITLE
pypy-3.11: move main git-checkout to top of pipeline

### DIFF
--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.11
   description: PyPy is a very fast and compliant implementation of the Python language v 3.11
-  epoch: 35
+  epoch: 36
   version: "7.3.19"
   copyright:
     - license: Apache-2.0
@@ -55,6 +55,16 @@ var-transforms:
     to: extracted-version
 
 pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypy/pypy.git
+      tag: release-pypy${{vars.extracted-version}}-v${{package.version}}
+      expected-commit: 0253c85bf5f86a45760eda7f0af8953ed8a253c7
+
+  - uses: patch
+    with:
+      patches: pypy-3.11-set-sysconfigdata-wheel-pkg-dir.patch
+
   - runs: mkdir -p "$PY_BUILD"
 
   - working-directory: "$PY_BUILD"
@@ -97,16 +107,6 @@ pipeline:
     runs: |
       PATH="$PY_INSTALL/usr/bin:$PATH" LD_LIBRARY_PATH="$PY_INSTALL/usr/lib" \
         python setup.py install
-
-  - uses: git-checkout
-    with:
-      repository: https://github.com/pypy/pypy.git
-      tag: release-pypy${{vars.extracted-version}}-v${{package.version}}
-      expected-commit: 0253c85bf5f86a45760eda7f0af8953ed8a253c7
-
-  - uses: patch
-    with:
-      patches: pypy-3.11-set-sysconfigdata-wheel-pkg-dir.patch
 
   - working-directory: pypy/goal
     runs: |

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -128,7 +128,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://bootstrap.pypa.io/get-pip.py
-      expected-sha512: 4e04911474edb9df9dd2c40538fd7b164381c576d65a48c4555de240abc8a9a53f4e381eba6a93a07bc2339181b7530276a1a2648d7cc979dde759718ab20c37
+      expected-sha512: 77bed3b54c09c8587b345b53304eca964f3f14deb479b54bdea559c5bbba9e98f0aef5974251a7a2d0a424c21bb44cb341e8a8f1c2eac15a81d0e9434eb12f59
       extract: false
       strip-components: 0
 


### PR DESCRIPTION
The automation which generates new update PRs assumes that the first `git-checkout` stanza corresponds to the git repo described by the update configuration. When that isn't true (as here), it will always find a mismatch in expected commits and so always generate a new update PR.

This commit reorders the `git-checkout`s to avoid this problem.

Closes: #45753