### PR TITLE
gperftools: Disable compiler optimizations & spec file usage, fixing tests

### DIFF
--- a/gperftools.yaml
+++ b/gperftools.yaml
@@ -2,7 +2,7 @@
 package:
   name: gperftools
   version: "2.16"
-  epoch: 0
+  epoch: 1
   description: Fast, multi-threaded malloc and nifty performance analysis tools
   copyright:
     - license: BSD-3-Clause
@@ -130,6 +130,8 @@ test:
         - tcmalloc # Explicit tcmalloc dependency
         - tcmalloc-profiler # For profiling functionality
         - gperftools-dev # For headers and development files
+    environment:
+      GCC_SPEC_FILE: "/dev/null" # Our spec file interferes with the tests
   pipeline:
     - name: "Test basic heap profiler functionality"
       runs: |
@@ -143,7 +145,7 @@ test:
           return 0;
         }
         EOF
-        g++ -o heap_test heap_test.cpp -ltcmalloc
+        g++ -O0 -o heap_test heap_test.cpp -ltcmalloc
         HEAPPROFILE=/tmp/test ./heap_test
         test -f /tmp/test.0001.heap
     - name: "Test CPU profiler functionality"
@@ -158,7 +160,7 @@ test:
           return 0;
         }
         EOF
-        g++ -o cpu_test cpu_test.cpp -ltcmalloc_and_profiler
+        g++ -O0 -o cpu_test cpu_test.cpp -ltcmalloc_and_profiler
         CPUPROFILE=/tmp/cpu.prof ./cpu_test
         test -f /tmp/cpu.prof
     - name: "Test linking against tcmalloc"
@@ -171,9 +173,9 @@ test:
           return 0;
         }
         EOF
-        g++ -o malloc_test malloc_test.cpp -ltcmalloc
+        g++ -O0 -o malloc_test malloc_test.cpp -ltcmalloc
         ./malloc_test
     - name: "Test minimal TCMalloc compilation"
       runs: |
-        g++ -o minimal_test malloc_test.cpp -ltcmalloc_minimal
+        g++ -O0 -o minimal_test malloc_test.cpp -ltcmalloc_minimal
         ./minimal_test


### PR DESCRIPTION
The tests were being affected by compiler optimizations and our spec file.  Let's disable both because they're not important during tests.

Closes: #48766