### PR TITLE
pipeline/test/docs: Exclude non-manpages from the test

### DIFF
--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -32,7 +32,9 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.path-prefix}}/man/"); do
+      # Exclude things installed under /usr/share/man/db/ since it contains
+      # files installed by the man-db-doc package.
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.path-prefix}}/man/" | grep -v "^usr/share/man/db/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)


### PR DESCRIPTION
The db-doc package happens to install quite a number of non-manpage files under /usr/share/man.  This confuses the test/docs pipeline because it tries to render these files as manpages, and "man" obviously doesn't like it.

This commit filters out these non-manpage files and makes sure that we don't try to run tests on them.

Closes: #48194