### PR TITLE
fix(strimzi-kafka): support kafka 3.9

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.46.0"
-  epoch: 3
+  epoch: 4
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ environment:
     DEST_DIR: opt/strimzi
 
 vars:
-  java-version: '21'
+  java-version: '17' # https://github.com/strimzi/strimzi-kafka-operator/blob/0.46.0/development-docs/DEV_GUIDE.md#java-versions
   shellcheck_version: 0.10.0
   shellcheck_aarch64_shasum512: 77abeaa8bee293264ebfd94a2021bd490695ed5518f2da7c0f9ec4b402cd1e5da6642a0e9f953961510cef7351cc9afae7c7a528a597d1befd1867b8c69e15b1
   shellcheck_x86_64_shasum512: 31006830087c2b9ffe9fa36c1ab4a8b11c85078cac8203265d0cfd630c70a4a506e66dd9d7ccde964360ad95045894149de457db34f10cad76708c7a4aa544ca
@@ -105,6 +105,7 @@ data:
       cluster-operator: cluster-operator
       kafka-init: kafka-init
       kafka-agent: kafka-agent
+      kafka-agent-3: kafka-agent-3
       topic-operator: topic-operator
       tracing-agent: tracing-agent
       user-operator: user-operator
@@ -131,11 +132,12 @@ subpackages:
       replaces:
         - kafka
     pipeline:
-      - working-directory: docker-images/artifacts/kafka-thirdparty-libs/3.9.x/target/dependency
+      - working-directory: docker-images/artifacts/kafka-thirdparty-libs
         pipeline:
           - runs: |
               mkdir -p "${{targets.contextdir}}"/usr/lib/kafka/libs/
-              cp -r ./* "${{targets.contextdir}}"/usr/lib/kafka/libs/
+              cp -r ./3.9.x/target/dependency/* "${{targets.contextdir}}"/usr/lib/kafka/libs/
+              cp -r ./4.0.x/target/dependency/* "${{targets.contextdir}}"/usr/lib/kafka/libs/
 
   - name: "${{package.name}}-kafka-thirdparty-libs-cc"
     description: "Required 3rd party libraries for the Cruise Control"
@@ -164,7 +166,6 @@ subpackages:
         - nmap
         - openssl
         - sed
-        - strimzi-kafka-operator-kafka-agent
         - strimzi-kafka-operator-topic-operator
         - strimzi-kafka-operator-kafka-thirdparty-libs
         - strimzi-kafka-operator-kafka-thirdparty-libs-cc

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -228,11 +228,24 @@ test:
         echo "Both directories are not empty."
     - name: check files are there
       runs: |
-        # Directory to check
+        # Bin directory to check
         dir="/opt/strimzi/bin"
 
         # Check if each file exists in the directory
         for file in cluster_operator_run.sh kafka_init_run.sh launch_java.sh tls_prepare_certificates.sh topic_operator_run.sh user_operator_run.sh; do
+          if [ -f "$dir/$file" ]; then
+            echo "$file exists in $dir."
+          else
+            echo "Error: $file does not exist in $dir."
+            exit 1
+          fi
+        done
+
+        # Lib directory to check
+        dir="/opt/strimzi/lib"
+
+        # Ensure both agent and agent-3 jars are present as long as strimzi-kafka supports kafka 3.x
+        for file in io.strimzi.kafka-agent-${{package.version}}.jar io.strimzi.kafka-agent-3-${{package.version}}.jar; do
           if [ -f "$dir/$file" ]; then
             echo "$file exists in $dir."
           else


### PR DESCRIPTION
v0.46 defaults to kafka-4.0, though kafka-3.9 is also supported. Strimzi provides a new [kafka-agent-3](https://github.com/strimzi/strimzi-kafka-operator/tree/main/kafka-agent-3) as well as required libs and deps (e.g. [jetty](https://github.com/strimzi/strimzi-kafka-operator/blob/57fe573d83d955270f2cd291893bac6fbecbdd97/pom.xml#L167-L172) and [extras](https://github.com/strimzi/strimzi-kafka-operator/tree/main/docker-images/artifacts/kafka-thirdparty-libs)) for use in a kafka-3.9 environment.

Our agent subpackage did not consider this `-3` variant which led to failures when using `strimzi-kafka-operator` with kafka-3.9.  This PR includes a new `-3` subpackage as well as both sets of extra libs to support either kafka-3.9 or 4.0.

The `strimzi-kafka-operator-kafka-agent` subpackage is no longer a runtime dependency of `-kafka-base` as the appropriate agent will now depend on the available kafka version.

I'm also adjusting the build env to use java 17 per current [build docs](https://github.com/strimzi/strimzi-kafka-operator/blob/release-0.46.x/development-docs/DEV_GUIDE.md#java-versions).  This doesn't affect any runtime java since the correct jre will come as a dependency from kafka.

Related: https://github.com/chainguard-dev/image-release-stats/issues/5249