### PR TITLE
Add `nohup` and output redir to `memcached` tests

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: "1.6.38"
-  epoch: 40
+  epoch: 41
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -167,7 +167,7 @@ test:
             MEMCACHED_PORT=$(for p in $(shuf -i 30000-40000 -n 10); do ss -ltn | awk '{print $4}' | grep -q ":$p\$" || { echo $p; break; }; done)
             ACCEPT_PORT=$(for p in $(shuf -i 30000-40000 -n 10); do ss -ltn | awk '{print $4}' | grep -q ":$p\$" || { echo $p; break; }; done)
 
-            memcached -Z -p $MEMCACHED_PORT -o ssl_chain_cert=example.crt,ssl_key=example.key&
+            nohup memcached -Z -p $MEMCACHED_PORT -o ssl_chain_cert=example.crt,ssl_key=example.key > /dev/null 2>&1 &
 
             cat <<EOF > stunnel.cnf
             [memcached]


### PR DESCRIPTION
Without this the tests hang under QEMU.

