### PR TITLE
logstash-8: remediate CVE-2025-46727 and CVE-2025-46336

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.18.1"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -98,7 +98,8 @@ pipeline:
       echo "gem 'puma', '6.6.0'" >> Gemfile.template
       echo "gem 'sinatra', '4.1.1'" >> Gemfile.template
       echo "gem 'logstash-integration-kafka', '11.6.0'" >> Gemfile.template
-      echo "gem 'rack', '3.1.12'" >> Gemfile.template
+      echo "gem 'rack', '3.1.14'" >> Gemfile.template
+      echo "gem 'rack-session', '2.1.1'" >> Gemfile.template
       echo "gem 'net-imap', '0.5.8'" >> Gemfile.template
       # Fix GHSA-xc9x-jj77-9p9j
       sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"


### PR DESCRIPTION
Remediate CVE-2025-46727:
Bump rack gem to 3.1.14.

Remediate CVE-2025-46336:
Bump rack-session gem to 2.1.1