### PR TITLE
utmps: cherry-pick header fix from upstream

### DIFF
--- a/utmps.yaml
+++ b/utmps.yaml
@@ -1,7 +1,7 @@
 package:
   name: utmps
   version: "0.1.3.0"
-  epoch: 0
+  epoch: 1
   description: A secure utmp/wtmp implementation
   copyright:
     - license: ISC
@@ -27,6 +27,8 @@ pipeline:
       repository: https://github.com/skarnet/utmps
       expected-commit: 82656db92d4fcd49d10ffba215e86c910e98a14b
       tag: v${{package.version}}
+      cherry-picks: |
+        main/add996f129f27eb9954427aa79099d8e8c934e81: Fix duplicate definition
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Fixed due to the bug reported in
https://github.com/skarnet/utmps/issues/3.

Thanks to @skarnet for the speedy fix!

Fixes: #52868 