### PR TITLE
config(octosts/cve-pr-closer): issues write permissions for adding PR labels

### DIFF
--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -6,6 +6,6 @@ subject: "101045395775641394837"
 permissions:
   contents: read
   pull_requests: write
-  issues: read
+  issues: write
   checks: read
   actions: read


### PR DESCRIPTION
`cve-pr-closer` now needs an updated octosts policy to include issues write permissions. This is because we added a new label that gets appended once the PR is closed.