### PR TITLE
Update lean4 to 4.19.0 and add patches for FTBFS w/ libuv 1.51

### DIFF
--- a/lean4.yaml
+++ b/lean4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lean4
-  version: "4.18.0"
-  epoch: 0
+  version: "4.19.0"
+  epoch: 1
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,18 @@ pipeline:
     with:
       repository: https://github.com/leanprover/lean4
       tag: v${{package.version}}
-      expected-commit: 11ccbced796476be020459a83c599b301a765d3e
+      expected-commit: 6caaee842e9495688c1567e78c0e68dbb96942aa
+
+  # The package ftbfs after the update of libuv to 1.51
+  - uses: patch
+    with:
+      patches: libuv-1.51.patch
+
+  # we really shouldn't be modifying stage0 files, which are used for
+  # bootstrapping, but I was unable to find a way to regenerate them
+  - uses: patch
+    with:
+      patches: libuv-1.51-stage0.patch
 
   - runs: |
       # This doesn't work with Ninja so we can't use our default pipelines.

--- a/lean4.yaml
+++ b/lean4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lean4
   version: "4.19.0"
-  epoch: 1
+  epoch: 0
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: Apache-2.0

--- a/lean4/libuv-1.51-stage0.patch
+++ b/lean4/libuv-1.51-stage0.patch
@@ -1,0 +1,36 @@
+diff --git a/stage0/src/runtime/uv/event_loop.h b/stage0/src/runtime/uv/event_loop.h
+index 0fd6517f41..c62a9f0986 100644
+--- a/stage0/src/runtime/uv/event_loop.h
++++ b/stage0/src/runtime/uv/event_loop.h
+@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Sofia Rodrigues
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/io.h"
+ #include "runtime/object.h"
+diff --git a/stage0/src/runtime/uv/net_addr.h b/stage0/src/runtime/uv/net_addr.h
+index 9bfc2672d8..4415efd6ec 100644
+--- a/stage0/src/runtime/uv/net_addr.h
++++ b/stage0/src/runtime/uv/net_addr.h
+@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Henrik Böving
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/object.h"
+ 
+diff --git a/stage0/src/runtime/uv/timer.h b/stage0/src/runtime/uv/timer.h
+index 5edeae7af1..5b676cb67a 100644
+--- a/stage0/src/runtime/uv/timer.h
++++ b/stage0/src/runtime/uv/timer.h
+@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Sofia Rodrigues, Henrik Böving
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/uv/event_loop.h"
+ 

--- a/lean4/libuv-1.51.patch
+++ b/lean4/libuv-1.51.patch
@@ -1,0 +1,36 @@
+diff --git a/src/runtime/uv/event_loop.h b/src/runtime/uv/event_loop.h
+index 0fd6517f41..c62a9f0986 100644
+--- a/src/runtime/uv/event_loop.h
++++ b/src/runtime/uv/event_loop.h
+@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Sofia Rodrigues
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/io.h"
+ #include "runtime/object.h"
+diff --git a/src/runtime/uv/net_addr.h b/src/runtime/uv/net_addr.h
+index 9bfc2672d8..4415efd6ec 100644
+--- a/src/runtime/uv/net_addr.h
++++ b/src/runtime/uv/net_addr.h
+@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Henrik Böving
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/object.h"
+ 
+diff --git a/src/runtime/uv/timer.h b/src/runtime/uv/timer.h
+index 5edeae7af1..5b676cb67a 100644
+--- a/src/runtime/uv/timer.h
++++ b/src/runtime/uv/timer.h
+@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
+ Author: Sofia Rodrigues, Henrik Böving
+ */
+ #pragma once
++#include <cmath>
+ #include <lean/lean.h>
+ #include "runtime/uv/event_loop.h"
+ 


### PR DESCRIPTION
The lean4 package is failing to build from source after the update of libuv to 1.51. An excerpt of the failure follows:

```
[ 69%] Built target leancpp_1
[ 69%] Built target leancpp
[ 69%] Built target make_stdlib
In file included from /usr/include/c++/14/math.h:36,
                 from /usr/include/uv.h:61,
                 from /home/build/stage0/src/runtime/uv/event_loop.h:18,
                 from /home/build/stage0/src/runtime/uv/event_loop.cpp:7:
/usr/include/c++/14/cmath:89:11: error: 'acos' has not been declared in '::'
   89 |   using ::acos;
      |           ^~~~
/usr/include/c++/14/cmath:108:11: error: 'asin' has not been declared in '::'
  108 |   using ::asin;
      |           ^~~~
/usr/include/c++/14/cmath:127:11: error: 'atan' has not been declared in '::'
  127 |   using ::atan;
      |           ^~~~
/usr/include/c++/14/cmath:146:11: error: 'atan2' has not been declared in '::'
  146 |   using ::atan2;
      |           ^~~~~
/usr/include/c++/14/cmath:158:11: error: 'ceil' has not been declared in '::'
  158 |   using ::ceil;
      |           ^~~~
/usr/include/c++/14/cmath:177:11: error: 'cos' has not been declared in '::'
  177 |   using ::cos;
      |           ^~~
 ```
 
This is due to the fact that in libuv 1.51.0 the public header uv.h was modified to pull in the C math definitions, which then has knock on effects with C++'s math.h.