### PR TITLE
fix(secure-build) Add resource limits for cpu and memory in package definitions

### DIFF
--- a/apache-kvrocks.yaml
+++ b/apache-kvrocks.yaml
@@ -5,6 +5,9 @@ package:
   description: Apache Kvrocks is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol.
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 33
+    memory: 32Gi
 
 environment:
   contents:

--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -5,6 +5,9 @@ package:
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 33
+    memory: 32Gi
 
 environment:
   contents:

--- a/rancher-2.11.yaml
+++ b/rancher-2.11.yaml
@@ -5,6 +5,9 @@ package:
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 33
+    memory: 32Gi
   dependencies:
     provides:
       - rancher=${{package.full-version}}

--- a/teleport.yaml
+++ b/teleport.yaml
@@ -8,6 +8,9 @@ package:
   dependencies:
     runtime:
       - posix-libc-utils # getent
+  resources:
+    cpu: 33
+    memory: 32Gi
 
 environment:
   contents:


### PR DESCRIPTION
During the miigration to the QEMU runners by defaults, we're noticing a potential increase in OOMs especially during tests. This will increase the CPU and memory limits of the following packages (which were recently caught OOM'ing)
* teleport
* rancher-2-11
* qdrant
* apache-kvrocks

```
  resources:
    cpu: 33
    memory: 32Gi
```

Based on the items tracked here: https://docs.google.com/spreadsheets/d/1EhCjo2hdxBspPZTrIVrw6Df5vatuxfOuH2m21PFH34w/edit?gid=1023215575#gid=1023215575