### PR TITLE
curl-rustls: bump epoch

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: "8.13.0"
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT


### PR DESCRIPTION
-r0 didn't make it through post, likely because a compatible curl
wasn't yet available when it tried to test.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
