### PR TITLE
CODEOWNERS: Unclaim curl and curl-rustls

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,8 +19,6 @@ pipelines/ @wolfi-dev/foundations-squad
 # These packages require approval from the Foundations squad.
 ca-certificates.yaml @wolfi-dev/foundations-squad
 clang-*.yaml         @wolfi-dev/foundations-squad
-curl.yaml            @wolfi-dev/foundations-squad
-curl-rustls.yaml     @wolfi-dev/foundations-squad
 gcc*.yaml            @wolfi-dev/foundations-squad
 glibc.yaml           @wolfi-dev/foundations-squad
 llvm*.yaml           @wolfi-dev/foundations-squad


### PR DESCRIPTION
The tricky thing about these packages had to do with mismatched
curl/libcurl versions. This is now resolved through use of the
libcurl-abi virtual package.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
