### PR TITLE
feat: microvm-init setup additional ports

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,12 +1,13 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 2
+  epoch: 3
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - attr
       - busybox
       - e2fsprogs
       - gnutar
@@ -43,6 +44,34 @@ pipeline:
           ${{targets.destdir}}/var/cache \
           ${{targets.destdir}}/var/run
       ln -sf /usr/share/zoneinfo/UTC  ${{targets.destdir}}/etc/localtime
+      # Setting up Chroot and accept env AcceptEnv
+      # Order here is important! ChrootDirectory must be the first!
+      mkdir -p ${{targets.destdir}}/etc/ssh/sshd_config.d
+      cat <<EOF > ${{targets.destdir}}/etc/ssh/sshd_config.d/microvm-init.conf
+      Port 22
+      Port 2223
+      Protocol 2
+      ChrootDirectory /mount
+      AcceptEnv *
+      AddressFamily inet
+      UseDNS no
+      PasswordAuthentication no
+      PubkeyAuthentication yes
+      PermitEmptyPasswords no
+      AllowAgentForwarding no
+      StrictModes yes
+      X11Forwarding no
+      AllowTcpForwarding no
+      GatewayPorts no
+      PermitTunnel no
+      PermitOpen none
+      DisableForwarding yes
+      AllowStreamLocalForwarding no
+      HostKeyAlgorithms ssh-ed25519
+      Ciphers aes128-gcm@openssh.com
+      Match LocalPort 2223
+          ChrootDirectory none
+      EOF
 
 update:
   enabled: false

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -82,20 +82,6 @@ if [ -e /dev/vda ]; then
 	mount --bind /mount/home/build /home/build
 fi
 
-# Set default hard limit of open file descriptors to match systemd init
-# behavior. The pam_limit module uses the settings in /proc/1/limit as
-# its default values.
-if [ -f /proc/sys/fs/nr_open ] ; then
-	nofile_limit=$(ulimit -H -n)
-	kernel_max_limit=$(cat /proc/sys/fs/nr_open)
-	# ensure that we are increasing the hard limit
-	if [[ "${kernel_max_limit}" =~ ^[0-9]+$ ]] &&
-		[ "${nofile_limit}" -lt "${kernel_max_limit}" ] ; then
-
-		ulimit -H -n "$kernel_max_limit"
-	fi
-fi
-
 # Setup default mountpoint for 9p shared dir
 mount -t 9p \
 	-o trans=virtio \
@@ -111,8 +97,21 @@ chmod 0777 /mount/mnt
 mount --bin /proc /mount/proc
 mount --bin /dev /mount/dev
 mount --bin /sys /mount/sys
-mount --bin /tmp /mount/tmp
 mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /mount/sys/fs/cgroup
+
+# Set default hard limit of open file descriptors to match systemd init
+# behavior. The pam_limit module uses the settings in /proc/1/limit as
+# its default values.
+if [ -f /proc/sys/fs/nr_open ] ; then
+	nofile_limit=$(ulimit -H -n)
+	kernel_max_limit=$(cat /proc/sys/fs/nr_open)
+	# ensure that we are increasing the hard limit
+	if [[ "${kernel_max_limit}" =~ ^[0-9]+$ ]] &&
+		[ "${nofile_limit}" -lt "${kernel_max_limit}" ] ; then
+
+		ulimit -H -n "$kernel_max_limit"
+	fi
+fi
 
 # ldconfig is run to prime ld.so.cache for glibc packages which require it.
 chroot /mount /bin/sh -c "[ -x /sbin/ldconfig ] && /sbin/ldconfig /lib /usr/lib /usr/lib64"

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -78,8 +78,6 @@ if [ -e /dev/vda ]; then
 
 	# Make /home/build world writeable under /mount
 	chmod 0777 /mount/home/build
-	# Make it accessible also from initramfs
-	mount --bind /mount/home/build /home/build
 fi
 
 # Setup default mountpoint for 9p shared dir

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -78,6 +78,8 @@ if [ -e /dev/vda ]; then
 
 	# Make /home/build world writeable under /mount
 	chmod 0777 /mount/home/build
+	# Make it accessible also from initramfs
+	mount --bind /mount/home/build /home/build
 fi
 
 # Set default hard limit of open file descriptors to match systemd init
@@ -149,11 +151,5 @@ for i in $(awk -F: '$7 == "/bin/sh" {print $1}' /etc/passwd); do
 	chown -R "$i":"$group" "$home"
 done
 
-# Setting up Chroot and accept env AcceptEnv
-# Order here is important! ChrootDirectory must be the first!
-echo "ChrootDirectory /mount" > /etc/ssh/sshd_config
-echo "AcceptEnv *" >> /etc/ssh/sshd_config
-echo "AddressFamily inet" >> /etc/ssh/sshd_config
-echo "UseDNS no" >> /etc/ssh/sshd_config
 ssh-keygen -A -a 1
 exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
Harden SSHD config a bit, and add an additional port to listen to that can be used to syphon back the workspace when done. This will allow us to avoid adding additional packages to build environments.
