### PR TITLE
apache2: split apache2 config(s) into subpackage

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,12 +1,13 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 41
+  epoch: 42
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - ${{package.name}}-config
       - libgcc
       - lua5.4
       - merged-usrsbin
@@ -161,39 +162,39 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: ${{package.name}}-compat
-    description: "Config compatibility to upstream docker image"
-    dependencies:
-      runtime:
-        - ${{package.name}}
-        - busybox # the httpd-foreground script calls `rm`
-        - merged-usrsbin
-        - wolfi-baselayout
+  - name: ${{package.name}}-config
+    description: ${{package.name}} configuration files
     pipeline:
       - runs: |
-          set -x
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
+          mv "${{targets.destdir}}"/etc/apache2/httpd.conf "${{targets.contextdir}}"/etc/apache2/httpd.conf
+          mv "${{targets.destdir}}"/etc/apache2/extra/httpd-ssl.conf "${{targets.contextdir}}"/etc/apache2/extra/httpd-ssl.conf
+    test:
+      pipeline:
+        - runs: |
+            stat /etc/apache2/httpd.conf
+            stat /etc/apache2/extra/httpd-ssl.conf
 
-          # Create necessary folders
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+  # This subpackage is to keep the backwards compatibility with the compat image.
+  # By having this subpackage, it allows packages that depend on apache2 config files
+  # (i.e., httpd.conf, httpd-ssl.conf) to be installed without having conflict with
+  # the ${{package.name}}-config and ${{package.name}}-compat subpackages. Some packages
+  # needs particular config adjustments in the httpd.conf file, and this subpackage
+  # allows them to be installed without having to modify the ${{package.name}}-compat
+  # subpackage if the package has a runtime dependency on it.
+  - name: ${{package.name}}-config-compat
+    description: ${{package.name}} configuration files for compat
+    dependencies:
+      replaces:
+        - ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/etc/apache2
+          mkdir -p "${{targets.contextdir}}"/etc/apache2/extra
 
-          # Install necessary config files
-          mkdir -p "${{targets.subpkgdir}}"/etc/apache2
           cp "${{targets.destdir}}"/etc/apache2/original/httpd.conf "${{targets.subpkgdir}}"/etc/apache2
           cp -r "${{targets.destdir}}"/etc/apache2/original/extra/ "${{targets.subpkgdir}}"/etc/apache2
-
-          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
-          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
-          # Create symlinks
-          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
-          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
-          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
 
           # Modify User/Group and verify changes are applied.
           sed -ri \
@@ -232,11 +233,45 @@ subpackages:
             -e 's|etc/|usr/local/apache2/conf/|g' \
             -e 's|/var/run/apache2/|usr/local/apache2/logs/|g' \
             "${{targets.subpkgdir}}"/etc/apache2/extra/httpd-ssl.conf;
+
+          ### Add Include directive for additional configs
+          echo "IncludeOptional /etc/apache2/conf.d/*.conf" >> "${{targets.subpkgdir}}"/etc/apache2/httpd.conf
+
+  - name: ${{package.name}}-compat
+    description: "Config compatibility to upstream docker image"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - ${{package.name}}-config-compat
+        - busybox # the httpd-foreground script calls `rm`
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          set -x
+
+          # Create necessary folders
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
+
+          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
+          install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
+          # Create symlinks
+          ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/extra "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/mime.types "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /etc/apache2/magic "${{targets.subpkgdir}}"/usr/local/apache2/conf/
+          ln -s /usr/lib/apache2/modules/ "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/share/apache2/default-site/htdocs "${{targets.subpkgdir}}"/usr/local/apache2/
+          ln -s /usr/lib/cgi-bin/ "${{targets.subpkgdir}}"/usr/local/apache2/
     test:
       environment:
         contents:
           packages:
             - curl
+            - ${{package.name}}-config-compat
       pipeline:
         - runs: |
             # Verify config is as expected upstream docker instance


### PR DESCRIPTION
Allows packages that depend on apache2 config files to provide their own apache2 configurations.

This is NOT a breaking change. `apache2`, `apache2-config`, `apache2-compat`, and `apache2-config-compat` all `apk add` able at the same time.