### PR TITLE
feat(CODEOWNERS): Add guardrails around changes to workflows and withdrawn-packages.txt which can remove packages from package repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,15 @@ CODEOWNERS @wolfi-dev/foundations-squad
 Makefile   @wolfi-dev/foundations-squad
 pipelines/ @wolfi-dev/foundations-squad
 
+# There are workflows which alter the state of the package repository and
+# changes must be approved by the Foundations or acceleration team before merging.
+workflows/  @wolfi-dev/foundations-squad @wolfi-dev/acceleration
+
+# withdrawn-packages.txt is used in conjunction with the workflows/withdraw-packages.yaml
+# workflow to completely withdraw packages from the package repository. Any withdrawals must be
+# approved by the Foundations squad to avoid removals that would have unintended consequences.
+withdrawn-packages.txt   @wolfi-dev/foundations-squad
+
 # These packages require approval from the Foundations squad.
 ca-certificates.yaml @wolfi-dev/foundations-squad
 clang-*.yaml         @wolfi-dev/foundations-squad


### PR DESCRIPTION
There are workflows which alter the state of the package repository and
changes must be approved by the Foundations or acceleration team before merging.

Also, withdrawn-packages.txt is used in conjunction with the workflows/withdraw-packages.yaml
workflow to completely withdraw packages from the package repository. Any withdrawals must be
approved by the Foundations squad to avoid removals that would have unintended consequences.

Prompted by a discussion during onboarding about reproducible builds we realised that the
package versions in our .melange.yaml could be altered despite having the same version. This could
only be achieved via package withdrawal and subsequent re-upload but the conversation highlighted
the importance on ensuring that any package withdrawal is made with great care and thought.

In this commit I assign the responsibility of ensuring responsible use of withdrawn-packages.txt to
the foundations squad.

Signed-off-by: philroche <phil.roche@chainguard.dev>
