### PR TITLE
linkerd2-proxy: add coreutils and tzdata as runtime deps

### DIFF
--- a/linkerd2-proxy.yaml
+++ b/linkerd2-proxy.yaml
@@ -1,8 +1,12 @@
 package:
   name: linkerd2-proxy
   version: "2.296.0"
-  epoch: 0
+  epoch: 1
   description: "A program that validates linkerd networks"
+  dependencies:
+    runtime:
+      - coreutils
+      - tzdata
   copyright:
     - license: Apache-2.0
 


### PR DESCRIPTION
sleep is required 