### PR TITLE
linux-pam - add pam_systemd.so to base-session-noninteractive

### DIFF
--- a/linux-pam.yaml
+++ b/linux-pam.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-pam
   version: 1.7.0
-  epoch: 40
+  epoch: 41
   description: Linux PAM (Pluggable Authentication Modules for Linux)
   copyright:
     - license: BSD-3-Clause

--- a/linux-pam/base-session-noninteractive.pamd
+++ b/linux-pam/base-session-noninteractive.pamd
@@ -3,3 +3,4 @@
 session required pam_env.so
 session required pam_limits.so
 session required pam_unix.so
+session optional pam_systemd.so


### PR DESCRIPTION
This is what allows systemd to start its user sessions. 
Without this:

    chainguard:~$ systemctl --user status
    Failed to connect to user scope bus via local transport:
       $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
       (consider using --machine=<user>@.host
        --user to connect to bus of other user)

With this:

    $ systemctl --user status
    * chainguard
        State: running
        Units: 100 loaded (incl. loaded aliases)
         Jobs: 0 queued
         Failed: 0 units
         Since: Tue 2025-05-13 20:13:48 UTC; 1min 1s ago
         systemd: 257.5
         CGroup: /user.slice/user-1000.slice/user@1000.service
         `-init.scope |-316 /usr/lib/systemd/systemd --user `-319
         "(sd-pam)"
