### PR TITLE
Create the mount points.

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 3
+  epoch: 4
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -1,5 +1,6 @@
 #!/bin/busybox sh
 set -e
+set -x
 
 PATH=/usr/bin:/usr/sbin:/sbin:/bin
 
@@ -71,7 +72,7 @@ if [ -e /dev/vda ]; then
 	mount -o nobarrier,noatime,nodiratime,nobh,barrier=0 -t ext4 /dev/vda /mount
 	# Extract build environment in /mount
 	tar --xattrs --xattrs-include='*' -xpf /dev/vdb -m -k --ignore-zeros --record-size=64K --numeric-owner -C /mount/
-	mkdir -p /mount/mnt
+	mkdir -p /mount/mnt /mount/proc /mount/dev /mount/sys
 	# ensure permissions are correct for sshd's ChrootDirectory
 	chown root:root /mount
 	chmod 0755 /mount
@@ -112,7 +113,7 @@ if [ -f /proc/sys/fs/nr_open ] ; then
 fi
 
 # ldconfig is run to prime ld.so.cache for glibc packages which require it.
-chroot /mount /bin/sh -c "[ -x /sbin/ldconfig ] && /sbin/ldconfig /lib /usr/lib /usr/lib64"
+[ -x /mount/sbin/ldconfig ] && chroot /mount /bin/sh -c "/sbin/ldconfig /lib /usr/lib /usr/lib64"
 
 # Setup default network
 interface_name="$(ip -o link show | grep 'BROADCAST,MULTICAST' | head -n 1 | cut -d':' -f2 | tr -d ' ')"


### PR DESCRIPTION
This is needed for when the guest environment doesn't depend on a baselayout that creates these.
