### PR TITLE
Rabbitmq default user credential bitnami compat

### DIFF
--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -52,17 +52,12 @@ subpackages:
           image: rmq-default-credential-updater
           version-path: "1/debian-12"
       - runs: |
-          # Make directory structure
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin
-
-          # Set up binary symlink
           ln -sf /usr/bin/default-user-credential-updater "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater
 
-          # Handle license
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/licenses
           cp LICENSE "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/licenses/LICENSE
 
-          # Remove conflicting certificates to avoid collision with ca-certificates-bundle
           rm -rf "${{targets.subpkgdir}}"/etc/ssl/certs/ca-certificates.crt
     test:
       environment:

--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-default-user-credential-updater
   version: "1.0.5"
-  epoch: 3
+  epoch: 4
   description: Updates RabbitMQ default user password
   copyright:
     - license: MPL-2.0
@@ -36,6 +36,45 @@ subpackages:
     test:
       pipeline:
         - runs: "[ \"$(stat -c '%N' /default-user-credential-updater 2>/dev/null)\" = \"'/default-user-credential-updater' -> '/usr/bin/default-user-credential-updater'\" ]"
+
+  - name: ${{package.name}}-bitnami-compat
+    description: "Bitnami compatibility package for ${{package.name}}"
+    dependencies:
+      runtime:
+        - bash
+        - procps
+        - ca-certificates-bundle
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: rmq-default-credential-updater
+          version-path: "1/debian-12"
+      - runs: |
+          # Make directory structure
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin
+
+          # Set up binary symlink
+          ln -sf /usr/bin/default-user-credential-updater "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater
+
+          # Handle license
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/licenses
+          cp LICENSE "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/licenses/LICENSE
+
+          # Remove conflicting certificates to avoid collision with ca-certificates-bundle
+          rm -rf "${{targets.subpkgdir}}"/etc/ssl/certs/ca-certificates.crt
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - ca-certificates-bundle
+      pipeline:
+        - runs: |
+            [ "$(stat -c '%N' /opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater 2>/dev/null)" = "'/opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater' -> '/usr/bin/default-user-credential-updater'" ]
+            [ -d "/opt/bitnami/rmq-default-credential-updater/licenses" ]
+            [ -f "/opt/bitnami/rmq-default-credential-updater/licenses/LICENSE" ]
 
 test:
   pipeline:

--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -47,10 +47,6 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: rmq-default-credential-updater
-          version-path: "1/debian-12"
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin
           ln -sf /usr/bin/default-user-credential-updater "${{targets.subpkgdir}}"/opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater


### PR DESCRIPTION
added new bitami compatable subpackage to rabbitmq-default-user-credential-updater