### PR TITLE
Allow writing to /etc/datadog-agent/

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.65.1"
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -608,7 +608,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/init.d
       - working-directory: Dockerfiles/dogstatsd/alpine
         runs: |
-          mkdir -p ${{targets.subpkgdir}}/etc/datadog-agent/
+          mkdir -m 777 -p ${{targets.subpkgdir}}/etc/datadog-agent/
           cp ./install_info ${{targets.subpkgdir}}/etc/datadog-agent/
           cp ./dogstatsd.yaml ${{targets.subpkgdir}}/etc/datadog-agent/
           install -Dm755 entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh


### PR DESCRIPTION
dogstatsd attempts to write lock and temporary files to /etc/datadog-agent/ which it cannot do and fails. Giving write permission to the directory allows for success in starting dogstatsd. Not clear if there is a somewhat less permissive way to do this.

Expected to resolve https://github.com/chainguard-dev/image-release-stats/issues/5301