### PR TITLE
fix: format ext4 with news profile

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 3
+  epoch: 4
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -66,7 +66,7 @@ fi
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
 	grep -q ext4 /proc/filesystems || modprobe ext4
-	mkfs.ext4 -O ^has_journal /dev/vda
+	mkfs.ext4 -T news -O ^has_journal /dev/vda
 	mkdir -p /mount
 	mount -o nobarrier,noatime,nodiratime,nobh,barrier=0 -t ext4 /dev/vda /mount
 	# Extract build environment in /mount


### PR DESCRIPTION
This is useful to allow a greater number of inodes, which is ideal for source files and compilation