### PR TITLE
llvm: misc housekeeping - consistent toolchain for libs

### DIFF
--- a/llvm-libcxx-18.yaml
+++ b/llvm-libcxx-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-18
   version: 18.1.8
-  epoch: 0
+  epoch: 1
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-18
+      - clang
       - cmake
       - curl
       - git

--- a/llvm-libunwind-15.yaml
+++ b/llvm-libunwind-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-15
   version: 15.0.7
-  epoch: 2
+  epoch: 3
   description: LLVM version of libunwind library
   copyright:
     - license: MIT
@@ -18,8 +18,7 @@ environment:
       - clang
       - cmake
       - gcc-12-default # needed for -nostdlib++
-      - llvm15
-      - llvm15-dev
+      - llvm-dev
       - samurai
 
 pipeline:

--- a/llvm-libunwind-16.yaml
+++ b/llvm-libunwind-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-16
   version: 16.0.6
-  epoch: 5
+  epoch: 6
   description: LLVM version of libunwind library
   copyright:
     - license: MIT
@@ -18,8 +18,7 @@ environment:
       - clang
       - cmake
       - gcc-12-default # needed for -nostdlib++
-      - llvm16
-      - llvm16-dev
+      - llvm-dev
       - samurai
 
 pipeline:

--- a/llvm-libunwind-17.yaml
+++ b/llvm-libunwind-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-17
   version: 17.0.6
-  epoch: 2
+  epoch: 3
   description: LLVM version of libunwind library
   copyright:
     - license: MIT
@@ -18,8 +18,7 @@ environment:
       - clang
       - cmake
       - gcc-12-default # needed for -nostdlib++
-      - llvm17
-      - llvm17-dev
+      - llvm-dev
       - samurai
 
 pipeline:


### PR DESCRIPTION
Use versionless clang and llvm dependencies for building older
llvm-libunwind and llvm-libcxx packages.

This brings all versions of these older llvm-lib packages inline
in terms of clang and llvm build toolchain versioning.
