### PR TITLE
qemu - enable vnc support.

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: "10.0.0"
-  epoch: 0
+  epoch: 1
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -28,6 +28,7 @@ environment:
       - ncurses-dev
       - ninja-build
       - perl
+      - pixman-dev
       - py3-packaging
       - py3-pip
       - py3-sphinx
@@ -47,7 +48,7 @@ pipeline:
   - runs: |
       mkdir build
       cd build
-      ../configure --enable-system --enable-slirp --target-list=x86_64-softmmu,aarch64-softmmu --prefix=${{targets.destdir}}/usr
+      ../configure --enable-system --enable-slirp --enable-vnc --target-list=x86_64-softmmu,aarch64-softmmu --prefix=${{targets.destdir}}/usr
       make -j$(nproc)
       make install
       # Remove this firmware file, which we don't need, but requires so:dld.sl, which we don't have


### PR DESCRIPTION
Without this change, using 'qemu-system-x86 -vnc' pretends to not know what vnc is.
