### PR TITLE
grafana-12.0: fix FTBFS

### DIFF
--- a/grafana-12.0.yaml
+++ b/grafana-12.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-12.0
   version: "12.0.0"
-  epoch: 1
+  epoch: 2
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -40,7 +40,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: append-buildvcs-false-to-go-build.patch
+      patches: append-buildvcs-false-to-go-build.patch fix-pkg-storage-unified-resource-health.go.patch
 
   - runs: |
       # Update the workspace to the Go version required by dependencies: `make

--- a/grafana-12.0/fix-pkg-storage-unified-resource-health.go.patch
+++ b/grafana-12.0/fix-pkg-storage-unified-resource-health.go.patch
@@ -1,0 +1,37 @@
+From 8738bab8b2e6dadfe120062904da3efc83330869 Mon Sep 17 00:00:00 2001
+From: Ryan McKinley <ryantxu@gmail.com>
+Date: Tue, 13 May 2025 12:49:42 +0300
+Subject: [PATCH] Chore: Update grpc to v1.72.0 (#105311)
+
+---
+ pkg/storage/unified/resource/health.go | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/pkg/storage/unified/resource/health.go b/pkg/storage/unified/resource/health.go
+index 6c08643edc6..bb55864ce7f 100644
+--- a/pkg/storage/unified/resource/health.go
++++ b/pkg/storage/unified/resource/health.go
+@@ -31,6 +31,20 @@ func (s *healthServer) AuthFuncOverride(ctx context.Context, _ string) (context.
+ 	return ctx, nil
+ }
+ 
++func (s *healthServer) List(ctx context.Context, req *grpc_health_v1.HealthListRequest) (*grpc_health_v1.HealthListResponse, error) {
++	h, err := s.Check(ctx, &grpc_health_v1.HealthCheckRequest{
++		Service: "all", // not used for anything
++	})
++	if err != nil {
++		return nil, err
++	}
++	return &grpc_health_v1.HealthListResponse{
++		Statuses: map[string]*grpc_health_v1.HealthCheckResponse{
++			"all": h,
++		},
++	}, nil
++}
++
+ func (s *healthServer) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+ 	r, err := s.srv.IsHealthy(ctx, &HealthCheckRequest{})
+ 	if err != nil {
+-- 
+2.47.2
+


### PR DESCRIPTION
Currently grafana-12.0 fails to build from source due to an error as the HealthService is missing the method List, this patch is pulled from upstream commit
https://github.com/grafana/grafana/commit/8738bab8b2e6dadfe120062904da3efc83330869 of file pkg/storage/unified/resource/health.go