### PR TITLE
glibc: Enable openssf-compiler-options

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 50
+  epoch: 51
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -44,8 +44,6 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
-    # https://github.com/chainguard-dev/internal-dev/issues/7756
-    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout
@@ -111,6 +109,7 @@ pipeline:
         release/2.41/master/624285af3bfc0d2a513cc921d21142a46e3cebb0: elf: Test case for bug 32976 (CVE-2025-4802)
         release/2.41/master/899dd3ab2fc2bff6b8d37345ee34b7b1ef23fa0c: x86_64: Fix typo in ifunc-impl-list.c.
         release/2.41/master/515d4166f4dbcf43b1568e3f63a19d9a92b2d50e: elf: Fix subprocess status handling for tst-dlopen-sgid (bug 32987)
+        master/81467d4b6168c7ce40d951d6b32e387109c0e5ae: elf: Add optimization barrier for __ehdr_start and _end
 
   - uses: patch
     with:


### PR DESCRIPTION
Restore openssf-compiler-options hardening on glibc.

This build is now passing on both amd64 and arm64.

Relates: https://github.com/chainguard-dev/internal-dev/issues/7756
Relates: https://github.com/wolfi-dev/os/pull/39303
Relates: https://github.com/chainguard-dev/internal-dev/issues/7940