### PR TITLE
fix(kubevela): split vela-cli into its own subpackage

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -9,7 +9,6 @@ package:
     runtime:
       - ca-certificates-bundle
       - vela-cli
-      - vela-core
 
 pipeline:
   - uses: git-checkout

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -29,13 +29,33 @@ pipeline:
       output: manager
       packages: ./cmd/core/main.go
 
-  - uses: go/build
-    with:
-      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
-      output: vela
-      packages: ./references/cmd/cli/main.go
-
   - uses: strip
+
+subpackages:
+  - name: vela-cli
+    pipeline:
+      - uses: go/build
+        with:
+          ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
+          output: vela
+          packages: ./references/cmd/cli/main.go
+      - uses: strip
+  
+    test:
+      pipeline:
+        - name: Version information tests (vela)
+          runs: |
+            VERSION_OUTPUT=$(vela version)
+            echo "$VERSION_OUTPUT" | grep "CLI Version"
+            echo "$VERSION_OUTPUT" | grep "Core Version"
+            echo "$VERSION_OUTPUT" | grep ${{package.version}}
+        - name: Setup KWOK cluster
+          uses: test/kwok/cluster
+        - name: Test if Vela installation is functional
+          runs: |
+            vela env init prod --namespace prod
+            vela install
+
 
 update:
   enabled: true
@@ -45,15 +65,6 @@ update:
 
 test:
   pipeline:
-    - name: Version information tests (vela)
+    - name: Version information tests (manager)
       runs: |
-        VERSION_OUTPUT=$(vela version)
-        echo "$VERSION_OUTPUT" | grep "CLI Version"
-        echo "$VERSION_OUTPUT" | grep "Core Version"
-        echo "$VERSION_OUTPUT" | grep ${{package.version}}
-    - name: Setup KWOK cluster
-      uses: test/kwok/cluster
-    - name: Test if Vela installation is functional
-      runs: |
-        vela env init prod --namespace prod
-        vela install
+        manager --help

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -33,6 +33,7 @@ pipeline:
 
 subpackages:
   - name: vela-cli
+    description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.
     pipeline:
       - uses: go/build
         with:

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - ca-certificates-bundle
-      - vela-core
       - vela-cli
+      - vela-core
 
 pipeline:
   - uses: git-checkout
@@ -41,7 +41,6 @@ subpackages:
           runs: |
             manager --help
 
-  
   - name: vela-cli
     description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.
     pipeline:

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: "1.10.3"
-  epoch: 1
+  epoch: 2
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -8,6 +8,8 @@ package:
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - vela-core
+      - vela-cli
 
 pipeline:
   - uses: git-checkout
@@ -23,15 +25,23 @@ pipeline:
         go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       replaces: github.com/docker/docker=github.com/moby/moby@v26.1.0+incompatible
 
-  - uses: go/build
-    with:
-      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
-      output: manager
-      packages: ./cmd/core/main.go
-
-  - uses: strip
-
 subpackages:
+  - name: vela-core
+    description: The KubeVela controller manager is a daemon that embeds the core control loops shipped with KubeVel
+    pipeline:
+      - uses: go/build
+        with:
+          ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
+          output: manager
+          packages: ./cmd/core/main.go
+      - uses: strip
+    test:
+      pipeline:
+        - name: Version information tests
+          runs: |
+            manager --help
+
+  
   - name: vela-cli
     description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.
     pipeline:
@@ -43,7 +53,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
-        - name: Version information tests (vela)
+        - name: Version information tests
           runs: |
             VERSION_OUTPUT=$(vela version)
             echo "$VERSION_OUTPUT" | grep "CLI Version"
@@ -61,9 +71,3 @@ update:
   github:
     identifier: kubevela/kubevela
     strip-prefix: v
-
-test:
-  pipeline:
-    - name: Version information tests (manager)
-      runs: |
-        manager --help

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -40,7 +40,6 @@ subpackages:
           output: vela
           packages: ./references/cmd/cli/main.go
       - uses: strip
-  
     test:
       pipeline:
         - name: Version information tests (vela)
@@ -55,7 +54,6 @@ subpackages:
           runs: |
             vela env init prod --namespace prod
             vela install
-
 
 update:
   enabled: true


### PR DESCRIPTION
That way we dont need to have the entire vela-cli when installing the kubevela operator (vela-core).
Saves about 40MB when you just want the operator

![image](https://github.com/user-attachments/assets/8374b841-9564-4b16-8ee1-b48b39b8f154)

I'm not how to approach this tho, should it be an entirely separate package or just a subpackage here?
