### PR TITLE
fix: Resolve jaeger/GHSA-vvgc-356p-c3xw

### DIFF
--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: |-
+      deps : |-
         golang.org/x/oauth2@v0.27.0
 
   - uses: go/build

--- a/blob-csi-1.26.yaml
+++ b/blob-csi-1.26.yaml
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps : |-
+      deps: |-
         golang.org/x/oauth2@v0.27.0
 
   - uses: go/build

--- a/jaeger.yaml
+++ b/jaeger.yaml
@@ -16,7 +16,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps : |-
+      deps: |-
         golang.org/x/net@v0.39.0
 
 environment:

--- a/jaeger.yaml
+++ b/jaeger.yaml
@@ -1,7 +1,7 @@
 package:
   name: jaeger
   version: "1.69.0"
-  epoch: 0
+  epoch: 1
   description: Jaeger, a Distributed Tracing Platform
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 02128431cc2566b5cc3f38b8aea88a30f182ce3d
       recurse-submodules: true
+
+  - uses: go/bump
+    with:
+      deps : |-
+        golang.org/x/net@v0.39.0
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
