### PR TITLE
emissary/kubeflow-jupyter-web-app/kubeflow-volumes-web-app: fix cve

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: "3.10.0"
-  epoch: 2
+  epoch: 3
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0

--- a/emissary.yaml
+++ b/emissary.yaml
@@ -83,6 +83,8 @@ subpackages:
 
           # durationpy 0.5 fails to install with modern setuptools
           sed -i 's/durationpy==0.5/durationpy==0.6/' python/requirements.txt
+          # CVE-2025-47278
+          sed -i 's/flask==3.1.0/flask==3.1.1/' python/requirements.txt
 
           # Install to target dir.
           # Ignore installed packages, since this looks at the builder host packages, when we're trying to install

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: "1.10.0"
-  epoch: 1
+  epoch: 2
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: "1.10.0"
-  epoch: 0
+  epoch: 1
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Remediate cve GHSA-4grg-w6v8-c28g by bumping the packages and in turn this will rebuild the packages with the fixed version of Flask.

On emissary, flask is pinned to 3.1.0, and we pin it to the fixed flask version of 3.1.1.