### PR TITLE
test(ollama): better package definition + more consistent tests

### DIFF
--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,19 +1,10 @@
 package:
   name: ollama
-  version: "0.6.8"
+  version: 0.6.8
   epoch: 0
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - cmake
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -43,17 +34,20 @@ test:
       packages:
         - curl
   pipeline:
-    - name: Start ollama server
+    - name: Ensure CLI works
       runs: |
-        # Start the ollama server in the background
-        ollama serve &
+        ollama --version | grep "${{package.version}}"
+        ollama --help | grep "Large language model"
+    - name: Test if Ollama server works
+      runs: |
+        HOST_IP=localhost
+        PREDEFINED_PORT=9999
+        OLLAMA_HOST=$HOST_IP:$PREDEFINED_PORT ollama serve &
         SERVER_PID=$!
         sleep 5
 
         # Check if the server is running
-        curl -s localhost:11434 | grep -q "Ollama is running"
+        curl -s $HOST_IP:$PREDEFINED_PORT | grep -q "Ollama is running"
 
         # Kill the server process
         kill $SERVER_PID
-        ollama --version
-        ollama --help

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,7 +1,7 @@
 package:
   name: ollama
   version: 0.6.8
-  epoch: 0
+  epoch: 1
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT


### PR DESCRIPTION
This basically just cleans up the package a bit and makes it so the test wont fail if they change the default port at some point

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
