### PR TITLE
fix: remove confusing error messages

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 5
+  epoch: 6
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -42,7 +42,7 @@ fi
 # and network will work anyway
 # If this fails and we won't have network, the ifconfig command will fail anyway.
 # Also we load cpu accelleration drivers in case those are needed.
-depmod -a || :
+[ -e "/lib/modules/$(uname -r)/" ] && depmod -a
 sort -u /sys/devices/system/cpu/modalias | xargs -n1 modprobe 2>/dev/null || :
 sort -u /sys/devices/pci*/*/virtio*/modalias | xargs -n1 modprobe 2>/dev/null || :
 # modprobe 9p if absent


### PR DESCRIPTION
There were depmod errors that are not fatal that were confusing to users