### PR TITLE
opensearch-3: Move docker entrypoint

### DIFF
--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.0.0"
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -106,7 +106,10 @@ pipeline:
   - runs: |
       # Use a modified entrypoint script as the official one duplicates env vars and system properties used by the JVM on startup
       # This means we avoid errors like: ERROR: setting [discovery.seed_hosts] already set, saw [opensearch-cluster-master-headless] and [opensearch-cluster-master-headless]
-      mv opensearch-docker-entrypoint.sh  ${{targets.destdir}}/usr/share/opensearch/bin/
+      #
+      # Opensearch operator requires opensearch-docker-entrypoint.sh in /usr/share/opensearch but historically we had it in bin, so also make a symlink to avoid breaking things.
+      mv opensearch-docker-entrypoint.sh  ${{targets.destdir}}/usr/share/opensearch/
+      ln -s /usr/share/opensearch/opensearch-docker-entrypoint.sh ${{targets.destdir}}/usr/share/opensearch/bin/opensearch-docker-entrypoint.sh
 
   - runs: |
       # Set permissions to read/write the config dir


### PR DESCRIPTION
This commit lifts part of Max's change from #53225 that wasn't applied
to this version stream (likely because the PR that landed this was
already in flight).  The opensearch-operator expects the entrypoint to
be in a specific place, this commit moves the script and symlinks it
back to the old location.
