### PR TITLE
fix(gitlab-es-indexer): Correct description

### DIFF
--- a/gitlab-cng-17.11.yaml
+++ b/gitlab-cng-17.11.yaml
@@ -32,7 +32,7 @@ package:
   name: gitlab-cng-17.11
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "17.11.2"
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -330,7 +330,7 @@ subpackages:
             kill $PID
 
   - name: gitlab-elasticsearch-indexer-${{vars.major-minor-version}}
-    description: Elasticsearch indexer for GitLab EE, written in Go
+    description: Elasticsearch indexer for GitLab, written in Go
     dependencies:
       provides:
         - gitlab-elasticsearch-indexer=${{package.full-version}}


### PR DESCRIPTION
The indexer is licensed under MIT, correct the description to remove the reference to GitLab EE