### PR TITLE
chore(kubevela): add `kubevela-` prefix for vela-{core,cli} subpackages

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,14 +1,14 @@
 package:
   name: kubevela
   version: "1.10.3"
-  epoch: 2
+  epoch: 3
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - ${{package.name}}-vela-cli
       - ca-certificates-bundle
-      - vela-cli
 
 pipeline:
   - uses: git-checkout
@@ -25,7 +25,7 @@ pipeline:
       replaces: github.com/docker/docker=github.com/moby/moby@v26.1.0+incompatible
 
 subpackages:
-  - name: vela-core
+  - name: ${{package.name}}-vela-core
     description: The KubeVela controller manager is a daemon that embeds the core control loops shipped with KubeVel
     pipeline:
       - uses: go/build
@@ -40,7 +40,7 @@ subpackages:
           runs: |
             manager --help
 
-  - name: vela-cli
+  - name: ${{package.name}}-vela-cli
     description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.
     pipeline:
       - uses: go/build


### PR DESCRIPTION

Kubevela has a [`vela-cli`](https://github.com/kubevela/kubevela/tree/master/references) reference implementation that differs from the [`vela-cli`](https://github.com/go-vela/cli) project. Adding the prefix would be nice in order to clear up any confusion around these or anything. Talked about this with @Dentrax and he seemed to agree.
