### PR TITLE
test(dotnet): add link and sdk tests

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -194,5 +194,44 @@ update:
     - '-preview'
 
 test:
+  environment:
+    contents:
+      packages:
+        - dotnet-6-sdk
   pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+    - name: Compile and run a simple .NET application
+      runs: |
+        cat <<'EOF' > HelloWorld.cs
+        using System;
+
+        class Program
+        {
+            static void Main()
+            {
+                Console.WriteLine("Hello, World!");
+            }
+        }
+        EOF
+        dotnet new console -o HelloWorldApp --force
+        mv HelloWorld.cs HelloWorldApp/Program.cs
+        dotnet run --project HelloWorldApp
+    - name: Compile and run a .NET application with arguments
+      runs: |
+        cat <<'EOF' > ArgumentEcho.cs
+        using System;
+
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                Console.WriteLine("Arguments: " + String.Join(", ", args));
+            }
+        }
+        EOF
+        dotnet new console -o ArgumentEchoApp --force
+        mv ArgumentEcho.cs ArgumentEchoApp/Program.cs
+        dotnet run --project ArgumentEchoApp -- arg1 arg2 arg3
     - uses: test/tw/ldd-check

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -180,5 +180,44 @@ update:
     tag-filter: "v7.0.1" # We specifically the 7.0.1xx releases since those are intended for prod.
 
 test:
+  environment:
+    contents:
+      packages:
+        - dotnet-7-sdk
   pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+    - name: Compile and run a simple .NET application
+      runs: |
+        cat <<'EOF' > HelloWorld.cs
+        using System;
+
+        class Program
+        {
+            static void Main()
+            {
+                Console.WriteLine("Hello, World!");
+            }
+        }
+        EOF
+        dotnet new console -o HelloWorldApp --force
+        mv HelloWorld.cs HelloWorldApp/Program.cs
+        dotnet run --project HelloWorldApp
+    - name: Compile and run a .NET application with arguments
+      runs: |
+        cat <<'EOF' > ArgumentEcho.cs
+        using System;
+
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                Console.WriteLine("Arguments: " + String.Join(", ", args));
+            }
+        }
+        EOF
+        dotnet new console -o ArgumentEchoApp --force
+        mv ArgumentEcho.cs ArgumentEchoApp/Program.cs
+        dotnet run --project ArgumentEchoApp -- arg1 arg2 arg3
     - uses: test/tw/ldd-check

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -220,3 +220,4 @@ test:
         dotnet new console -o ArgumentEchoApp --force
         mv ArgumentEcho.cs ArgumentEchoApp/Program.cs
         dotnet run --project ArgumentEchoApp -- arg1 arg2 arg3
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
This PR adds test for missing required shared libraries and tests with .NET SDK as we do for the other .NET runtime versions.