### PR TITLE
Makefile - ake 'authget' notice failure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,6 @@ fetch-kernel:
 
 kernel/%/APKINDEX.tar.gz:
 	@$(call authget,apk.cgr.dev,$@,$(QEMU_KERNEL_REPO)/$(ARCH)/APKINDEX.tar.gz)
-	# Retry in case of failure
-	@if grep -q "UNAUTHORIZED" kernel/$(ARCH)/APKINDEX.tar.gz; then \
-		echo "Auth failed, retrying"; \
-		rm -rf kernel/$(ARCH); \
-		make kernel/$(ARCH)/APKINDEX.tar.gz; \
-	fi
 
 kernel/%/APKINDEX: kernel/%/APKINDEX.tar.gz
 	tar -x -C kernel --to-stdout -f $< APKINDEX > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@
@@ -283,5 +277,5 @@ authget = tok=$$(chainctl auth token --audience=$(1)) || \
   { echo "failed token from $(1) for target $@"; exit 1; }; \
   mkdir -p $$(dirname $(2)) && \
   echo "auth-download[$(1)] to $(2) from $(3)" && \
-  curl -LS --silent -o $(2).tmp --user "user:$$tok" $(3) && \
+  curl --fail -LS --silent -o $(2).tmp --user "user:$$tok" $(3) && \
 	mv "$(2).tmp" "$(2)"


### PR DESCRIPTION
curl --fail identifies many failures.  Per curl documentation it isn't always perfect, but this at least catches it at the point of failure (and does work in my testing).  It also means that all (2) callers of authget get the fix.
