### PR TITLE
chainguard-security-guide: update to v3.2.0 (based on v3r2 GPOS SRG)

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "0.1.3"
+  version: "3.2.0"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: 10b756177f720eea21cc7ca65ba3db03a4aa0dff
+      expected-commit: acfbd3faa113f66e19cd23beb45c09c19750b046
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
Update Chainguard stig to be based on the General Purpose OS (GPOS) Security Reference Guide (SRG) v3r2.