### PR TITLE
rootlesskit switch to go/build

### DIFF
--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,7 +1,7 @@
 package:
   name: rootlesskit
   version: "2.3.5"
-  epoch: 0
+  epoch: 1
   description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   copyright:
     - license: Apache-2.0
@@ -11,14 +11,6 @@ package:
     runtime:
       - rootlesskit-config
 
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
-
 pipeline:
   - uses: git-checkout
     with:
@@ -26,11 +18,20 @@ pipeline:
       expected-commit: 0cc0811acc6e4daee71817383e62fb811590bc13
       tag: v${{package.version}}
 
-  - runs: |
-      CGO_ENABLED=0 make all
-      DESTDIR=${{targets.destdir}} BINDIR="/usr/bin" make install
+  - uses: go/build
+    with:
+      output: rootlesskit
+      packages: ./cmd/rootlesskit
 
-  - uses: strip
+  - uses: go/build
+    with:
+      output: rootlessctl
+      packages: ./cmd/rootlessctl
+
+  - uses: go/build
+    with:
+      output: rootlesskit-docker-proxy
+      packages: ./cmd/rootlesskit-docker-proxy
 
 subpackages:
   - name: "rootlesskit-config-nonroot"


### PR DESCRIPTION
Switch rootlesskit to go/build such that binary is built optimized,
and is easier to fipsify.
