### PR TITLE
llvm-libcxx-18: ensure compiled with -fpic

### DIFF
--- a/llvm-libcxx-18.yaml
+++ b/llvm-libcxx-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-18
   version: 18.1.8
-  epoch: 1
+  epoch: 2
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,7 @@ pipeline:
         -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
         -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
         -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_ENABLE_PIC=ON \
         -DLIBCXX_INCLUDE_BENCHMARKS=OFF
 
   - runs: |


### PR DESCRIPTION
Explicitly enable LLVM_ENABLE_PIC to ensure that library is
built with -fpic enabled.
