### PR TITLE
rename cloud-sql-proxy for version stream

### DIFF
--- a/cloud-sql-proxy-2.16.yaml
+++ b/cloud-sql-proxy-2.16.yaml
@@ -1,20 +1,13 @@
 package:
-  name: cloud-sql-proxy
+  name: cloud-sql-proxy-2.16
   version: "2.16.0"
   epoch: 0
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
-  environment:
-    CGO_ENABLED: 0
+  dependencies:
+    provides:
+      - cloud-sql-proxy=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout
@@ -29,8 +22,6 @@ pipeline:
       output: cloud-sql-proxy
       ldflags: -X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container
 
-  - uses: strip
-
 subpackages:
   - name: ${{package.name}}-compat
     description: Compatibility package to place binaries in the location expected by upstream helm charts
@@ -39,15 +30,15 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}
           ln -sf /usr/bin/cloud-sql-proxy ${{targets.subpkgdir}}/cloud-sql-proxy
     dependencies:
-      runtime:
-        - cloud-sql-proxy
+      provides:
+        - cloud-sql-proxy-compat=${{package.full-version}}
 
 update:
   enabled: true
   github:
     identifier: GoogleCloudPlatform/cloud-sql-proxy
     strip-prefix: v
-    tag-filter: v2
+    tag-filter: v2.16.
 
 test:
   environment:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

