### PR TITLE
pipx: init at 1.7.1

### DIFF
--- a/pipx.yaml
+++ b/pipx.yaml
@@ -1,0 +1,57 @@
+package:
+  name: pipx
+  version: 1.7.1
+  epoch: 0
+  description: Install and Run Python Applications in Isolated Environments
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - bash # pipx ensurepath
+      - py${{vars.py-version}}-argcomplete
+      - py${{vars.py-version}}-packaging
+      - py${{vars.py-version}}-platformdirs
+      - py${{vars.py-version}}-userpath
+
+vars:
+  py-version: 3.13
+
+environment:
+  contents:
+    packages:
+      - py${{vars.py-version}}-build-base
+      - py${{vars.py-version}}-hatch-vcs
+      - py${{vars.py-version}}-hatchling
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/pipx.git
+      tag: ${{package.version}}
+      expected-commit: 4462299fa391b7349074facc39c73767853c9d02
+
+  - uses: py/pip-build-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pypa/pipx
+
+test:
+  pipeline:
+    - name: Ensure command line works
+      runs: |
+        pipx --version | grep ${{package.version}}
+        pipx --help
+    - name: Ensure package management works
+      runs: |
+        pipx ensurepath
+        pipx install flake8
+        source ~/.bashrc
+        realpath $(which flake8) | grep pipx
+        pipx inject flake8 pylint
+        pipx reinstall flake8
+        flake8 --help
+        pipx uninstall flake8


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented