### PR TITLE
chore(kubevela): vela-core-entrypoint compatibility package for upstream image compat

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -56,6 +56,7 @@ subpackages:
           runs: |
             test $(which entrypoint.sh)
             entrypoint.sh --help
+            entrypoint.sh manager --help
             test /usr/local/bin/manager
             /usr/local/bin/manager --help
 

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -56,6 +56,8 @@ subpackages:
           runs: |
             test $(which entrypoint.sh)
             entrypoint.sh --help
+            test /usr/local/bin/manager
+            /usr/local/bin/manager --help
 
   - name: ${{package.name}}-vela-cli
     description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -54,10 +54,10 @@ subpackages:
       pipeline:
         - name: Run Manager
           runs: |
-            test $(which entrypoint.sh)
+            stat $(which entrypoint.sh)
             entrypoint.sh --help
             entrypoint.sh manager --help
-            test /usr/local/bin/manager
+            stat /usr/local/bin/manager
             /usr/local/bin/manager --help
 
   - name: ${{package.name}}-vela-cli

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -47,9 +47,9 @@ subpackages:
         - ${{package.name}}-vela-core
     pipeline:
       - runs: |
-          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/usr/local/bin/manager
           # NOTE: https://github.com/kubevela/kubevela/blob/ef9b6f3cc10a4b6871b5698ca41fea3f6b3bcaec/Dockerfile#L46
           install -Dpm0755 -t ${{targets.subpkgdir}}/usr/local/bin entrypoint.sh
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/usr/local/bin/manager
     test:
       pipeline:
         - name: Run Manager

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: "1.10.3"
-  epoch: 3
+  epoch: 4
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -40,6 +40,23 @@ subpackages:
           runs: |
             manager --help
 
+  - name: ${{package.name}}-vela-core-compat
+    description: Upstream image runs `entrypoint.sh` instead of `/usr/bin/manager`
+    dependencies:
+      runtime:
+        - ${{package.name}}-vela-core
+    pipeline:
+      - runs: |
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/usr/local/bin/manager
+          # NOTE: https://github.com/kubevela/kubevela/blob/ef9b6f3cc10a4b6871b5698ca41fea3f6b3bcaec/Dockerfile#L46
+          install -Dpm0755 -t ${{targets.subpkgdir}}/usr/local/bin entrypoint.sh
+    test:
+      pipeline:
+        - name: Run Manager
+          runs: |
+            test $(which entrypoint.sh)
+            entrypoint.sh --help
+
   - name: ${{package.name}}-vela-cli
     description: Vela is a Pipeline Automation (CI/CD) framework built on Linux container technology written in Golang.
     pipeline:


### PR DESCRIPTION

Needs to be here so that we get the same entrypoint as the [upstream image](https://github.com/kubevela/kubevela/blob/ef9b6f3cc10a4b6871b5698ca41fea3f6b3bcaec/Dockerfile#L46).
