### PR TITLE
feat(ollama): add `ollama-cpu` for ggml CPU component

### DIFF
--- a/ollama.yaml
+++ b/ollama.yaml
@@ -60,6 +60,7 @@ test:
     contents:
       packages:
         - curl
+        - wait-for-it
   pipeline:
     - name: Ensure CLI works
       runs: |
@@ -71,7 +72,7 @@ test:
         PREDEFINED_PORT=9999
         OLLAMA_HOST=$HOST_IP:$PREDEFINED_PORT ollama serve &
         SERVER_PID=$!
-        sleep 5
+        wait-for-it -t 10 --strict $HOST_IP:$PREDEFINED_PORT
 
         # Check if the server is running
         curl -s $HOST_IP:$PREDEFINED_PORT | grep -q "Ollama is running"

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,10 +1,15 @@
 package:
   name: ollama
   version: "0.7.0"
-  epoch: 0
+  epoch: 1
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT
+
+environment:
+  contents:
+    packages:
+      - cmake
 
 pipeline:
   - uses: git-checkout
@@ -21,6 +26,28 @@ pipeline:
       ldflags: -X=github.com/ollama/ollama/version.Version=${{package.version}} -linkmode external -extldflags "-static"
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-cpu
+    description: Ollama CPU inferencing component
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - libstdc++
+    pipeline:
+      - name: Build LibGGML CPU
+        runs: |
+          set -e
+          cmake --preset 'CPU'
+          cmake --build build --parallel $(nproc) --preset 'CPU'
+          cmake --install build
+          install -Dpm0644 -t ${{ targets.subpkgdir }}/lib/ollama/ ./dist/lib/ollama/*.so
+          install -Dpm0644 -t ${{ targets.subpkgdir }}/lib/ ./dist/lib/ollama/*.so
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+          with:
+            packages: ollama-cpu
 
 update:
   enabled: true

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -32,11 +32,10 @@ subpackages:
     pipeline:
       - uses: cmake/configure
         with:
-          opts:
-            --preset "CPU"
+          opts: --preset "CPU"
       - uses: cmake/build
       - uses: cmake/install
-      - name: Build LibGGML CPU
+      - name: Install LibGGML CPU to main LD_LIBRARY_PATH
         runs: |
           set -e
           install -Dpm0644 -t ${{ targets.subpkgdir }}/usr/lib/ ${{ targets.subpkgdir }}/usr/lib/ollama/libggml*.so

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -35,14 +35,16 @@ subpackages:
         - ${{package.name}}
         - libstdc++
     pipeline:
+      - uses: cmake/configure
+        with:
+          opts:
+            --preset "CPU"
+      - uses: cmake/build
+      - uses: cmake/install
       - name: Build LibGGML CPU
         runs: |
           set -e
-          cmake --preset 'CPU'
-          cmake --build build --parallel $(nproc) --preset 'CPU'
-          cmake --install build
-          install -Dpm0644 -t ${{ targets.subpkgdir }}/lib/ollama/ ./dist/lib/ollama/*.so
-          install -Dpm0644 -t ${{ targets.subpkgdir }}/lib/ ./dist/lib/ollama/*.so
+          install -Dpm0644 -t ${{ targets.subpkgdir }}/usr/lib/ ${{ targets.subpkgdir }}/usr/lib/ollama/libggml*.so
     test:
       pipeline:
         - uses: test/tw/ldd-check

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -6,11 +6,6 @@ package:
   copyright:
     - license: MIT
 
-environment:
-  contents:
-    packages:
-      - cmake
-
 pipeline:
   - uses: git-checkout
     with:


### PR DESCRIPTION

Adds the `ggml-cpu` and `ggml-base` components for CPU inferencing on Ollama. 
