### PR TITLE
fix(update): use git instead of github api to get all the tags available

### DIFF
--- a/ruby3.0-bundler.yaml
+++ b/ruby3.0-bundler.yaml
@@ -64,11 +64,10 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: rubygems/rubygems
+  git:
     strip-prefix: bundler-v
     # Starting from v2.6.x, upstream drops support for Ruby 3.0.
-    tag-filter: bundler-v2.5.
+    tag-filter-prefix: bundler-v2.5.
 
 test:
   pipeline:


### PR DESCRIPTION
Epoch Update is not required here as this will not effect the build in anyway.