### PR TITLE
glibc: no change rebuild to fix unstripped binaries

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 3
+  epoch: 4
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later


### PR DESCRIPTION
There was a bug in `melange` introduced in v0.23.13[0] and subsequently
fixed in v0.23.15[1] that prevented the strip pipeline from working.

[0] https://github.com/chainguard-dev/melange/commit/6935178aa924131a38f7067927649c73c50dc1d3
[1] https://github.com/chainguard-dev/melange/commit/b489539855bdcb981e2ecac3b2de1280da8f0c71

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
