### PR TITLE
chore(pipelines/auth): Use home directory

### DIFF
--- a/neo4j-browser-2025.04.yaml
+++ b/neo4j-browser-2025.04.yaml
@@ -30,7 +30,7 @@ pipeline:
       tag: neo4j-${{package.version}}
       expected-commit: 6011f52e65c77ab775a8f6e7ceac8d4e6d5a5825
 
-  - uses: ecosystems/maven
+  - uses: auth/maven
 
   - runs: |
       yarn install --frozen-lockfile

--- a/neo4j-browser-5.26.yaml
+++ b/neo4j-browser-5.26.yaml
@@ -30,7 +30,7 @@ pipeline:
       tag: neo4j-${{package.version}}
       expected-commit: 6011f52e65c77ab775a8f6e7ceac8d4e6d5a5825
 
-  - uses: ecosystems/maven
+  - uses: auth/maven
 
   - runs: |
       yarn install --frozen-lockfile

--- a/pdftk.yaml
+++ b/pdftk.yaml
@@ -2,7 +2,7 @@
 package:
   name: pdftk
   version: 3.3.3
-  epoch: 3
+  epoch: 4
   description: Command-line tool for working with PDFs
   copyright:
     - license: GPL-2.0-or-later
@@ -28,7 +28,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: e4292c8f1bd2580a44d3cbf3570a4505bd3a74b6
 
-  - uses: ecosystems/gradle
+  - uses: auth/gradle
 
   - name: Build
     runs: |

--- a/pipelines/auth/github.yaml
+++ b/pipelines/auth/github.yaml
@@ -1,4 +1,4 @@
-name: Setup auth to clone private ecosystems repos using OctoSTS
+name: Setup auth to clone private repos using OctoSTS
 
 needs:
   packages:

--- a/pipelines/auth/gradle.yaml
+++ b/pipelines/auth/gradle.yaml
@@ -29,10 +29,10 @@ pipeline:
       fi
 
       echo "Removing gradle cache, if exists..."
-      rm -rf /root/.gradle && mkdir -p /root/.gradle
+      rm -rf $HOME/.gradle && mkdir -p $HOME/.gradle
 
       echo "Creating gradle init script..."
-      cat > /root/.gradle/init.gradle <<EOF
+      cat > $HOME/.gradle/init.gradle <<EOF
       import org.gradle.api.artifacts.dsl.RepositoryHandler
       import org.gradle.api.artifacts.verification.DependencyVerificationMode
 
@@ -63,3 +63,9 @@ pipeline:
         }
       }
       EOF
+
+      # Home is not respected under bwrap
+      if [ "$HOME" != "/root" ]; then
+        rm -rf /root/.gradle 
+        cp -r $HOME/.gradle /root/.gradle
+      fi

--- a/pipelines/auth/maven.yaml
+++ b/pipelines/auth/maven.yaml
@@ -29,24 +29,24 @@ pipeline:
       fi
 
       echo "Removing local maven repository, if exists..."
-      rm -rf /root/.m2 && mkdir -p /root/.m2
+      rm -rf $HOME/.m2 && mkdir -p $HOME/.m2
 
       echo "Creating maven settings manifest..."
-      cat > /root/.m2/settings.xml <<EOF
+      cat > $HOME/.m2/settings.xml <<EOF
       <settings>
         <mirrors>
           <mirror>
-            <id>ecosystems</id>
+            <id>chainguard</id>
             <mirrorOf>*</mirrorOf>
             <url>https://libraries.cgr.dev/java-all/</url>
           </mirror>
         </mirrors>
         <activeProfiles>
-          <activeProfile>ecosystems</activeProfile>
+          <activeProfile>chainguard</activeProfile>
         </activeProfiles>
         <profiles>
           <profile>
-            <id>ecosystems</id>
+            <id>chainguard</id>
             <repositories>
               <repository>
                 <id>central</id>
@@ -67,10 +67,16 @@ pipeline:
         </profiles>
         <servers>
           <server>
-            <id>ecosystems</id>
+            <id>chainguard</id>
             <username></username>
             <password>$cgtoken</password>
           </server>
         </servers>
       </settings>
       EOF
+
+      # Home is not respected under bwrap
+      if [ "$HOME" != "/root" ]; then
+        rm -rf /root/.m2 
+        cp -r $HOME/.m2 /root/.m2
+      fi

--- a/pipelines/iamguarded/build-compat.yaml
+++ b/pipelines/iamguarded/build-compat.yaml
@@ -22,7 +22,7 @@ inputs:
     description: package version stream to build compat for
 
 pipeline:
-  - uses: ecosystems/auth
+  - uses: auth/github
     with:
       repo: chainguard-dev/iamguarded-tools
 
@@ -32,7 +32,7 @@ pipeline:
       branch: main
       destination: ./.iamguarded-tools
 
-  - uses: ecosystems/auth
+  - uses: auth/github
     with:
       repo: chainguard-dev/iamguarded-containers
 

--- a/pipelines/iamguarded/test-compat.yaml
+++ b/pipelines/iamguarded/test-compat.yaml
@@ -18,7 +18,7 @@ inputs:
     description: package version stream to build compat for
 
 pipeline:
-  - uses: ecosystems/auth
+  - uses: auth/github
     with:
       repo: chainguard-dev/iamguarded-tools
 

--- a/spdx-tools-java.yaml
+++ b/spdx-tools-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdx-tools-java
   version: "2.0.1"
-  epoch: 3
+  epoch: 4
   description: SPDX Command Line Tools using the Spdx-Java-Library
   copyright:
     - license: Apache-2.0
@@ -35,7 +35,7 @@ pipeline:
     with:
       patches: fix-operating-system.patch
 
-  - uses: ecosystems/maven
+  - uses: auth/maven
 
   - uses: maven/pombump
 


### PR DESCRIPTION
The home directory is correctly set in melange under docker and qemu. bwrap still assumes /root/.m2 is where the settings manifest lives so we still need to accomdoate that

Also rename and relocate auth pipelines to better reflect usage