### PR TITLE
openssf-compiler-options: Support GCC 15

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 18
+  epoch: 19
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:
@@ -9,7 +9,7 @@ package:
 
 vars:
   clang-major-versions: 15 16 17 18 19 20
-  gcc-major-versions: 11 12 13 14
+  gcc-major-versions: 11 12 13 14 15
 
 environment:
   contents:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -1,0 +1,8 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
@@ -1,0 +1,8 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
+
+*link:
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
As a preparation for GCC 15, I'd like to merge this PR which adds support for this compiler version to `openssf-compiler-options`.