### PR TITLE
pre-commit: use yam hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
+# Update with `pre-commit autoupdate --freeze` which
+# pins all repos using commit hashes, not mutable references
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    # Use commit hashes here, not tags.
     rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
     hooks:
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
       - id: check-symlinks
       - id: detect-private-key
         exclude: ^ruby-3\.0/0001-ruby-3\.0\.6-openssl-patch\.patch$
+  - repo: https://github.com/chainguard-dev/yam
+    rev: 498642e77997ba79709f43a7ee2c84b12b2145bb # v0.2.12
+    hooks:
+      - id: yam
+        files: ^[^/]+\.yaml$


### PR DESCRIPTION
There's a bunch of other ones in https://github.com/chainguard-dev/pre-commit-hooks we should add as well, but start with this one.