### PR TITLE
Default to the QEMU runner.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 QEMU_KERNEL_REPO := https://apk.cgr.dev/chainguard-private/
 
+# Default to the QEMU runner, but allow overriding it
+# with the MELANGE_RUNNER environment variable.
+MELANGE_RUNNER ?= qemu
+
 ifneq (${MELANGE_RUNNER},)
 	MELANGE_OPTS += --runner=${MELANGE_RUNNER}
 	MELANGE_TEST_OPTS += --runner=${MELANGE_RUNNER}

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,17 @@ KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 QEMU_KERNEL_REPO := https://apk.cgr.dev/chainguard-private/
 
-# Default to the QEMU runner, but allow overriding it
-# with the MELANGE_RUNNER environment variable.
-MELANGE_RUNNER ?= qemu
-
-ifneq (${MELANGE_RUNNER},)
-	MELANGE_OPTS += --runner=${MELANGE_RUNNER}
-	MELANGE_TEST_OPTS += --runner=${MELANGE_RUNNER}
+ifeq (${MELANGE_RUNNER},)
+MELANGE_RUNNER = qemu
+$(warning ****************************** WARNING ******************************)
+$(warning *** MELANGE_RUNNER is unset. The default runner is now qemu, which)
+$(warning *** requires chainctl authentication to access the Chainguard kernel.)
+$(warning *** See `melange build --help` for a list of other runner options.)
+$(warning ****************************** WARNING ******************************)
 endif
+
+MELANGE_OPTS += --runner=${MELANGE_RUNNER}
+MELANGE_TEST_OPTS += --runner=${MELANGE_RUNNER}
 QEMU_KERNEL_IMAGE ?= kernel/$(ARCH)/vmlinuz
 ifeq (${MELANGE_RUNNER},qemu)
 	QEMU_KERNEL_DEP = ${QEMU_KERNEL_IMAGE}


### PR DESCRIPTION
This can be overridden with:
```
export MELANGE_RUNNER=bubblewrap
make package/ko
```
