### PR TITLE
ci-license-check: add issues write permissions

### DIFF
--- a/.github/chainguard/ci-license-check.sts.yaml
+++ b/.github/chainguard/ci-license-check.sts.yaml
@@ -6,3 +6,4 @@ subject_pattern: "(111508570611001124410)"
 
 permissions:
   checks: write
+  issues: write


### PR DESCRIPTION
We need to write/read comments on PRs.