### PR TITLE
code-server: remediate CVE-2025-47279

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.100.2"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -59,7 +59,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: node-memory.patch GHSA-pq67-2wwv-3xjx.patch
+      patches: node-memory.patch GHSA-pq67-2wwv-3xjx.patch fix-CVE-2025-47279.patch
 
   - runs: |
       mkdir -p "${{targets.contextdir}}"/usr/lib/code-server

--- a/code-server/fix-CVE-2025-47279.patch
+++ b/code-server/fix-CVE-2025-47279.patch
@@ -1,0 +1,39 @@
+From 4e9587796fb8be34231b9f8e5c37f86ffdd1ac87 Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Tue, 20 May 2025 17:06:55 +0000
+Subject: [PATCH] bump undici to 7.5.0 to remediate CVE-2025-47279
+
+---
+ lib/vscode/package-lock.json        | 2 +-
+ lib/vscode/remote/package-lock.json | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/vscode/package-lock.json b/lib/vscode/package-lock.json
+index d7d07d301e1..1a6e3befb48 100644
+--- a/lib/vscode/package-lock.json
++++ b/lib/vscode/package-lock.json
+@@ -2731,7 +2731,7 @@
+         "http-proxy-agent": "^7.0.0",
+         "https-proxy-agent": "^7.0.2",
+         "socks-proxy-agent": "^8.0.1",
+-        "undici": "^7.2.0"
++        "undici": "^7.5.0"
+       },
+       "optionalDependencies": {
+         "@vscode/windows-ca-certs": "^0.3.1"
+diff --git a/lib/vscode/remote/package-lock.json b/lib/vscode/remote/package-lock.json
+index a99aa799f69..137ed7c593a 100644
+--- a/lib/vscode/remote/package-lock.json
++++ b/lib/vscode/remote/package-lock.json
+@@ -430,7 +430,7 @@
+         "http-proxy-agent": "^7.0.0",
+         "https-proxy-agent": "^7.0.2",
+         "socks-proxy-agent": "^8.0.1",
+-        "undici": "^7.2.0"
++        "undici": "^7.5.0"
+       },
+       "optionalDependencies": {
+         "@vscode/windows-ca-certs": "^0.3.1"
+-- 
+2.49.0
+


### PR DESCRIPTION
bump undici to 7.5.0 on vscode to remediate CVE-2025-47279