### PR TITLE
chainguard: enable more identities to clone git repo

### DIFF
--- a/.github/chainguard/elastic-build.sts.yaml
+++ b/.github/chainguard/elastic-build.sts.yaml
@@ -8,7 +8,11 @@ issuer: https://accounts.google.com
 #  presubmit: 114870839879105817572: ebuild-zasv64d5x1oc4m3epw39yod@prod-enforce-fabc.iam.gserviceaccount.com
 #  postsubmit: 118124811908286464886: ebuild-ckhudf69he6dfl1xy83uuke@prod-enforce-fabc.iam.gserviceaccount.com
 #  world: 100027593799559093519: ebuild-n0ppcbm8uzc6ew2wy4gesfg@prod-enforce-fabc.iam.gserviceaccount.com
-subject_pattern: "(116478844699827634314|115457633213442188328|118305965159726888964|114870839879105817572|118124811908286464886|100027593799559093519)"
+# eco-2-28:
+#  presubmit: 109278469796396932019: ebuild-456o8jve9m82pzkyd0rxyya@prod-enforce-fabc.iam.gserviceaccount.com
+#  postsubmit: 116606566869655215545: ebuild-dg05lqlr2tymodkwd5go6a9@prod-enforce-fabc.iam.gserviceaccount.com
+#  world: 115998046588963941434: ebuild-d7lrzt8tuql0tod9242jkco@prod-enforce-fabc.iam.gserviceaccount.com
+subject_pattern: "(116478844699827634314|115457633213442188328|118305965159726888964|114870839879105817572|118124811908286464886|100027593799559093519|109278469796396932019|116606566869655215545|115998046588963941434)"
 
 permissions:
   contents: read


### PR DESCRIPTION
Add additional eco-2.28 identities to access wolfi.
