### PR TITLE
Support systemd-logind in our sshd pam session

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "10.0_p1"
-  epoch: 0
+  epoch: 1
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC

--- a/openssh/sshd.pam
+++ b/openssh/sshd.pam
@@ -22,6 +22,9 @@ session required pam_mkhomedir.so
 # Set the loginuid process attribute.
 session required pam_loginuid.so
 
+# Use pam_systemd to register this session with logind
+session required pam_systemd.so
+
 # Standard base session setup and teardown.
 session include base-session-noninteractive
 


### PR DESCRIPTION
The user sessions via ssh needs to be registered with systemd-logind to support features like lingering sessions