### PR TITLE
jupyter-base-notebook/cve remediation

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: "7.4.2"
-  epoch: 1
+  epoch: 2
   description: Jupyter Notebook
   dependencies:
     runtime:
@@ -27,8 +27,13 @@ pipeline:
       pip install jupyterhub --prefix=/usr --root=${{targets.contextdir}}
       # https://github.com/jupyter/docker-stacks/blob/9ffeb238dc8e363b5bddd779442b4f32d06aff0d/images/base-notebook/Dockerfile#L50 (else browser is not detected)
       pip install jupyterlab
+
       # Remediate GHSA-vqfr-h8mv-ghfj
       pip install --upgrade h11==0.16.0
+
+      # CVE-2025-47287
+      pip install --upgrade tornado==6.5.0
+
       jupyter server --generate-config
       # The default config is written to the user's home directory.
       cp $HOME/.jupyter/jupyter_server_config.py ${{targets.contextdir}}/home/jovyan/.jupyter/jupyter_server_config.py


### PR DESCRIPTION
upgrading tornado to 6.5.0 to fix CVE-2025-47287