### PR TITLE
Pin libxml2's runtime dependencies on libmxl2 to the same version

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: "2.13.6"
-  epoch: 1
+  epoch: 2
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -124,10 +124,10 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - libxml2
+        - libxml2=${{package.version}}
         - zlib-dev
         - xz-dev
-        - libxml2-utils
+        - libxml2-utils=${{package.version}}
     description: libxml2 dev
     test:
       environment:
@@ -135,7 +135,7 @@ subpackages:
           packages:
             - gcc
             - glibc-dev
-            - libxml2-utils
+            - libxml2-utils=${{package.version}}
       pipeline:
         - name: Verify libxml2-dev installation
           runs: |

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -124,10 +124,10 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - libxml2=${{package.version}}
+        - libxml2=${{package.full-version}}
         - zlib-dev
         - xz-dev
-        - libxml2-utils=${{package.version}}
+        - libxml2-utils=${{package.full-version}}
     description: libxml2 dev
     test:
       environment:
@@ -135,7 +135,7 @@ subpackages:
           packages:
             - gcc
             - glibc-dev
-            - libxml2-utils=${{package.version}}
+            - libxml2-utils=${{package.full-version}}
       pipeline:
         - name: Verify libxml2-dev installation
           runs: |


### PR DESCRIPTION
We should ensure that mismatched versions of libxml2-dev and libxml2 (or libxml2-utils) cannot be installed at the same time.