### PR TITLE
Pin various postgresql related packages to clang-19

### DIFF
--- a/pg-failover-slots-16.yaml
+++ b/pg-failover-slots-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg-failover-slots-16
   version: 1.1.0
-  epoch: 2
+  epoch: 3
   description: PG Failover Slots extension for PostgreSQL 16
   copyright:
     - license: BSD-3-Clause
@@ -12,7 +12,8 @@ environment:
       - automake
       - build-base
       - busybox
-      - clang
+      # NOTE: align with clang version in postgresql-*-dev
+      - clang-19
       - krb5-dev
       - postgresql-16-dev
 

--- a/pgaudit-17.yaml
+++ b/pgaudit-17.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-17
   version: "17.1"
-  epoch: 2
+  epoch: 3
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang
+      # NOTE: align with clang version in postgresql-*-dev
+      - clang-19
       - glibc-dev
       - krb5-dev
       - postgresql-17-dev

--- a/pgvector-16.yaml
+++ b/pgvector-16.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgvector-16
   version: 0.8.0
-  epoch: 1
+  epoch: 2
   description: Open-source vector similarity search for PostgreSQL
   copyright:
     - license: PostgreSQL
@@ -15,7 +15,8 @@ environment:
       - automake
       - build-base
       - busybox
-      - clang
+      # NOTE: align with clang version in postgresql-*-dev
+      - clang-19
       - postgresql-16-dev
 
 pipeline:

--- a/pgvector-17.yaml
+++ b/pgvector-17.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgvector-17
   version: 0.8.0
-  epoch: 1
+  epoch: 2
   description: Open-source vector similarity search for PostgreSQL
   copyright:
     - license: PostgreSQL
@@ -21,7 +21,8 @@ environment:
       - automake
       - build-base
       - busybox
-      - clang
+      # NOTE: align with clang version in postgresql-*-dev
+      - clang-19
       - postgresql-${{vars.pg-version}}-dev
 
 pipeline:

--- a/postgis-17.yaml
+++ b/postgis-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgis-17
   version: "3.5.3"
-  epoch: 0
+  epoch: 1
   description: Geographic Information Systems Extensions to PostgreSQL
   copyright:
     - license: GPL-2.0-or-later

--- a/postgis-17.yaml
+++ b/postgis-17.yaml
@@ -13,7 +13,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - clang
+      # NOTE: align with clang version in postgresql-*-dev
+      - clang-19
       - gdal-dev
       - geos-dev
       - json-c-dev


### PR DESCRIPTION
postgresql uses clang-19 to build so related packages that use
the postgresql dev packages need to be version aligned.
