### PR TITLE
Pgpool package update: Add busybox to pgpool2-oci-entrypoint subpackage

### DIFF
--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2-4.6
   version: "4.6.1"
-  epoch: 0
+  epoch: 1
   description: Middleware that works between PostgreSQL servers and a PostgreSQL database client.
   copyright:
     - license: BSD-3-Clause AND MIT
@@ -104,6 +104,7 @@ subpackages:
         - grep
         - gawk
         - gnutar
+        - busybox # needed by entrypoint script
     pipeline:
       - uses: git-checkout
         with:


### PR DESCRIPTION
- Added `busybox` to entrypoint subpackage and bump up epoch.