### PR TITLE
melange: 0.26.0

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.25.1"
+  version: "0.26.0"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e23f548858796928fd89c65819b1203390547958
+      expected-commit: 73723fb269d1f13ef21d8beb42956bbc42c2239b
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
SBOM improvements for generation of downloadLocations for git
sources.
