### PR TITLE
feat(pipelines): add xcover pipelines

### DIFF
--- a/pipelines/xcover/ensure.yaml
+++ b/pipelines/xcover/ensure.yaml
@@ -1,0 +1,34 @@
+name: Ensure a minimum coverage reported by xcover
+
+needs:
+  packages:
+    - busybox
+    - jq
+    - ${{inputs.package}}
+
+inputs:
+  package:
+    description: The xcover package
+    required: false
+    default: xcover
+  min-coverage:
+    description: The minimum coverage to accept as percentage.
+    required: false
+    default: ""
+
+pipeline:
+  - runs: |
+
+      # Extract coverage percentage from the report.
+      coverage=$(jq '.cov_by_func' < <(cat xcover-report.json))
+      echo "Coverage is ${coverage} %"
+
+      # If set, set up the gate.
+      if [ -n "${{inputs.min-coverage}}" ]; then
+        true=1
+        if [[ $(echo "$coverage > ${{inputs.min-coverage}}" | bc -l) != $true ]]; then
+          echo "Coverage ${coverage} % is below the expected minimum ${{inputs.min-coverage}}"
+          exit 1
+        fi
+      fi
+

--- a/pipelines/xcover/profile.yaml
+++ b/pipelines/xcover/profile.yaml
@@ -1,0 +1,47 @@
+name: Start the coverage profile with the xcover tool 
+
+needs:
+  packages:
+    - busybox
+    - ${{inputs.package}}
+
+inputs:
+  package:
+    description: The xcover package
+    required: false
+    default: xcover
+  executable-path:
+    description: The path to the executable of the application to test.
+    required: true
+  exclude-functions:
+    description: The function symbols to exclude from profiling as a regular expression.
+    required: false
+  log-level:
+    description: The log level of the xcover profile command.
+    required: false
+    default: info
+  verbose:
+    description: Enable verbosity of the xcover profile command. It prints out all the functions being traced real-time.
+    required: false
+    default: "false"
+  wait-timeout:
+    description: The maximum amount of time to wait for the xcover profiler to be ready for profiling, in seconds.
+    required: false
+    default: "60"
+
+pipeline:
+  - runs: |
+
+      # Run profile in background.
+      xcover profile \
+        --path ${{inputs.executable-path}} \
+        --exclude ${{inputs.exclude-functions}} \
+        --log-level=${{inputs.log-level}} \
+        --verbose=${{inputs.verbose}} \
+        --status >xcover.log 2>&1 &
+
+      # Run a sync barrier, that is:
+      # the tracee that is going to be tested
+      # is being traced.
+      xcover wait --timeout ${{inputs.wait-timeout}}s
+

--- a/pipelines/xcover/stop.yaml
+++ b/pipelines/xcover/stop.yaml
@@ -1,0 +1,16 @@
+name: Stop the xcover profiler tool 
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  package:
+    description: The xcover package
+    required: false
+    default: xcover
+
+pipeline:
+  - runs: |
+      pkill xcover
+


### PR DESCRIPTION
This commit adds xcover pipelines, for starting a coverage profiling, stopping the profiling, and ensuring a minimum coverage threshold is respected, before completing tests.

The xcover/ensure pipeline will exits 1 if the threshold is not respected.

xcover/profile requires sys_admin to create BPF uprobes multi link, and sys_resource for setting memlock rlimit.