### PR TITLE
dask-kubernetes: remediate cve GHSA-7cx3-6m66-7c5m

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.4.3"
-  epoch: 0
+  epoch: 1
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"


### PR DESCRIPTION
Bump epoch to rebuild with patched Tornado for GHSA-7cx3-6m66-7c5m remediation.
