### PR TITLE
Add tests for cluster-autoscaler && cluster-proportional-autoscaler p…

### DIFF
--- a/cluster-autoscaler-1.32.yaml
+++ b/cluster-autoscaler-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.32
   version: "1.32.1"
-  epoch: 3
+  epoch: 4
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cluster-autoscaler-1.32.yaml
+++ b/cluster-autoscaler-1.32.yaml
@@ -106,7 +106,7 @@ test:
           --clusterrole=system:nginx-autoscaler \
           --serviceaccount=default:nginx-autoscaler
 
-        sleep 2
+        kubectl rollout status deployment/nginx-autoscale-example --namespace=default
 
         # Set up the necessary environment for the autoscaler to communicate with the API
         mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
@@ -118,10 +118,3 @@ test:
 
         # Run the cluster-autoscaler to scale the deployment
         cluster-autoscaler --namespace=default --configmap=nginx-autoscaler --target=deployment/nginx-autoscale-example --logtostderr=true --v=2 > /dev/null 2>&1 &
-        sleep 5
-
-        # Check if the scaling worked by querying the deployment
-        kubectl get pods -A
-
-        # Check deployment status
-        kubectl rollout status deployment/nginx-autoscale-example --namespace=default

--- a/cluster-autoscaler-1.32.yaml
+++ b/cluster-autoscaler-1.32.yaml
@@ -54,6 +54,10 @@ subpackages:
     dependencies:
       provides:
         - cluster-autoscaler-compat=${{package.full-version}}
+    test:
+      pipeline:
+        - runs: |
+            readlink -f /cluster-autoscaler | grep /usr/bin/cluster-autoscaler
 
 update:
   enabled: true
@@ -65,7 +69,59 @@ update:
     tag-filter: cluster-autoscaler-1.32.
 
 test:
+  environment:
+    contents:
+      packages:
+        - kubectl
   pipeline:
     - runs: |
         # cluster-autoscaler --help exits with exit code 2
         cluster-autoscaler --help | grep "pflag: help requested"
+    - uses: test/kwok/cluster
+    - runs: |
+        # Create the ConfigMap for autoscaler configuration
+        kubectl create configmap nginx-autoscaler --from-literal=linear='{
+          "coresPerReplica": 2,
+          "nodesPerReplica": 1,
+          "max": 3,
+          "preventSinglePointFailure": true
+        }' --namespace=default
+
+        # Create the Deployment
+        kubectl create deployment nginx-autoscale-example --image=nginx --replicas=1 --namespace=default
+        kubectl expose deployment nginx-autoscale-example --port=80 --target-port=80 --namespace=default
+
+        # Create the ServiceAccount
+        kubectl create serviceaccount nginx-autoscaler --namespace=default
+
+        # Create the ClusterRole
+        kubectl create clusterrole system:nginx-autoscaler \
+          --verb=list,watch --resource=nodes \
+          --verb=get,update --resource=replicationcontrollers/scale \
+          --verb=get,update --resource=deployments/scale,replicasets/scale \
+          --verb=get,create --resource=configmaps
+
+        # Create the ClusterRoleBinding
+        kubectl create clusterrolebinding system:nginx-autoscaler \
+          --clusterrole=system:nginx-autoscaler \
+          --serviceaccount=default:nginx-autoscaler
+
+        sleep 2
+
+        # Set up the necessary environment for the autoscaler to communicate with the API
+        mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
+        export KUBERNETES_SERVICE_HOST=127.0.0.1
+        export KUBERNETES_SERVICE_PORT=32764
+        CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+        cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        kubectl create token nginx-autoscaler > /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # Run the cluster-autoscaler to scale the deployment
+        cluster-autoscaler --namespace=default --configmap=nginx-autoscaler --target=deployment/nginx-autoscale-example --logtostderr=true --v=2 > /dev/null 2>&1 &
+        sleep 5
+
+        # Check if the scaling worked by querying the deployment
+        kubectl get pods -A
+
+        # Check deployment status
+        kubectl rollout status deployment/nginx-autoscale-example --namespace=default

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -45,7 +45,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            readlink -f /cluster-proportional-autoscaler | grep /usr/bin/cluster-proportional-autoscaler 
+            readlink -f /cluster-proportional-autoscaler | grep /usr/bin/cluster-proportional-autoscaler
 
 update:
   enabled: true

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: "1.10.2"
-  epoch: 2
+  epoch: 3
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0
@@ -42,6 +42,10 @@ subpackages:
         runs: |
           # The helm chart expects to be able to call "./cluster-proportional-autoscaler"
           ln -s /usr/bin/cluster-proportional-autoscaler "cluster-proportional-autoscaler"
+    test:
+      pipeline:
+        - runs: |
+            readlink -f /cluster-proportional-autoscaler | grep /usr/bin/cluster-proportional-autoscaler 
 
 update:
   enabled: true


### PR DESCRIPTION
…ackages

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
