### PR TITLE
Test: Add test for subpackages and also fix the placement of the config file

### DIFF
--- a/cass-operator.yaml
+++ b/cass-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-operator
   version: "1.24.0"
-  epoch: 0
+  epoch: 1
   description: Manages Cassandra cluster as standalone product or as part of the k8ssandra-operator
   copyright:
     - license: Apache-2.0
@@ -44,13 +44,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
       - uses: strip
+    test:
+      pipeline:
+        - runs: |
+            # Verify that the symlink exists and points to the correct location
+            test -L /manager && test "$(readlink /manager)" = "/usr/bin/manager"
 
   - name: cass-operator-config
     description: "A configuration file for the Vector"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.destdir}}/etc/vector
-          cp ./config/logger/vector_config.toml ${{targets.destdir}}/etc/vector/vector.toml
+          mkdir -p ${{targets.contextdir}}/etc/vector
+          cp ./config/logger/vector_config.toml ${{targets.contextdir}}/etc/vector/vector.toml
+    test:
+      pipeline:
+        - runs: |
+            # Verify that the configuration file exists and is readable
+            test -f /etc/vector/vector.toml && test -r /etc/vector/vector.toml
 
 update:
   enabled: true


### PR DESCRIPTION
cass-operator-config was empty before that was a mistake