### PR TITLE
talloc: add comprehensive test and bump epoch

### DIFF
--- a/talloc.yaml
+++ b/talloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: talloc
   version: "2.4.3"
-  epoch: 2
+  epoch: 3
   description: Memory pool management library
   copyright:
     - license: GPL-3.0-or-later
@@ -57,6 +57,79 @@ pipeline:
       rm -f  "${{targets.contextdir}}"/usr/lib/pkgconfig/pytalloc-util.*.pc
 
   - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - talloc-dev
+        
+  pipeline:
+    - name: Check talloc library
+      runs: |
+        # Verify the shared library exists
+        if [ ! -f /usr/lib/libtalloc.so.2 ]; then
+          echo "ERROR: libtalloc.so.2 library not found"
+          exit 1
+        fi
+        
+        echo "talloc library test passed"
+        cat > /tmp/talloc_test.c << 'EOF'
+        #include <stdio.h>
+        #include <stdlib.h>
+        #include <talloc.h>
+
+        int main(void) {
+            /* Create a top-level context */
+            void *root_ctx = talloc_new(NULL);
+            if (!root_ctx) {
+                fprintf(stderr, "Failed to create talloc context\n");
+                return 1;
+            }
+
+            /* Allocate a string as a child of the context */
+            char *str = talloc_strdup(root_ctx, "Hello Talloc World");
+            if (!str) {
+                fprintf(stderr, "Failed to allocate string\n");
+                talloc_free(root_ctx);
+                return 1;
+            }
+
+            /* Get the parent of the string */
+            void *parent = talloc_parent(str);
+            if (parent != root_ctx) {
+                fprintf(stderr, "Parent mismatch\n");
+                talloc_free(root_ctx);
+                return 1;
+            }
+
+            printf("Successfully allocated string: %s\n", str);
+            printf("Parent relationship verified\n");
+
+            /* Free the entire hierarchy */
+            talloc_free(root_ctx);
+
+            printf("Memory successfully freed\n");
+            return 0;
+        }
+        EOF
+
+        # Compile and run the test program
+        gcc -o /tmp/talloc_test /tmp/talloc_test.c -ltalloc
+        if [ $? -ne 0 ]; then
+          echo "ERROR: Failed to compile talloc test program"
+          exit 1
+        fi
+
+        # Run the test
+        /tmp/talloc_test
+        if [ $? -ne 0 ]; then
+          echo "ERROR: Talloc test program failed"
+          exit 1
+        fi
+
+        echo "talloc library test passed"
 
 subpackages:
   - name: talloc-dev

--- a/talloc.yaml
+++ b/talloc.yaml
@@ -64,7 +64,6 @@ test:
       packages:
         - build-base
         - talloc-dev
-        
   pipeline:
     - name: Check talloc library
       runs: |
@@ -73,7 +72,7 @@ test:
           echo "ERROR: libtalloc.so.2 library not found"
           exit 1
         fi
-        
+
         echo "talloc library test passed"
         cat > /tmp/talloc_test.c << 'EOF'
         #include <stdio.h>


### PR DESCRIPTION
Added a comprehensive test for the talloc package that verifies both the library existence and functionality. The test compiles and runs a simple C program that uses the talloc API to create memory contexts, allocate memory, and verify parent-child relationships.

Bumped epoch from 2 to 3 to trigger a rebuild.

Testing: Verified the test runs successfully with the qemu runner.