### PR TITLE
The empty package test should fail if the package is not empty

### DIFF
--- a/pipelines/test/emptypackage.yaml
+++ b/pipelines/test/emptypackage.yaml
@@ -13,4 +13,5 @@ pipeline:
       else
         echo "Expected this package [$pkg] to be empty, but it isn't:"
         apk info -qL "$pkg"
+        exit 1
       fi


### PR DESCRIPTION
My understanding of the empty package test written by @dustinkirkland was that he wanted to detect packages which are expected to be empty and are no long empty. If the test is not exiting 1 then we will never know if the package is no longer empty.