### PR TITLE
clamav-1.4: add tests / remove commented packages

### DIFF
--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: 1.4.2
-  epoch: 41
+  epoch: 42
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -43,8 +43,6 @@ environment:
       - rust
       - samurai
       - zlib-dev
-      # - clamav-scanner
-      # - clamav-daemon
 
 vars:
   CLAMAV_DOCKER_COMMIT: "ebb9ae94e5b57c9f3aef1de128feae22fabd8920"
@@ -236,6 +234,9 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
     description: ClamAV dummy package for compatibility
+    test:
+      pipeline:
+        - uses: test/emptypackage
 
   - name: freshclam
     pipeline:


### PR DESCRIPTION
Remove 2 year old commented packages
add tests for empty package of subpackage clamav-db