### PR TITLE
quality: improve test for kubernetes-dashboard-auth package

### DIFF
--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -48,13 +48,14 @@ test:
   pipeline:
     - uses: test/kwok/cluster
     - name: "Setup test environment"
+    - name: Verify kubernetes-dashboard-auth installation
       runs: |
-        # Create service account and RBAC
-        kubectl create serviceaccount test-user
-        kubectl create clusterrolebinding test-user-admin \
-          --clusterrole=cluster-admin \
-          --serviceaccount=default:test-user
-        sleep 2
+        dashboard-auth --address=0.0.0.0 --apiserver-host="https://accounts.google.com" --kubeconfig=/root/.kube/config &> dashboard-auth.log &
+        sleep 5
+        grep "Starting Kubernetes Dashboard Auth" dashboard-auth.log || exit 1
+    - name: Check version in logs
+      runs: |
+        grep "${{package.version}}" dashboard-auth.log || exit 1
     - name: "Start dashboard-auth service"
       uses: test/daemon-check-output
       with:
@@ -75,8 +76,8 @@ test:
         expected_output: |
           "Starting Kubernetes Dashboard Auth" version="${{package.version}}"
           "Listening and serving insecurely on" address="0.0.0.0:8000"
+        # Limited to port 8000, can't test full API without proxy (k8s API server runs on 8001)
         post: |
-          # Limited to port 8000, can't test full API without proxy (k8s API server runs on 8001)
           wait-for-it -t 30 localhost:8000 || exit 1
 
 update:

--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -76,6 +76,7 @@ test:
           "Starting Kubernetes Dashboard Auth" version="${{package.version}}"
           "Listening and serving insecurely on" address="0.0.0.0:8000"
         post: |
+          # Limited to port 8000, can't test full API without proxy (k8s API server runs on 8001)
           wait-for-it -t 30 localhost:8000 || exit 1
 
 update:

--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-auth
   version: "1.2.4"
-  epoch: 6
+  epoch: 7
   description: Stateless Go module, which could be referred to as a Kubernetes API extension
   copyright:
     - license: Apache-2.0
@@ -41,16 +41,42 @@ subpackages:
         - runs: stat /dashboard-auth
 
 test:
+  environment:
+    contents:
+      packages:
+        - wait-for-it
   pipeline:
     - uses: test/kwok/cluster
-    - name: Verify kubernetes-dashboard-auth installation
+    - name: "Setup test environment"
       runs: |
-        dashboard-auth --address=0.0.0.0 --apiserver-host="https://accounts.google.com" --kubeconfig=/root/.kube/config &> dashboard-auth.log &
-        sleep 5
-        grep "Starting Kubernetes Dashboard Auth" dashboard-auth.log || exit 1
-    - name: Check version in logs
-      runs: |
-        grep "${{package.version}}" dashboard-auth.log || exit 1
+        # Create service account and RBAC
+        kubectl create serviceaccount test-user
+        kubectl create clusterrolebinding test-user-admin \
+          --clusterrole=cluster-admin \
+          --serviceaccount=default:test-user
+        sleep 2
+    - name: "Start dashboard-auth service"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          if nc -z localhost 8000; then
+            echo "Port 8000 is already in use"
+            exit 1
+          fi
+        start: |
+          dashboard-auth \
+            --address=0.0.0.0 \
+            --port=8000 \
+            --apiserver-host="https://127.0.0.1:32764" \
+            --kubeconfig=/root/.kube/config \
+            --apiserver-skip-tls-verify \
+            -v=4
+        timeout: 30
+        expected_output: |
+          "Starting Kubernetes Dashboard Auth" version="${{package.version}}"
+          "Listening and serving insecurely on" address="0.0.0.0:8000"
+        post: |
+          wait-for-it -t 30 localhost:8000 || exit 1
 
 update:
   enabled: true

--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -76,9 +76,17 @@ test:
         expected_output: |
           "Starting Kubernetes Dashboard Auth" version="${{package.version}}"
           "Listening and serving insecurely on" address="0.0.0.0:8000"
-        # Limited to port 8000, can't test full API without proxy (k8s API server runs on 8001)
         post: |
           wait-for-it -t 30 localhost:8000 || exit 1
+
+          # Check Kubernetes API health
+          for endpoint in / /readyz /livez /openapi/v2; do
+          echo "Checking $endpoint..."
+          kubectl get --raw "$endpoint" || {
+            echo "Failed to query $endpoint"
+            exit 1
+          }
+          done
 
 update:
   enabled: true


### PR DESCRIPTION
In package tests, we run the `dashboard-auth` service directly on localhost and cannot use `kubectl proxy`. This means we cannot test API endpoints like `/api`, `/livez`, or `/readyz`, as they are exposed via the k8s API server (on port 8001) and not directly by the service on port 8000.

