### PR TITLE
Py3 installer tests

### DIFF
--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -60,6 +60,7 @@ subpackages:
         - runs: |
             git clone --branch ${{package.version}} https://github.com/pypa/installer.git py${{range.key}}-installer
             cd py${{range.key}}-installer
+            # gets mad if you don't copy the tests to a separate directory
             cp -r tests ../
             cd ../tests
             python${{range.key}} -m pytest .

--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-installer
   version: 0.7.0
-  epoch: 10
+  epoch: 11
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
@@ -45,6 +45,24 @@ subpackages:
       - uses: py/pip-build-install-bootstrap
         with:
           python: python${{range.key}}
+    test:
+      environment:
+        contents:
+          packages:
+            - git
+            - py${{range.key}}-pytest
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import installer
+        - runs: |
+            git clone --branch ${{package.version}} https://github.com/pypa/installer.git py${{range.key}}-installer
+            cd py${{range.key}}-installer
+            cp -r tests ../..
+            cd ../../tests
+            python${{range.key}} -m pytest .
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -60,8 +60,8 @@ subpackages:
         - runs: |
             git clone --branch ${{package.version}} https://github.com/pypa/installer.git py${{range.key}}-installer
             cd py${{range.key}}-installer
-            cp -r tests ../..
-            cd ../../tests
+            cp -r tests ../
+            cd ../tests
             python${{range.key}} -m pytest .
 
   - name: py3-supported-${{vars.pypi-package}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
