### PR TITLE
add tests for kubernetes components

### DIFF
--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -81,7 +81,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-${{vars.kubernetes-version}}
     test:
-      # Refer to main test pipeline for more tests.
       pipeline:
         - runs: |
             /usr/bin/kubectl-${{vars.kubernetes-version}} --help
@@ -167,7 +166,7 @@ subpackages:
       pipeline:
         - name: Check kubeadm binary
           runs: |
-            /usr/bin/kubeadm-${{vars.kubernetes-version}} --version
+            /usr/bin/kubeadm-${{vars.kubernetes-version}} --help
         - name: Check kubeadm completion file
           runs: |
             stat /usr/share/bash-completion/completions/kubeadm
@@ -188,11 +187,11 @@ subpackages:
       pipeline:
         - name: Check kubelet binary
           runs: |
-            /usr/bin/kubelet-${{vars.kubernetes-version}} --version
+            /usr/bin/kubelet-${{vars.kubernetes-version}} --help
         - name: Check kubelet directories
           runs: |
             stat /var/lib/kubelet
-            stat -d /var/log/kubelet
+            stat /var/log/kubelet
 
   - name: kube-scheduler-${{vars.kubernetes-version}}
     description: Kubernetes control plane component watching over pods on nodes
@@ -206,7 +205,7 @@ subpackages:
       pipeline:
         - name: Check kube-scheduler binary
           runs: |
-            /usr/bin/kube-scheduler-${{vars.kubernetes-version}} --version
+            /usr/bin/kube-scheduler-${{vars.kubernetes-version}} --help
         - name: Check kube-scheduler log directory
           runs: |
             stat /var/log/kube-scheduler
@@ -231,7 +230,7 @@ subpackages:
       pipeline:
         - name: Check kube-proxy binary
           runs: |
-            /usr/bin/kube-proxy-${{vars.kubernetes-version}} --version
+            /usr/bin/kube-proxy-${{vars.kubernetes-version}} --help
         - name: Check kube-proxy directories
           runs: |
             stat /var/lib/kube-proxy
@@ -249,7 +248,7 @@ subpackages:
       pipeline:
         - name: Check kube-controller-manager binary
           runs: |
-            /usr/bin/kube-controller-manager-${{vars.kubernetes-version}} --version
+            /usr/bin/kube-controller-manager-${{vars.kubernetes-version}} --help
         - name: Check kube-controller-manager log directory
           runs: |
             stat /var/log/kube-controller-manager
@@ -266,7 +265,7 @@ subpackages:
       pipeline:
         - name: Check kube-apiserver binary
           runs: |
-            /usr/bin/kube-apiserver-${{vars.kubernetes-version}} --version
+            /usr/bin/kube-apiserver-${{vars.kubernetes-version}} --help
         - name: Check kube-apiserver log directory
           runs: |
             stat /var/log/kube-apiserver

--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -80,6 +80,11 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-${{vars.kubernetes-version}}
+    test:
+      # Refer to main test pipeline for more tests.
+      pipeline:
+        - runs: |
+            /usr/bin/kubectl-${{vars.kubernetes-version}} --version
 
   - name: kubectl-bash-completion-${{vars.kubernetes-version}}
     dependencies:
@@ -89,6 +94,10 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-${{vars.kubernetes-version}}
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/share/bash-completion/completions/kubectl-${{vars.kubernetes-version}}
 
   - name: kubectl-${{vars.kubernetes-version}}-bitnami-compat
     description: "compat package with bitnami/kubectl image"
@@ -105,6 +114,14 @@ subpackages:
           ln -s /usr/bin/kubectl "${{targets.subpkgdir}}/opt/bitnami/kubectl/bin/kubectl"
           mkdir -p "${{targets.subpkgdir}}/opt/bitnami/common/bin"
           ln -s /usr/bin/yq "${{targets.subpkgdir}}/opt/bitnami/common/bin/yq"
+    test:
+      pipeline:
+        - name: Check kubectl bitnami compat symlink
+          runs: |
+            readlink -f /opt/bitnami/kubectl/bin/kubectl | grep "/usr/bin/kubectl"
+        - name: Check yq bitnami compat symlink
+          runs: |
+            readlink -f /opt/bitnami/common/bin/yq | grep "/usr/bin/yq"
 
   - name: kubectl-${{vars.kubernetes-version}}-iamguarded-compat
     description: "compat package with iamguarded/kubectl image"
@@ -121,6 +138,14 @@ subpackages:
           ln -s /usr/bin/kubectl "${{targets.subpkgdir}}/opt/iamguarded/kubectl/bin/kubectl"
           mkdir -p "${{targets.subpkgdir}}/opt/iamguarded/common/bin"
           ln -s /usr/bin/yq "${{targets.subpkgdir}}/opt/iamguarded/common/bin/yq"
+    test:
+      pipeline:
+        - name: Check kubectl iamguarded compat symlink
+          runs: |
+            readlink -f /opt/iamguarded/kubectl/bin/kubectl | grep "/usr/bin/kubectl"
+        - name: Check yq iamguarded compat symlink
+          runs: |
+            readlink -f /opt/iamguarded/common/bin/yq | grep "/usr/bin/yq"
 
   - name: kubeadm-${{vars.kubernetes-version}}
     description: A tool for quickly installing Kubernetes and setting up a secure cluster
@@ -138,6 +163,14 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
+    test:
+      pipeline:
+        - name: Check kubeadm binary
+          runs: |
+            /usr/bin/kubeadm-${{vars.kubernetes-version}} --version
+        - name: Check kubeadm completion file
+          runs: |
+            stat /usr/share/bash-completion/completions/kubeadm
 
   - name: kubelet-${{vars.kubernetes-version}}
     description: An agent that runs on each node in a Kubernetes cluster making sure that containers are running in a Pod
@@ -151,6 +184,15 @@ subpackages:
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
+    test:
+      pipeline:
+        - name: Check kubelet binary
+          runs: |
+            /usr/bin/kubelet-${{vars.kubernetes-version}} --version
+        - name: Check kubelet directories
+          runs: |
+            stat /var/lib/kubelet
+            stat -d /var/log/kubelet
 
   - name: kube-scheduler-${{vars.kubernetes-version}}
     description: Kubernetes control plane component watching over pods on nodes
@@ -160,6 +202,14 @@ subpackages:
           install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-${{vars.kubernetes-version}}
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
+    test:
+      pipeline:
+        - name: Check kube-scheduler binary
+          runs: |
+            /usr/bin/kube-scheduler-${{vars.kubernetes-version}} --version
+        - name: Check kube-scheduler log directory
+          runs: |
+            stat /var/log/kube-scheduler
 
   - name: kube-proxy-${{vars.kubernetes-version}}
     description: Kubernetes network proxy that runs on each node
@@ -177,6 +227,15 @@ subpackages:
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
+    test:
+      pipeline:
+        - name: Check kube-proxy binary
+          runs: |
+            /usr/bin/kube-proxy-${{vars.kubernetes-version}} --version
+        - name: Check kube-proxy directories
+          runs: |
+            stat /var/lib/kube-proxy
+            stat /var/log/kube-proxy
 
   - name: kube-controller-manager-${{vars.kubernetes-version}}
     description: Kubernetes control plane component that runs controller processes
@@ -186,6 +245,14 @@ subpackages:
           install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-${{vars.kubernetes-version}}
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
+    test:
+      pipeline:
+        - name: Check kube-controller-manager binary
+          runs: |
+            /usr/bin/kube-controller-manager-${{vars.kubernetes-version}} --version
+        - name: Check kube-controller-manager log directory
+          runs: |
+            stat /var/log/kube-controller-manager
 
   - name: kube-apiserver-${{vars.kubernetes-version}}
     description: Kubernetes control plane component exposing the Kubernetes API
@@ -195,6 +262,14 @@ subpackages:
           install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-${{vars.kubernetes-version}}
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
+    test:
+      pipeline:
+        - name: Check kube-apiserver binary
+          runs: |
+            /usr/bin/kube-apiserver-${{vars.kubernetes-version}} --version
+        - name: Check kube-apiserver log directory
+          runs: |
+            stat /var/log/kube-apiserver
 
   - name: kubernetes-pause-${{vars.kubernetes-version}}
     dependencies:
@@ -217,6 +292,11 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/
           ln -sf /usr/bin/pause ${{targets.subpkgdir}}/pause
+    test:
+      pipeline:
+        - name: Check pause compat symlink
+          runs: |
+            readlink -f /pause | grep "/usr/bin/pause"
 
   - range: components
     name: "${{range.key}}-${{vars.kubernetes-version}}-default"
@@ -284,7 +364,13 @@ test:
         - jq
         - libcap-utils
         - openssl
+        - iproute2
+        - socat
+        - conntrack-tools
+        - iptables
+        - crictl
   pipeline:
+    - uses: test/kwok/cluster
     - name: Binary version checks
       runs: |
         kube-apiserver --version
@@ -396,3 +482,128 @@ test:
         kubectl get secret test-secret -o json | jq -e '.data.password=="c2VjcmV0"'
         kubectl create configmap test-config --from-literal=key=value
         kubectl get configmap test-config -o json | jq -e '.data.key=="value"'
+
+        # --- Functional Test: kube-controller-manager ---
+        kube-controller-manager \
+          --kubeconfig=~/.kube/config \
+          --cluster-signing-cert-file=/tmp/ca.crt \
+          --cluster-signing-key-file=/tmp/ca.key \
+          --leader-elect=false \
+          --service-account-private-key-file=/tmp/apiserver.key \
+          --root-ca-file=/tmp/ca.crt \
+          --controllers=* \
+          --use-service-account-credentials=true \
+          --authentication-kubeconfig=/tmp/kubeconfig \
+          --authorization-kubeconfig=/tmp/kubeconfig \
+          --secure-port=0 > /tmp/controller-manager.log 2>&1 &
+        CONTROLLER_PID=$!
+        sleep 5 # Give it time to start and try to connect
+
+        if ! kill -0 $CONTROLLER_PID 2>/dev/null; then
+          echo "Controller Manager failed to start:"
+          cat /tmp/controller-manager.log
+          kill $API_PID $ETCD_PID
+          exit 1
+        fi
+        echo "Controller Manager started successfully."
+
+        # --- Functional Test: kube-scheduler ---
+        kube-scheduler \
+          --kubeconfig=~/.kube/config \
+          --leader-elect=false \
+          --authentication-kubeconfig=/tmp/kubeconfig \
+          --authorization-kubeconfig=/tmp/kubeconfig \
+          --secure-port=0 > /tmp/scheduler.log 2>&1 &
+        SCHEDULER_PID=$!
+        sleep 5 # Give it time to start and try to connect
+
+        if ! kill -0 $SCHEDULER_PID 2>/dev/null; then
+          echo "Scheduler failed to start:"
+          cat /tmp/scheduler.log
+          kill $API_PID $ETCD_PID $CONTROLLER_PID
+          exit 1
+        fi
+        echo "Scheduler started successfully."
+
+        # --- Functional Test: kube-proxy ---
+        kube-proxy \
+          --kubeconfig=~/.kube/config \
+          --cluster-cidr=10.0.0.0/24 \
+          --proxy-mode=userspace \
+          --hostname-override=test-node \
+          --v=2 > /tmp/proxy.log 2>&1 &
+        PROXY_PID=$!
+        sleep 5 # Give it time to start
+
+        if ! kill -0 $PROXY_PID 2>/dev/null; then
+          echo "Kube-proxy failed to start:"
+          cat /tmp/proxy.log
+          kill $API_PID $ETCD_PID $CONTROLLER_PID $SCHEDULER_PID
+          exit 1
+        fi
+        echo "Kube-proxy started successfully."
+
+        # --- Functional Test: kubelet (most challenging for full test) ---
+        # Kubelet needs a container runtime. We'll run it with a minimal config
+        # and expect it to complain about the missing runtime, but not crash immediately.
+        # This confirms parsing and initial execution.
+        mkdir -p /tmp/kubelet-data /tmp/kubelet-config
+        cat > /tmp/kubelet-config/config.yaml <<EOF
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        authentication:
+          anonymous:
+            enabled: true
+          webhook:
+            enabled: false
+          x509:
+            clientCAFile: /tmp/ca.crt
+        authorization:
+          mode: AlwaysAllow
+        clusterDNS:
+        - 10.0.0.10
+        clusterDomain: cluster.local
+        containerRuntimeEndpoint: unix:///var/run/cri-mock.sock # Mock or non-existent endpoint
+        cgroupDriver: cgroupfs
+        eventRecordQPS: 0
+        healthzPort: 10248
+        kubeconfig: /tmp/kubeconfig
+        readOnlyPort: 0
+        rotateCertificates: false
+        staticPodPath: /tmp/kubelet-data/static-pods
+        streamingConnectionIdleTimeout: 4h0m0s
+        syncFrequency: 1m0s
+        volumePluginDir: /tmp/kubelet-data/plugins
+        EOF
+
+        kubelet \
+          --config=/tmp/kubelet-config/config.yaml \
+          --kubeconfig=~/.kube/config \
+          --hostname-override=test-node \
+          --pod-infra-container-image=registry.k8s.io/pause:3.9 \
+          --root-dir=/tmp/kubelet-data \
+          --container-runtime=remote \
+          --container-runtime-endpoint=unix:///var/run/cri-mock.sock \
+          --logtostderr=true \
+          --v=2 > /tmp/kubelet.log 2>&1 &
+        KUBELET_PID=$!
+        sleep 5 # Give it time to start and try to connect to CRI/API
+
+        if ! kill -0 $KUBELET_PID 2>/dev/null; then
+          echo "Kubelet failed to start:"
+          cat /tmp/kubelet.log
+          kill $API_PID $ETCD_PID $CONTROLLER_PID $SCHEDULER_PID $PROXY_PID
+          exit 1
+        fi
+        echo "Kubelet started successfully (likely complaining about missing CRI, which is expected)."
+
+        # --- Functional Test: kubeadm (very basic, non-intrusive checks) ---
+        kubeadm init phase upload-certs --dry-run > /tmp/kubeadm.log 2>&1
+        if [ $? -ne 0 ]; then
+          echo "Kubeadm init phase upload-certs dry-run failed."
+          cat /tmp/kubeadm.log
+          kill $API_PID $ETCD_PID $CONTROLLER_PID $SCHEDULER_PID $PROXY_PID $KUBELET_PID
+          exit 1
+        fi
+        grep -q "dry-run mode, will not make any actual changes" /tmp/kubeadm.log
+        echo "Kubeadm dry-run command executed successfully."

--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.33
   version: "1.33.1"
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -84,7 +84,7 @@ subpackages:
       # Refer to main test pipeline for more tests.
       pipeline:
         - runs: |
-            /usr/bin/kubectl-${{vars.kubernetes-version}} --version
+            /usr/bin/kubectl-${{vars.kubernetes-version}} --help
 
   - name: kubectl-bash-completion-${{vars.kubernetes-version}}
     dependencies:
@@ -485,7 +485,7 @@ test:
 
         # --- Functional Test: kube-controller-manager ---
         kube-controller-manager \
-          --kubeconfig=~/.kube/config \
+          --kubeconfig=/root/.kube/config \
           --cluster-signing-cert-file=/tmp/ca.crt \
           --cluster-signing-key-file=/tmp/ca.key \
           --leader-elect=false \
@@ -509,7 +509,7 @@ test:
 
         # --- Functional Test: kube-scheduler ---
         kube-scheduler \
-          --kubeconfig=~/.kube/config \
+          --kubeconfig=/root/.kube/config \
           --leader-elect=false \
           --authentication-kubeconfig=/tmp/kubeconfig \
           --authorization-kubeconfig=/tmp/kubeconfig \
@@ -527,9 +527,9 @@ test:
 
         # --- Functional Test: kube-proxy ---
         kube-proxy \
-          --kubeconfig=~/.kube/config \
+          --kubeconfig=/root/.kube/config \
           --cluster-cidr=10.0.0.0/24 \
-          --proxy-mode=userspace \
+          --proxy-mode=iptables \
           --hostname-override=test-node \
           --v=2 > /tmp/proxy.log 2>&1 &
         PROXY_PID=$!
@@ -542,68 +542,3 @@ test:
           exit 1
         fi
         echo "Kube-proxy started successfully."
-
-        # --- Functional Test: kubelet (most challenging for full test) ---
-        # Kubelet needs a container runtime. We'll run it with a minimal config
-        # and expect it to complain about the missing runtime, but not crash immediately.
-        # This confirms parsing and initial execution.
-        mkdir -p /tmp/kubelet-data /tmp/kubelet-config
-        cat > /tmp/kubelet-config/config.yaml <<EOF
-        apiVersion: kubelet.config.k8s.io/v1beta1
-        kind: KubeletConfiguration
-        authentication:
-          anonymous:
-            enabled: true
-          webhook:
-            enabled: false
-          x509:
-            clientCAFile: /tmp/ca.crt
-        authorization:
-          mode: AlwaysAllow
-        clusterDNS:
-        - 10.0.0.10
-        clusterDomain: cluster.local
-        containerRuntimeEndpoint: unix:///var/run/cri-mock.sock # Mock or non-existent endpoint
-        cgroupDriver: cgroupfs
-        eventRecordQPS: 0
-        healthzPort: 10248
-        kubeconfig: /tmp/kubeconfig
-        readOnlyPort: 0
-        rotateCertificates: false
-        staticPodPath: /tmp/kubelet-data/static-pods
-        streamingConnectionIdleTimeout: 4h0m0s
-        syncFrequency: 1m0s
-        volumePluginDir: /tmp/kubelet-data/plugins
-        EOF
-
-        kubelet \
-          --config=/tmp/kubelet-config/config.yaml \
-          --kubeconfig=~/.kube/config \
-          --hostname-override=test-node \
-          --pod-infra-container-image=registry.k8s.io/pause:3.9 \
-          --root-dir=/tmp/kubelet-data \
-          --container-runtime=remote \
-          --container-runtime-endpoint=unix:///var/run/cri-mock.sock \
-          --logtostderr=true \
-          --v=2 > /tmp/kubelet.log 2>&1 &
-        KUBELET_PID=$!
-        sleep 5 # Give it time to start and try to connect to CRI/API
-
-        if ! kill -0 $KUBELET_PID 2>/dev/null; then
-          echo "Kubelet failed to start:"
-          cat /tmp/kubelet.log
-          kill $API_PID $ETCD_PID $CONTROLLER_PID $SCHEDULER_PID $PROXY_PID
-          exit 1
-        fi
-        echo "Kubelet started successfully (likely complaining about missing CRI, which is expected)."
-
-        # --- Functional Test: kubeadm (very basic, non-intrusive checks) ---
-        kubeadm init phase upload-certs --dry-run > /tmp/kubeadm.log 2>&1
-        if [ $? -ne 0 ]; then
-          echo "Kubeadm init phase upload-certs dry-run failed."
-          cat /tmp/kubeadm.log
-          kill $API_PID $ETCD_PID $CONTROLLER_PID $SCHEDULER_PID $PROXY_PID $KUBELET_PID
-          exit 1
-        fi
-        grep -q "dry-run mode, will not make any actual changes" /tmp/kubeadm.log
-        echo "Kubeadm dry-run command executed successfully."


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
