### PR TITLE
feat(bind.yaml): add emptypackage test to bind

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,4 @@ repos:
     hooks:
       - id: yam
         files: ^[^/]+\.yaml$
+        language_version: "go1.23"

--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -39,3 +39,8 @@ subpackages:
 update:
   release-monitor:
     identifier: 142
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage

--- a/bind.yaml
+++ b/bind.yaml
@@ -260,3 +260,8 @@ update:
     - ^\d+\.\d*[13579]\.\d+$
   git:
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( bind.yaml): add emptypackage test to bind\n\nBased on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)