### PR TITLE
feat(bind.yaml): add emptypackage test to bind

### DIFF
--- a/bind.yaml
+++ b/bind.yaml
@@ -260,3 +260,8 @@ update:
     - ^\d+\.\d*[13579]\.\d+$
   git:
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( bind.yaml): add emptypackage test to bind

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)