### PR TITLE
feat(Catch2.yaml): add emptypackage test to Catch2

### DIFF
--- a/Catch2.yaml
+++ b/Catch2.yaml
@@ -1,7 +1,7 @@
 package:
   name: Catch2
   version: "3.8.1"
-  epoch: 0
+  epoch: 1
   description: "A modern, C++-native, test framework"
   copyright:
     - license: 'BSL-1.0'
@@ -46,3 +46,8 @@ update:
   github:
     identifier: catchorg/Catch2
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( Catch2.yaml): add emptypackage test to Catch2

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)