### PR TITLE
fix: :percona-server-mongodb-operator: add missing runtime deps

### DIFF
--- a/percona-server-mongodb-operator.yaml
+++ b/percona-server-mongodb-operator.yaml
@@ -1,10 +1,14 @@
 package:
   name: percona-server-mongodb-operator
   version: "1.20.0"
-  epoch: 0
+  epoch: 1
   description: Kubernetes Operator which deploys and manages Percona Server for MongoDB on Kubernetes clusters.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash-binsh
+      - coreutils
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
- adds missing runtime dependencies
  - `coreutils`
  - `bash-binsh` 
