### PR TITLE
feat(autoconf-archive.yaml): add emptypackage test to autoconf-archive

### DIFF
--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -2,7 +2,7 @@
 package:
   name: autoconf-archive
   version: 2023.02.20
-  epoch: 0
+  epoch: 1
   description: Collection of re-usable GNU Autoconf macros
   copyright:
     - license: GPL-3.0-or-later
@@ -39,3 +39,8 @@ subpackages:
 update:
   release-monitor:
     identifier: 142
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( autoconf-archive.yaml): add emptypackage test to autoconf-archive

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)