### PR TITLE
feat(cargo-auditable.yaml): add emptypackage test to cargo-auditable

### DIFF
--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-auditable
   version: "0.6.7"
-  epoch: 0
+  epoch: 1
   description: Cargo wrapper for embedding auditing data
   copyright:
     - license: MIT OR Apache-2.0
@@ -59,3 +59,8 @@ update:
     identifier: rust-secure-code/cargo-auditable
     use-tag: true
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( cargo-auditable.yaml): add emptypackage test to cargo-auditable

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)