### PR TITLE
feat(certificate-transparency.yaml): add emptypackage test to certificate-transparency

### DIFF
--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: "1.3.1"
-  epoch: 7
+  epoch: 8
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0
@@ -58,3 +58,8 @@ update:
   github:
     identifier: google/certificate-transparency-go
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( certificate-transparency.yaml): add emptypackage test to certificate-transparency

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)