### PR TITLE
feat(cgal.yaml): add emptypackage test to cgal

### DIFF
--- a/cgal.yaml
+++ b/cgal.yaml
@@ -1,7 +1,7 @@
 package:
   name: cgal
   version: 6.0.1
-  epoch: 0
+  epoch: 1
   description: Efficient and reliable geometric algorithms as C++ library
   copyright:
     - license: GPL-3.0-or-later
@@ -62,3 +62,8 @@ update:
   enabled: true
   git:
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( cgal.yaml): add emptypackage test to cgal

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)