### PR TITLE
feat(cloud-provider-aws-1.31.yaml): add emptypackage test to cloud-provider-aws-1.31

### DIFF
--- a/cloud-provider-aws-1.31.yaml
+++ b/cloud-provider-aws-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-aws-1.31
   version: "1.31.6"
-  epoch: 0
+  epoch: 1
   description: The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs.
   copyright:
     - license: Apache-2.0
@@ -79,3 +79,8 @@ update:
     identifier: kubernetes/cloud-provider-aws
     strip-prefix: v
     tag-filter: v1.31
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( cloud-provider-aws-1.31.yaml): add emptypackage test to cloud-provider-aws-1.31

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)