### PR TITLE
feat(cni-plugins.yaml): add emptypackage test to cni-plugins

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: "1.7.1"
-  epoch: 0
+  epoch: 1
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0
@@ -118,3 +118,8 @@ update:
   github:
     identifier: containernetworking/plugins
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( cni-plugins.yaml): add emptypackage test to cni-plugins

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)