### PR TITLE
feat(confluent-kafka-images.yaml): add emptypackage test to confluent-kafka-images

### DIFF
--- a/confluent-kafka-images.yaml
+++ b/confluent-kafka-images.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-kafka-images
   version: "8.1.0.8"
-  epoch: 0
+  epoch: 1
   description: Provides build files for Apache Kafka and Confluent Docker images
   copyright:
     - license: Apache-2.0
@@ -81,3 +81,8 @@ update:
   git:
     tag-filter-prefix: v
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( confluent-kafka-images.yaml): add emptypackage test to confluent-kafka-images

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)