### PR TITLE
feat(container-entrypoint.yaml): add emptypackage test to container-entrypoint

### DIFF
--- a/container-entrypoint.yaml
+++ b/container-entrypoint.yaml
@@ -1,7 +1,7 @@
 package:
   name: container-entrypoint
   version: 0.1.0
-  epoch: 30
+  epoch: 31
   description: Simple entrypoint script for containers
   copyright:
     - license: Apache-2.0
@@ -31,3 +31,8 @@ update:
   enabled: true
   github:
     identifier: wolfi-dev/container-entrypoint
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( container-entrypoint.yaml): add emptypackage test to container-entrypoint

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)