### PR TITLE
feat(cxxopts.yaml): add emptypackage test to cxxopts

### DIFF
--- a/cxxopts.yaml
+++ b/cxxopts.yaml
@@ -2,7 +2,7 @@
 package:
   name: cxxopts
   version: 3.2.1
-  epoch: 1
+  epoch: 2
   description: Lightweight C++ command line option parser as a header only library
   copyright:
     - license: MIT
@@ -50,3 +50,8 @@ update:
     identifier: jarro2783/cxxopts
     strip-prefix: v
     use-tag: true
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( cxxopts.yaml): add emptypackage test to cxxopts

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)