### PR TITLE
feat(debezium-3.0.yaml): add emptypackage test to debezium-3.0

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0
@@ -222,3 +222,8 @@ update:
     tag-filter: v3.0.
     strip-prefix: v
     strip-suffix: .Final
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( debezium-3.0.yaml): add emptypackage test to debezium-3.0

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)