### PR TITLE
feat(dnssec-root.yaml): add emptypackage test to dnssec-root

### DIFF
--- a/dnssec-root.yaml
+++ b/dnssec-root.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnssec-root
   version: "20190225"
-  epoch: 1
+  epoch: 2
   description: The DNSSEC root key(s)
   copyright:
     - license: CC-PDDC
@@ -35,3 +35,8 @@ pipeline:
 update:
   enabled: true
   manual: true # no releases or tags, commit sha is used, not auto updatable
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( dnssec-root.yaml): add emptypackage test to dnssec-root

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)