### PR TITLE
feat(dstat.yaml): add emptypackage test to dstat

### DIFF
--- a/dstat.yaml
+++ b/dstat.yaml
@@ -1,7 +1,7 @@
 package:
   name: dstat
   version: 0.7.4
-  epoch: 2
+  epoch: 3
   description: A versatile resource statistics tool
   copyright:
     - license: GPL-2.0-only
@@ -48,3 +48,8 @@ update:
   github:
     identifier: dagwieers/dstat
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( dstat.yaml): add emptypackage test to dstat

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)