### PR TITLE
feat(encodings.yaml): add emptypackage test to encodings

### DIFF
--- a/encodings.yaml
+++ b/encodings.yaml
@@ -1,7 +1,7 @@
 package:
   name: encodings
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: X.org font encoding files
   copyright:
     - license: LicenseRef-xorg-font-encoding
@@ -36,3 +36,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 15051
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( encodings.yaml): add emptypackage test to encodings

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)