### PR TITLE
feat(exploitdb.yaml): add emptypackage test to exploitdb

### DIFF
--- a/exploitdb.yaml
+++ b/exploitdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: exploitdb
   version: "2025.05.19"
-  epoch: 0
+  epoch: 1
   description: "the exploit database is an archive of public exploits and corresponding vulnerable software, developed for use by penetration testers and vulnerability researchers"
   copyright:
     - license: GPL-2.0-or-later
@@ -41,3 +41,8 @@ update:
   version-separator: "-"
   enabled: true
   git: {}
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( exploitdb.yaml): add emptypackage test to exploitdb

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)