### PR TITLE
feat(faiss.yaml): add emptypackage test to faiss

### DIFF
--- a/faiss.yaml
+++ b/faiss.yaml
@@ -1,7 +1,7 @@
 package:
   name: faiss
   version: "1.11.0"
-  epoch: 0
+  epoch: 1
   description: A library for efficient similarity search and clustering of dense vectors.
   copyright:
     - license: MIT
@@ -51,3 +51,8 @@ update:
     identifier: facebookresearch/faiss
     strip-prefix: v
     tag-filter: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( faiss.yaml): add emptypackage test to faiss

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)