### PR TITLE
feat(falco-libs.yaml): add emptypackage test to falco-libs

### DIFF
--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-libs
   version: "0.21.0"
-  epoch: 0
+  epoch: 1
   description: Foundational components necessary to build Falco
   copyright:
     - license: Apache-2.0
@@ -107,3 +107,8 @@ update:
     - '.*\+driver'
   github:
     identifier: falcosecurity/libs
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( falco-libs.yaml): add emptypackage test to falco-libs

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)