### PR TITLE
feat(falco-rules.yaml): add emptypackage test to falco-rules

### DIFF
--- a/falco-rules.yaml
+++ b/falco-rules.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-rules
   version: 3.2.0
-  epoch: 0
+  epoch: 1
   description: Falco rule repository
   copyright:
     - license: Apache-2.0
@@ -35,3 +35,8 @@ update:
   github:
     identifier: falcosecurity/rules
     strip-prefix: falco-rules-
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( falco-rules.yaml): add emptypackage test to falco-rules

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)