### PR TITLE
feat(fluent-bit-docker-image.yaml): add emptypackage test to fluent-bit-docker-image

### DIFF
--- a/fluent-bit-docker-image.yaml
+++ b/fluent-bit-docker-image.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-bit-docker-image
   version: 20220322
-  epoch: 0
+  epoch: 1
   description: Docker image for Fluent Bit
   copyright:
     - license: Apache-2.0
@@ -28,3 +28,8 @@ pipeline:
 update:
   enabled: false
   exclude-reason: this repository is no longer maintained
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( fluent-bit-docker-image.yaml): add emptypackage test to fluent-bit-docker-image

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)