### PR TITLE
feat(flux-kustomize-controller.yaml): add emptypackage test to flux-kustomize-controller

### DIFF
--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: "1.5.1"
-  epoch: 6
+  epoch: 7
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -94,3 +94,8 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( flux-kustomize-controller.yaml): add emptypackage test to flux-kustomize-controller

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)