### PR TITLE
feat(fontsproto.yaml): add emptypackage test to fontsproto

### DIFF
--- a/fontsproto.yaml
+++ b/fontsproto.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontsproto
   version: 2.1.3
-  epoch: 2
+  epoch: 3
   description: X.org fontsproto
   copyright:
     - license: MIT-open-group
@@ -42,3 +42,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 13472
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( fontsproto.yaml): add emptypackage test to fontsproto

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)