### PR TITLE
feat(font-xproto.yaml): add emptypackage test to font-xproto

### DIFF
--- a/font-xproto.yaml
+++ b/font-xproto.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-xproto
   version: 7.0.31
-  epoch: 2
+  epoch: 3
   description: X.org font xproto
   copyright:
     - license: MIT
@@ -39,3 +39,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 13650
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( font-xproto.yaml): add emptypackage test to font-xproto

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)