### PR TITLE
feat(fuse-overlayfs-snapshotter.yaml): add emptypackage test to fuse-overlayfs-snapshotter

### DIFF
--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: "2.1.6"
-  epoch: 0
+  epoch: 1
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0
@@ -38,3 +38,8 @@ update:
   github:
     identifier: containerd/fuse-overlayfs-snapshotter
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( fuse-overlayfs-snapshotter.yaml): add emptypackage test to fuse-overlayfs-snapshotter

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)