### PR TITLE
feat(gdal.yaml): add emptypackage test to gdal

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.0"
-  epoch: 1
+  epoch: 2
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -233,3 +233,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 881
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( gdal.yaml): add emptypackage test to gdal

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)