### PR TITLE
feat(gi-docgen.yaml): add emptypackage test to gi-docgen

### DIFF
--- a/gi-docgen.yaml
+++ b/gi-docgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: gi-docgen
   version: "2025.3"
-  epoch: 0
+  epoch: 1
   description: A documentation generator for GObject-based libraries
   copyright:
     - license: Apache-2.0 OR GPL-3.0-or-later
@@ -115,3 +115,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 178582
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( gi-docgen.yaml): add emptypackage test to gi-docgen

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)