### PR TITLE
feat(gitsign.yaml): add emptypackage test to gitsign

### DIFF
--- a/gitsign.yaml
+++ b/gitsign.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitsign
   version: "0.13.0"
-  epoch: 1
+  epoch: 2
   description: Keyless Git signing with Sigstore!
   copyright:
     - license: Apache-2.0
@@ -61,3 +61,8 @@ update:
   github:
     identifier: sigstore/gitsign
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( gitsign.yaml): add emptypackage test to gitsign

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)