### PR TITLE
feat(glew.yaml): add emptypackage test to glew

### DIFF
--- a/glew.yaml
+++ b/glew.yaml
@@ -1,7 +1,7 @@
 package:
   name: glew
   version: 2.2.0
-  epoch: 3
+  epoch: 4
   description: "A cross-platform C/C++ extension loading library"
   copyright:
     - license: GPL-2.0-or-later
@@ -66,3 +66,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 7878
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( glew.yaml): add emptypackage test to glew

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)