### PR TITLE
feat(go-tools.yaml): add emptypackage test to go-tools

### DIFF
--- a/go-tools.yaml
+++ b/go-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-tools
   version: "0.33.0"
-  epoch: 0
+  epoch: 1
   description: Virtual package to install Go tools from golang.org/x/tools.
   copyright:
     - license: BSD-3-Clause
@@ -64,3 +64,8 @@ subpackages:
               echo $output
               exit 1
             fi
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( go-tools.yaml): add emptypackage test to go-tools

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)