### PR TITLE
chore(docs/fonts): Allow specifying prefix

### DIFF
--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -8,7 +8,7 @@ needs:
     - texinfo
 
 inputs:
-  prefix:
+  path-prefix:
     description: "Prefix used for documentation."
     default: "usr/share"
 
@@ -32,7 +32,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/man/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.path-prefix}}/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -42,16 +42,16 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/info/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.path-prefix}}/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.path-prefix}}/"); do
         if [ -f /"$doc_file" ]; then
-          # Check that we have readable files installed in /${{inputs.prefix}}
+          # Check that we have readable files installed in /${{inputs.path-prefix}}
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
           cat /"$doc_file" >/dev/null
           doc_files=true

--- a/pipelines/test/docs.yaml
+++ b/pipelines/test/docs.yaml
@@ -7,6 +7,11 @@ needs:
     - man-db
     - texinfo
 
+inputs:
+  prefix:
+    description: "Prefix used for documentation."
+    default: "usr/share"
+
 pipeline:
   - name: docs readability check
     runs: |
@@ -27,7 +32,7 @@ pipeline:
       cd /
       doc_files=false
       # Test man pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/man/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/man/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that man can read and render
           # NOTE: man will dutifully, print any text file, not just troff manpages (e.g. html or plain text too)
@@ -37,16 +42,16 @@ pipeline:
         fi
       done
       # Test info pages
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/info/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/info/"); do
         if [ -f /"$doc_file" ]; then
           # Ensure that info can read at least one file that looks like an info page
           [ $(info -f /"$doc_file" -o - | wc -l) -gt 0 ] && doc_files=true
         fi
       done
       # Test any other text files
-      for doc_file in $(apk info -qL "$doc_pkg" | grep "^usr/share/"); do
+      for doc_file in $(apk info -qL "$doc_pkg" | grep "^${{inputs.prefix}}/"); do
         if [ -f /"$doc_file" ]; then
-          # Check that we have readable files installed in /usr/share
+          # Check that we have readable files installed in /${{inputs.prefix}}
           # There are too many types to test explicitly (text, html, pdf, images, etc.)
           cat /"$doc_file" >/dev/null
           doc_files=true

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -19,7 +19,7 @@ pipeline:
       cd /
       font_files=false
       # Test font files
-      for font_file in $(apk info -L "$font_pkg" | grep "^${{inputs.path-prefix}}/fonts/"); do
+      for font_file in $(apk info -qL "$font_pkg" | grep "^${{inputs.path-prefix}}/fonts/"); do
         if [ -f /"$font_file" ]; then
           case /"$font_file" in
             *.alias|*.dir)
@@ -45,7 +45,7 @@ pipeline:
       # Make sure this isn't an empty package
       if [ "$font_files" = "false" ] || [ $(apk info -L "$font_pkg" | wc -l) -le 3 ]; then
         echo "See:"
-        apk info -L "$font_pkg"
+        apk info -qL "$font_pkg"
         echo "This package [$font_pkg] is completely empty (i.e. installs no files)."
         echo "Please check the package build for proper fonts installation, and either:"
         echo "  (a) fix the package build to actually include some fonts, or"

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -6,7 +6,7 @@ needs:
     - py3-fonttools
 
 inputs:
-  prefix:
+  path-prefix:
     description: "Prefix used for fonts."
     default: "usr/share"
 
@@ -19,7 +19,7 @@ pipeline:
       cd /
       font_files=false
       # Test font files
-      for font_file in $(apk info -L "$font_pkg" | grep "^${{inputs.prefix}}/fonts/"); do
+      for font_file in $(apk info -L "$font_pkg" | grep "^${{inputs.path-prefix}}/fonts/"); do
         if [ -f /"$font_file" ]; then
           case /"$font_file" in
             *.alias|*.dir)

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -5,6 +5,11 @@ needs:
     - file
     - py3-fonttools
 
+inputs:
+  prefix:
+    description: "Prefix used for fonts."
+    default: "usr/share"
+
 pipeline:
   - name: font usability test
     runs: |
@@ -14,7 +19,7 @@ pipeline:
       cd /
       font_files=false
       # Test font files
-      for font_file in $(apk info -L "$font_pkg" | grep "^usr/share/fonts/"); do
+      for font_file in $(apk info -L "$font_pkg" | grep "^${{inputs.prefix}}/fonts/"); do
         if [ -f /"$font_file" ]; then
           case /"$font_file" in
             *.alias|*.dir)


### PR DESCRIPTION
It may be intentional for documentation and fonts to exist within a private prefix
