### PR TITLE
cyrus-sasl: disable insecure NTLM support

### DIFF
--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 40
+  epoch: 41
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -68,7 +68,7 @@ pipeline:
         --enable-cram \
         --enable-digest \
         --enable-httpform \
-        --enable-ntlm \
+        --disable-ntlm \
         --enable-plain \
         --enable-login \
         --enable-auth-sasldb \


### PR DESCRIPTION
NTLM support has been deprecated in 2023 and removed from all
supported operating systems by Microsoft in 2024.

In 2024, Chainguard removed NTLM support from curl and wget.

Remove insecure NTLM support from cyrus-saml as well. It has also been
removed from cyrus-sasl project mainline in 2023.

References:
- https://github.com/cyrusimap/cyrus-sasl/commit/60f2b06ca13f8f1390a11139083104e5a52e1ab0
- https://aka.ms/ntlm
- https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features

Everyone who was previously using NTLM must upgrade to Kerberos
authentication.
