### PR TITLE
build remaining components of crossplane-provider-aws family

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -95,7 +95,7 @@ data:
       # config: provider-aws-config (Removed from upbound)
       configservice: provider-aws-configservice
       cur: provider-aws-cur
-      datadog: provider-datadog
+      # datadog: provider-aws-datadog (Removed from upbound)
       datasync: provider-aws-datasync
       devicefarm: provider-aws-devicefarm
       detective: provider-aws-detective
@@ -135,7 +135,7 @@ data:
       # managedgrafana: provider-aws-managedgrafana (Removed from upbound)
       mediaconvert: provider-aws-mediaconvert
       mediastore: provider-aws-mediastore
-      mysql: provider-upjet-mysql
+      # mysql: provider-aws-mysql (Removed from upbound)
       opensearch: provider-aws-opensearch
       opsworks: provider-aws-opsworks
       organizations: provider-aws-organizations

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -113,7 +113,7 @@ data:
       elasticsearch: provider-aws-elasticsearch
       emr: provider-aws-emr
       emrserverless: provider-aws-emrserverless
-      events: provider-aws-events
+      # events: provider-aws-events (Removed from upbound)
       firehose: provider-aws-firehose
       fsx: provider-aws-fsx
       globalaccelerator: provider-aws-globalaccelerator

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -95,7 +95,7 @@ data:
       # config: provider-aws-config (Removed from upbound)
       configservice: provider-aws-configservice
       cur: provider-aws-cur
-      datadog: provider-aws-datadog
+      # datadog: provider-aws-datadog (Removed from upbound)
       datasync: provider-aws-datasync
       devicefarm: provider-aws-devicefarm
       detective: provider-aws-detective

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: "1.22.0"
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -130,7 +130,7 @@ data:
       lambda: provider-aws-lambda
       lightsail: provider-aws-lightsail
       location: provider-aws-location
-      logs: provider-aws-logs
+      # logs: provider-aws-logs (Removed from upbound)
       macie2: provider-aws-macie2
       managedgrafana: provider-aws-managedgrafana
       mediaconvert: provider-aws-mediaconvert

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -62,19 +62,97 @@ data:
     items:
       family: provider-family-aws
       # List from: https://github.com/gitops-bridge-dev/gitops-bridge-argocd-control-plane-template/blob/main/charts/addons/crossplane/resources/values.yaml
-      cloudfront: provider-aws-cloudfront
-      cloudwatchlogs: provider-aws-cloudwatchlogs
+      accessanalyzer: provider-aws-accessanalyzer
+      acm: provider-aws-acm
+      apigateway: provider-aws-apigateway
+      apigatewayv2: provider-aws-apigatewayv2
+      appautoscaling: provider-aws-appautoscaling
+      appconfig: provider-aws-appconfig
+      appflow: provider-aws-appflow
+      applicationinsights: provider-aws-applicationinsights
+      appmesh: provider-aws-appmesh
+      apprunner: provider-aws-apprunner
+      appstream: provider-aws-appstream
+      appsync: provider-aws-appsync
+      athena: provider-aws-athena
+      autoscaling: provider-aws-autoscaling
+      autoscalingplans: provider-aws-autoscalingplans
+      backup: provider-aws-backup
+      batch: provider-aws-batch
+      bedrock: provider-aws-bedrock
+      budgets: provider-aws-budgets
+      ce: provider-aws-ce
+      chime: provider-aws-chime
+      cloud9: provider-aws-cloud9
+      cloudcontrol: provider-aws-cloudcontrol
+      codeartifact: provider-aws-codeartifact
+      codecommit: provider-aws-codecommit
+      codeguruprofiler: provider-aws-codeguruprofiler
+      codepipeline: provider-aws-codepipeline
+      codestarconnections: provider-aws-codestarconnections
+      codestarnotifications: provider-aws-codestarnotifications
+      cognitoidentity: provider-aws-cognitoidentity
+      cognitoidp: provider-aws-cognitoidp
+      config: provider-aws-config
+      configservice: provider-aws-configservice
+      cur: provider-aws-cur
+      datadog: provider-aws-datadog
+      datasync: provider-aws-datasync
+      devicefarm: provider-aws-devicefarm
+      detective: provider-aws-detective
+      dlm: provider-aws-dlm
+      dms: provider-aws-dms
+      directconnect: provider-aws-directconnect
+      docdb: provider-aws-docdb
       dynamodb: provider-aws-dynamodb
+      ecr: provider-aws-ecr
+      ecrpublic: provider-aws-ecrpublic
       ec2: provider-aws-ec2
       eks: provider-aws-eks
+      elasticache: provider-aws-elasticache
+      elasticbeanstalk: provider-aws-elasticbeanstalk
+      elasticsearch: provider-aws-elasticsearch
+      emr: provider-aws-emr
+      emrserverless: provider-aws-emrserverless
+      events: provider-aws-events
       firehose: provider-aws-firehose
+      fsx: provider-aws-fsx
+      globalaccelerator: provider-aws-globalaccelerator
+      glue: provider-aws-glue
+      guardduty: provider-aws-guardduty
       iam: provider-aws-iam
+      inspector: provider-aws-inspector
+      inspector2: provider-aws-inspector2
+      iot: provider-aws-iot
+      ivs: provider-aws-ivs
+      kafka: provider-aws-kafka
+      kinesis: provider-aws-kinesis
       kms: provider-aws-kms
       lambda: provider-aws-lambda
+      lightsail: provider-aws-lightsail
+      location: provider-aws-location
+      logs: provider-aws-logs
+      macie2: provider-aws-macie2
+      managedgrafana: provider-aws-managedgrafana
+      mediaconvert: provider-aws-mediaconvert
+      mediastore: provider-aws-mediastore
+      mysql: provider-aws-mysql
+      opensearch: provider-aws-opensearch
+      opsworks: provider-aws-opsworks
+      organizations: provider-aws-organizations
+      pinpoint: provider-aws-pinpoint
       rds: provider-aws-rds
+      redshift: provider-aws-redshift
       s3: provider-aws-s3
+      sagemaker: provider-aws-sagemaker
       sns: provider-aws-sns
       sqs: provider-aws-sqs
+      stepfunctions: provider-aws-stepfunctions
+      timestreamwrite: provider-aws-timestreamwrite
+      transfer: provider-aws-transfer
+      vpc: provider-aws-vpc
+      waf: provider-aws-waf
+      wafregional: provider-aws-wafregional
 
 subpackages:
   - name: crossplane-provider-aws-${{range.key}}

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -95,7 +95,7 @@ data:
       # config: provider-aws-config (Removed from upbound)
       configservice: provider-aws-configservice
       cur: provider-aws-cur
-      # datadog: provider-aws-datadog (Removed from upbound)
+      datadog: provider-datadog
       datasync: provider-aws-datasync
       devicefarm: provider-aws-devicefarm
       detective: provider-aws-detective
@@ -132,10 +132,10 @@ data:
       location: provider-aws-location
       # logs: provider-aws-logs (Removed from upbound)
       macie2: provider-aws-macie2
-      managedgrafana: provider-aws-managedgrafana
+      # managedgrafana: provider-aws-managedgrafana (Removed from upbound)
       mediaconvert: provider-aws-mediaconvert
       mediastore: provider-aws-mediastore
-      mysql: provider-aws-mysql
+      mysql: provider-upjet-mysql
       opensearch: provider-aws-opensearch
       opsworks: provider-aws-opsworks
       organizations: provider-aws-organizations
@@ -146,7 +146,7 @@ data:
       sagemaker: provider-aws-sagemaker
       sns: provider-aws-sns
       sqs: provider-aws-sqs
-      stepfunctions: provider-aws-stepfunctions
+      # stepfunctions: provider-aws-stepfunctions (Removed from upbound)
       timestreamwrite: provider-aws-timestreamwrite
       transfer: provider-aws-transfer
       vpc: provider-aws-vpc

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -61,7 +61,6 @@ data:
   - name: packages
     items:
       family: provider-family-aws
-      # List from: https://github.com/gitops-bridge-dev/gitops-bridge-argocd-control-plane-template/blob/main/charts/addons/crossplane/resources/values.yaml
       accessanalyzer: provider-aws-accessanalyzer
       acm: provider-aws-acm
       apigateway: provider-aws-apigateway
@@ -93,7 +92,7 @@ data:
       codestarnotifications: provider-aws-codestarnotifications
       cognitoidentity: provider-aws-cognitoidentity
       cognitoidp: provider-aws-cognitoidp
-      config: provider-aws-config
+      # config: provider-aws-config (Removed from upbound)
       configservice: provider-aws-configservice
       cur: provider-aws-cur
       datadog: provider-aws-datadog


### PR DESCRIPTION
Builds all of the crossplane-provider-aws components.
https://github.com/crossplane-contrib/provider-upjet-aws/tree/main/cmd/provider