### PR TITLE
DNM: feat: Staging for the Glasgow Haskell Compiler

### DIFF
--- a/ghc-bootstrap.yaml
+++ b/ghc-bootstrap.yaml
@@ -1,0 +1,43 @@
+package:
+  name: ghc-bootstrap
+  version: 9.6.6
+  epoch: 0
+  description: "Bootstrap for the Glasgow Haskell Compiler."
+  copyright:
+    - license: BSD-3-Clause
+  options:
+    no-depends: true
+    no-provides: true
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - dpkg # Extracts deb to installdir
+      - gmp # Needed to build cache
+      - libffi # Needed to build cache
+      - numactl # Needed to build cache
+
+pipeline:
+  - if: ${{build.goarch}} == "amd64"
+    uses: fetch
+    with:
+      uri: http://ftp.debian.org/debian/pool/main/g/ghc/ghc_${{package.version}}-4_${{build.goarch}}.deb
+      expected-sha256: 6f47c85fdb72a1b8e7b654592e5014dbfb2b32915893704fa3bf1a1c7cac56c4
+      extract: false
+
+  - if: ${{build.goarch}} == "arm64"
+    uses: fetch
+    with:
+      uri: http://ftp.debian.org/debian/pool/main/g/ghc/ghc_${{package.version}}-4_${{build.goarch}}.deb
+      expected-sha256: 6f47c85fdb72a1b8e7b654592e5014dbfb2b32915893704fa3bf1a1c7cac56c4
+      extract: false
+
+  - runs: |
+      # Extract GHC
+      mkdir -p ${{targets.contextdir}}
+      dpkg -x ghc_${{package.version}}-4_${{build.goarch}}.deb ${{targets.contextdir}}
+
+update:
+  enabled: false
+  exclude-reason: This is bootstrap and should not be updated

--- a/ghc-stage0.yaml
+++ b/ghc-stage0.yaml
@@ -1,0 +1,53 @@
+package:
+  name: ghc-stage0
+  version: 9.12.2
+  epoch: 0
+  description: "Stage 0 for the Glasgow Haskell Compiler."
+  copyright:
+    - license: BSD-3-Clause
+  options:
+    no-provides: true
+  dependencies:
+    runtime:
+      - gcc
+      - gmp-dev
+      - libbsd-dev
+      - libffi-dev
+      - llvm-${{vars.llvm-version}}
+      - ncurses-dev
+      - numactl-dev
+
+vars:
+  llvm-version: '20'
+
+environment:
+  contents:
+    # Need cabal, happy, and alex
+    packages:
+      - busybox
+      - gcc
+      - ghc-bootstrap
+      - gmp-dev
+      - libbsd-dev
+      - libffi-dev
+      - llvm-${{vars.llvm-version}}
+      - ncurses-dev
+      - numactl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      uri: https://github.com/ghc/ghc.git
+      expected-commit: 383be28ffdddf65b57b7b111bfc89808b4229ebc
+
+  - runs: ghc-pkg recache
+
+update:
+  enabled: false
+  exclude-reason: This is a staged compiler and should not be updated
+  github:
+    identifier: ghc/ghc
+    strip-prefix: ghc-
+    strip-suffix: -release
+    tag-filter-contains: -release
+    tag-filter-prefix: ghc-


### PR DESCRIPTION
This is not ready and may never be ready. Do not merge.

Cleanly bootstrapping GHC is, as far as I can tell, near impossible. Every available release requires GHC. GHC includes features not available in other Haskell compilers, making a bootstrap with those futile without modification of GHC itself. Instead of a clean bootstrap, I've chosen to use the current release of GHC from Debian