### PR TITLE
fix: flacky test for cadvisor

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -67,8 +67,9 @@ test:
     - runs: |
         cadvisor --version
         cadvisor --help
-        nohup cadvisor >/dev/null 2>&1 </dev/null &
-        sleep 5 # wait for cadvisor to start
+        nohup cadvisor > cadvisor.log 2>&1 </dev/null &
+        # wait for cadvisor to start
+        while ! grep -q "Starting cAdvisor" cadvisor.log ; do sleep 1; done
     # Test case 1: Verify cadvisor health check endpoint
     # This test ensures that the cadvisor service is up and running by checking its health endpoint.
     - runs: |


### PR DESCRIPTION
properly wait for the service to be up

this is blocking our presubmits CI