### PR TITLE
py3-cassandra-medusa: remediate cve / update python to 3.12

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.24.0"
-  epoch: 3
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.24.0"
-  epoch: 1
+  epoch: 3
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
       - wolfi-baselayout
 
 vars:
-  py-version: 3.11
+  py-version: 3.12
 
 environment:
   contents:
@@ -39,6 +39,8 @@ pipeline:
       poetry add "cryptography@^44.0.1"
       # GHSA-34jh-p97f-mpxf: urllib3
       poetry add "urllib3@^1.26.19"
+      # GHSA-5rjg-fvgr-3xxf
+      poetry add "setuptools@^78.1.1"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
       POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
       poetry build


### PR DESCRIPTION
Bump setuptools of py3-cassandra-medusa
to 78.1.1 in order to remediate the cve https://github.com/advisories/GHSA-5rjg-fvgr-3xxf.
Update package to use python 3.12 as it is the latest version supported
by py3-cassandra-medusa.