### PR TITLE
fix(etcd-3.6): use version path 3.6 for etcd bitnami compat

### DIFF
--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -85,7 +85,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: etcd
-          version-path: 3.6/debian-12
+          version-path: 3.5/debian-12 # change to 3.6 once it is available
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/etcd/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami

--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -85,7 +85,8 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: etcd
-          version-path: 3.5/debian-12 # change to 3.6 once it is available
+          version-path: 3.6/debian-12
+          commit: ad78516a21b24c81d6a6f766d68951a1e70b6d17
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/etcd/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami

--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -85,7 +85,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: etcd
-          version-path: 3.5/debian-12 # change to 3.6 once it is available
+          version-path: 3.6/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/etcd/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami

--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: etcd-3.6
   version: "3.6.0"
-  epoch: 2
+  epoch: 3
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0

--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -85,8 +85,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: etcd
-          version-path: 3.6/debian-12
-          commit: ad78516a21b24c81d6a6f766d68951a1e70b6d17
+          version-path: ${{vars.major-minor-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/etcd/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami


### PR DESCRIPTION
We are currently using `version-path: 3.5/debian-12` in etcd 3.6 bitnami, which might be causing an image build failure, this PR updates it to 3.6