### PR TITLE
datadog-agent: remediate cve

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.65.2"
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump epoch to pull in the new setuptools dependency in order to remediate GHSA-5rjg-fvgr-3xxf
