### PR TITLE
conman: Add support for journald

### DIFF
--- a/conmon.yaml
+++ b/conmon.yaml
@@ -1,7 +1,7 @@
 package:
   name: conmon
   version: "2.1.13"
-  epoch: 0
+  epoch: 1
   description: OCI container runtime monitor
   copyright:
     - license: Apache-2.0

--- a/conmon.yaml
+++ b/conmon.yaml
@@ -15,6 +15,7 @@ environment:
       - glib-dev
       - go-md2man
       - libseccomp-dev
+      - systemd-dev # adds support for journald if libsystemd is detected by make
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
1. Conmon without support for systemd fails like:

```
[conmon:e] Include journald in compilation path to log to systemd journal
```

2. journald is the default mode for operating of podman:

```

Error: conmon failed: exit status 1

In journald we see:
May 26 12:36:05 localhost conmon[1724]: conmon 89fef2f1d3d7018955ca <error>: Include journald in compilation path to log to systemd journal
```

3. Workaround for this was:
```
podman run --log-driver none [--cgroup-manager=cgroupfs] -it docker.io/library/hello-world:latest
```
but we shouldn't be using workarounds if we don't have to.

4. The only user of conmon is podman that already depends on systemd-dev, so this is not 'exploding' the dependency tree.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
