### PR TITLE
test(ipfs-cluster): dont depend on hardcoded timeout + check logs

### DIFF
--- a/ipfs-cluster.yaml
+++ b/ipfs-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs-cluster
   version: "1.1.4"
-  epoch: 0
+  epoch: 1
   description: Pinset orchestration for IPFS
   copyright:
     - license: Apache-2.0 AND MIT
@@ -74,9 +74,29 @@ test:
     - runs: |
         ipfs init
         ipfs daemon &
-        wait-for-it -t 60 127.0.0.1:5001
+        IPFS_DAEMON_PID=$!
+
+        wait-for-it -t 10 127.0.0.1:5001
         ipfs-cluster-service init --consensus=crdt
-        ipfs-cluster-service daemon &> ipfs-cluster-output.txt &
-        sleep 30
-        ipfs-cluster-ctl peers ls
-        grep "IPFS Cluster is READY" ipfs-cluster-output.txt
+        IPFS_CLUSTER_LOGFILE=$(mktemp)
+        ipfs-cluster-service daemon &> "${IPFS_CLUSTER_LOGFILE}" &
+        IPFS_CLUSTER_PID=$!
+
+        MAX_RETRIES=10
+        RETRY_INTERVAL=1
+        BACKOFF_FACTOR=2
+        retry_count=0
+        while ! grep "IPFS Cluster is READY" $IPFS_CLUSTER_LOGFILE; do
+          if [ $retry_count -ge $MAX_RETRIES ]; then
+            echo "Max retries reached. IPFS Cluster did not start."
+            exit 1
+          fi
+          # Wait before the next retry
+          echo "Failed to find IPFS started logs. Retrying in ${RETRY_INTERVAL}s..."
+          sleep $RETRY_INTERVAL
+          # Increase retry interval (backoff)
+          RETRY_INTERVAL=$((RETRY_INTERVAL * BACKOFF_FACTOR))
+          retry_count=$((retry_count + 1))
+        done
+        kill -9 $IPFS_CLUSTER_PID
+        kill -9 $IPFS_DAEMON_PID


### PR DESCRIPTION
Quality improvement for ipfs-cluster tests so we dont have a hardcoded 30s timeout on it
