### PR TITLE
feat(gitlab-cng-18.0.yaml): add emptypackage test to gitlab-cng-18.0

### DIFF
--- a/gitlab-cng-18.0.yaml
+++ b/gitlab-cng-18.0.yaml
@@ -26,7 +26,7 @@ package:
   name: gitlab-cng-18.0
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "18.0.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -436,3 +436,8 @@ update:
   git:
     strip-prefix: v
     tag-filter-prefix: v18.0
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( gitlab-cng-18.0.yaml): add emptypackage test to gitlab-cng-18.0

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)