### PR TITLE
feat(jitsucom-jitsu.yaml): add emptypackage test to jitsucom-jitsu

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.9.0"
-  epoch: 1
+  epoch: 2
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -106,3 +106,8 @@ update:
   github:
     identifier: jitsucom/jitsu
     strip-prefix: jitsu2-v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( jitsucom-jitsu.yaml): add emptypackage test to jitsucom-jitsu

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)