### PR TITLE
feat(jupyter-docker-stacks.yaml): add emptypackage test to jupyter-docker-stacks

### DIFF
--- a/jupyter-docker-stacks.yaml
+++ b/jupyter-docker-stacks.yaml
@@ -2,7 +2,7 @@
 package:
   name: jupyter-docker-stacks
   version: "0.0.0_git20250526"
-  epoch: 0
+  epoch: 1
   description: Ready-to-run images containing Jupyter applications
   copyright:
     - license: BSD-3-Clause
@@ -67,3 +67,8 @@ update:
   schedule:
     period: weekly
     reason: Upstream does not maintain tags or releases
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( jupyter-docker-stacks.yaml): add emptypackage test to jupyter-docker-stacks

Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)