### PR TITLE
feat(knative-serving-1.17.yaml): add emptypackage test to knative-serving-1.17

### DIFF
--- a/knative-serving-1.17.yaml
+++ b/knative-serving-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-serving-1.17
   version: "1.17.1"
-  epoch: 0
+  epoch: 1
   description: Kubernetes-based, scale-to-zero, request-driven compute
   copyright:
     - license: Apache-2.0
@@ -99,3 +99,8 @@ update:
     identifier: knative/serving
     strip-prefix: knative-v
     tag-filter: knative-v1.17.
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( knative-serving-1.17.yaml): add emptypackage test to knative-serving-1.17

Based on package contents inspection, it was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)