### PR TITLE
feat(kubeflow-pipelines.yaml): add emptypackage test to kubeflow-pipelines

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.5.0"
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -271,3 +271,8 @@ update:
     - 'sdk-'
   github:
     identifier: kubeflow/pipelines
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( kubeflow-pipelines.yaml): add emptypackage test to kubeflow-pipelines

Based on package contents inspection, it was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)