### PR TITLE
feat(kubevela.yaml): add emptypackage test to kubevela

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: "1.10.3"
-  epoch: 4
+  epoch: 5
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0
@@ -89,3 +89,8 @@ update:
   github:
     identifier: kubevela/kubevela
     strip-prefix: v
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat(kubevela.yaml): add emptypackage test to kubevela

Based on package contents inspection, it was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)