### PR TITLE
feat(kuma-2.10.yaml): add emptypackage test to kuma-2.10

### DIFF
--- a/kuma-2.10.yaml
+++ b/kuma-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: kuma-2.10
   version: "2.10.1"
-  epoch: 3
+  epoch: 4
   description: A multi-zone service mesh for containers, Kubernetes and VMs.
   copyright:
     - license: Apache-2.0
@@ -172,3 +172,8 @@ update:
     identifier: kumahq/kuma
     tag-filter: "2.10"
     use-tag: true
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat(kuma-2.10.yaml): add emptypackage test to kuma-2.10

Based on package contents inspection, it was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)