### PR TITLE
feat(linkerd2.yaml): add emptypackage test to linkerd2

### DIFF
--- a/linkerd2.yaml
+++ b/linkerd2.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2
   version: "25.5.4"
-  epoch: 0
+  epoch: 1
   description: "meta linkerd package"
   copyright:
     - license: Apache-2.0
@@ -242,3 +242,8 @@ update:
     identifier: linkerd/linkerd2
     tag-filter: edge-
     strip-prefix: edge-
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( linkerd2.yaml): add emptypackage test to linkerd2

Based on package contents inspection, it was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)