### PR TITLE
feat(nvidia-container-toolkit.yaml): add emptypackage test to nvidia-container-toolkit

### DIFF
--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-container-toolkit
   version: "1.17.7"
-  epoch: 0
+  epoch: 1
   description: Build and run containers leveraging NVIDIA GPUs
   copyright:
     - license: Apache-2.0
@@ -78,3 +78,8 @@ update:
   github:
     identifier: NVIDIA/nvidia-container-toolkit
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( nvidia-container-toolkit.yaml): add emptypackage test to nvidia-container-toolkit

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)