### PR TITLE
feat(py3-auditwheel.yaml): add emptypackage test to py3-auditwheel

### DIFF
--- a/py3-auditwheel.yaml
+++ b/py3-auditwheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-auditwheel
   version: "6.4.0"
-  epoch: 0
+  epoch: 1
   description: auditing and relabeling of PEP 600 Linux wheels
   copyright:
     - license: MIT
@@ -100,3 +100,8 @@ update:
     - post
   github:
     identifier: pypa/auditwheel
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-auditwheel.yaml): add emptypackage test to py3-auditwheel

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)