### PR TITLE
feat(py3-dask.yaml): add emptypackage test to py3-dask

### DIFF
--- a/py3-dask.yaml
+++ b/py3-dask.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dask
   version: "2025.5.1"
-  epoch: 0
+  epoch: 1
   description: Dask is a flexible parallel computing library for analytics.
   annotations:
     cgr.dev/ecosystem: python
@@ -201,3 +201,8 @@ update:
   github:
     identifier: dask/dask
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-dask.yaml): add emptypackage test to py3-dask

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)