### PR TITLE
feat(py3-deepmerge.yaml): add emptypackage test to py3-deepmerge

### DIFF
--- a/py3-deepmerge.yaml
+++ b/py3-deepmerge.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-deepmerge
   version: 2.0
-  epoch: 0
+  epoch: 1
   description: A deep merging tool for Python core data structures
   annotations:
     cgr.dev/ecosystem: python
@@ -68,3 +68,8 @@ update:
     identifier: toumorokoshi/deepmerge
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-deepmerge.yaml): add emptypackage test to py3-deepmerge

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)