### PR TITLE
feat(py3-faiss-cpu.yaml): add emptypackage test to py3-faiss-cpu

### DIFF
--- a/py3-faiss-cpu.yaml
+++ b/py3-faiss-cpu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-faiss-cpu
   version: "1.11.0"
-  epoch: 0
+  epoch: 1
   description: Community-maintained faiss wheel builder
   annotations:
     cgr.dev/ecosystem: python
@@ -105,3 +105,8 @@ update:
     identifier: kyamagu/faiss-wheels
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-faiss-cpu.yaml): add emptypackage test to py3-faiss-cpu

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)