### PR TITLE
feat(py3-graph-tool.yaml): add emptypackage test to py3-graph-tool

### DIFF
--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-graph-tool
   version: 2.97
-  epoch: 1
+  epoch: 2
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
@@ -181,3 +181,8 @@ update:
   enabled: true
   git:
     strip-prefix: release-
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-graph-tool.yaml): add emptypackage test to py3-graph-tool

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)