### PR TITLE
feat(py3-jsonpatch.yaml): add emptypackage test to py3-jsonpatch

### DIFF
--- a/py3-jsonpatch.yaml
+++ b/py3-jsonpatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsonpatch
   version: 1.33
-  epoch: 1
+  epoch: 2
   description: Apply JSON-Patches (RFC 6902)
   copyright:
     - license: BSD-3-Clause
@@ -101,3 +101,8 @@ update:
     identifier: stefankoegl/python-json-patch
     strip-prefix: v
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-jsonpatch.yaml): add emptypackage test to py3-jsonpatch

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)