### PR TITLE
feat(py3-jupyter-server-fileid.yaml): add emptypackage test to py3-jupyter-server-fileid

### DIFF
--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-server-fileid
   version: 0.9.3
-  epoch: 0
+  epoch: 1
   description: An extension that maintains file IDs for documents in a running Jupyter Server
   annotations:
     cgr.dev/ecosystem: python
@@ -99,3 +99,8 @@ update:
     identifier: jupyter-server/jupyter_server_fileid
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-jupyter-server-fileid.yaml): add emptypackage test to py3-jupyter-server-fileid

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)