### PR TITLE
feat(py3-jupyter-ydoc.yaml): add emptypackage test to py3-jupyter-ydoc

### DIFF
--- a/py3-jupyter-ydoc.yaml
+++ b/py3-jupyter-ydoc.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-ydoc
   version: "3.0.5"
-  epoch: 0
+  epoch: 1
   description: Jupyter document structures for collaborative editing using Yjs/pycrdt
   annotations:
     cgr.dev/ecosystem: python
@@ -78,3 +78,8 @@ update:
     identifier: jupyter-server/jupyter_ydoc
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-jupyter-ydoc.yaml): add emptypackage test to py3-jupyter-ydoc

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)