### PR TITLE
feat(py3-langchain.yaml): add emptypackage test to py3-langchain

### DIFF
--- a/py3-langchain.yaml
+++ b/py3-langchain.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-langchain
   version: "0.3.25"
-  epoch: 0
+  epoch: 1
   description: Building applications with LLMs through composability
   annotations:
     cgr.dev/ecosystem: python
@@ -78,3 +78,8 @@ update:
     identifier: langchain-ai/langchain
     strip-prefix: langchain==
     tag-filter: langchain==
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-langchain.yaml): add emptypackage test to py3-langchain

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)