### PR TITLE
feat(py3-langchain-text-splitters.yaml): add emptypackage test to py3-langchain-text-splitters

### DIFF
--- a/py3-langchain-text-splitters.yaml
+++ b/py3-langchain-text-splitters.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-langchain-text-splitters
   version: 0.3.8
-  epoch: 0
+  epoch: 1
   description: LangChain Text Splitters contains utilities for splitting into chunks a wide variety of text documents.
   annotations:
     cgr.dev/ecosystem: python
@@ -75,3 +75,8 @@ update:
   git:
     strip-prefix: langchain-text-splitters==
     tag-filter-prefix: langchain-text-splitters==
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-langchain-text-splitters.yaml): add emptypackage test to py3-langchain-text-splitters

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)