### PR TITLE
feat(py3-langsmith.yaml): add emptypackage test to py3-langsmith

### DIFF
--- a/py3-langsmith.yaml
+++ b/py3-langsmith.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-langsmith
   version: "0.3.42"
-  epoch: 0
+  epoch: 1
   description: LangSmith Client SDK Implementations
   annotations:
     cgr.dev/ecosystem: python
@@ -112,3 +112,8 @@ update:
     identifier: langchain-ai/langsmith-sdk
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-langsmith.yaml): add emptypackage test to py3-langsmith

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)