### PR TITLE
feat(py3-locket.yaml): add emptypackage test to py3-locket

### DIFF
--- a/py3-locket.yaml
+++ b/py3-locket.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-locket
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: File-based locks for Python on Linux and Windows
   annotations:
     cgr.dev/ecosystem: python
@@ -84,3 +84,8 @@ update:
   github:
     identifier: mwilliamson/locket.py
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-locket.yaml): add emptypackage test to py3-locket

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)