### PR TITLE
feat(py3-lz4.yaml): add emptypackage test to py3-lz4

### DIFF
--- a/py3-lz4.yaml
+++ b/py3-lz4.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lz4
   version: 4.4.4
-  epoch: 0
+  epoch: 1
   description: LZ4 bindings for Python
   annotations:
     cgr.dev/ecosystem: python
@@ -101,3 +101,8 @@ update:
     identifier: python-lz4/python-lz4
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-lz4.yaml): add emptypackage test to py3-lz4

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)