### PR TITLE
feat(py3-notebook-shim.yaml): add emptypackage test to py3-notebook-shim

### DIFF
--- a/py3-notebook-shim.yaml
+++ b/py3-notebook-shim.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-notebook-shim
   version: 0.2.4
-  epoch: 2
+  epoch: 3
   description: A shim layer for notebook traits and config
   copyright:
     - license: BSD-3-Clause
@@ -69,3 +69,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 31429
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-notebook-shim.yaml): add emptypackage test to py3-notebook-shim

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)