### PR TITLE
feat(py3-partd.yaml): add emptypackage test to py3-partd

### DIFF
--- a/py3-partd.yaml
+++ b/py3-partd.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-partd
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: Concurrent appendable key-value storage
   annotations:
     cgr.dev/ecosystem: python
@@ -94,3 +94,8 @@ update:
   github:
     identifier: dask/partd
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-partd.yaml): add emptypackage test to py3-partd

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)