### PR TITLE
feat(py3-prettytable.yaml): add emptypackage test to py3-prettytable

### DIFF
--- a/py3-prettytable.yaml
+++ b/py3-prettytable.yaml
@@ -2,7 +2,7 @@ package:
   name: py3-prettytable
   version: "3.16.0"
   description: "Display tabular data in a visually appealing ASCII table format"
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-3-Clause
 
@@ -108,3 +108,8 @@ update:
   enabled: true
   github:
     identifier: prettytable/prettytable
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-prettytable.yaml): add emptypackage test to py3-prettytable

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)