### PR TITLE
feat(py3-pycrdt.yaml): add emptypackage test to py3-pycrdt

### DIFF
--- a/py3-pycrdt.yaml
+++ b/py3-pycrdt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycrdt
   version: "0.12.20"
-  epoch: 0
+  epoch: 1
   description: CRDTs based on Yrs.
   annotations:
     cgr.dev/ecosystem: python
@@ -73,3 +73,8 @@ update:
   github:
     identifier: jupyter-server/pycrdt
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-pycrdt.yaml): add emptypackage test to py3-pycrdt

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)