### PR TITLE
feat(py3-pycrdt-websocket.yaml): add emptypackage test to py3-pycrdt-websocket

### DIFF
--- a/py3-pycrdt-websocket.yaml
+++ b/py3-pycrdt-websocket.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycrdt-websocket
   version: 0.15.5
-  epoch: 0
+  epoch: 1
   description: pycrdt-websocket is an async WebSocket connector for pycrdt.
   annotations:
     cgr.dev/ecosystem: python
@@ -79,3 +79,8 @@ update:
     identifier: jupyter-server/pycrdt-websocket
     tag-filter: v
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-pycrdt-websocket.yaml): add emptypackage test to py3-pycrdt-websocket

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)