### PR TITLE
feat(py3-pysyncobj.yaml): add emptypackage test to py3-pysyncobj

### DIFF
--- a/py3-pysyncobj.yaml
+++ b/py3-pysyncobj.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pysyncobj
   version: "0.3.14"
-  epoch: 0
+  epoch: 1
   description: "A library for replicating your python class between multiple servers, based on raft protocol"
   copyright:
     - license: MIT
@@ -83,3 +83,8 @@ update:
     identifier: bakwc/PySyncObj
     strip-prefix: v
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-pysyncobj.yaml): add emptypackage test to py3-pysyncobj

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)