### PR TITLE
feat(py3-python-daemon.yaml): add emptypackage test to py3-python-daemon

### DIFF
--- a/py3-python-daemon.yaml
+++ b/py3-python-daemon.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-daemon
   version: 3.1.2
-  epoch: 1
+  epoch: 2
   description: Library to implement a well-behaved Unix daemon process.
   copyright:
     - license: Apache-2.0
@@ -68,3 +68,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 3816
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-python-daemon.yaml): add emptypackage test to py3-python-daemon

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)