### PR TITLE
feat(py3-sqlite-anyio.yaml): add emptypackage test to py3-sqlite-anyio

### DIFF
--- a/py3-sqlite-anyio.yaml
+++ b/py3-sqlite-anyio.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlite-anyio
   version: 0.2.3
-  epoch: 0
+  epoch: 1
   description: Asynchronous client for SQLite using AnyIO
   annotations:
     cgr.dev/ecosystem: python
@@ -69,3 +69,8 @@ update:
     identifier: davidbrochart/sqlite-anyio
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-sqlite-anyio.yaml): add emptypackage test to py3-sqlite-anyio

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)