### PR TITLE
feat(py3-tblib.yaml): add emptypackage test to py3-tblib

### DIFF
--- a/py3-tblib.yaml
+++ b/py3-tblib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tblib
   version: 3.1.0
-  epoch: 0
+  epoch: 1
   description: Serialization library for Exceptions and Tracebacks.
   annotations:
     cgr.dev/ecosystem: python
@@ -99,3 +99,8 @@ update:
     identifier: ionelmc/python-tblib
     strip-prefix: v
     tag-filter: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-tblib.yaml): add emptypackage test to py3-tblib

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)