### PR TITLE
feat(py3-toolz.yaml): add emptypackage test to py3-toolz

### DIFF
--- a/py3-toolz.yaml
+++ b/py3-toolz.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-toolz
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: A set of utility functions for iterators, functions, and dictionaries.
   annotations:
     cgr.dev/ecosystem: python
@@ -95,3 +95,8 @@ update:
   github:
     identifier: pytoolz/toolz
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-toolz.yaml): add emptypackage test to py3-toolz

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)