### PR TITLE
feat(py3-wcwidth.yaml): add emptypackage test to py3-wcwidth

### DIFF
--- a/py3-wcwidth.yaml
+++ b/py3-wcwidth.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-wcwidth
   version: 0.2.13
-  epoch: 5
+  epoch: 6
   description: Measures the displayed width of unicode strings in a terminal
   copyright:
     - license: MIT
@@ -70,3 +70,8 @@ update:
   enabled: true
   github:
     identifier: jquast/wcwidth
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-wcwidth.yaml): add emptypackage test to py3-wcwidth

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)