### PR TITLE
feat(py3-ydiff.yaml): add emptypackage test to py3-ydiff

### DIFF
--- a/py3-ydiff.yaml
+++ b/py3-ydiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ydiff
   version: "1.4.2"
-  epoch: 0
+  epoch: 1
   description: "View colored, incremental diff in workspace or from stdin, side by side and auto paged"
   copyright:
     - license: MIT
@@ -87,3 +87,8 @@ update:
   github:
     identifier: ymattw/ydiff
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-ydiff.yaml): add emptypackage test to py3-ydiff

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)