### PR TITLE
feat(py3-zict.yaml): add emptypackage test to py3-zict

### DIFF
--- a/py3-zict.yaml
+++ b/py3-zict.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-zict
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: Useful Mutable Mappings
   annotations:
     cgr.dev/ecosystem: python
@@ -86,3 +86,8 @@ update:
   github:
     identifier: dask/zict
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( py3-zict.yaml): add emptypackage test to py3-zict

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)