### PR TITLE
feat(rancher-fleet.yaml): add emptypackage test to rancher-fleet

### DIFF
--- a/rancher-fleet.yaml
+++ b/rancher-fleet.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-fleet
   version: "0.12.3"
-  epoch: 0
+  epoch: 1
   description: Deploy workloads from Git to large fleets of Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -120,3 +120,8 @@ update:
   github:
     identifier: rancher/fleet
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( rancher-fleet.yaml): add emptypackage test to rancher-fleet

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)