### PR TITLE
feat(ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml): add emptypackage test to ruby3.3-fluentd-kubernetes-daemonset-1.18

### DIFF
--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 2
+  epoch: 3
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -136,3 +136,8 @@ update:
     strip-prefix: v
     tag-filter: v1.18.
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml): add emptypackage test to ruby3.3-fluentd-kubernetes-daemonset-1.18

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)