### PR TITLE
feat(sigstore-scaffolding.yaml): add emptypackage test to sigstore-scaffolding

### DIFF
--- a/sigstore-scaffolding.yaml
+++ b/sigstore-scaffolding.yaml
@@ -1,7 +1,7 @@
 package:
   name: sigstore-scaffolding
   version: "0.7.23"
-  epoch: 0
+  epoch: 1
   description: Software Supply Chain Transparency Log
   copyright:
     - license: Apache-2.0
@@ -77,3 +77,8 @@ update:
   github:
     identifier: sigstore/scaffolding
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( sigstore-scaffolding.yaml): add emptypackage test to sigstore-scaffolding

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)