### PR TITLE
feat(tekton-pipelines-1.0.yaml): add emptypackage test to tekton-pipelines-1.0

### DIFF
--- a/tekton-pipelines-1.0.yaml
+++ b/tekton-pipelines-1.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines-1.0
   version: "1.0.0"
-  epoch: 3
+  epoch: 4
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -120,3 +120,8 @@ update:
     identifier: tektoncd/pipeline
     strip-prefix: v
     tag-filter: v1.0.
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( tekton-pipelines-1.0.yaml): add emptypackage test to tekton-pipelines-1.0

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)