### PR TITLE
feat(thingsboard.yaml): add emptypackage test to thingsboard

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.0.1"
-  epoch: 2
+  epoch: 3
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
@@ -195,3 +195,8 @@ update:
     identifier: thingsboard/thingsboard
     tag-filter: v
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( thingsboard.yaml): add emptypackage test to thingsboard

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)