### PR TITLE
feat(timestamp-authority.yaml): add emptypackage test to timestamp-authority

### DIFF
--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -1,7 +1,7 @@
 package:
   name: timestamp-authority
   version: "1.2.7"
-  epoch: 0
+  epoch: 1
   description: RFC3161 Timestamp Authority
   copyright:
     - license: Apache-2.0
@@ -64,3 +64,8 @@ update:
   github:
     identifier: sigstore/timestamp-authority
     strip-prefix: v
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( timestamp-authority.yaml): add emptypackage test to timestamp-authority

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)