### PR TITLE
feat(tomcat-11.0.yaml): add emptypackage test to tomcat-11.0

### DIFF
--- a/tomcat-11.0.yaml
+++ b/tomcat-11.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-11.0
   version: "11.0.7"
-  epoch: 0
+  epoch: 1
   description: Apache Tomcat Web Server
   copyright:
     - license: Apache-2.0
@@ -179,3 +179,8 @@ update:
     identifier: apache/tomcat
     use-tag: true
     tag-filter: 11.0.
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( tomcat-11.0.yaml): add emptypackage test to tomcat-11.0

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)