### PR TITLE
feat(victoriametrics-cluster.yaml): add emptypackage test to victoriametrics-cluster

### DIFF
--- a/victoriametrics-cluster.yaml
+++ b/victoriametrics-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-cluster
   version: "1.118.0"
-  epoch: 0
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0
@@ -62,3 +62,8 @@ update:
     strip-suffix: -cluster
     tag-filter-contains: -cluster
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( victoriametrics-cluster.yaml): add emptypackage test to victoriametrics-cluster

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)