### PR TITLE
feat(wildfly.yaml): add emptypackage test to wildfly

### DIFF
--- a/wildfly.yaml
+++ b/wildfly.yaml
@@ -1,7 +1,7 @@
 package:
   name: wildfly
   version: "36.0.1"
-  epoch: 1
+  epoch: 2
   description: WildFly Application Server
   copyright:
     - license: Apache-2.0
@@ -131,3 +131,8 @@ update:
     strip-suffix: .Final
     tag-filter-contains: .Final
     use-tag: true
+
+# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
feat( wildfly.yaml): add emptypackage test to wildfly

Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)