### PR TITLE
celeborn-0.5: add missing runtime deps

### DIFF
--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -10,12 +10,14 @@ package:
       - celeborn=${{package.full-version}}
     runtime:
       - bash
-      - busybox
+      - coreutils
       - glibc-locale-en
       - jemalloc
-      - openjdk-${{vars.java-version}}-default-jvm
+      - openjdk-${{vars.java-version}}-jre
       - openssh
       - procps
+      - sed
+      - tzdata
 
 vars:
   base-package-name: celeborn
@@ -117,10 +119,13 @@ test:
       packages:
         - ${{package.name}}-compat
         - wait-for-it
+    # Some of these are set to match defaults in the external counterpart image
     environment:
       CELEBORN_HOME: /opt/celeborn
-      CELEBORN_LOCAL_IP: 127.0.0.1
+      CELEBORN_JEMALLOC_PATH: /usr/lib/libjemalloc.so.2
+      CELEBORN_PREFER_JEMALLOC: true
       JAVA_HOME: /usr/lib/jvm/java-1.${{vars.java-version}}-openjdk
+      LC_ALL: en_US.UTF-8
   pipeline:
     - name: Test starting master
       runs: |

--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -13,7 +13,7 @@ package:
       - coreutils
       - glibc-locale-en
       - jemalloc
-      - openjdk-${{vars.java-version}}-jre
+      - openjdk-${{vars.java-version}}-default-jvm
       - openssh
       - procps
       - sed

--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.5
   version: 0.5.4
-  epoch: 0
+  epoch: 1
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,9 @@ package:
       - celeborn=${{package.full-version}}
     runtime:
       - bash
-      - coreutils
+      - busybox
+      - glibc-locale-en
+      - jemalloc
       - openjdk-${{vars.java-version}}-default-jvm
       - openssh
       - procps


### PR DESCRIPTION
Adding missing runtime dependencies for `celeborn-0.5`:
- `glibc-locale-en`: default `LC_ALL` env var is `en_US.UTF-8`
- `jemalloc`: `celeborn` can use either `glibc` or `jemalloc` - defaults to `jemalloc` on the image
- `sed`: startup scripts have some `sed` commands in them