### PR TITLE
eclipse-GHSA-vrpq-qp53-qv56-fix

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
   version: "25.04.2"
-  epoch: 0
+  epoch: 1
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       repository: https://github.com/nextflow-io/nextflow.git
       expected-commit: ea75b301c7928dfea20af47ad9b4f9212fa3b1e7
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: eclipse-GHSA-vrpq-qp53-qv56-fix.patch
 
   - runs: |
       sed -i 's/jar\.enabled = false/jar.enabled = true/' build.gradle

--- a/nextflow/eclipse-GHSA-vrpq-qp53-qv56-fix.patch
+++ b/nextflow/eclipse-GHSA-vrpq-qp53-qv56-fix.patch
@@ -1,0 +1,23 @@
+From 16b88aca2ea222b264171535b3a3735031b9f1d2 Mon Sep 17 00:00:00 2001
+From: Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+Date: Sat, 24 May 2025 21:59:34 +0200
+Subject: [PATCH] Bump jgit:7.1.1.202505221757-r [ci fast]
+
+Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+---
+ modules/nextflow/build.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/nextflow/build.gradle b/modules/nextflow/build.gradle
+index 57dfa8aa33..ae3dc903f8 100644
+--- a/modules/nextflow/build.gradle
++++ b/modules/nextflow/build.gradle
+@@ -44,7 +44,7 @@ dependencies {
+     api "com.beust:jcommander:1.35"
+     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
+     api('org.iq80.leveldb:leveldb:0.12')
+-    api('org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r')
++    api('org.eclipse.jgit:org.eclipse.jgit:7.1.1.202505221757-r')
+     api ('javax.activation:activation:1.1.1')
+     api ('javax.mail:mail:1.4.7')
+     api ('org.yaml:snakeyaml:2.2')


### PR DESCRIPTION
The CVE is remediated by implementing a patch for the newer version of org.eclipse.jgit 