### PR TITLE
github: upgrade setup-chainctl

### DIFF
--- a/.github/workflows/backfill.yaml
+++ b/.github/workflows/backfill.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           project_id: "prod-images-c6e5"
 
-      - uses: chainguard-dev/setup-chainctl@8d93dcbef466d3cf3533f67084f52eb74ef9d262 # v0.2.4
+      - uses: chainguard-dev/setup-chainctl@272698817627c158bbd813cb783b62a4b9bbbc67 # v0.3.1
         with:
             # Managed here:
             # https://github.com/chainguard-dev/mono/blob/main/env/chainguard-images/iac/wolfi-os-pusher.tf
@@ -33,12 +33,6 @@ jobs:
       - name: 'Backfill packages to apk.cgr.dev'
         run: |
           set -e
-          # Populate the token here, since chainctl auth token
-          # doesn't support all of the options we need.
-          chainctl auth login --audience apk.cgr.dev \
-            --identity "720909c9f5279097d847ad02a2f24ba8f59de36a/6a26f2970f880c31"
-          echo "::add-mask::$(chainctl auth token --audience apk.cgr.dev)"
-
           for arch in "aarch64" "x86_64"; do
             echo "Processing ${arch}"
             while IFS= read -r pkg; do

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -115,7 +115,7 @@ jobs:
           done
 
       # use public chainguard provider.
-      - uses: chainguard-dev/setup-chainctl@8d93dcbef466d3cf3533f67084f52eb74ef9d262 # v0.2.4
+      - uses: chainguard-dev/setup-chainctl@272698817627c158bbd813cb783b62a4b9bbbc67 # v0.3.1
         with:
           # Managed here:
           # https://github.com/chainguard-dev/mono/blob/main/env/chainguard-images/iac/wolfi-os-pusher.tf
@@ -124,12 +124,6 @@ jobs:
       - name: 'Withdraw packages from apk.cgr.dev'
         run: |
           set -e
-          # Populate the token here, since chainctl auth token
-          # doesn't support all of the options we need.
-          chainctl auth login --audience apk.cgr.dev \
-            --identity "720909c9f5279097d847ad02a2f24ba8f59de36a/6a26f2970f880c31"
-          echo "::add-mask::$(chainctl auth token --audience apk.cgr.dev)"
-
           for arch in "aarch64" "x86_64"; do
             while IFS= read -r pkg; do
               curl -X DELETE \


### PR DESCRIPTION
Upgrade setup-chainctl to 0.3.1, which has started to login with apk.cgr.dev audience since 0.3.0 release, see:
- https://github.com/chainguard-dev/setup-chainctl/pull/19
