### PR TITLE
Add package: botkube 1.14.0

### DIFF
--- a/botkube.yaml
+++ b/botkube.yaml
@@ -6,10 +6,6 @@ package:
   copyright:
     - license: MIT
 
-environment:
-  contents:
-    packages:
-
 pipeline:
   - uses: git-checkout
     with:
@@ -27,6 +23,11 @@ pipeline:
 
   - uses: go/build
     with:
+      packages: ./cmd/cli
+      output: botkube
+
+  - uses: go/build
+    with:
       packages: ./cmd/botkube-agent
       output: botkube-agent
 
@@ -37,12 +38,7 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - jq
   pipeline:
     - name: Verify Botkube installation
       runs: |
-        botkube-agent version || exit 1
-        botkube-agent --help
+        botkube install | grep "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"

--- a/botkube.yaml
+++ b/botkube.yaml
@@ -1,0 +1,50 @@
+package:
+  name: botkube
+  version: "1.14.0"
+  epoch: 0
+  description: Botkube is a messaging bot for monitoring and debugging Kubernetes clusters.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubeshop/botkube
+      tag: v${{package.version}}
+      expected-commit: 30e95881e4f100a19d679e6f18f5ae91ee038894
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/golang-jwt/jwt/v4@v4.5.2
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/botkube-agent
+      output: botkube-agent
+
+update:
+  enabled: true
+  github:
+    identifier: kubeshop/botkube
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - jq
+  pipeline:
+    - name: Verify Botkube installation
+      runs: |
+        botkube-agent version || exit 1
+        botkube-agent --help

--- a/botkube.yaml
+++ b/botkube.yaml
@@ -9,8 +9,6 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Signed-off-by: Michelle McAveety <michelle.mcaveety@chainguard.dev>

Add package: botkube 1.14.0

Related: https://github.com/chainguard-dev/image-requests/issues/4983

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license (https://github.com/kubeshop/botkube?tab=MIT-1-ov-file#readme)
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
