### PR TITLE
sonarqube-10/GHSA-vrpq-qp53-qv56 fixes

### DIFF
--- a/sonarqube-10.yaml
+++ b/sonarqube-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube-10
   version: "25.5.0.107428"
-  epoch: 0
+  epoch: 1
   description: SonarQube is an open source platform for continuous inspection of code quality
   copyright:
     - license: LGPL-3.0-or-later
@@ -43,6 +43,10 @@ pipeline:
       repository: https://github.com/SonarSource/sonarqube
       tag: ${{package.version}}
       expected-commit: bf47187553b709a17f3017089fc64a062d2f50d0
+
+  - uses: patch
+    with:
+      patches: sonar-eclipse-GHSA-vrpq-qp53-qv56.patch sonar-text-plugin-GHSA-vrpq-qp53-qv56.patch
 
   - name: build
     runs: |

--- a/sonarqube-10/sonar-eclipse-GHSA-vrpq-qp53-qv56.patch
+++ b/sonarqube-10/sonar-eclipse-GHSA-vrpq-qp53-qv56.patch
@@ -1,0 +1,23 @@
+From c16f0449afb93177b54f31fdf8407a591a1c624b Mon Sep 17 00:00:00 2001
+From: Alain Kermis <alain.kermis@sonarsource.com>
+Date: Mon, 24 Mar 2025 16:15:09 +0100
+Subject: [PATCH] SONAR-24448 Upgrade org.eclipse.jgit:org.eclipse.jgit to
+ 7.2.0.202503040940-r
+
+---
+ build.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index 29436b2b76f..bb1442b2e2a 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -469,7 +469,7 @@ subprojects {
+       }
+       dependency "org.elasticsearch.plugin:transport-netty4-client:${elasticSearchClientVersion}"
+       dependency 'org.elasticsearch:mocksocket:1.2'
+-      dependency 'org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r'
++      dependency 'org.eclipse.jgit:org.eclipse.jgit:7.2.1.202505142326-r'
+       dependency "org.codelibs.elasticsearch.module:analysis-common:7.17.22"
+       dependency "org.codelibs.elasticsearch.module:reindex:7.17.22"
+       dependency 'org.tmatesoft.svnkit:svnkit:1.10.11') {

--- a/sonarqube-10/sonar-text-plugin-GHSA-vrpq-qp53-qv56.patch
+++ b/sonarqube-10/sonar-text-plugin-GHSA-vrpq-qp53-qv56.patch
@@ -1,0 +1,28 @@
+From f6adae9973bc89a43732265d579d015e45238e8f Mon Sep 17 00:00:00 2001
+From: "github-actions[bot]"
+ <41898282+github-actions[bot]@users.noreply.github.com>
+Date: Thu, 22 May 2025 10:44:20 +0000
+Subject: [PATCH] SONAR-25149 Upgrade `text` plugins to version 2.24.0.6480
+
+Co-authored-by: GabinL21 <GabinL21@users.noreply.github.com>
+---
+ build.gradle | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 14adfb9412e..98783074bb4 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -327,9 +327,9 @@ subprojects {
+       dependency 'org.sonarsource.xml:sonar-xml-plugin:2.13.0.5938'
+       dependency 'org.sonarsource.iac:sonar-iac-plugin:1.46.0.15097'
+       dependency 'com.sonarsource.iac:sonar-iac-enterprise-plugin:1.46.0.15097'
+-      dependency 'org.sonarsource.text:sonar-text-plugin:2.21.1.5779'
+-      dependency 'com.sonarsource.text:sonar-text-developer-plugin:2.21.1.5779'
+-      dependency 'com.sonarsource.text:sonar-text-enterprise-plugin:2.21.1.5779'
++      dependency 'org.sonarsource.text:sonar-text-plugin:2.24.0.6480'
++      dependency 'com.sonarsource.text:sonar-text-developer-plugin:2.24.0.6480'
++      dependency 'com.sonarsource.text:sonar-text-enterprise-plugin:2.24.0.6480'
+       dependency 'com.sonarsource.jcl:sonar-jcl-plugin:1.4.1.1493'
+       dependency 'com.sonarsource.architecture:sonar-architecture-plugin:1.10.0.5305'
+       dependency 'com.sonarsource.architecture:sonar-architecture-java-frontend-plugin:1.10.0.5305'


### PR DESCRIPTION
Due to this project being gradle we are required to use patches here. The two patches are for separate components that both bring in the affected dependency, bringing them to the most recent versions remediates the CVE for sonarqube-10