### PR TITLE
chainguard-security-guide: update cg stig to 3.2.1

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "3.2.0"
+  version: "3.2.1"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: acfbd3faa113f66e19cd23beb45c09c19750b046
+      expected-commit: 5a25438df5f75d1ab7c9b6ad1f7446e97538ebb9
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
Update to pull in:
- conversion of sha check on /etc/ssl/certs/ca-certificates.crt from a shell script to OVAL based check
- update sha hash to the current version as shipped in ca-certificates-bundle 20241121-r41


Ref: https://github.com/chainguard-dev/stigs/pull/13
Ref: https://github.com/chainguard-dev/prodsec/issues/189