### PR TITLE
fix(debezium): bump rest of debezium packages

### DIFF
--- a/debezium-connect-entrypoint-3.0.yaml
+++ b/debezium-connect-entrypoint-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connect-entrypoint-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: Helper package to provide necessary files for the Debezium images
   copyright:
     - license: MIT

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: "3.0.8"
-  epoch: 3
+  epoch: 4
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
debezium 3.0 was bumped to r4 5 days ago while others were not. This causes the following error
```
Multiple packages match with different versions: debezium-3.0-connectors-all (3.0.8-r4) and debezium-connect-entrypoint-3.0 (3.0.8-r3)
```
This bumps epoch on rest of debezium packages.