### PR TITLE
Add a link for modules to nginx package

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: "1.27.5"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -174,7 +174,7 @@ subpackages:
           # Don't really like using a symlink here, but seems better than copying
           mkdir -p ${{targets.subpkgdir}}/usr/share/nginx/html
           ln -sf /var/lib/nginx/html/50x.html ${{targets.subpkgdir}}/usr/share/nginx/html/50x.html
-          ln -sf /var/lib/nginx/html/index.html ${{targets.subpkgdir}}/usr/share/nginx/html/index.html
+          ln -sf /var/lib/nginx/html/index.html ${{targets.subpkgdir}}/usr/share/nginx/html/index.html      
       - name: "Create templates directory"
         runs: |
           mkdir -p ${{targets.contextdir}}/etc/nginx/templates
@@ -204,6 +204,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/modules
+          # --modules-path is only used for installing modules, not loading them
+          mkdir -p ${{targets.subpkgdir}}/var/lib/nginx/
+          ln -sf /usr/lib/nginx/modules ${{targets.subpkgdir}}/var/lib/nginx/modules    
 
           mv ${{targets.destdir}}/usr/lib/nginx/modules/ngx_${{range.key}}_module.so ${{targets.subpkgdir}}/usr/lib/nginx/modules/
 
@@ -265,6 +268,7 @@ test:
       packages:
         - ${{package.name}}-config
         - ${{package.name}}-config-compat
+        - ${{package.name}}-mod-stream
         - curl
   pipeline:
     - name: Create Nginx user and directories
@@ -303,6 +307,10 @@ test:
         nginx -t  # Verify the configuration is valid
         sleep 5  # Give some time for Nginx to start
         curl -I http://localhost || exit 1  # Check if Nginx is serving a basic request
+    - name: Check modules are installed/loadable
+      runs: |
+        sed -i '1i include /etc/nginx/modules/*.conf;' /etc/nginx/nginx.conf
+        nginx -t
 
 update:
   enabled: true

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -264,6 +264,13 @@ subpackages:
 
 test:
   environment:
+    accounts:
+      users:
+        - username: nginx
+          uid: 65532
+      groups:
+        - groupname: nginx
+          gid: 65532
     contents:
       packages:
         - ${{package.name}}-config
@@ -273,13 +280,8 @@ test:
   pipeline:
     - name: Create Nginx user and directories
       runs: |
-        # Create the 'nginx' user if it does not exist
-        if ! id -u nginx > /dev/null 2>&1; then
-          adduser -D -g 'Nginx User' nginx
-        fi
         # Create necessary directories
         mkdir -p /var/lib/nginx/tmp/client_body /var/lib/nginx/tmp/proxy /var/lib/nginx/tmp/fastcgi /var/lib/nginx/tmp/uwsgi /var/lib/nginx/tmp/scgi /run/nginx
-        chown -R nginx:nginx /var/lib/nginx /run/nginx
     - name: Verify Nginx Version
       runs: |
         # Ensure Nginx is installed and shows the correct version

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -174,7 +174,7 @@ subpackages:
           # Don't really like using a symlink here, but seems better than copying
           mkdir -p ${{targets.subpkgdir}}/usr/share/nginx/html
           ln -sf /var/lib/nginx/html/50x.html ${{targets.subpkgdir}}/usr/share/nginx/html/50x.html
-          ln -sf /var/lib/nginx/html/index.html ${{targets.subpkgdir}}/usr/share/nginx/html/index.html      
+          ln -sf /var/lib/nginx/html/index.html ${{targets.subpkgdir}}/usr/share/nginx/html/index.html
       - name: "Create templates directory"
         runs: |
           mkdir -p ${{targets.contextdir}}/etc/nginx/templates
@@ -206,7 +206,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/modules
           # --modules-path is only used for installing modules, not loading them
           mkdir -p ${{targets.subpkgdir}}/var/lib/nginx/
-          ln -sf /usr/lib/nginx/modules ${{targets.subpkgdir}}/var/lib/nginx/modules    
+          ln -sf /usr/lib/nginx/modules ${{targets.subpkgdir}}/var/lib/nginx/modules
 
           mv ${{targets.destdir}}/usr/lib/nginx/modules/ngx_${{range.key}}_module.so ${{targets.subpkgdir}}/usr/lib/nginx/modules/
 

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: "1.26.3"
-  epoch: 40
+  epoch: 41
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -192,6 +192,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/modules
+          # --modules-path is only used for installing modules, not loading them
+          mkdir -p ${{targets.subpkgdir}}/var/lib/nginx/
+          ln -sf /usr/lib/nginx/modules ${{targets.subpkgdir}}/var/lib/nginx/modules
 
           mv ${{targets.destdir}}/usr/lib/nginx/modules/ngx_${{range.key}}_module.so ${{targets.subpkgdir}}/usr/lib/nginx/modules/
 


### PR DESCRIPTION
Nginx does not use the --module-path when loading modules... It uses the --prefix directory.

Rather than move the modules from /usr/lib/nginx to /var/lib/nginx, I made a symlink. Maybe we should just move them but that feels like it could have knock on consequences.