### PR TITLE
openssl: remediate CVE-2025-4575

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: "3.5.0"
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,17 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch
+      # fix-cve-2025-4575.patch
+      # cannot be cherry-picked from master because of
+      # a merge conflict in the test file est/recipes/25-test_x509.t
+      # Had to modify from:
+      # `- plan tests => 136;`
+      # `+ plan tests => 140;`
+      # to
+      # `- plan tests => 134;`
+      # `+ plan tests => 138;`
+      # This patch can probably be removed in the next 3.5.1 openssl upstream release.
+      patches: fix-jitter.patch fix-cve-2025-4575.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl/fix-cve-2025-4575.patch
+++ b/openssl/fix-cve-2025-4575.patch
@@ -1,0 +1,62 @@
+From 0eb9acc24febb1f3f01f0320cfba9654cf66b0ac Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Tue, 20 May 2025 16:34:10 +0200
+Subject: [PATCH] apps/x509.c: Fix the -addreject option adding trust instead
+ of rejection
+
+Fixes CVE-2025-4575
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Paul Dale <ppzgs1@gmail.com>
+(Merged from https://github.com/openssl/openssl/pull/27672)
+---
+ apps/x509.c                 |  2 +-
+ test/recipes/25-test_x509.t | 12 +++++++++++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/apps/x509.c b/apps/x509.c
+index 9bae7fa722..d080228730 100644
+--- a/apps/x509.c
++++ b/apps/x509.c
+@@ -467,7 +467,7 @@ int x509_main(int argc, char **argv)
+                            prog, opt_arg());
+                 goto opthelp;
+             }
+-            if (!sk_ASN1_OBJECT_push(trust, objtmp))
++            if (!sk_ASN1_OBJECT_push(reject, objtmp))
+                 goto end;
+             trustout = 1;
+             break;
+diff --git a/test/recipes/25-test_x509.t b/test/recipes/25-test_x509.t
+index efda91d15e..1b343392aa 100644
+--- a/test/recipes/25-test_x509.t
++++ b/test/recipes/25-test_x509.t
+@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
+ 
+ setup("test_x509");
+ 
+-plan tests => 134;
++plan tests => 138;
+ 
+ # Prevent MSys2 filename munging for arguments that look like file paths but
+ # aren't
+@@ -111,6 +111,16 @@ ok(run(app(["openssl", "x509", "-new", "-force_pubkey", $key, "-subj", "/CN=EE",
+ && run(app(["openssl", "verify", "-no_check_time",
+             "-trusted", $ca, "-partial_chain", $caout])));
+ 
++# test trust decoration
++ok(run(app(["openssl", "x509", "-in", $ca, "-addtrust", "emailProtection",
++            "-out", "ca-trusted.pem"])));
++cert_contains("ca-trusted.pem", "Trusted Uses: E-mail Protection",
++              1, 'trusted use - E-mail Protection');
++ok(run(app(["openssl", "x509", "-in", $ca, "-addreject", "emailProtection",
++            "-out", "ca-rejected.pem"])));
++cert_contains("ca-rejected.pem", "Rejected Uses: E-mail Protection",
++              1, 'rejected use - E-mail Protection');
++
+ subtest 'x509 -- x.509 v1 certificate' => sub {
+     tconversion( -type => 'x509', -prefix => 'x509v1',
+                  -in => srctop_file("test", "testx509.pem") );
+-- 
+2.47.2
+


### PR DESCRIPTION
Import patch from https://github.com/openssl/openssl/commit/0eb9acc24febb1f3f01f0320cfba9654cf66b0ac
and slightly modify `est/recipes/25-test_x509.t` to fix a conflict.