### PR TITLE
feat(virtualpackage.yaml): Add new virtualpackage test pipeline with example usage

### DIFF
--- a/pipelines/test/virtualpackage.yaml
+++ b/pipelines/test/virtualpackage.yaml
@@ -1,0 +1,38 @@
+name: virtualpackage
+
+# virtual packages should never be installed - instead one of the providing packages should be installed.
+# This package test ensures this remains true and does not regress.
+needs:
+  packages:
+    - apk-tools
+    - gawk
+    - busybox
+
+pipeline:
+  - name: virtual package check
+    description: Check that the virtual package is not installed
+    runs: |
+      is_installed_version() {
+        pkg="$1"
+        expected_version="$2"  # Example: 8.6.0-r0
+
+        installed_information=$(apk list installed "$pkg" 2>/dev/null)
+
+        // split the output on the first space to get the installed version
+        installed_version=$(echo "$installed_information" | awk '{print $1}')
+        if [ "$installed_version" = "${pkg}-${expected_version}" ]; then
+          return 0  # true: version matches
+        else
+          return 1  # false: not installed or version mismatch
+        fi
+      }
+      # Get our virtual package name and version
+      package_name_and_version="${{package.name}}-${{package.version}}-r${{package.epoch}}"
+      echo "Checking that the virtual package [${package_name_and_version}] does not install itself"
+      if is_installed_version "${{package.name}}" "${{package.version}}-r${{package.epoch}}"; then
+        echo "$package_name_and_version is installed. This is not expected. ${{package.name}} is a virtual package."
+        exit 1
+      else
+        echo "$package_name_and_version is not installed. This is expected."
+        exit 0
+      fi

--- a/pipelines/test/virtualpackage.yaml
+++ b/pipelines/test/virtualpackage.yaml
@@ -2,37 +2,42 @@ name: virtualpackage
 
 # virtual packages should never be installed - instead one of the providing packages should be installed.
 # This package test ensures this remains true and does not regress.
-needs:
-  packages:
-    - apk-tools
-    - gawk
-    - busybox
+inputs:
+  virtual_pkg_name:
+    description: "virtual package name to test"
+    required: true
+  real_pkg_name:
+    description: |
+      if you want to ensure at least one of the real packages are installed, set its name here
+    required: false
+    default: ''
 
 pipeline:
-  - name: virtual package check
-    description: Check that the virtual package is not installed
+  - name: virtual package not installed
+    description: Check that a virtual package does not install itself
     runs: |
-      is_installed_version() {
+      get_installed_version() {
         pkg="$1"
-        expected_version="$2"  # Example: 8.6.0-r0
-
-        installed_information=$(apk list installed "$pkg" 2>/dev/null)
-
-        // split the output on the first space to get the installed version
-        installed_version=$(echo "$installed_information" | awk '{print $1}')
-        if [ "$installed_version" = "${pkg}-${expected_version}" ]; then
-          return 0  # true: version matches
-        else
-          return 1  # false: not installed or version mismatch
-        fi
+        apk list installed "${pkg}" 2>/dev/null | awk '{print $1}'
       }
-      # Get our virtual package name and version
-      package_name_and_version="${{package.name}}-${{package.version}}-r${{package.epoch}}"
-      echo "Checking that the virtual package [${package_name_and_version}] does not install itself"
-      if is_installed_version "${{package.name}}" "${{package.version}}-r${{package.epoch}}"; then
-        echo "$package_name_and_version is installed. This is not expected. ${{package.name}} is a virtual package."
+
+      virtual_pkg_name_and_version="${{inputs.virtual_pkg_name}}-${{package.full-version}}"
+      maybe_installed_pkg_name_and_version="$(get_installed_version ${{inputs.virtual_pkg_name}})"
+
+      if [ "${virtual_pkg_name_and_version}" == "${maybe_installed_pkg_name_and_version}" ] ; then
+        echo "${virtual_pkg_name_and_version} is installed. This is not expected, is a virtual package."
         exit 1
-      else
-        echo "$package_name_and_version is not installed. This is expected."
-        exit 0
+      fi
+
+      echo "${virtual_pkg_name_and_version} is not installed. This is expected, is a virtual package."
+
+      if [ "${{inputs.real_pkg_name}}" != "" ] ; then
+        maybe_real_pkg_installed_name_and_version="$(get_installed_version ${{inputs.real_pkg_name}})"
+        if [ "${maybe_real_pkg_installed_name_and_version}" != "" ] ; then
+          echo "${maybe_real_pkg_installed_name_and_version} is installed. This is expected, is a real package"
+          exit 0
+        else
+          echo "No real package ${{inputs.real_pkg_name}} installed for virtual package ${{inputs.virtual_pkg_name}}. Unexpected."
+          exit 1
+        fi
       fi

--- a/pipelines/test/virtualpackage.yaml
+++ b/pipelines/test/virtualpackage.yaml
@@ -3,17 +3,17 @@ name: virtualpackage
 # virtual packages should never be installed - instead one of the providing packages should be installed.
 # This package test ensures this remains true and does not regress.
 inputs:
-  virtual_pkg_name:
+  virtual-pkg-name:
     description: "virtual package name to test"
     required: true
-  real_pkg_name:
+  real-pkg-name:
     description: |
       if you want to ensure at least one of the real packages are installed, set its name here
     required: false
     default: ''
 
 pipeline:
-  - name: virtual package not installed
+  - name: virtual package checks
     description: Check that a virtual package does not install itself
     runs: |
       get_installed_version() {
@@ -21,23 +21,23 @@ pipeline:
         apk list installed "${pkg}" 2>/dev/null | awk '{print $1}'
       }
 
-      virtual_pkg_name_and_version="${{inputs.virtual_pkg_name}}-${{package.full-version}}"
-      maybe_installed_pkg_name_and_version="$(get_installed_version ${{inputs.virtual_pkg_name}})"
+      virtual_pkg_name_and_version="${{inputs.virtual-pkg-name}}-${{package.full-version}}"
+      maybe_installed_pkg_name_and_version="$(get_installed_version ${{inputs.virtual-pkg-name}})"
 
       if [ "${virtual_pkg_name_and_version}" == "${maybe_installed_pkg_name_and_version}" ] ; then
-        echo "${virtual_pkg_name_and_version} is installed. This is not expected, is a virtual package."
+        echo "FAIL: ${virtual_pkg_name_and_version} is installed." >&2
         exit 1
       fi
 
-      echo "${virtual_pkg_name_and_version} is not installed. This is expected, is a virtual package."
+      echo "PASS: ${virtual_pkg_name_and_version} is not installed."
 
-      if [ "${{inputs.real_pkg_name}}" != "" ] ; then
-        maybe_real_pkg_installed_name_and_version="$(get_installed_version ${{inputs.real_pkg_name}})"
+      if [ "${{inputs.real-pkg-name}}" != "" ] ; then
+        maybe_real_pkg_installed_name_and_version="$(get_installed_version ${{inputs.real-pkg-name}})"
         if [ "${maybe_real_pkg_installed_name_and_version}" != "" ] ; then
-          echo "${maybe_real_pkg_installed_name_and_version} is installed. This is expected, is a real package"
+          echo "PASS: ${maybe_real_pkg_installed_name_and_version} is installed."
           exit 0
         else
-          echo "No real package ${{inputs.real_pkg_name}} installed for virtual package ${{inputs.virtual_pkg_name}}. Unexpected."
+          echo "FAIL: No real package ${{inputs.real-pkg-name}} installed for virtual package ${{inputs.virtual-pkg-name}}." >&2
           exit 1
         fi
       fi

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fsspec
   version: "2025.5.1"
-  epoch: 0
+  epoch: 1
   description: File-system specification
   copyright:
     - license: BSD-3-Clause
@@ -76,3 +76,10 @@ update:
   github:
     identifier: fsspec/filesystem_spec
     use-tag: true
+
+# Based on provider-priority and the same name provided by other packages, it was determined that this package is a
+# virtual package and should never be installed - instead one of the providing packages should be installed.
+# This package test ensures this remains true and does not regress.
+test:
+  pipeline:
+    - uses: test/virtualpackage

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -69,6 +69,9 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: test/virtualpackage
 
 update:
   enabled: true

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -62,8 +62,8 @@ subpackages:
             import: ${{vars.pypi-package}}
         - uses: test/virtualpackage
           with:
-            virtual_pkg_name: ${{package.name}}
-            real_pkg_name: "${{subpkg.name}}"
+            virtual-pkg-name: ${{package.name}}
+            real-pkg-name: "${{subpkg.name}}"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -85,4 +85,4 @@ test:
   pipeline:
     - uses: test/virtualpackage
       with:
-        virtual_pkg_name: ${{package.name}}
+        virtual-pkg-name: ${{package.name}}

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -47,7 +47,7 @@ subpackages:
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       provides:
-        - py3-${{vars.pypi-package}}
+        - ${{package.name}}
       provider-priority: ${{range.value}}
     pipeline:
       - uses: py/pip-build-install
@@ -60,6 +60,10 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+        - uses: test/virtualpackage
+          with:
+            virtual_pkg_name: ${{package.name}}
+            real_pkg_name: "${{subpkg.name}}"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -69,9 +73,6 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
 
 update:
   enabled: true
@@ -80,9 +81,8 @@ update:
     identifier: fsspec/filesystem_spec
     use-tag: true
 
-# Based on provider-priority and the same name provided by other packages, it was determined that this package is a
-# virtual package and should never be installed - instead one of the providing packages should be installed.
-# This package test ensures this remains true and does not regress.
 test:
   pipeline:
     - uses: test/virtualpackage
+      with:
+        virtual_pkg_name: ${{package.name}}


### PR DESCRIPTION
Based on provider-priority and the same name provided by other packages, it was determined we have many virtual packages that should never be installed.

Instead one of the providing packages should be installed.

This package test ensures this remains true and does not regress.

Virtual package is defined as a package that has another package providing the exact same name with a higher provider priority.

This is tracked @ https://github.com/wolfi-dev/os/issues/44820 and internal to chainguard @ https://github.com/chainguard-dev/internal-dev/issues/12573

Signed-off-by: philroche <phil.roche@chainguard.dev>
