### PR TITLE
abseil-cpp: fix upgrades and do optimized build

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,8 @@
 package:
   name: abseil-cpp
-  version: "20250127.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  # On update, please check if -fdelete-null-pointer-checks is still required
+  version: "20250127.1"
+  epoch: 2
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -32,7 +33,7 @@ pipeline:
       cmake -B build -G Ninja \
       -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
       -DCMAKE_CXX_STANDARD=17 \
-      -DCMAKE_BUILD_TYPE=MinSizeRel \
+      -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
In melange, default cmake build type was switched to Release, also
switch abseil-cpp to optimized Release builds.

Move comment to be on the separate line, as it prevents bot updates
which do not like inline comments.
