### PR TITLE
Revert "src/6.3.1 package update (#53327)"

### DIFF
--- a/src.yaml
+++ b/src.yaml
@@ -1,6 +1,6 @@
 package:
   name: src
-  version: "6.3.1"
+  version: "6.2.0"
   epoch: 0
   description: Sourcegraph CLI
   copyright:
@@ -22,7 +22,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sourcegraph/src-cli
-      expected-commit: f72ed6c0f09efc8e1c32b3d54b5d42abb41f1698
+      expected-commit: a7dfc602cc7290887e08e59b445cbe69555842f1
       tag: ${{package.version}}
 
   - uses: go/bump


### PR DESCRIPTION
Never built, and tag appears to have been removed upstream. Thus
simply revert this commit. Currently this is causing elasticbuild
failure on every push.

Note that 6.3.0 upstream tag exists, so automation should attempt
upgrade to that, once this is merged.

This reverts commit f089055c2a6a9cdc75fd4ffeda6b5fcdee88e75f.
