### PR TITLE
Remove Usage of git-checkout from test-pipelines

### DIFF
--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -82,7 +82,7 @@ test:
         git clone --branch v${{package.version}} --depth 1 https://github.com/kubernetes-sigs/cluster-api
         cd cluster-api
     - uses: test/kwok/cluster
-    - runs: kubectl apply -f config/crd/bases/
+    - runs: kubectl apply -f cluster-api/config/crd/bases/
     - uses: test/daemon-check-output
       with:
         start: /controller --profiler-address=127.0.0.1:8080 --health-addr=127.0.0.1:8081

--- a/cluster-api-1.9.yaml
+++ b/cluster-api-1.9.yaml
@@ -69,6 +69,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - ${{package.name}}-controller
         - ${{package.name}}-kubeadm-bootstrap-controller
         - ${{package.name}}-kubeadm-controlplane-controller
@@ -76,11 +77,10 @@ test:
         - ${{package.name}}-controller-compat
         - ${{package.name}}-clusterctl-compat
   pipeline:
-    - uses: git-checkout
-      with:
-        expected-commit: 955b30b3e8adc15efe01ad396ddac4745837f76f
-        repository: https://github.com/kubernetes-sigs/cluster-api
-        tag: v${{package.version}}
+    - name: Clone cluster-api repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/kubernetes-sigs/cluster-api
+        cd cluster-api
     - uses: test/kwok/cluster
     - runs: kubectl apply -f config/crd/bases/
     - uses: test/daemon-check-output

--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -49,6 +49,7 @@ test:
       packages:
         - kustomize
         - make
+        - git
         - go
         - curl
         - openssl

--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -57,11 +57,10 @@ test:
     - uses: test/kwok/cluster
     - name: Wait for nodes
       runs: kubectl wait --for=condition=Ready nodes --all
-    - uses: git-checkout
-      with:
-        repository: https://github.com/kserve/modelmesh-serving.git
-        tag: v${{package.version}}
-        expected-commit: d0e56fa4ac7547e644c87d63dc97a14f612c0391
+    - name: Clone modelmesh-serving repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/kserve/modelmesh-serving.git
+        cd modelmesh-serving
     - name: Install CRDs
       runs: |
         kubectl create ns modelmesh-serving

--- a/openpmix.yaml
+++ b/openpmix.yaml
@@ -99,7 +99,7 @@ test:
         pquery --version
         pquery --help
     - runs: |
-        cd examples
+        cd openpmix/examples
         gcc hello.c $(pkg-config pmix --libs) -o hello
         ./hello
     - uses: test/tw/ldd-check

--- a/openpmix.yaml
+++ b/openpmix.yaml
@@ -74,16 +74,15 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - hwloc-dev
         - openpmix-dev
-  pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/openpmix/openpmix
-        tag: v${{package.version}}
-        expected-commit: e87b2ee832d249fadd61938a578aaee407b976b9
-        recurse-submodules: true
+  pipeline:- name: Clone openpmix repo and run tests
+  runs: |
+    git clone --branch v${{package.version}} --depth 1 https://github.com/openpmix/openpmix
+    cd openpmix
+    # Original test commands would go here
     - runs: |
         palloc --version
         palloc --help

--- a/openpmix.yaml
+++ b/openpmix.yaml
@@ -78,11 +78,11 @@ test:
         - build-base
         - hwloc-dev
         - openpmix-dev
-  pipeline:- name: Clone openpmix repo and run tests
-  runs: |
-    git clone --branch v${{package.version}} --depth 1 https://github.com/openpmix/openpmix
-    cd openpmix
-    # Original test commands would go here
+  pipeline:
+    - name: Clone openpmix repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/openpmix/openpmix
+        cd openpmix
     - runs: |
         palloc --version
         palloc --help

--- a/pgaudit-17.yaml
+++ b/pgaudit-17.yaml
@@ -52,11 +52,10 @@ test:
       PGUSER: wolfi
   pipeline:
     - uses: test/tw/ldd-check
-    - uses: git-checkout
-      with:
-        repository: https://github.com/pgaudit/pgaudit.git
-        tag: ${{package.version}}
-        expected-commit: 538f89a93d8fd0d8913f3d740cacaea7b7eb66d9
+    - name: Clone pgaudit repo and run tests
+      runs: |
+        git clone --branch ${{package.version}} --depth 1 https://github.com/pgaudit/pgaudit.git
+        cd pgaudit
     - runs: |
         # Based on upstream tests in https://github.com/pgaudit/pgaudit/tree/main/test
         useradd $PGUSER

--- a/pgaudit-17.yaml
+++ b/pgaudit-17.yaml
@@ -56,7 +56,7 @@ test:
       runs: |
         git clone --branch ${{package.version}} --depth 1 https://github.com/pgaudit/pgaudit.git
         cd pgaudit
-    - runs: |
+
         # Based on upstream tests in https://github.com/pgaudit/pgaudit/tree/main/test
         useradd $PGUSER
         sudo -u $PGUSER initdb -D $PGDATA

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -100,11 +100,10 @@ test:
         - ruby${{vars.rubyMM}}-concurrent-ruby-edge
   pipeline:
     - runs: mkdir -p $HOME
-    - uses: git-checkout
-      with:
-        expected-commit: 33abefb6823a07699f4b8665abba9297ef5d2ccd
-        repository: https://github.com/ruby-concurrency/concurrent-ruby.git
-        tag: v${{package.version}}
+    - name: Clone concurrent-ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
+        cd concurrent-ruby
     - runs: |
         export JRUBY_HOME=/usr/share/jruby/
         bundle install

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -94,6 +94,7 @@ test:
       HOME: /tmp/test
     contents:
       packages:
+        - git
         - ruby${{vars.rubyMM}}-bundler
         # Install the subpackages for testing
         - ruby${{vars.rubyMM}}-concurrent-ruby-ext
@@ -104,7 +105,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
         cd concurrent-ruby
-    - runs: |
+
         export JRUBY_HOME=/usr/share/jruby/
         bundle install
 

--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -74,7 +74,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
         cd net-imap
-    - runs: |
+
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities
         bundle install

--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -59,6 +59,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -69,11 +70,10 @@ test:
     - runs: |
         # Test that our installed package is importable
         ruby -e "require 'net/imap'"
-    - uses: git-checkout
-      with:
-        expected-commit: f76d433f73c1b0ac67dc831357cbf267174f54cb
-        repository: https://github.com/ruby/net-imap
-        tag: v${{package.version}}
+    - name: Clone net-imap repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
+        cd net-imap
     - runs: |
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities

--- a/ruby3.2-prometheus-client.yaml
+++ b/ruby3.2-prometheus-client.yaml
@@ -53,15 +53,15 @@ test:
   environment:
     contents:
       packages:
+        - git
         - curl
         - ruby${{vars.rubyMM}}-puma
         - ruby${{vars.rubyMM}}-rackup
   pipeline:
-    - uses: git-checkout
-      with:
-        expected-commit: 32b0e8fd49b0e4822f02a375f836494c0d8f4017
-        repository: https://github.com/prometheus/client_ruby
-        tag: v${{package.version}}
+    - name: Clone client_ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
+        cd client_ruby
     - runs: |
         cd examples/rack
         rackup &

--- a/ruby3.2-prometheus-client.yaml
+++ b/ruby3.2-prometheus-client.yaml
@@ -63,7 +63,7 @@ test:
         git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
         cd client_ruby
     - runs: |
-        cd examples/rack
+        cd client_ruby/examples/rack
         rackup &
         sleep 1
         # Put output into ~/debug.log to make figuring error out easier

--- a/ruby3.2-timers.yaml
+++ b/ruby3.2-timers.yaml
@@ -69,7 +69,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
         cd timers
-    - runs: |
+
         # Run upstream tests to find incompatibilities
         bundle install
         bundle exec bake test

--- a/ruby3.2-timers.yaml
+++ b/ruby3.2-timers.yaml
@@ -57,6 +57,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -64,11 +65,10 @@ test:
     - runs: |
         # Ensure our installed gem is importable
         ruby -e "require 'timers'"
-    - uses: git-checkout
-      with:
-        expected-commit: 23bccc713a244a339500318616fae79d9922a78f
-        repository: https://github.com/socketry/timers
-        tag: v${{package.version}}
+    - name: Clone timers repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
+        cd timers
     - runs: |
         # Run upstream tests to find incompatibilities
         bundle install

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -100,11 +100,10 @@ test:
         - ruby${{vars.rubyMM}}-concurrent-ruby-edge
   pipeline:
     - runs: mkdir -p $HOME
-    - uses: git-checkout
-      with:
-        expected-commit: 33abefb6823a07699f4b8665abba9297ef5d2ccd
-        repository: https://github.com/ruby-concurrency/concurrent-ruby.git
-        tag: v${{package.version}}
+    - name: Clone concurrent-ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
+        cd concurrent-ruby
     - runs: |
         export JRUBY_HOME=/usr/share/jruby/
         bundle install

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -94,6 +94,7 @@ test:
       HOME: /tmp/test
     contents:
       packages:
+        - git
         - ruby${{vars.rubyMM}}-bundler
         # Install the subpackages for testing
         - ruby${{vars.rubyMM}}-concurrent-ruby-ext
@@ -104,7 +105,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
         cd concurrent-ruby
-    - runs: |
+
         export JRUBY_HOME=/usr/share/jruby/
         bundle install
 

--- a/ruby3.3-net-imap.yaml
+++ b/ruby3.3-net-imap.yaml
@@ -74,7 +74,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
         cd net-imap
-    - runs: |
+
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities
         bundle install

--- a/ruby3.3-net-imap.yaml
+++ b/ruby3.3-net-imap.yaml
@@ -59,6 +59,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -69,11 +70,10 @@ test:
     - runs: |
         # Test that our installed package is importable
         ruby -e "require 'net/imap'"
-    - uses: git-checkout
-      with:
-        expected-commit: f76d433f73c1b0ac67dc831357cbf267174f54cb
-        repository: https://github.com/ruby/net-imap
-        tag: v${{package.version}}
+    - name: Clone net-imap repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
+        cd net-imap
     - runs: |
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities

--- a/ruby3.3-prometheus-client.yaml
+++ b/ruby3.3-prometheus-client.yaml
@@ -53,15 +53,15 @@ test:
   environment:
     contents:
       packages:
+        - git
         - curl
         - ruby${{vars.rubyMM}}-puma
         - ruby${{vars.rubyMM}}-rackup
   pipeline:
-    - uses: git-checkout
-      with:
-        expected-commit: 32b0e8fd49b0e4822f02a375f836494c0d8f4017
-        repository: https://github.com/prometheus/client_ruby
-        tag: v${{package.version}}
+    - name: Clone client_ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
+        cd client_ruby
     - runs: |
         cd examples/rack
         rackup &

--- a/ruby3.3-prometheus-client.yaml
+++ b/ruby3.3-prometheus-client.yaml
@@ -63,7 +63,7 @@ test:
         git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
         cd client_ruby
     - runs: |
-        cd examples/rack
+        cd client_ruby/examples/rack
         rackup &
         sleep 1
         # Put output into ~/debug.log to make figuring error out easier

--- a/ruby3.3-timers.yaml
+++ b/ruby3.3-timers.yaml
@@ -69,7 +69,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
         cd timers
-    - runs: |
+
         # Run upstream tests to find incompatibilities
         bundle install
         bundle exec bake test

--- a/ruby3.3-timers.yaml
+++ b/ruby3.3-timers.yaml
@@ -57,6 +57,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -64,11 +65,10 @@ test:
     - runs: |
         # Ensure our installed gem is importable
         ruby -e "require 'timers'"
-    - uses: git-checkout
-      with:
-        expected-commit: 23bccc713a244a339500318616fae79d9922a78f
-        repository: https://github.com/socketry/timers
-        tag: v${{package.version}}
+    - name: Clone timers repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
+        cd timers
     - runs: |
         # Run upstream tests to find incompatibilities
         bundle install

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -100,11 +100,10 @@ test:
         - ruby${{vars.rubyMM}}-concurrent-ruby-edge
   pipeline:
     - runs: mkdir -p $HOME
-    - uses: git-checkout
-      with:
-        expected-commit: 33abefb6823a07699f4b8665abba9297ef5d2ccd
-        repository: https://github.com/ruby-concurrency/concurrent-ruby.git
-        tag: v${{package.version}}
+    - name: Clone concurrent-ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
+        cd concurrent-ruby
     - runs: |
         export JRUBY_HOME=/usr/share/jruby/
         bundle install

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -94,6 +94,7 @@ test:
       HOME: /tmp/test
     contents:
       packages:
+        - git
         - ruby${{vars.rubyMM}}-bundler
         # Install the subpackages for testing
         - ruby${{vars.rubyMM}}-concurrent-ruby-ext
@@ -104,7 +105,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby-concurrency/concurrent-ruby.git
         cd concurrent-ruby
-    - runs: |
+
         export JRUBY_HOME=/usr/share/jruby/
         bundle install
 

--- a/ruby3.4-net-imap.yaml
+++ b/ruby3.4-net-imap.yaml
@@ -74,7 +74,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
         cd net-imap
-    - runs: |
+
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities
         bundle install

--- a/ruby3.4-net-imap.yaml
+++ b/ruby3.4-net-imap.yaml
@@ -59,6 +59,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -69,11 +70,10 @@ test:
     - runs: |
         # Test that our installed package is importable
         ruby -e "require 'net/imap'"
-    - uses: git-checkout
-      with:
-        expected-commit: f76d433f73c1b0ac67dc831357cbf267174f54cb
-        repository: https://github.com/ruby/net-imap
-        tag: v${{package.version}}
+    - name: Clone net-imap repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/ruby/net-imap
+        cd net-imap
     - runs: |
         # Run upstream tests: against the repo's code not our installed
         # package, but at least find out if we have incompatibilities

--- a/ruby3.4-prometheus-client.yaml
+++ b/ruby3.4-prometheus-client.yaml
@@ -53,15 +53,15 @@ test:
   environment:
     contents:
       packages:
+        - git
         - curl
         - ruby${{vars.rubyMM}}-puma
         - ruby${{vars.rubyMM}}-rackup
   pipeline:
-    - uses: git-checkout
-      with:
-        expected-commit: 32b0e8fd49b0e4822f02a375f836494c0d8f4017
-        repository: https://github.com/prometheus/client_ruby
-        tag: v${{package.version}}
+    - name: Clone client_ruby repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
+        cd client_ruby
     - runs: |
         cd examples/rack
         rackup &

--- a/ruby3.4-prometheus-client.yaml
+++ b/ruby3.4-prometheus-client.yaml
@@ -63,7 +63,7 @@ test:
         git clone --branch v${{package.version}} --depth 1 https://github.com/prometheus/client_ruby
         cd client_ruby
     - runs: |
-        cd examples/rack
+        cd client_ruby/examples/rack
         rackup &
         sleep 1
         # Put output into ~/debug.log to make figuring error out easier

--- a/ruby3.4-timers.yaml
+++ b/ruby3.4-timers.yaml
@@ -69,7 +69,7 @@ test:
       runs: |
         git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
         cd timers
-    - runs: |
+
         # Run upstream tests to find incompatibilities
         bundle install
         bundle exec bake test

--- a/ruby3.4-timers.yaml
+++ b/ruby3.4-timers.yaml
@@ -57,6 +57,7 @@ test:
   environment:
     contents:
       packages:
+        - git
         - build-base
         - ruby-${{vars.rubyMM}}-dev
         - ruby${{vars.rubyMM}}-bundler
@@ -64,11 +65,10 @@ test:
     - runs: |
         # Ensure our installed gem is importable
         ruby -e "require 'timers'"
-    - uses: git-checkout
-      with:
-        expected-commit: 23bccc713a244a339500318616fae79d9922a78f
-        repository: https://github.com/socketry/timers
-        tag: v${{package.version}}
+    - name: Clone timers repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/socketry/timers
+        cd timers
     - runs: |
         # Run upstream tests to find incompatibilities
         bundle install

--- a/sops.yaml
+++ b/sops.yaml
@@ -47,5 +47,5 @@ test:
         gpg-agent --daemon
         gpg --import pgp/sops_functional_tests_key.asc
 
-        cd examples/all_in_one
+        cd sops/examples/all_in_one
         sops decrypt config/secret.enc.json

--- a/sops.yaml
+++ b/sops.yaml
@@ -30,14 +30,14 @@ test:
   environment:
     contents:
       packages:
+        - git
         - gpg
         - gpg-agent
   pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/getsops/sops
-        tag: v${{package.version}}
-        expected-commit: a95e5258b42c3aa91d2e745996f0c87e9c4af172
+    - name: Clone sops repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/getsops/sops
+        cd sops
     - name: version check
       runs: |
         sops --version

--- a/tinydir.yaml
+++ b/tinydir.yaml
@@ -34,16 +34,16 @@ test:
   environment:
     contents:
       packages:
+        - git
         - gcc
         - cmake
         - make
         - glibc-locales
   pipeline:
-    - uses: git-checkout
-      with:
-        repository: ${{vars.repository}}
-        tag: ${{package.version}}
-        expected-commit: ${{vars.expected-commit}}
+    - name: Clone cloned_repo repo and run tests
+      runs: |
+        git clone --branch ${{package.version}} --depth 1 ${{vars.repository}}
+        cd cloned_repo
     - name: "run upstream tests"
       runs: |
         # Based on upstream workflow: https://github.com/cxong/tinydir/blob/master/.github/workflows/cmake.yml

--- a/tinydir.yaml
+++ b/tinydir.yaml
@@ -43,7 +43,7 @@ test:
     - name: Clone cloned_repo repo and run tests
       runs: |
         git clone --branch ${{package.version}} --depth 1 ${{vars.repository}}
-        cd cloned_repo
+        cd tinydir
     - name: "run upstream tests"
       runs: |
         # Based on upstream workflow: https://github.com/cxong/tinydir/blob/master/.github/workflows/cmake.yml
@@ -53,7 +53,7 @@ test:
         cmake -B ./build -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON tests
         cmake --build ./build --config Release
         # test
-        cd build
+        cd tinydir/build
         ctest -C Release
 
 update:

--- a/vendir.yaml
+++ b/vendir.yaml
@@ -31,6 +31,10 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - git
   pipeline:
     - name: version check
       runs: |
@@ -43,7 +47,7 @@ test:
         cd vendir
     - name: run sync
       runs: |
-        cd examples/inline
+        cd vendir/examples/inline
         vendir sync
     - name: test help command
       runs: "# Test command help \nvendir --version\nvendir -h\nvendir sync -h\n"

--- a/vendir.yaml
+++ b/vendir.yaml
@@ -37,11 +37,10 @@ test:
         vendir version | grep ${{package.version}}
         vendir --version
         vendir --help
-    - uses: git-checkout
-      with:
-        expected-commit: 7326502a792ee9a9feea1a9bb1c883650fd55646
-        repository: https://github.com/carvel-dev/vendir
-        tag: v${{package.version}}
+    - name: Clone vendir repo and run tests
+      runs: |
+        git clone --branch v${{package.version}} --depth 1 https://github.com/carvel-dev/vendir
+        cd vendir
     - name: run sync
       runs: |
         cd examples/inline

--- a/zig.yaml
+++ b/zig.yaml
@@ -67,17 +67,17 @@ test:
   environment:
     contents:
       packages:
+        - git
         - clang-${{vars.llvm-vers}}
         - llvm-${{vars.llvm-vers}}-dev
         - libstdc++
     environment:
       CC: clang
   pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/ziglang/zig
-        tag: ${{package.version}}
-        expected-commit: d03a147ea0a590ca711b3db07106effc559b0fc6
+    - name: Clone zig repo and run tests
+      runs: |
+        git clone --branch ${{package.version}} --depth 1 https://github.com/ziglang/zig
+        cd zig
     - working-directory: test/
       runs: |
         zig --help

--- a/zig.yaml
+++ b/zig.yaml
@@ -78,7 +78,7 @@ test:
       runs: |
         git clone --branch ${{package.version}} --depth 1 https://github.com/ziglang/zig
         cd zig
-    - working-directory: test/
+    - working-directory: zig/test/
       runs: |
         zig --help
         zig version


### PR DESCRIPTION
Having` git-ckeckout` in tests piepline causes failures each time we have an update, so avoid using it moving forward. [Slack thread discussion](https://chainguard-dev.slack.com/archives/C0627BW5GLF/p1748370360809029)