### PR TITLE
chainguard-security-guide: update to CG stig 3.2.2, add tests

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "3.2.1"
+  version: "3.2.2"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: 5a25438df5f75d1ab7c9b6ad1f7446e97538ebb9
+      expected-commit: cbeaacf878bcdf6647f2d0bcc5082cd1290a811f
       tag: v${{package.version}}
 
   - runs: |
@@ -35,7 +35,21 @@ test:
     contents:
       packages:
         - openscap
+        - python-3.12
+        - ca-certificates-bundle
   pipeline:
     - name: Verify gpos content is recognized by oscap
       runs: |
         oscap info /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+    - name: Verify that the trust anchor check passes
+      runs: |
+        if ! oscap xccdf eval --verbose WARNING --rule xccdf_._rule_V_263659 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
+            # if we failed, then re-run more verbosely to help make diagnosing easier
+            oscap xccdf eval --verbose INFO --rule xccdf_._rule_V_263659 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+        fi
+    - name: Verify that the remote service check passes, even with python-3.12 (telnetlib.py) installed
+      runs: |
+        if ! oscap xccdf eval --verbose WARNING --rule xccdf_._rule_V_203736 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
+            # if we failed, then re-run more verbosely to help make diagnosing easier
+            oscap xccdf eval --verbose INFO --rule xccdf_._rule_V_203736 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+        fi


### PR DESCRIPTION
v3.2.2 release tightens up the package pattern match in the Remote Services check to avoid false positives.

Also add tests of individual rules and checks to ensure that we don't regress in the future:

- ensure the certificate bundle hash passes / commit matches (will fail on updates to ca-certificates as the stig will need to be updated)

- ensure the "no remote services" check passes even when python 3.12 with telnetlib.py in the standard python library is installed (telnetlib.py was removed in python 3.13, will need to come up with a different check then).


Ref: https://github.com/chainguard-dev/stigs/pull/14
Ref: https://github.com/chainguard-dev/prodsec/issues/220
