### PR TITLE
fix spdx 2.3 schema

### DIFF
--- a/spdx-tools-java.yaml
+++ b/spdx-tools-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdx-tools-java
   version: "2.0.1"
-  epoch: 0
+  epoch: 1
   description: SPDX Command Line Tools using the Spdx-Java-Library
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       repository: https://github.com/spdx/tools-java.git
       tag: v${{package.version}}
       expected-commit: cccac767593012795e1d879f30ebd60e87e1fde6
+
+  - uses: patch
+    with:
+      patches: fix-operating-system.patch
 
   - uses: ecosystems/maven
 

--- a/spdx-tools-java/fix-operating-system.patch
+++ b/spdx-tools-java/fix-operating-system.patch
@@ -1,0 +1,17 @@
+Description: avoid breaking change by accepting the current upstream
+ value with underscore, and the value specified in the spec with a dash
+Upstream: https://github.com/spdx/tools-java/pull/211
+
+diff --git a/resources/spdx-schema-v2.3.json b/resources/spdx-schema-v2.3.json
+index 403d202..36c955a 100644
+--- a/resources/spdx-schema-v2.3.json
++++ b/resources/spdx-schema-v2.3.json
+@@ -413,7 +413,7 @@
+           "primaryPackagePurpose" : {
+             "description" : "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
+             "type" : "string",
+-            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "FILE" ]
++            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "OPERATING-SYSTEM", "FILE" ]
+           },
+           "releaseDate" : {
+             "description" : "This field provides a place for recording the date the package was released.",


### PR DESCRIPTION
- **Revert "src/6.3.1 package update (#53327)"**
  Never built, and tag appears to have been removed upstream. Thus
  simply revert this commit. Currently this is causing elasticbuild
  failure on every push.
  
  Note that 6.3.0 upstream tag exists, so automation should attempt
  upgrade to that, once this is merged.
  
  This reverts commit f089055c2a6a9cdc75fd4ffeda6b5fcdee88e75f.
  

- **spdx-tools-java: fix schmea with spec compliant dashed operating-system**
  Current schema upstream use underscore, where as the spec requires to
  use a dash. Fix the constant in the spec to be with a dash.
  
  Reference: https://github.com/spdx/tools-java/pull/211
  