### PR TITLE
fix: remove efs symlinks

### DIFF
--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: "2.3.1"
-  epoch: 0
+  epoch: 1
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT
@@ -83,8 +83,6 @@ pipeline:
 # This package exists separately because aws-efs-csi-driver requires a custom efs-utils.
 # Upstream moves /etc/amazon/efs to /etc/amazon/efs-static-files
 # (https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L91)
-# and symlinks /etc/amazon/efs to /var/amazon/efs at runtime
-# (https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/66c2106f313d20d97c8a8ca8efc59c957b245ba6/pkg/driver/config_dir.go#L37).
 # Since the official deployment mounts a PV at /var/amazon/efs
 # (https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/66c2106f313d20d97c8a8ca8efc59c957b245ba6/charts/aws-efs-csi-driver/templates/node-daemonset.yaml#L109),
 # modifying efs-utils directly would break its standard usage.
@@ -142,8 +140,6 @@ subpackages:
           install -p -m 755 src/watchdog/__init__.py ${BUILD_ROOT}/usr/bin/amazon-efs-mount-watchdog
 
           mv ${{targets.contextdir}}/etc/amazon/efs ${{targets.contextdir}}/etc/amazon/efs-static-files
-          mkdir -p ${{targets.contextdir}}/var/amazon/efs
-          ln -s /var/amazon/efs ${{targets.contextdir}}/etc/amazon/efs
       - name: edit shbang for python
         runs: |
           d=${{targets.destdir}}
@@ -154,9 +150,6 @@ subpackages:
       pipeline:
         - runs: |
             efs-proxy --help
-        - runs: |
-            test "$(readlink /etc/amazon/efs)" = "/var/amazon/efs"
-            test -d "$(readlink -f /etc/amazon/efs)"
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
