### PR TITLE
python-3.12, python-3.13: Apply CVE-2025-4516 patch

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.10"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -64,7 +64,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: gh-118224.patch gh-127301.patch
+      patches: gh-118224.patch gh-127301.patch CVE-2025-4516.patch
 
   - name: Configure
     runs: |

--- a/python-3.12/CVE-2025-4516.patch
+++ b/python-3.12/CVE-2025-4516.patch
@@ -1,0 +1,490 @@
+diff --git a/Include/cpython/bytesobject.h b/Include/cpython/bytesobject.h
+index e982031c107de2..eef607a5760eda 100644
+--- a/Include/cpython/bytesobject.h
++++ b/Include/cpython/bytesobject.h
+@@ -25,6 +25,10 @@ PyAPI_FUNC(PyObject*) _PyBytes_FromHex(
+     int use_bytearray);
+ 
+ /* Helper for PyBytes_DecodeEscape that detects invalid escape chars. */
++PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape2(const char *, Py_ssize_t,
++                                             const char *,
++                                             int *, const char **);
++// Export for binary compatibility.
+ PyAPI_FUNC(PyObject *) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
+                                              const char *, const char **);
+ 
+diff --git a/Include/cpython/unicodeobject.h b/Include/cpython/unicodeobject.h
+index f177cd9e2af9de..cf38928686019b 100644
+--- a/Include/cpython/unicodeobject.h
++++ b/Include/cpython/unicodeobject.h
+@@ -684,6 +684,19 @@ PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeStateful(
+ );
+ /* Helper for PyUnicode_DecodeUnicodeEscape that detects invalid escape
+    chars. */
++PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal2(
++    const char *string,     /* Unicode-Escape encoded string */
++    Py_ssize_t length,      /* size of string */
++    const char *errors,     /* error handling */
++    Py_ssize_t *consumed,   /* bytes consumed */
++    int *first_invalid_escape_char, /* on return, if not -1, contain the first
++                                       invalid escaped char (<= 0xff) or invalid
++                                       octal escape (> 0xff) in string. */
++    const char **first_invalid_escape_ptr); /* on return, if not NULL, may
++                                        point to the first invalid escaped
++                                        char in string.
++                                        May be NULL if errors is not NULL. */
++// Export for binary compatibility.
+ PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal(
+         const char *string,     /* Unicode-Escape encoded string */
+         Py_ssize_t length,      /* size of string */
+diff --git a/Lib/test/test_codeccallbacks.py b/Lib/test/test_codeccallbacks.py
+index 4991330489d139..d85f609d806932 100644
+--- a/Lib/test/test_codeccallbacks.py
++++ b/Lib/test/test_codeccallbacks.py
+@@ -1,6 +1,7 @@
+ import codecs
+ import html.entities
+ import itertools
++import re
+ import sys
+ import unicodedata
+ import unittest
+@@ -1124,7 +1125,7 @@ def test_bug828737(self):
+             text = 'abc<def>ghi'*n
+             text.translate(charmap)
+ 
+-    def test_mutatingdecodehandler(self):
++    def test_mutating_decode_handler(self):
+         baddata = [
+             ("ascii", b"\xff"),
+             ("utf-7", b"++"),
+@@ -1159,6 +1160,42 @@ def mutating(exc):
+         for (encoding, data) in baddata:
+             self.assertEqual(data.decode(encoding, "test.mutating"), "\u4242")
+ 
++    def test_mutating_decode_handler_unicode_escape(self):
++        decode = codecs.unicode_escape_decode
++        def mutating(exc):
++            if isinstance(exc, UnicodeDecodeError):
++                r = data.get(exc.object[:exc.end])
++                if r is not None:
++                    exc.object = r[0] + exc.object[exc.end:]
++                    return ('\u0404', r[1])
++            raise AssertionError("don't know how to handle %r" % exc)
++
++        codecs.register_error('test.mutating2', mutating)
++        data = {
++            br'\x0': (b'\\', 0),
++            br'\x3': (b'xxx\\', 3),
++            br'\x5': (b'x\\', 1),
++        }
++        def check(input, expected, msg):
++            with self.assertWarns(DeprecationWarning) as cm:
++                self.assertEqual(decode(input, 'test.mutating2'), (expected, len(input)))
++            self.assertIn(msg, str(cm.warning))
++
++        check(br'\x0n\z', '\u0404\n\\z', r"invalid escape sequence '\z'")
++        check(br'\x0n\501', '\u0404\n\u0141', r"invalid octal escape sequence '\501'")
++        check(br'\x0z', '\u0404\\z', r"invalid escape sequence '\z'")
++
++        check(br'\x3n\zr', '\u0404\n\\zr', r"invalid escape sequence '\z'")
++        check(br'\x3zr', '\u0404\\zr', r"invalid escape sequence '\z'")
++        check(br'\x3z5', '\u0404\\z5', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x3z5x')[:-1], '\u0404\\z5', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x3z5xy')[:-2], '\u0404\\z5', r"invalid escape sequence '\z'")
++
++        check(br'\x5n\z', '\u0404\n\\z', r"invalid escape sequence '\z'")
++        check(br'\x5n\501', '\u0404\n\u0141', r"invalid octal escape sequence '\501'")
++        check(br'\x5z', '\u0404\\z', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x5zy')[:-1], '\u0404\\z', r"invalid escape sequence '\z'")
++
+     # issue32583
+     def test_crashing_decode_handler(self):
+         # better generating one more character to fill the extra space slot
+diff --git a/Lib/test/test_codecs.py b/Lib/test/test_codecs.py
+index f683f069ae1397..2e64a52acbae3a 100644
+--- a/Lib/test/test_codecs.py
++++ b/Lib/test/test_codecs.py
+@@ -1196,23 +1196,39 @@ def test_escape(self):
+         check(br"[\1010]", b"[A0]")
+         check(br"[\x41]", b"[A]")
+         check(br"[\x410]", b"[A0]")
++
++    def test_warnings(self):
++        decode = codecs.escape_decode
++        check = coding_checker(self, decode)
+         for i in range(97, 123):
+             b = bytes([i])
+             if b not in b'abfnrtvx':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % i):
+                     check(b"\\" + b, b"\\" + b)
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid escape sequence '\\%c'" % (i-32)):
+                 check(b"\\" + b.upper(), b"\\" + b.upper())
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\8'"):
+             check(br"\8", b"\\8")
+         with self.assertWarns(DeprecationWarning):
+             check(br"\9", b"\\9")
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\\xfa'") as cm:
+             check(b"\\\xfa", b"\\\xfa")
+         for i in range(0o400, 0o1000):
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid octal escape sequence '\\%o'" % i):
+                 check(rb'\%o' % i, bytes([i & 0o377]))
+ 
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\z'"):
++            self.assertEqual(decode(br'\x\z', 'ignore'), (b'\\z', 4))
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid octal escape sequence '\\501'"):
++            self.assertEqual(decode(br'\x\501', 'ignore'), (b'A', 6))
++
+     def test_errors(self):
+         decode = codecs.escape_decode
+         self.assertRaises(ValueError, decode, br"\x")
+@@ -2479,24 +2495,40 @@ def test_escape_decode(self):
+         check(br"[\x410]", "[A0]")
+         check(br"\u20ac", "\u20ac")
+         check(br"\U0001d120", "\U0001d120")
++
++    def test_decode_warnings(self):
++        decode = codecs.unicode_escape_decode
++        check = coding_checker(self, decode)
+         for i in range(97, 123):
+             b = bytes([i])
+             if b not in b'abfnrtuvx':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % i):
+                     check(b"\\" + b, "\\" + chr(i))
+             if b.upper() not in b'UN':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % (i-32)):
+                     check(b"\\" + b.upper(), "\\" + chr(i-32))
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\8'"):
+             check(br"\8", "\\8")
+         with self.assertWarns(DeprecationWarning):
+             check(br"\9", "\\9")
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\\xfa'") as cm:
+             check(b"\\\xfa", "\\\xfa")
+         for i in range(0o400, 0o1000):
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid octal escape sequence '\\%o'" % i):
+                 check(rb'\%o' % i, chr(i))
+ 
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\z'"):
++            self.assertEqual(decode(br'\x\z', 'ignore'), ('\\z', 4))
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid octal escape sequence '\\501'"):
++            self.assertEqual(decode(br'\x\501', 'ignore'), ('\u0141', 6))
++
+     def test_decode_errors(self):
+         decode = codecs.unicode_escape_decode
+         for c, d in (b'x', 2), (b'u', 4), (b'U', 4):
+diff --git a/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst b/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst
+new file mode 100644
+index 00000000000000..39d2f1e1a892cf
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst
+@@ -0,0 +1,2 @@
++Fix use-after-free in the "unicode-escape" decoder with a non-"strict" error
++handler.
+diff --git a/Objects/bytesobject.c b/Objects/bytesobject.c
+index f3a978c86c3606..dae84127a7df4b 100644
+--- a/Objects/bytesobject.c
++++ b/Objects/bytesobject.c
+@@ -1048,10 +1048,11 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
+ }
+ 
+ /* Unescape a backslash-escaped string. */
+-PyObject *_PyBytes_DecodeEscape(const char *s,
++PyObject *_PyBytes_DecodeEscape2(const char *s,
+                                 Py_ssize_t len,
+                                 const char *errors,
+-                                const char **first_invalid_escape)
++                                int *first_invalid_escape_char,
++                                const char **first_invalid_escape_ptr)
+ {
+     int c;
+     char *p;
+@@ -1065,7 +1066,8 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+         return NULL;
+     writer.overallocate = 1;
+ 
+-    *first_invalid_escape = NULL;
++    *first_invalid_escape_char = -1;
++    *first_invalid_escape_ptr = NULL;
+ 
+     end = s + len;
+     while (s < end) {
+@@ -1103,9 +1105,10 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+                     c = (c<<3) + *s++ - '0';
+             }
+             if (c > 0377) {
+-                if (*first_invalid_escape == NULL) {
+-                    *first_invalid_escape = s-3; /* Back up 3 chars, since we've
+-                                                    already incremented s. */
++                if (*first_invalid_escape_char == -1) {
++                    *first_invalid_escape_char = c;
++                    /* Back up 3 chars, since we've already incremented s. */
++                    *first_invalid_escape_ptr = s - 3;
+                 }
+             }
+             *p++ = c;
+@@ -1146,9 +1149,10 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+             break;
+ 
+         default:
+-            if (*first_invalid_escape == NULL) {
+-                *first_invalid_escape = s-1; /* Back up one char, since we've
+-                                                already incremented s. */
++            if (*first_invalid_escape_char == -1) {
++                *first_invalid_escape_char = (unsigned char)s[-1];
++                /* Back up one char, since we've already incremented s. */
++                *first_invalid_escape_ptr = s - 1;
+             }
+             *p++ = '\\';
+             s--;
+@@ -1162,23 +1166,37 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+     return NULL;
+ }
+ 
++// Export for binary compatibility.
++PyObject *_PyBytes_DecodeEscape(const char *s,
++                                Py_ssize_t len,
++                                const char *errors,
++                                const char **first_invalid_escape)
++{
++    int first_invalid_escape_char;
++    return _PyBytes_DecodeEscape2(
++            s, len, errors,
++            &first_invalid_escape_char,
++            first_invalid_escape);
++}
++
+ PyObject *PyBytes_DecodeEscape(const char *s,
+                                 Py_ssize_t len,
+                                 const char *errors,
+                                 Py_ssize_t Py_UNUSED(unicode),
+                                 const char *Py_UNUSED(recode_encoding))
+ {
+-    const char* first_invalid_escape;
+-    PyObject *result = _PyBytes_DecodeEscape(s, len, errors,
+-                                             &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyBytes_DecodeEscape2(s, len, errors,
++                                             &first_invalid_escape_char,
++                                             &first_invalid_escape_ptr);
+     if (result == NULL)
+         return NULL;
+-    if (first_invalid_escape != NULL) {
+-        unsigned char c = *first_invalid_escape;
+-        if ('4' <= c && c <= '7') {
++    if (first_invalid_escape_char != -1) {
++        if (first_invalid_escape_char > 0xff) {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+-                                 "invalid octal escape sequence '\\%.3s'",
+-                                 first_invalid_escape) < 0)
++                                 "invalid octal escape sequence '\\%o'",
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+@@ -1187,7 +1205,7 @@ PyObject *PyBytes_DecodeEscape(const char *s,
+         else {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                                  "invalid escape sequence '\\%c'",
+-                                 c) < 0)
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+diff --git a/Objects/unicodeobject.c b/Objects/unicodeobject.c
+index 05562ad9927989..5accbd6d1ddcbb 100644
+--- a/Objects/unicodeobject.c
++++ b/Objects/unicodeobject.c
+@@ -6046,13 +6046,15 @@ PyUnicode_AsUTF16String(PyObject *unicode)
+ /* --- Unicode Escape Codec ----------------------------------------------- */
+ 
+ PyObject *
+-_PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
++_PyUnicode_DecodeUnicodeEscapeInternal2(const char *s,
+                                Py_ssize_t size,
+                                const char *errors,
+                                Py_ssize_t *consumed,
+-                               const char **first_invalid_escape)
++                               int *first_invalid_escape_char,
++                               const char **first_invalid_escape_ptr)
+ {
+     const char *starts = s;
++    const char *initial_starts = starts;
+     _PyUnicodeWriter writer;
+     const char *end;
+     PyObject *errorHandler = NULL;
+@@ -6061,7 +6063,8 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+     PyInterpreterState *interp = _PyInterpreterState_Get();
+ 
+     // so we can remember if we've seen an invalid escape char or not
+-    *first_invalid_escape = NULL;
++    *first_invalid_escape_char = -1;
++    *first_invalid_escape_ptr = NULL;
+ 
+     if (size == 0) {
+         if (consumed) {
+@@ -6149,9 +6152,12 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+                 }
+             }
+             if (ch > 0377) {
+-                if (*first_invalid_escape == NULL) {
+-                    *first_invalid_escape = s-3; /* Back up 3 chars, since we've
+-                                                    already incremented s. */
++                if (*first_invalid_escape_char == -1) {
++                    *first_invalid_escape_char = ch;
++                    if (starts == initial_starts) {
++                        /* Back up 3 chars, since we've already incremented s. */
++                        *first_invalid_escape_ptr = s - 3;
++                    }
+                 }
+             }
+             WRITE_CHAR(ch);
+@@ -6252,9 +6258,12 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+             goto error;
+ 
+         default:
+-            if (*first_invalid_escape == NULL) {
+-                *first_invalid_escape = s-1; /* Back up one char, since we've
+-                                                already incremented s. */
++            if (*first_invalid_escape_char == -1) {
++                *first_invalid_escape_char = c;
++                if (starts == initial_starts) {
++                    /* Back up one char, since we've already incremented s. */
++                    *first_invalid_escape_ptr = s - 1;
++                }
+             }
+             WRITE_ASCII_CHAR('\\');
+             WRITE_CHAR(c);
+@@ -6293,24 +6302,40 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+     return NULL;
+ }
+ 
++// Export for binary compatibility.
++PyObject *
++_PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
++                               Py_ssize_t size,
++                               const char *errors,
++                               Py_ssize_t *consumed,
++                               const char **first_invalid_escape)
++{
++    int first_invalid_escape_char;
++    return _PyUnicode_DecodeUnicodeEscapeInternal2(
++            s, size, errors, consumed,
++            &first_invalid_escape_char,
++            first_invalid_escape);
++}
++
+ PyObject *
+ _PyUnicode_DecodeUnicodeEscapeStateful(const char *s,
+                               Py_ssize_t size,
+                               const char *errors,
+                               Py_ssize_t *consumed)
+ {
+-    const char *first_invalid_escape;
+-    PyObject *result = _PyUnicode_DecodeUnicodeEscapeInternal(s, size, errors,
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyUnicode_DecodeUnicodeEscapeInternal2(s, size, errors,
+                                                       consumed,
+-                                                      &first_invalid_escape);
++                                                      &first_invalid_escape_char,
++                                                      &first_invalid_escape_ptr);
+     if (result == NULL)
+         return NULL;
+-    if (first_invalid_escape != NULL) {
+-        unsigned char c = *first_invalid_escape;
+-        if ('4' <= c && c <= '7') {
++    if (first_invalid_escape_char != -1) {
++        if (first_invalid_escape_char > 0xff) {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+-                                 "invalid octal escape sequence '\\%.3s'",
+-                                 first_invalid_escape) < 0)
++                                 "invalid octal escape sequence '\\%o'",
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+@@ -6319,7 +6344,7 @@ _PyUnicode_DecodeUnicodeEscapeStateful(const char *s,
+         else {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                                  "invalid escape sequence '\\%c'",
+-                                 c) < 0)
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+diff --git a/Parser/string_parser.c b/Parser/string_parser.c
+index 8607885f2e46bd..c4c41b07f6b63d 100644
+--- a/Parser/string_parser.c
++++ b/Parser/string_parser.c
+@@ -181,15 +181,18 @@ decode_unicode_with_escapes(Parser *parser, const char *s, size_t len, Token *t)
+     len = p - buf;
+     s = buf;
+ 
+-    const char *first_invalid_escape;
+-    v = _PyUnicode_DecodeUnicodeEscapeInternal(s, len, NULL, NULL, &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    v = _PyUnicode_DecodeUnicodeEscapeInternal2(s, (Py_ssize_t)len, NULL, NULL,
++                                                &first_invalid_escape_char,
++                                                &first_invalid_escape_ptr);
+ 
+     // HACK: later we can simply pass the line no, since we don't preserve the tokens
+     // when we are decoding the string but we preserve the line numbers.
+-    if (v != NULL && first_invalid_escape != NULL && t != NULL) {
+-        if (warn_invalid_escape_sequence(parser, s, first_invalid_escape, t) < 0) {
+-            /* We have not decref u before because first_invalid_escape points
+-               inside u. */
++    if (v != NULL && first_invalid_escape_ptr != NULL && t != NULL) {
++        if (warn_invalid_escape_sequence(parser, s, first_invalid_escape_ptr, t) < 0) {
++            /* We have not decref u before because first_invalid_escape_ptr
++               points inside u. */
+             Py_XDECREF(u);
+             Py_DECREF(v);
+             return NULL;
+@@ -202,14 +205,17 @@ decode_unicode_with_escapes(Parser *parser, const char *s, size_t len, Token *t)
+ static PyObject *
+ decode_bytes_with_escapes(Parser *p, const char *s, Py_ssize_t len, Token *t)
+ {
+-    const char *first_invalid_escape;
+-    PyObject *result = _PyBytes_DecodeEscape(s, len, NULL, &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyBytes_DecodeEscape2(s, len, NULL,
++                                              &first_invalid_escape_char,
++                                              &first_invalid_escape_ptr);
+     if (result == NULL) {
+         return NULL;
+     }
+ 
+-    if (first_invalid_escape != NULL) {
+-        if (warn_invalid_escape_sequence(p, s, first_invalid_escape, t) < 0) {
++    if (first_invalid_escape_ptr != NULL) {
++        if (warn_invalid_escape_sequence(p, s, first_invalid_escape_ptr, t) < 0) {
+             Py_DECREF(result);
+             return NULL;
+         }

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.3"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -64,7 +64,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: gh-118224.patch gh-127301.patch
+      patches: gh-118224.patch gh-127301.patch CVE-2025-4516.patch
 
   - name: Configure
     runs: |

--- a/python-3.13/CVE-2025-4516.patch
+++ b/python-3.13/CVE-2025-4516.patch
@@ -1,0 +1,551 @@
+diff --git a/Include/internal/pycore_bytesobject.h b/Include/internal/pycore_bytesobject.h
+index 300e7f4896a39e..8ea9b3ebb88454 100644
+--- a/Include/internal/pycore_bytesobject.h
++++ b/Include/internal/pycore_bytesobject.h
+@@ -20,8 +20,9 @@ extern PyObject* _PyBytes_FromHex(
+ 
+ // Helper for PyBytes_DecodeEscape that detects invalid escape chars.
+ // Export for test_peg_generator.
+-PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
+-                                            const char *, const char **);
++PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape2(const char *, Py_ssize_t,
++                                             const char *,
++                                             int *, const char **);
+ 
+ 
+ // Substring Search.
+diff --git a/Include/internal/pycore_unicodeobject.h b/Include/internal/pycore_unicodeobject.h
+index 173c0868cf17bc..e9cf9bed5b8527 100644
+--- a/Include/internal/pycore_unicodeobject.h
++++ b/Include/internal/pycore_unicodeobject.h
+@@ -142,14 +142,18 @@ extern PyObject* _PyUnicode_DecodeUnicodeEscapeStateful(
+ // Helper for PyUnicode_DecodeUnicodeEscape that detects invalid escape
+ // chars.
+ // Export for test_peg_generator.
+-PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal(
++PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal2(
+     const char *string,     /* Unicode-Escape encoded string */
+     Py_ssize_t length,      /* size of string */
+     const char *errors,     /* error handling */
+     Py_ssize_t *consumed,   /* bytes consumed */
+-    const char **first_invalid_escape); /* on return, points to first
+-                                           invalid escaped char in
+-                                           string. */
++    int *first_invalid_escape_char, /* on return, if not -1, contain the first
++                                       invalid escaped char (<= 0xff) or invalid
++                                       octal escape (> 0xff) in string. */
++    const char **first_invalid_escape_ptr); /* on return, if not NULL, may
++                                        point to the first invalid escaped
++                                        char in string.
++                                        May be NULL if errors is not NULL. */
+ 
+ /* --- Raw-Unicode-Escape Codecs ---------------------------------------------- */
+ 
+diff --git a/Lib/test/test_codeccallbacks.py b/Lib/test/test_codeccallbacks.py
+index 4991330489d139..d85f609d806932 100644
+--- a/Lib/test/test_codeccallbacks.py
++++ b/Lib/test/test_codeccallbacks.py
+@@ -1,6 +1,7 @@
+ import codecs
+ import html.entities
+ import itertools
++import re
+ import sys
+ import unicodedata
+ import unittest
+@@ -1124,7 +1125,7 @@ def test_bug828737(self):
+             text = 'abc<def>ghi'*n
+             text.translate(charmap)
+ 
+-    def test_mutatingdecodehandler(self):
++    def test_mutating_decode_handler(self):
+         baddata = [
+             ("ascii", b"\xff"),
+             ("utf-7", b"++"),
+@@ -1159,6 +1160,42 @@ def mutating(exc):
+         for (encoding, data) in baddata:
+             self.assertEqual(data.decode(encoding, "test.mutating"), "\u4242")
+ 
++    def test_mutating_decode_handler_unicode_escape(self):
++        decode = codecs.unicode_escape_decode
++        def mutating(exc):
++            if isinstance(exc, UnicodeDecodeError):
++                r = data.get(exc.object[:exc.end])
++                if r is not None:
++                    exc.object = r[0] + exc.object[exc.end:]
++                    return ('\u0404', r[1])
++            raise AssertionError("don't know how to handle %r" % exc)
++
++        codecs.register_error('test.mutating2', mutating)
++        data = {
++            br'\x0': (b'\\', 0),
++            br'\x3': (b'xxx\\', 3),
++            br'\x5': (b'x\\', 1),
++        }
++        def check(input, expected, msg):
++            with self.assertWarns(DeprecationWarning) as cm:
++                self.assertEqual(decode(input, 'test.mutating2'), (expected, len(input)))
++            self.assertIn(msg, str(cm.warning))
++
++        check(br'\x0n\z', '\u0404\n\\z', r"invalid escape sequence '\z'")
++        check(br'\x0n\501', '\u0404\n\u0141', r"invalid octal escape sequence '\501'")
++        check(br'\x0z', '\u0404\\z', r"invalid escape sequence '\z'")
++
++        check(br'\x3n\zr', '\u0404\n\\zr', r"invalid escape sequence '\z'")
++        check(br'\x3zr', '\u0404\\zr', r"invalid escape sequence '\z'")
++        check(br'\x3z5', '\u0404\\z5', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x3z5x')[:-1], '\u0404\\z5', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x3z5xy')[:-2], '\u0404\\z5', r"invalid escape sequence '\z'")
++
++        check(br'\x5n\z', '\u0404\n\\z', r"invalid escape sequence '\z'")
++        check(br'\x5n\501', '\u0404\n\u0141', r"invalid octal escape sequence '\501'")
++        check(br'\x5z', '\u0404\\z', r"invalid escape sequence '\z'")
++        check(memoryview(br'\x5zy')[:-1], '\u0404\\z', r"invalid escape sequence '\z'")
++
+     # issue32583
+     def test_crashing_decode_handler(self):
+         # better generating one more character to fill the extra space slot
+diff --git a/Lib/test/test_codecs.py b/Lib/test/test_codecs.py
+index d539a86ec262eb..e98570ba19f029 100644
+--- a/Lib/test/test_codecs.py
++++ b/Lib/test/test_codecs.py
+@@ -1196,23 +1196,39 @@ def test_escape(self):
+         check(br"[\1010]", b"[A0]")
+         check(br"[\x41]", b"[A]")
+         check(br"[\x410]", b"[A0]")
++
++    def test_warnings(self):
++        decode = codecs.escape_decode
++        check = coding_checker(self, decode)
+         for i in range(97, 123):
+             b = bytes([i])
+             if b not in b'abfnrtvx':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % i):
+                     check(b"\\" + b, b"\\" + b)
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid escape sequence '\\%c'" % (i-32)):
+                 check(b"\\" + b.upper(), b"\\" + b.upper())
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\8'"):
+             check(br"\8", b"\\8")
+         with self.assertWarns(DeprecationWarning):
+             check(br"\9", b"\\9")
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\\xfa'") as cm:
+             check(b"\\\xfa", b"\\\xfa")
+         for i in range(0o400, 0o1000):
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid octal escape sequence '\\%o'" % i):
+                 check(rb'\%o' % i, bytes([i & 0o377]))
+ 
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\z'"):
++            self.assertEqual(decode(br'\x\z', 'ignore'), (b'\\z', 4))
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid octal escape sequence '\\501'"):
++            self.assertEqual(decode(br'\x\501', 'ignore'), (b'A', 6))
++
+     def test_errors(self):
+         decode = codecs.escape_decode
+         self.assertRaises(ValueError, decode, br"\x")
+@@ -2661,24 +2677,40 @@ def test_escape_decode(self):
+         check(br"[\x410]", "[A0]")
+         check(br"\u20ac", "\u20ac")
+         check(br"\U0001d120", "\U0001d120")
++
++    def test_decode_warnings(self):
++        decode = codecs.unicode_escape_decode
++        check = coding_checker(self, decode)
+         for i in range(97, 123):
+             b = bytes([i])
+             if b not in b'abfnrtuvx':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % i):
+                     check(b"\\" + b, "\\" + chr(i))
+             if b.upper() not in b'UN':
+-                with self.assertWarns(DeprecationWarning):
++                with self.assertWarnsRegex(DeprecationWarning,
++                        r"invalid escape sequence '\\%c'" % (i-32)):
+                     check(b"\\" + b.upper(), "\\" + chr(i-32))
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\8'"):
+             check(br"\8", "\\8")
+         with self.assertWarns(DeprecationWarning):
+             check(br"\9", "\\9")
+-        with self.assertWarns(DeprecationWarning):
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\\xfa'") as cm:
+             check(b"\\\xfa", "\\\xfa")
+         for i in range(0o400, 0o1000):
+-            with self.assertWarns(DeprecationWarning):
++            with self.assertWarnsRegex(DeprecationWarning,
++                    r"invalid octal escape sequence '\\%o'" % i):
+                 check(rb'\%o' % i, chr(i))
+ 
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid escape sequence '\\z'"):
++            self.assertEqual(decode(br'\x\z', 'ignore'), ('\\z', 4))
++        with self.assertWarnsRegex(DeprecationWarning,
++                r"invalid octal escape sequence '\\501'"):
++            self.assertEqual(decode(br'\x\501', 'ignore'), ('\u0141', 6))
++
+     def test_decode_errors(self):
+         decode = codecs.unicode_escape_decode
+         for c, d in (b'x', 2), (b'u', 4), (b'U', 4):
+diff --git a/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst b/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst
+new file mode 100644
+index 00000000000000..39d2f1e1a892cf
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2025-05-09-20-22-54.gh-issue-133767.kN2i3Q.rst
+@@ -0,0 +1,2 @@
++Fix use-after-free in the "unicode-escape" decoder with a non-"strict" error
++handler.
+diff --git a/Objects/bytesobject.c b/Objects/bytesobject.c
+index 733043c1447c5a..3176a559b28fe9 100644
+--- a/Objects/bytesobject.c
++++ b/Objects/bytesobject.c
+@@ -1065,10 +1065,11 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
+ }
+ 
+ /* Unescape a backslash-escaped string. */
+-PyObject *_PyBytes_DecodeEscape(const char *s,
++PyObject *_PyBytes_DecodeEscape2(const char *s,
+                                 Py_ssize_t len,
+                                 const char *errors,
+-                                const char **first_invalid_escape)
++                                int *first_invalid_escape_char,
++                                const char **first_invalid_escape_ptr)
+ {
+     int c;
+     char *p;
+@@ -1082,7 +1083,8 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+         return NULL;
+     writer.overallocate = 1;
+ 
+-    *first_invalid_escape = NULL;
++    *first_invalid_escape_char = -1;
++    *first_invalid_escape_ptr = NULL;
+ 
+     end = s + len;
+     while (s < end) {
+@@ -1120,9 +1122,10 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+                     c = (c<<3) + *s++ - '0';
+             }
+             if (c > 0377) {
+-                if (*first_invalid_escape == NULL) {
+-                    *first_invalid_escape = s-3; /* Back up 3 chars, since we've
+-                                                    already incremented s. */
++                if (*first_invalid_escape_char == -1) {
++                    *first_invalid_escape_char = c;
++                    /* Back up 3 chars, since we've already incremented s. */
++                    *first_invalid_escape_ptr = s - 3;
+                 }
+             }
+             *p++ = c;
+@@ -1163,9 +1166,10 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
+             break;
+ 
+         default:
+-            if (*first_invalid_escape == NULL) {
+-                *first_invalid_escape = s-1; /* Back up one char, since we've
+-                                                already incremented s. */
++            if (*first_invalid_escape_char == -1) {
++                *first_invalid_escape_char = (unsigned char)s[-1];
++                /* Back up one char, since we've already incremented s. */
++                *first_invalid_escape_ptr = s - 1;
+             }
+             *p++ = '\\';
+             s--;
+@@ -1185,17 +1189,18 @@ PyObject *PyBytes_DecodeEscape(const char *s,
+                                 Py_ssize_t Py_UNUSED(unicode),
+                                 const char *Py_UNUSED(recode_encoding))
+ {
+-    const char* first_invalid_escape;
+-    PyObject *result = _PyBytes_DecodeEscape(s, len, errors,
+-                                             &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyBytes_DecodeEscape2(s, len, errors,
++                                             &first_invalid_escape_char,
++                                             &first_invalid_escape_ptr);
+     if (result == NULL)
+         return NULL;
+-    if (first_invalid_escape != NULL) {
+-        unsigned char c = *first_invalid_escape;
+-        if ('4' <= c && c <= '7') {
++    if (first_invalid_escape_char != -1) {
++        if (first_invalid_escape_char > 0xff) {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+-                                 "invalid octal escape sequence '\\%.3s'",
+-                                 first_invalid_escape) < 0)
++                                 "invalid octal escape sequence '\\%o'",
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+@@ -1204,7 +1209,7 @@ PyObject *PyBytes_DecodeEscape(const char *s,
+         else {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                                  "invalid escape sequence '\\%c'",
+-                                 c) < 0)
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+diff --git a/Objects/unicodeobject.c b/Objects/unicodeobject.c
+index 27e66b2a7ca18c..40e12ba45c3823 100644
+--- a/Objects/unicodeobject.c
++++ b/Objects/unicodeobject.c
+@@ -6184,13 +6184,15 @@ _PyUnicode_GetNameCAPI(void)
+ /* --- Unicode Escape Codec ----------------------------------------------- */
+ 
+ PyObject *
+-_PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
++_PyUnicode_DecodeUnicodeEscapeInternal2(const char *s,
+                                Py_ssize_t size,
+                                const char *errors,
+                                Py_ssize_t *consumed,
+-                               const char **first_invalid_escape)
++                               int *first_invalid_escape_char,
++                               const char **first_invalid_escape_ptr)
+ {
+     const char *starts = s;
++    const char *initial_starts = starts;
+     _PyUnicodeWriter writer;
+     const char *end;
+     PyObject *errorHandler = NULL;
+@@ -6198,7 +6200,8 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+     _PyUnicode_Name_CAPI *ucnhash_capi;
+ 
+     // so we can remember if we've seen an invalid escape char or not
+-    *first_invalid_escape = NULL;
++    *first_invalid_escape_char = -1;
++    *first_invalid_escape_ptr = NULL;
+ 
+     if (size == 0) {
+         if (consumed) {
+@@ -6286,9 +6289,12 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+                 }
+             }
+             if (ch > 0377) {
+-                if (*first_invalid_escape == NULL) {
+-                    *first_invalid_escape = s-3; /* Back up 3 chars, since we've
+-                                                    already incremented s. */
++                if (*first_invalid_escape_char == -1) {
++                    *first_invalid_escape_char = ch;
++                    if (starts == initial_starts) {
++                        /* Back up 3 chars, since we've already incremented s. */
++                        *first_invalid_escape_ptr = s - 3;
++                    }
+                 }
+             }
+             WRITE_CHAR(ch);
+@@ -6383,9 +6389,12 @@ _PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
+             goto error;
+ 
+         default:
+-            if (*first_invalid_escape == NULL) {
+-                *first_invalid_escape = s-1; /* Back up one char, since we've
+-                                                already incremented s. */
++            if (*first_invalid_escape_char == -1) {
++                *first_invalid_escape_char = c;
++                if (starts == initial_starts) {
++                    /* Back up one char, since we've already incremented s. */
++                    *first_invalid_escape_ptr = s - 1;
++                }
+             }
+             WRITE_ASCII_CHAR('\\');
+             WRITE_CHAR(c);
+@@ -6430,18 +6439,19 @@ _PyUnicode_DecodeUnicodeEscapeStateful(const char *s,
+                               const char *errors,
+                               Py_ssize_t *consumed)
+ {
+-    const char *first_invalid_escape;
+-    PyObject *result = _PyUnicode_DecodeUnicodeEscapeInternal(s, size, errors,
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyUnicode_DecodeUnicodeEscapeInternal2(s, size, errors,
+                                                       consumed,
+-                                                      &first_invalid_escape);
++                                                      &first_invalid_escape_char,
++                                                      &first_invalid_escape_ptr);
+     if (result == NULL)
+         return NULL;
+-    if (first_invalid_escape != NULL) {
+-        unsigned char c = *first_invalid_escape;
+-        if ('4' <= c && c <= '7') {
++    if (first_invalid_escape_char != -1) {
++        if (first_invalid_escape_char > 0xff) {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+-                                 "invalid octal escape sequence '\\%.3s'",
+-                                 first_invalid_escape) < 0)
++                                 "invalid octal escape sequence '\\%o'",
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+@@ -6450,7 +6460,7 @@ _PyUnicode_DecodeUnicodeEscapeStateful(const char *s,
+         else {
+             if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                                  "invalid escape sequence '\\%c'",
+-                                 c) < 0)
++                                 first_invalid_escape_char) < 0)
+             {
+                 Py_DECREF(result);
+                 return NULL;
+diff --git a/Parser/string_parser.c b/Parser/string_parser.c
+index ce96b6e7b44f50..16d96cc5c0030b 100644
+--- a/Parser/string_parser.c
++++ b/Parser/string_parser.c
+@@ -184,15 +184,18 @@ decode_unicode_with_escapes(Parser *parser, const char *s, size_t len, Token *t)
+     len = (size_t)(p - buf);
+     s = buf;
+ 
+-    const char *first_invalid_escape;
+-    v = _PyUnicode_DecodeUnicodeEscapeInternal(s, (Py_ssize_t)len, NULL, NULL, &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    v = _PyUnicode_DecodeUnicodeEscapeInternal2(s, (Py_ssize_t)len, NULL, NULL,
++                                                &first_invalid_escape_char,
++                                                &first_invalid_escape_ptr);
+ 
+     // HACK: later we can simply pass the line no, since we don't preserve the tokens
+     // when we are decoding the string but we preserve the line numbers.
+-    if (v != NULL && first_invalid_escape != NULL && t != NULL) {
+-        if (warn_invalid_escape_sequence(parser, s, first_invalid_escape, t) < 0) {
+-            /* We have not decref u before because first_invalid_escape points
+-               inside u. */
++    if (v != NULL && first_invalid_escape_ptr != NULL && t != NULL) {
++        if (warn_invalid_escape_sequence(parser, s, first_invalid_escape_ptr, t) < 0) {
++            /* We have not decref u before because first_invalid_escape_ptr
++               points inside u. */
+             Py_XDECREF(u);
+             Py_DECREF(v);
+             return NULL;
+@@ -205,14 +208,17 @@ decode_unicode_with_escapes(Parser *parser, const char *s, size_t len, Token *t)
+ static PyObject *
+ decode_bytes_with_escapes(Parser *p, const char *s, Py_ssize_t len, Token *t)
+ {
+-    const char *first_invalid_escape;
+-    PyObject *result = _PyBytes_DecodeEscape(s, len, NULL, &first_invalid_escape);
++    int first_invalid_escape_char;
++    const char *first_invalid_escape_ptr;
++    PyObject *result = _PyBytes_DecodeEscape2(s, len, NULL,
++                                              &first_invalid_escape_char,
++                                              &first_invalid_escape_ptr);
+     if (result == NULL) {
+         return NULL;
+     }
+ 
+-    if (first_invalid_escape != NULL) {
+-        if (warn_invalid_escape_sequence(p, s, first_invalid_escape, t) < 0) {
++    if (first_invalid_escape_ptr != NULL) {
++        if (warn_invalid_escape_sequence(p, s, first_invalid_escape_ptr, t) < 0) {
+             Py_DECREF(result);
+             return NULL;
+         }
+
+From 99204fd12f5ef298e2cbd04759577e357e1443c4 Mon Sep 17 00:00:00 2001
+From: Serhiy Storchaka <storchaka@gmail.com>
+Date: Mon, 19 May 2025 14:47:10 +0300
+Subject: [PATCH 2/2] Add stub functions.
+
+---
+ Include/internal/pycore_bytesobject.h   |  3 +++
+ Include/internal/pycore_unicodeobject.h |  9 +++++++++
+ Objects/bytesobject.c                   | 13 +++++++++++++
+ Objects/unicodeobject.c                 | 15 +++++++++++++++
+ 4 files changed, 40 insertions(+)
+
+diff --git a/Include/internal/pycore_bytesobject.h b/Include/internal/pycore_bytesobject.h
+index 8ea9b3ebb88454..8c922a4fb3037a 100644
+--- a/Include/internal/pycore_bytesobject.h
++++ b/Include/internal/pycore_bytesobject.h
+@@ -23,6 +23,9 @@ extern PyObject* _PyBytes_FromHex(
+ PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape2(const char *, Py_ssize_t,
+                                              const char *,
+                                              int *, const char **);
++// Export for binary compatibility.
++PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
++                                            const char *, const char **);
+ 
+ 
+ // Substring Search.
+diff --git a/Include/internal/pycore_unicodeobject.h b/Include/internal/pycore_unicodeobject.h
+index e9cf9bed5b8527..5ebc7c120fc29d 100644
+--- a/Include/internal/pycore_unicodeobject.h
++++ b/Include/internal/pycore_unicodeobject.h
+@@ -154,6 +154,15 @@ PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal2(
+                                         point to the first invalid escaped
+                                         char in string.
+                                         May be NULL if errors is not NULL. */
++// Export for binary compatibility.
++PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscapeInternal(
++    const char *string,     /* Unicode-Escape encoded string */
++    Py_ssize_t length,      /* size of string */
++    const char *errors,     /* error handling */
++    Py_ssize_t *consumed,   /* bytes consumed */
++    const char **first_invalid_escape); /* on return, points to first
++                                           invalid escaped char in
++                                           string. */
+ 
+ /* --- Raw-Unicode-Escape Codecs ---------------------------------------------- */
+ 
+diff --git a/Objects/bytesobject.c b/Objects/bytesobject.c
+index 3176a559b28fe9..cebc27f618cba1 100644
+--- a/Objects/bytesobject.c
++++ b/Objects/bytesobject.c
+@@ -1183,6 +1183,19 @@ PyObject *_PyBytes_DecodeEscape2(const char *s,
+     return NULL;
+ }
+ 
++// Export for binary compatibility.
++PyObject *_PyBytes_DecodeEscape(const char *s,
++                                Py_ssize_t len,
++                                const char *errors,
++                                const char **first_invalid_escape)
++{
++    int first_invalid_escape_char;
++    return _PyBytes_DecodeEscape2(
++            s, len, errors,
++            &first_invalid_escape_char,
++            first_invalid_escape);
++}
++
+ PyObject *PyBytes_DecodeEscape(const char *s,
+                                 Py_ssize_t len,
+                                 const char *errors,
+diff --git a/Objects/unicodeobject.c b/Objects/unicodeobject.c
+index 40e12ba45c3823..a996d8f501ac2d 100644
+--- a/Objects/unicodeobject.c
++++ b/Objects/unicodeobject.c
+@@ -6433,6 +6433,21 @@ _PyUnicode_DecodeUnicodeEscapeInternal2(const char *s,
+     return NULL;
+ }
+ 
++// Export for binary compatibility.
++PyObject *
++_PyUnicode_DecodeUnicodeEscapeInternal(const char *s,
++                               Py_ssize_t size,
++                               const char *errors,
++                               Py_ssize_t *consumed,
++                               const char **first_invalid_escape)
++{
++    int first_invalid_escape_char;
++    return _PyUnicode_DecodeUnicodeEscapeInternal2(
++            s, size, errors, consumed,
++            &first_invalid_escape_char,
++            first_invalid_escape);
++}
++
+ PyObject *
+ _PyUnicode_DecodeUnicodeEscapeStateful(const char *s,
+                               Py_ssize_t size,


### PR DESCRIPTION
## Summary
Fix use-after-free vulnerability in the unicode-escape decoder with non-strict error handlers.

## Details
- **CVE**: CVE-2025-4516
- **Severity**: Medium
- **Issue**: Use-after-free crash when using `bytes.decode("unicode_escape", error="ignore|replace")`

## Changes
- Add CVE-2025-4516.patch from upstream merged PRs
  - Python 3.12: [PR #134337](https://github.com/python/cpython/pull/134337)
  - Python 3.13: [PR #133944](https://github.com/python/cpython/pull/133944)
- Increment epoch to 2 for both packages

## Status
- ✅ Python 3.12: Upstream patch merged and applied
- ✅ Python 3.13: Upstream patch merged and applied
- ⏳ Python 3.9, 3.10, 3.11: Waiting for upstream PRs to be merged

## Testing
CI will validate that:
- Patches apply cleanly
- Packages build successfully
- Tests pass

## References
- [CVE-2025-4516 Details](https://www.cve.org/CVERecord?id=CVE-2025-4516)
- [Security Advisory](https://mail.python.org/archives/list/security-announce@python.org/thread/L75IPBBTSCYEF56I2M4KIW353BB3AY74/)
- Related to: chainguard-dev/internal-dev#12589