### PR TITLE
python-3.10, python-3.11, python-3.12, python-3.13: Add missing cmd provides (P0)

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: "3.10.17"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -119,6 +119,9 @@ subpackages:
   - name: "${{package.name}}-base"
     description: "${{package.name}} without /usr/bin/python3"
     dependencies:
+      provides:
+        - cmd:python${{vars.pyversion}}=${{package.full-version}}
+        - cmd:pydoc${{vars.pyversion}}=${{package.full-version}}
       runtime:
         - py3-setuptools-wheel
         - py3-pip-wheel

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: "3.11.12"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -119,6 +119,9 @@ subpackages:
   - name: "${{package.name}}-base"
     description: "${{package.name}} without /usr/bin/python3"
     dependencies:
+      provides:
+        - cmd:python${{vars.pyversion}}=${{package.full-version}}
+        - cmd:pydoc${{vars.pyversion}}=${{package.full-version}}
       runtime:
         - py3-setuptools-wheel
         - py3-pip-wheel

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.10"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -130,6 +130,9 @@ subpackages:
   - name: "${{package.name}}-base"
     description: "${{package.name}} without /usr/bin/python3"
     dependencies:
+      provides:
+        - cmd:python${{vars.pyversion}}=${{package.full-version}}
+        - cmd:pydoc${{vars.pyversion}}=${{package.full-version}}
       runtime:
         - py3-pip-wheel
     pipeline:

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.3"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -130,6 +130,9 @@ subpackages:
   - name: "${{package.name}}-base"
     description: "${{package.name}} without /usr/bin/python3"
     dependencies:
+      provides:
+        - cmd:python${{vars.pyversion}}=${{package.full-version}}
+        - cmd:pydoc${{vars.pyversion}}=${{package.full-version}}
       runtime:
         - py3-pip-wheel
     pipeline:


### PR DESCRIPTION
## Summary
This PR fixes a P0 issue where APKO builds were resolving to ancient Python versions (e.g., python-3.12=3.12.2-r6) instead of current versions (e.g., 3.12.10-r1).

## Root Cause
The python-3.XX-base subpackages were missing critical `cmd:` provides entries that APKO uses for package resolution. When packages like numpy request `cmd:python3.12`, APKO couldn't find it in the current packages and fell back to very old versions that still had these provides.

This was an oversight from the March 2024 refactoring where the Python binaries were moved from the main package to the -base subpackage, but the provides metadata wasn't updated accordingly.

## Changes
Added the following provides to all python-3.XX-base subpackages (3.10, 3.11, 3.12, 3.13):
```yaml
provides:
  - cmd:python${{vars.pyversion}}=${{package.full-version}}
  - cmd:pydoc${{vars.pyversion}}=${{package.full-version}}
```

Also incremented the epoch for all affected packages to ensure updates are applied.

## Testing
- Verified that the binaries exist in the -base subpackages

Related to [#12590](https://github.com/chainguard-dev/internal-dev/issues/12590)

## Impact
This is a P0 issue affecting production images including:
- management-api-for-apache-cassandra-4.1
- py3-cassandra-medusa
- Other images that depend on specific Python versions via cmd: provides