### PR TITLE
[WIP] feat: add guarddog 

### DIFF
--- a/py3-disposable-email-domains.yaml
+++ b/py3-disposable-email-domains.yaml
@@ -1,0 +1,75 @@
+package:
+  name: disposable-email-domains
+  version: 0.0.126
+  epoch: 0
+  description: A set of disposable email domains
+  copyright:
+    - license: CC0-1.0
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: disposable-email-domains
+  import: disposable_email_domains
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      # TODO: I was execpting a uri like,
+      #    https://files.pythonhosted.org/packages/source/p/python-whois/python-whois-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/9e/78/2b154cefd8d0bacdcd288d576acf51512d2f96491834799655dfe4907856/disposable_email_domains-${{package.version}}.tar.gz
+      expected-sha256: 7cfc4038e4fbc884fb0e8ba99d4942ea2410581330e6268da07f218e358128c2
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  git: {}

--- a/py3-guarddog.yaml
+++ b/py3-guarddog.yaml
@@ -1,0 +1,123 @@
+package:
+  name: guarddog
+  version: 2.6.0
+  epoch: 0
+  description: GuardDog is a CLI tool to Identify malicious PyPI and npm packages
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: guarddog
+  import: gaurddog
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base-dev
+      - py3-supported-poetry
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/datadog/guarddog
+      tag: v${{package.version}}
+      expected-commit: 29d17260d392a42d60af27c4222183929157fc24
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+#      runtime:
+#        - py${{range.key}}-importlib-metadata
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - py${{range.key}}-pyyaml
+        - py${{range.key}}-yara-python
+        - py${{range.key}}-python-dateutil
+        - py${{range.key}}-python-whois
+        - py${{range.key}}-typing-extensions
+        - py${{range.key}}-requests
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help || :
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    #- uses: python/import
+    #  with:
+    #    imports: |
+    #      import ${{vars.import}}
+    - runs: |
+        guarddog pypi scan requests
+        guarddog npm scan express
+        guarddog go scan github.com/datadog/dd-trace-go
+
+update:
+  enabled: true
+  git: {}
+
+

--- a/py3-python-whois.yaml
+++ b/py3-python-whois.yaml
@@ -1,16 +1,16 @@
 package:
-  name: py3-typing-extensions
-  version: 4.13.2
+  name: py3-python-whois
+  version: 0.9.5
   epoch: 0
-  description: Backported and experimental type hints for Python 
+  description: Whois querying and parsing of domain registration information.
   copyright:
-    - license: PSF-2.0
+    - license: MIT
   dependencies:
     provider-priority: 0
 
 vars:
-  pypi-package: typing-extensions
-  import: typing_extensions
+  pypi-package: python-whois
+  import: whois
 
 data:
   - name: py-versions
@@ -24,14 +24,14 @@ environment:
   contents:
     packages:
       - py3-supported-build-base-dev
-      - py3-supported-flit-core
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/python/typing_extensions
-      tag: ${{package.version}}
-      expected-commit: 4525e9dbbd177b4ef8a84f55ff5fe127582a071d
+      # TODO: I was execpting a uri like,
+      #    https://files.pythonhosted.org/packages/source/p/python-whois/python-whois-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/f5/5b/5c0c705d14945954b23b69042c1597971da3cd6dc3ed23b96449be91d665/python_whois-${{package.version}}.tar.gz
+      expected-sha256: 18968c21484752fcc4b9a5f0af477ef6b8dc2e8bb7f1bd5c33831499c0dd41ca
 
 subpackages:
   - range: py-versions
@@ -41,6 +41,8 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-python-dateutil
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-yara-python.yaml
+++ b/py3-yara-python.yaml
@@ -1,16 +1,16 @@
 package:
-  name: py3-typing-extensions
-  version: 4.13.2
+  name: py3-yara-python
+  version: 4.5.3
   epoch: 0
-  description: Backported and experimental type hints for Python 
+  description: The Python interface for YARA
   copyright:
-    - license: PSF-2.0
+    - license: Apache-2.0
   dependencies:
     provider-priority: 0
 
 vars:
-  pypi-package: typing-extensions
-  import: typing_extensions
+  pypi-package: yara-python
+  import: yara
 
 data:
   - name: py-versions
@@ -24,14 +24,14 @@ environment:
   contents:
     packages:
       - py3-supported-build-base-dev
-      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/python/typing_extensions
-      tag: ${{package.version}}
-      expected-commit: 4525e9dbbd177b4ef8a84f55ff5fe127582a071d
+      repository: https://github.com/VirusTotal/yara-python
+      recurse-submodules: true
+      tag: v${{package.version}}
+      expected-commit: 5caac1ea81f7e700dc7969abd9706dd0cd1580ec
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
Adds guarddog package. Most dependencies are required for tests. make passes, tests do not. Library test does not pass when uncommented/re-enabled. Not sure what best practices are for creating a Python package which provides a library and binary.

I can add the `disposable_email_domains` runtime depenency next. Help with import test and best practice advice is greatly appreciated.

I accidentally rebuilt `py3-typing-extensions.yaml` :sweat_smile: ig that will be a good check of my first packages.

cc: @egibs @antitree 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented