### PR TITLE
No-change rebuild to refresh SBOM for binutils

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 2
+  epoch: 3
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0


### PR DESCRIPTION
We added `downloadLocation` to the sources, and some packages need to be rebuilt separately due to circular dependencies.