### PR TITLE
No-change rebuild to refresh SBOM for bash

### DIFF
--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.37
-  epoch: 30
+  epoch: 31
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
We added `downloadLocation` to the sources, and some packages need to be rebuilt separately due to circular dependencies.