### PR TITLE
sbom: add type hints for undiscoverable gitlab

### DIFF
--- a/dav1d.yaml
+++ b/dav1d.yaml
@@ -1,7 +1,7 @@
 package:
   name: dav1d
   version: "1.5.1"
-  epoch: 2
+  epoch: 3
   description: small and fast AV1 Decoder
   copyright:
     - license: BSD-2-Clause
@@ -23,6 +23,7 @@ pipeline:
       repository: https://code.videolan.org/videolan/dav1d.git
       tag: ${{package.version}}
       expected-commit: 42b2b24fb8819f1ed3643aa9cf2a62f03868e3aa
+      type-hint: gitlab
 
   - uses: meson/configure
     with:

--- a/openldap.yaml
+++ b/openldap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap
   version: "2.6.10"
-  epoch: 1
+  epoch: 2
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8
@@ -41,6 +41,7 @@ pipeline:
       repository: https://git.openldap.org/openldap/openldap.git
       tag: OPENLDAP_REL_ENG_${{vars.mangled-package-version}}
       expected-commit: 22fe35c6b4098e3ad166469f9574c79832c42952
+      type-hint: gitlab
 
   - uses: patch
     with:


### PR DESCRIPTION
Ensures that a downloadLocation is generated for the upstream source
of these packages.
