### PR TITLE
py3-cassandra-medusa: align Python version with cassandra

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.24.0"
-  epoch: 2
+  epoch: 3
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,8 @@ package:
       - wolfi-baselayout
 
 vars:
-  py-version: 3.12
+  # NOTE: align with py-version in cassandra* packages.
+  py-version: 3.11
 
 environment:
   contents:


### PR DESCRIPTION
cassandra only supports up to Python 3.11; align Python version to ensure compatibility within the same image.
