### PR TITLE
Right size `falco-no-driver` resources

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,13 +1,17 @@
 package:
   name: falco-no-driver
   version: "0.41.0"
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - falco-rules
+  resources:
+    # https://go/wolfi-rsc/falco-no-driver
+    cpu: 20
+    memory: 20Gi
 
 environment:
   contents:


### PR DESCRIPTION
See: https://go/wolfi-rsc/falco-no-driver
