### PR TITLE
external-secrets-operator: rename eso to eso-0.17

### DIFF
--- a/external-secrets-operator-0.17.yaml
+++ b/external-secrets-operator-0.17.yaml
@@ -1,5 +1,5 @@
 package:
-  name: external-secrets-operator
+  name: external-secrets-operator-0.17
   version: "0.17.0"
   epoch: 2
   description: Integrate external secret management systems with Kubernetes
@@ -52,4 +52,4 @@ update:
   github:
     identifier: external-secrets/external-secrets
     strip-prefix: v
-    tag-filter: v
+    tag-filter: v.0.17.

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -5,9 +5,8 @@ package:
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
-  dependencies:
-    provides:
-      - external-secrets-operator=${{package.full-version}}
+  provides:
+    - external-secrets-operator=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -5,6 +5,9 @@ package:
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - external-secrets-operator=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -5,8 +5,9 @@ package:
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
-  provides:
-    - external-secrets-operator=${{package.full-version}}
+  dependencies:
+    provides:
+      - external-secrets-operator=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator
   version: "0.17.0"
-  epoch: 1
+  epoch: 2
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Fixes: 

- Rename external-secrets-operator to external-secrets-operator-0.17
- Provide external-secrets-operator package.full-version
- Update its tag-filter
- Bump its epoch
