### PR TITLE
GCC 15 update (and addition of `gcc-14-default`)

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.2.0
-  epoch: 13
+  epoch: 14
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -191,6 +191,50 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+
+  - name: 'gcc-14-default'
+    description: 'Use GCC 14 as system gcc'
+    dependencies:
+      provides:
+        - gcc=${{package.full-version}}
+      runtime:
+        - gcc-14=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+
+          for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
+            ln -sf "${{host.triplet.gnu}}-"$i"-14" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+          done
+
+          for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
+            ln -sf $i"-14" "${{targets.subpkgdir}}"/usr/bin/$i
+          done
+    test:
+      pipeline:
+        - runs: |
+            c++ --version
+            c++ --help
+            cpp --version
+            cpp --help
+            g++ --version
+            g++ --help
+            gcc --version
+            gcc --help
+            gcc-ar --version
+            gcc-ar --help
+            gcc-nm --version
+            gcc-nm --help
+            gcc-ranlib --version
+            gcc-ranlib --help
+            gcov --version
+            gcov --help
+            gcov-dump --version
+            gcov-dump --help
+            gcov-tool --version
+            gcov-tool --help
+            lto-dump --version
+            lto-dump --help
 
 test:
   environment:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
-  version: 14.2.0
-  epoch: 13
+  version: 15.1.0
+  epoch: 0
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -50,11 +50,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: 932bdef0cda94bacedf452ab17f103c0cb511ff2cec55e9112fc0328cbf1d803b42595728ea7b200e0a057c03e85626f937012e49a7515bc5dd256b2bf4bc396
-
-  - uses: patch
-    with:
-      patches: pr117739.patch
+      expected-sha512: ddd35ca6c653dffa88f7c7ef9ee4cd806e156e0f3b30f4d63e75a8363361285cd566ee73127734cde6a934611de815bee3e32e24bfd2e0ab9f7ff35c929821c1
 
   - name: 'Set up build directory'
     runs: |


### PR DESCRIPTION
Now that we have `gcc-14` version streamed in the archive, we can proceed with the update of GCC 15.

This PR also introduces the `gcc-14-default` package.