### PR TITLE
[shard 0] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/apache-kvrocks.yaml
+++ b/apache-kvrocks.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-kvrocks
   version: "2.12.1"
-  epoch: 0
+  epoch: 1
   description: Apache Kvrocks is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol.
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - busybox
       - cmake
       - coreutils
+      - gcc-14-default
       - libtool
       - lld
       - openssl-dev

--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.37
-  epoch: 31
+  epoch: 32
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
@@ -16,6 +16,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - ncurses-dev
 
 pipeline:

--- a/bat.yaml
+++ b/bat.yaml
@@ -1,7 +1,7 @@
 package:
   name: bat
   version: 0.25.0
-  epoch: 1
+  epoch: 2
   description: "A cat(1) clone with wings"
   copyright:
     - license: MIT OR Apache-2.0
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - rust
       - zlib-dev
 

--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-6
   version: 6.5.0
-  epoch: 3
+  epoch: 4
   description: Bazel is an open-source build and test tool
   resources:
     cpu: 16
@@ -20,6 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gcc
+      - gcc-14-default
       - libstdc++-6
       - libstdc++-6-dev
       - openjdk-11

--- a/bazel-7.yaml
+++ b/bazel-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-7
   version: "7.6.1"
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   resources:
     cpu: 16
@@ -19,6 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - libstdc++-6
       - libstdc++-6-dev
       - openjdk-21

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 3
+  epoch: 4
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - flex
+      - gcc-14-default
       - isl
       - posix-libc-utils
       - texinfo

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.82"
-  epoch: 1
+  epoch: 2
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0 AND LGPL-2.1 AND BSD-2-Clause AND MIT
@@ -18,6 +18,7 @@ environment:
       - dbus
       - dbus-dev
       - ell-dev
+      - gcc-14-default
       - glib-dev
       - icu-dev
       - json-c-dev

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.3"
-  epoch: 40
+  epoch: 41
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later
@@ -18,6 +18,7 @@ environment:
       - automake
       - build-base
       - busybox
+      - gcc-14-default
       - keyutils-dev
       - krb5-dev
       - libcap-dev

--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-15
   version: 15.0.7
-  epoch: 8
+  epoch: 9
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - help2man
       - libLLVM-15
       - libffi-dev

--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-16
   version: 16.0.6
-  epoch: 7
+  epoch: 8
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - help2man
       - libLLVM-16
       - libffi-dev

--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-18
   version: 18.1.8
-  epoch: 7
+  epoch: 8
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - help2man
       - libLLVM-18
       - libffi-dev

--- a/cmake-bootstrap.yaml
+++ b/cmake-bootstrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-bootstrap
   version: 3.31.7
-  epoch: 0
+  epoch: 1
   description: "Bootstrap CMake without using system libraries, enabling to use CMake to build system libraries used by CMake"
   dependencies:
     provider-priority: 5
@@ -15,6 +15,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - gcc-14-default
       - openssl-dev
       - samurai
 

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.31.7
-  epoch: 0
+  epoch: 1
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10
@@ -17,6 +17,7 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - expat-dev
+      - gcc-14-default
       - jsoncpp-dev
       - libarchive-dev
       - libuv-dev

--- a/cpio.yaml
+++ b/cpio.yaml
@@ -1,7 +1,7 @@
 package:
   name: cpio
   version: "2.15"
-  epoch: 0
+  epoch: 1
   description: tool to copy files into or out of a cpio or tar archive
   copyright:
     - license: GPL-3.0-or-later
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/cronie.yaml
+++ b/cronie.yaml
@@ -1,7 +1,7 @@
 package:
   name: cronie
   version: 1.7.2
-  epoch: 40
+  epoch: 41
   description: Cron daemon for executing programs at set times
   copyright:
     - license: ISC
@@ -19,6 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: git-checkout

--- a/cxxopts.yaml
+++ b/cxxopts.yaml
@@ -2,7 +2,7 @@
 package:
   name: cxxopts
   version: "3.3.1"
-  epoch: 0
+  epoch: 1
   description: Lightweight C++ command line option parser as a header only library
   copyright:
     - license: MIT
@@ -14,6 +14,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - ninja
 
 pipeline:

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 41
+  epoch: 42
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -18,6 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - gdbm-dev
       - heimdal-dev
       - libtool

--- a/db.yaml
+++ b/db.yaml
@@ -1,7 +1,7 @@
 package:
   name: db
   version: 5.3.28
-  epoch: 2
+  epoch: 3
   description: The Berkeley DB embedded database system
   copyright:
     - license: LicenseRef-berkeley-db
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
   environment:
     CFLAGS: "-Wno-error=implicit-int -Wno-error=implicit-function-declaration"
 

--- a/db.yaml
+++ b/db.yaml
@@ -1,7 +1,7 @@
 package:
   name: db
   version: 5.3.28
-  epoch: 3
+  epoch: 2
   description: The Berkeley DB embedded database system
   copyright:
     - license: LicenseRef-berkeley-db
@@ -15,7 +15,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
   environment:
     CFLAGS: "-Wno-error=implicit-int -Wno-error=implicit-function-declaration"
 

--- a/ddp-tool.yaml
+++ b/ddp-tool.yaml
@@ -2,7 +2,7 @@
 package:
   name: ddp-tool
   version: "1.0.34.0_git20250529"
-  epoch: 0
+  epoch: 1
   description: Intel Dynamic Device Personalization Tool
   copyright:
     - license: BSD-2-Clause
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - gcc
+      - gcc-14-default
       - make
 
 pipeline:


### PR DESCRIPTION
Several of our packages fail to build with GCC 15.  These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin `gcc-14-default` as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 0.