### PR TITLE
fix: clocking down to previous version for melange

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
-  version: "0.26.2"
-  epoch: 0
+  version: "0.26.3"
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 590ed9de132256901db33c3e442538785a6cdc8b
+      expected-commit: 65b41ce13a37e4dfe7c4b7fcadc0d7b3a881e794
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.26.3"
+  version: "0.26.2"
   epoch: 0
   description: build APKs from source code
   copyright:


### PR DESCRIPTION
Fixes: Issue where melange is using the wrong tag

Related:

