### PR TITLE
[shard 1] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/delta.yaml
+++ b/delta.yaml
@@ -1,7 +1,7 @@
 package:
   name: delta
   version: 0.18.2
-  epoch: 1
+  epoch: 2
   description: Syntax-highlighting pager for git and diff output
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - rust
 
 pipeline:

--- a/dhclient.yaml
+++ b/dhclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: dhclient
   version: 4.4.3
-  epoch: 40
+  epoch: 41
   description: dhcp client program
   copyright:
     - license: BSD-2-Clause
@@ -22,6 +22,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - file
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/difftastic.yaml
+++ b/difftastic.yaml
@@ -1,7 +1,7 @@
 package:
   name: difftastic
   version: "0.63.0"
-  epoch: 0
+  epoch: 1
   description: "a structural diff that understands syntax"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - rust
 
 pipeline:

--- a/duckdb.yaml
+++ b/duckdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: duckdb
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: "DuckDB is an analytical in-process SQL database management system"
   copyright:
     - license: MIT
@@ -14,6 +14,7 @@ environment:
       - build-base
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - git
       - ninja
       - openssl-dev

--- a/erlang-25.yaml
+++ b/erlang-25.yaml
@@ -2,7 +2,7 @@
 package:
   name: erlang-25
   version: "25.3.2.21"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - ncurses-dev
       - openssl-dev
       - perl-dev

--- a/fluent-bit-4.0.yaml
+++ b/fluent-bit-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-4.0
   version: "4.0.2"
-  epoch: 1
+  epoch: 2
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
       - cmake
       - dpkg
       - flex
+      - gcc-14-default
       - glibc
       - openssl-dev
       - postgresql-dev

--- a/gd.yaml
+++ b/gd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gd
   version: 2.3.3
-  epoch: 10
+  epoch: 11
   description: Library for the dynamic creation of images by programmers
   copyright:
     - license: GD
@@ -16,6 +16,7 @@ environment:
       - ca-certificates-bundle
       - fontconfig-dev
       - freetype-dev
+      - gcc-14-default
       - libavif-dev
       - libjpeg-turbo-dev
       - libpng-dev

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -1,7 +1,7 @@
 package:
   name: ghostscript
   version: "10.05.1"
-  epoch: 0
+  epoch: 1
   description: Interpreter for the PostScript language and for PDF
   copyright:
     - license: AGPL-3.0-or-later
@@ -17,6 +17,7 @@ environment:
       - cups-dev
       - expat-dev
       - freetype-dev
+      - gcc-14-default
       - gtk-2.0-dev
       - jbig2dec-dev
       - lcms2-dev

--- a/glpk.yaml
+++ b/glpk.yaml
@@ -1,7 +1,7 @@
 package:
   name: glpk
   version: 5.0
-  epoch: 2
+  epoch: 3
   description: The GLPK (GNU Linear Programming Kit) package is intended for solving large-scale linear programming (LP), mixed integer programming (MIP), and other related problems
   copyright:
     - license: GPL-3.0-or-later
@@ -14,6 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -2,7 +2,7 @@
 package:
   name: glslang
   version: 1.3.261.1
-  epoch: 3
+  epoch: 4
   description: Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator
   copyright:
     - license: BSD-3-Clause
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - python3
       - samurai
       - spirv-tools-dev

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 5
+  epoch: 6
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - m4
       - texinfo
       - wolfi-baselayout

--- a/gnucobol.yaml
+++ b/gnucobol.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnucobol
   version: 3.2
-  epoch: 1
+  epoch: 2
   description: "compiler from COBOL to C"
   copyright:
     - license: GPL-3.0-or-later
@@ -14,6 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - gmp-dev
 
 pipeline:

--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.2.41
-  epoch: 41
+  epoch: 42
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -19,6 +19,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      - gcc-14-default
       - gettext-dev
       - glibc-iconv
       # - pinentry TODO skipping for now as seems to require gtk+3.0, gcr, libproxy and mesa

--- a/grafana-oncall.yaml
+++ b/grafana-oncall.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-oncall
   version: "1.16.1"
-  epoch: 0
+  epoch: 1
   description: "Developer-friendly incident response with brilliant Slack integration"
   copyright:
     - license: AGPL-3.0-or-later
@@ -26,6 +26,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - git
       - libffi-dev
       - linux-headers

--- a/graphite2.yaml
+++ b/graphite2.yaml
@@ -1,7 +1,7 @@
 package:
   name: graphite2
   version: 1.3.14
-  epoch: 3
+  epoch: 4
   description: reimplementation of the SIL Graphite text processing engine
   copyright:
     - license: LGPL-2.1-or-later OR MPL-1.1
@@ -16,6 +16,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - freetype-dev
+      - gcc-14-default
       - samurai
 
 pipeline:

--- a/guile.yaml
+++ b/guile.yaml
@@ -1,7 +1,7 @@
 package:
   name: guile
   version: 3.0.10
-  epoch: 1
+  epoch: 2
   description: portable, embeddable Scheme implementation written in C
   copyright:
     - license: LGPL-3.0-or-later AND GPL-3.0-or-later
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gc-dev
+      - gcc-14-default
       - glibc-iconv
       - gmp-dev
       - libffi-dev

--- a/iftop.yaml
+++ b/iftop.yaml
@@ -1,7 +1,7 @@
 package:
   name: iftop
   version: 0.17
-  epoch: 40
+  epoch: 41
   description: A tool to display bandwidth usage on an interface
   copyright:
     - license: GPL-2.0-or-later
@@ -18,6 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - libpcap-dev
       - ncurses-dev
   environment:

--- a/iperf3.yaml
+++ b/iperf3.yaml
@@ -1,7 +1,7 @@
 package:
   name: iperf3
   version: "3.19"
-  epoch: 0
+  epoch: 1
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: BSD-3-Clause-LBNL
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - openssl-dev
 
 pipeline:

--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: 1.7.1
-  epoch: 5
+  epoch: 6
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - libtool
       - oniguruma-dev
       - wolfi-base

--- a/kdash.yaml
+++ b/kdash.yaml
@@ -1,7 +1,7 @@
 package:
   name: kdash
   version: "0.6.2"
-  epoch: 4
+  epoch: 5
   description: "A simple and fast dashboard for Kubernetes"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - libxcb
       - libxcb-dev
       - openssl


### PR DESCRIPTION
Several of our packages fail to build with GCC 15. These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin gcc-14-default as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 1.