### PR TITLE
[shard 2] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: 1.21.3
-  epoch: 41
+  epoch: 42
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - e2fsprogs-dev
       - flex
+      - gcc-14-default
       - keyutils-dev
       - krb5-conf
       - libverto-dev

--- a/libburn.yaml
+++ b/libburn.yaml
@@ -2,7 +2,7 @@
 package:
   name: libburn
   version: 1.5.6
-  epoch: 1
+  epoch: 2
   description: Library for reading, mastering and writing optical discs
   copyright:
     - license: GPL-2.0-or-later
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - linux-headers
 
 pipeline:

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 9
+  epoch: 10
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - ncurses-dev
       - wolfi-base
 

--- a/libfido2.yaml
+++ b/libfido2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfido2
   version: "1.16.0"
-  epoch: 0
+  epoch: 1
   description: library for FIDO 2.0 functionality
   copyright:
     - license: BSD-2-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - gcc-14-default
       - libcbor-dev
       - linux-headers
       - openssl-dev

--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgdiplus
   version: 6.1
-  epoch: 2
+  epoch: 3
   description: "Open Source Implementation of the GDI+ API"
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ environment:
       - cmake
       - expat-dev
       - fribidi-dev
+      - gcc-14-default
       - giflib-dev
       - glib-dev
       - glib-static

--- a/libical.yaml
+++ b/libical.yaml
@@ -2,7 +2,7 @@
 package:
   name: libical
   version: 3.0.16
-  epoch: 5
+  epoch: 6
   description: Reference implementation of the iCalendar format
   copyright:
     - license: LGPL-2.1-only OR MPL-2.0
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - glib-dev
       - glib-gir
       - gobject-introspection-dev

--- a/libmcrypt.yaml
+++ b/libmcrypt.yaml
@@ -2,7 +2,7 @@
 package:
   name: libmcrypt
   version: 2.5.8
-  epoch: 1
+  epoch: 2
   description: "A library which provides a uniform interface to several symmetric encryption algorithms"
   copyright:
     - license: LGPL-2.1-or-later
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - gcc
+      - gcc-14-default
       - libtool
 
 pipeline:

--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: "1.17.7"
-  epoch: 0
+  epoch: 1
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - coreutils # for GNU date
       - curl
+      - gcc-14-default
       - glibc-dev
       - go-1.23
       - libcap-dev # for sys/capability.h

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: "3.7.1"
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - curl-dev
+      - gcc-14-default
       - gmock
       - gtest-dev
       - openssl-dev

--- a/librelp.yaml
+++ b/librelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: librelp
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: librelp is an easy-to-use library for the RELP (Reliable Event Logging Protocol)
   copyright:
     - license: GPL-3.0-or-later
@@ -14,6 +14,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - coreutils
+      - gcc-14-default
       - gnutls-dev
       - grep
       - libtool

--- a/libsemanage.yaml
+++ b/libsemanage.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsemanage
   version: "3.8.1"
-  epoch: 2
+  epoch: 3
   description: "SELinux library and simple utilities"
   copyright:
     - license: LGPL-2.1-only
@@ -21,6 +21,7 @@ environment:
       - docbook-xml
       - flex
       - gcc
+      - gcc-14-default
       - gettext
       - glib-dev
       - libcap-dev

--- a/libtirpc.yaml
+++ b/libtirpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtirpc
   version: 1.3.6
-  epoch: 0
+  epoch: 1
   description: Transport Independent RPC library (SunRPC replacement)
   copyright:
     - license: BSD-3-Clause
@@ -14,6 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - krb5-dev
       - libtool
 

--- a/libunwind.yaml
+++ b/libunwind.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunwind
   version: "1.8.2"
-  epoch: 0
+  epoch: 1
   description: "Portable and efficient C programming interface (API) to determine the call-chain of a program"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - autoconf
       - automake
       - build-base
+      - gcc-14-default
       - libtool
       - linux-headers
       - wolfi-base

--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-18
   version: 18.1.8
-  epoch: 3
+  epoch: 4
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - git
       - libffi-dev
       - libxml2-dev

--- a/llvm-lld-15.yaml
+++ b/llvm-lld-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-lld-15
   version: 15.0.7
-  epoch: 5
+  epoch: 6
   description: The LLVM Linker
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - clang-15
       - cmake
       - curl
+      - gcc-14-default
       - git
       - libedit-dev
       - llvm-cmake-15

--- a/llvm-lld-16.yaml
+++ b/llvm-lld-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-lld-16
   version: 16.0.6
-  epoch: 8
+  epoch: 9
   description: The LLVM Linker
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - clang-16
       - cmake
       - curl
+      - gcc-14-default
       - git
       - libedit-dev
       - llvm-cmake-16

--- a/llvm-lld-17.yaml
+++ b/llvm-lld-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-lld-17
   version: 17.0.6
-  epoch: 3
+  epoch: 4
   description: The LLVM Linker
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - clang-17
       - cmake
       - curl
+      - gcc-14-default
       - git
       - libedit-dev
       - llvm-cmake-17

--- a/llvm-lld-18.yaml
+++ b/llvm-lld-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-lld-18
   version: 18.1.8
-  epoch: 1
+  epoch: 2
   description: The LLVM Linker
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - clang-18
       - cmake
       - curl
+      - gcc-14-default
       - git
       - libedit-dev
       - llvm-18

--- a/llvm15.yaml
+++ b/llvm15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm15
   version: 15.0.7
-  epoch: 7
+  epoch: 8
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - libffi-dev
       - libxml2-dev
       - llvm-cmake-15

--- a/llvm16.yaml
+++ b/llvm16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm16
   version: 16.0.6
-  epoch: 3
+  epoch: 4
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - git
       - libffi-dev
       - libxml2-dev


### PR DESCRIPTION
Several of our packages fail to build with GCC 15. These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin gcc-14-default as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 2.