### PR TITLE
[shard 4] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/openmp-18.yaml
+++ b/openmp-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-18
   version: "18.1.8"
-  epoch: 0
+  epoch: 1
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - help2man
       - libLLVM-18
       - libffi-dev

--- a/oranda.yaml
+++ b/oranda.yaml
@@ -1,7 +1,7 @@
 package:
   name: oranda
   version: 0.6.5
-  epoch: 6
+  epoch: 7
   description: generate beautiful landing pages for your developer tools
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - openssl-dev
       - rust
 

--- a/parted.yaml
+++ b/parted.yaml
@@ -1,7 +1,7 @@
 package:
   name: parted
   version: "3.6"
-  epoch: 40
+  epoch: 41
   description: Utility to create, destroy, resize, check and copy partitions
   copyright:
     - license: GPL-3.0-or-later
@@ -22,6 +22,7 @@ environment:
       - check
       - cmake
       - coreutils
+      - gcc-14-default
       - gettext
       - glib-dev
       - gperf

--- a/perl-tk.yaml
+++ b/perl-tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-tk
   version: "804.036"
-  epoch: 4
+  epoch: 5
   description: Tk - a Graphical User Interface Toolkit
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - file
+      - gcc-14-default
       - libjpeg-turbo-dev
       - libpng-dev
       - libx11-dev

--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yaml-syck
   version: 1.34
-  epoch: 5
+  epoch: 6
   description: Fast, lightweight YAML loader and dumper
   copyright:
     - license: MIT
@@ -14,6 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - perl
       - perl-dev
 

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2-4.6
   version: "4.6.1"
-  epoch: 1
+  epoch: 2
   description: Middleware that works between PostgreSQL servers and a PostgreSQL database client.
   copyright:
     - license: BSD-3-Clause AND MIT
@@ -21,6 +21,7 @@ environment:
       - build-base
       - busybox
       - flex
+      - gcc-14-default
       - libtool
       - openssl-dev
       - postgresql-17-dev

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,6 +27,7 @@ environment:
       - cmake
       - curl-dev
       - gcc
+      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,6 +27,7 @@ environment:
       - cmake
       - curl-dev
       - gcc
+      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,6 +27,7 @@ environment:
       - cmake
       - curl-dev
       - gcc
+      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.4-pecl-http.yaml
+++ b/php-8.4-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-pecl-http
   version: 4.2.6
-  epoch: 1
+  epoch: 2
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,6 +27,7 @@ environment:
       - cmake
       - curl-dev
       - gcc
+      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: "3.0.1"
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later
@@ -16,6 +16,7 @@ environment:
       - bzip2
       - cmake
       - gawk
+      - gcc-14-default
       - git
       - gnutls-dev
       - grep

--- a/pstack.yaml
+++ b/pstack.yaml
@@ -1,7 +1,7 @@
 package:
   name: pstack
   version: "2.10"
-  epoch: 1
+  epoch: 2
   description: "Print stack traces from running processes, or core files."
   copyright:
     - license: BSD-2-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - build-base
       - cmake
+      - gcc-14-default
       - python-3.12
       - wolfi-base
       - xz-dev

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pulsar-client
   version: "3.7.0"
-  epoch: 0
+  epoch: 1
   description: Apache Pulsar Python client library
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - libpulsar-dev
       - py3-build
       - py3-installer

--- a/py3-sentencepiece.yaml
+++ b/py3-sentencepiece.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sentencepiece
   version: 0.2.0
-  epoch: 6
+  epoch: 7
   description: SentencePiece is an unsupervised text tokenizer and detokenizer
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ environment:
       - build-base
       - busybox
       - cmake
+      - gcc-14-default
       - py3-supported-pip
       - py3-supported-python-dev
 

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.11
   description: PyPy is a very fast and compliant implementation of the Python language v 3.11
-  epoch: 36
+  epoch: 37
   version: "7.3.19"
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,7 @@ environment:
       - busybox
       - bzip2-dev
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - libffi
       - libffi-pic-dev

--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: "1.14.0"
-  epoch: 1
+  epoch: 0
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,6 @@ environment:
       - cargo-auditable
       - clang-16-dev
       - curl
-      - gcc-14-default
       - jq
       - llvm-cmake-16
       - llvm-lld-16-dev

--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: "1.14.0"
-  epoch: 0
+  epoch: 1
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - cargo-auditable
       - clang-16-dev
       - curl
+      - gcc-14-default
       - jq
       - llvm-cmake-16
       - llvm-lld-16-dev

--- a/rlwrap.yaml
+++ b/rlwrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: rlwrap
   version: 0.46.1
-  epoch: 2
+  epoch: 3
   description: A readline wrapper
   copyright:
     - license: GPL-2.0-or-later
@@ -13,6 +13,7 @@ environment:
       - automake
       - build-base
       - ca-certificates-bundle
+      - gcc-14-default
       - ncurses-dev
       - readline-dev
       - wolfi-base

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 6
+  epoch: 7
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -18,6 +18,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - git
       - jemalloc-dev

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: "3.1.7"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -20,6 +20,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - jemalloc-dev
       - libffi-dev

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: "3.2.8"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -20,6 +20,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - glibc-dev
       - gmp-dev


### PR DESCRIPTION
Several of our packages fail to build with GCC 15. These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin gcc-14-default as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 4.