### PR TITLE
[shard 5] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: "3.3.8"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -20,6 +20,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - glibc-dev
       - gmp-dev

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.4
   version: "3.4.4"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -29,6 +29,7 @@ environment:
       - ca-certificates-bundle
       - coreutils
       - expat-dev
+      - gcc-14-default
       - gdbm-dev
       - glibc-dev
       - gmp-dev

--- a/runit.yaml
+++ b/runit.yaml
@@ -1,7 +1,7 @@
 package:
   name: runit
   version: 2.2.0
-  epoch: 20
+  epoch: 21
   description: UNIX init scheme with service supervision
   copyright:
     - license: BSD-3-Clause
@@ -18,6 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/rust-1.69.yaml
+++ b/rust-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.69
   version: 1.69.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.69.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -23,6 +23,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - ninja

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.70
   version: 1.70.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.70.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -23,6 +23,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - ninja

--- a/rust-1.71.yaml
+++ b/rust-1.71.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.71
   version: 1.71.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.71.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -23,6 +23,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - ninja

--- a/rust-1.72.yaml
+++ b/rust-1.72.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.72
   version: 1.72.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.72.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -23,6 +23,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - ninja

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.73
   version: 1.73.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.73.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,6 +25,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - llvm17

--- a/rust-1.74.yaml
+++ b/rust-1.74.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.74
   version: 1.74.1
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.74.1)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,6 +25,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libgit2-dev
       - libssh2-dev
       - llvm17

--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.75
   version: 1.75.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -24,6 +24,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-17
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.76.yaml
+++ b/rust-1.76.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.76
   version: 1.76.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -24,6 +24,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-17
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.77.yaml
+++ b/rust-1.77.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.77
   version: 1.77.2
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -24,6 +24,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-17
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.78.yaml
+++ b/rust-1.78.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.78
   version: 1.78.0
-  epoch: 5
+  epoch: 6
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -24,6 +24,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-18
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.79.yaml
+++ b/rust-1.79.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.79
   version: 1.79.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,6 +25,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-18
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.80.yaml
+++ b/rust-1.80.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.80
   version: 1.80.1
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,6 +25,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-18
       - libgit2-dev
       - libssh2-dev

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.81
   version: 1.81.0
-  epoch: 2
+  epoch: 3
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,6 +25,7 @@ environment:
       - coreutils
       - curl-dev
       - file
+      - gcc-14-default
       - libLLVM-18
       - libgit2-dev
       - libssh2-dev

--- a/spin.yaml
+++ b/spin.yaml
@@ -1,7 +1,7 @@
 package:
   name: spin
   version: "3.2.0"
-  epoch: 1
+  epoch: 2
   description: "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - openssl-dev
       - rustup
       - wolfi-base

--- a/squid.yaml
+++ b/squid.yaml
@@ -2,7 +2,7 @@
 package:
   name: squid
   version: "7.0.1"
-  epoch: 41
+  epoch: 40
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -20,7 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - ed # busybox ed is not sufficient for use by boostrap.sh
-      - gcc-14-default
       - heimdal-dev
       - libcap-dev
       - libtool

--- a/squid.yaml
+++ b/squid.yaml
@@ -2,7 +2,7 @@
 package:
   name: squid
   version: "7.0.1"
-  epoch: 40
+  epoch: 41
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -20,6 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - ed # busybox ed is not sufficient for use by boostrap.sh
+      - gcc-14-default
       - heimdal-dev
       - libcap-dev
       - libtool

--- a/strongswan.yaml
+++ b/strongswan.yaml
@@ -1,7 +1,7 @@
 package:
   name: strongswan
   version: "6.0.1"
-  epoch: 41
+  epoch: 42
   description: IPsec-based VPN solution focused on security and ease of use, supporting IKEv1/IKEv2 and MOBIKE
   copyright:
     # GPL-2.0-or-later WITH OpenSSL-Exception
@@ -42,6 +42,7 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - flex
+      - gcc-14-default
       - gettext-dev
       - gmp-dev
       - gperf

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: "0.22.0"
-  epoch: 0
+  epoch: 1
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"
@@ -14,6 +14,7 @@ environment:
       - build-base
       - cmake
       - flex
+      - gcc-14-default
       - glib-dev
       - libevent-dev
       - openssl-dev


### PR DESCRIPTION
Several of our packages fail to build with GCC 15. These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin gcc-14-default as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 5.