### PR TITLE
[shard 6] Pin GCC 14 build dependency on packages FTBFSing with GCC 15

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 0
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -25,6 +25,7 @@ environment:
       - cmake
       - curl-dev
       - fribidi-dev
+      - gcc-14-default
       - harfbuzz-dev
       - icu-dev
       - jq

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: "9.2.10"
-  epoch: 0
+  epoch: 1
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - libtool
       - linux-headers
       - openssl-dev

--- a/unifdef.yaml
+++ b/unifdef.yaml
@@ -1,7 +1,7 @@
 package:
   name: unifdef
   version: 2.12
-  epoch: 2
+  epoch: 3
   description: Selectively remove C preprocessor conditionals
   copyright:
     - license: BSD-2-Clause AND BSD-3-Clause
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/unrtf.yaml
+++ b/unrtf.yaml
@@ -2,7 +2,7 @@
 package:
   name: unrtf
   version: 0.21.10
-  epoch: 1
+  epoch: 2
   description: Command-line program which converts RTF documents to other formats
   copyright:
     - license: GPL-3.0-or-later
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/unzip.yaml
+++ b/unzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: unzip
   version: 6.0
-  epoch: 1
+  epoch: 2
   description: Extract PKZIP-compatible .zip files
   copyright:
     - license: Info-ZIP
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/uutils.yaml
+++ b/uutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: uutils
   version: "0.1.0"
-  epoch: 0
+  epoch: 1
   description: "Cross-platform Rust rewrite of the GNU coreutils."
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - cargo-auditable
       - clang-18-dev
+      - gcc-14-default
       - libselinux-dev
       - rust
       - wolfi-base

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.1"
-  epoch: 1
+  epoch: 2
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause
@@ -18,6 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - libtool
       - libunwind-dev
       - m4

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.47.0"
-  epoch: 0
+  epoch: 1
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -15,6 +15,7 @@ environment:
       - bash
       - build-base
       - cyrus-sasl-dev
+      - gcc-14-default
       - librdkafka
       - librdkafka-dev
       - openssl

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: "0.47.0"
-  epoch: 1
+  epoch: 0
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0
@@ -15,7 +15,6 @@ environment:
       - bash
       - build-base
       - cyrus-sasl-dev
-      - gcc-14-default
       - librdkafka
       - librdkafka-dev
       - openssl

--- a/w3m.yaml
+++ b/w3m.yaml
@@ -2,7 +2,7 @@
 package:
   name: w3m
   version: 0.5.3.20230121
-  epoch: 0
+  epoch: 1
   description: text-based web & gopher browser, as well as pager
   copyright:
     - license: MIT
@@ -19,6 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gc-dev
+      - gcc-14-default
       - imlib2-dev
       - linux-headers
       - ncurses-dev

--- a/wabt.yaml
+++ b/wabt.yaml
@@ -1,7 +1,7 @@
 package:
   name: wabt
   version: "1.0.37"
-  epoch: 1
+  epoch: 2
   description: The WebAssembly Binary Toolkit
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - python3
       - samurai
 

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmedge
   version: 0.14.1
-  epoch: 3
+  epoch: 4
   description: WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications.
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
       - cmake
+      - gcc-14-default
       - libLLVM-${{vars.llvm-vers}}
       - libxml2-dev
       - llvm-${{vars.llvm-vers}}

--- a/woff2.yaml
+++ b/woff2.yaml
@@ -1,7 +1,7 @@
 package:
   name: woff2
   version: 1.0.2
-  epoch: 3
+  epoch: 4
   description: Web Open Font Format 2 reference implementation
   copyright:
     - license: MIT
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-14-default
       - samurai
 
 pipeline:

--- a/x265.yaml
+++ b/x265.yaml
@@ -1,7 +1,7 @@
 package:
   name: x265
   version: "4.1"
-  epoch: 2
+  epoch: 3
   description: H.265/HEVC encoder
   copyright:
     - license: GPL-2.0-only
@@ -13,6 +13,7 @@ environment:
       - busybox
       - cmake
       - coreutils
+      - gcc-14-default
       - nasm
 
 pipeline:

--- a/xh.yaml
+++ b/xh.yaml
@@ -1,7 +1,7 @@
 package:
   name: xh
   version: "0.24.1"
-  epoch: 1
+  epoch: 2
   description: Friendly and fast tool for sending HTTP requests.
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - rust
 
 pipeline:

--- a/xtail.yaml
+++ b/xtail.yaml
@@ -3,7 +3,7 @@
 package:
   name: xtail
   version: 2.1.11
-  epoch: 1
+  epoch: 2
   description: Like "tail -f", but works on truncated files, directories, more
   copyright:
     - license: BSD-3-Clause
@@ -22,6 +22,7 @@ environment:
       - automake
       - build-base
       - busybox
+      - gcc-14-default
       - patch
 
 pipeline:

--- a/yaml-cpp.yaml
+++ b/yaml-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: yaml-cpp
   version: 0.8.0
-  epoch: 5
+  epoch: 6
   description: "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec."
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - wolfi-base
 
 pipeline:

--- a/yasm.yaml
+++ b/yasm.yaml
@@ -2,7 +2,7 @@
 package:
   name: yasm
   version: 1.3.0
-  epoch: 2
+  epoch: 3
   description: A rewrite of NASM to allow for multiple syntax supported (NASM, TASM, GAS, etc.)
   copyright:
     - license: BSD-2-Clause
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/yazi.yaml
+++ b/yazi.yaml
@@ -1,7 +1,7 @@
 package:
   name: yazi
   version: "25.5.28"
-  epoch: 0
+  epoch: 1
   description: Blazing fast terminal file manager written in Rust, based on async I/O.
   copyright:
     - license: MIT
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
+      - gcc-14-default
       - rust
 
 pipeline:


### PR DESCRIPTION
Several of our packages fail to build with GCC 15. These build failures are being reported to and worked on by upstream, but until everything is OK we need to pin gcc-14-default as a build dependency for those packages to guarantee that they will keep building fine.

This is shard 6.