### PR TITLE
akhq/CVE-2025-48734 bump commons-beanutils to remediate 

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.25.1
-  epoch: 3
+  epoch: 4
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ pipeline:
   - uses: patch
     with:
       patches: |
-        cves-20250220.patch
+        cves-20250220.patch cves-20250530.patch
 
   - runs: |
       ./gradlew build -x test -x startTestKafkaCluster --parallel --no-daemon

--- a/akhq/cves-20250530.patch
+++ b/akhq/cves-20250530.patch
@@ -1,0 +1,30 @@
+commit b94f5c4cf42d3c394cde61d4a793fff2053bc441 (HEAD)
+Author: Melange Build <melange-build@cgr.dev>
+Date:   Fri May 30 12:50:22 2025 +0000
+
+    feat: Bump commons-beanutils:commons-beanutils to remediate  CVE-2025-48734
+    
+    Signed-off-by: Melange Build <melange-build@cgr.dev>
+
+diff --git a/build.gradle b/build.gradle
+index f8107bb..a7814d4 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -49,6 +49,7 @@ configurations.all {
+         force("com.fasterxml.jackson.core:jackson-databind:" + jacksonVersion)
+         force("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:" + jacksonVersion)
+         force("com.fasterxml.jackson.module:jackson-module-scala_" + kafkaScalaVersion + ":" + jacksonVersion)
++        force("commons-beanutils:commons-beanutils:" + beansVersion)
+         force("io.vertx:vertx-core:" + vertxVersion)
+         force("org.apache.commons:commons-compress:" + commonsCompressVersion)
+         force("io.netty:netty-handler:" + nettyVersion)
+diff --git a/gradle.properties b/gradle.properties
+index 7a70b71..587ad22 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -9,3 +9,4 @@ commonsCompressVersion=1.26.0
+ vertxVersion=4.4.8
+ nettyVersion=4.1.118.Final
+ jettyHttpVersion=12.0.12
++beansVersion=1.11.0
+


### PR DESCRIPTION
Patch `gradle.properties` to bump `commons-beanutils` from `1.9.4` to `1.11.0`