### PR TITLE
fix(boost): Include library symlinks in dev package

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: "1.88.0"
-  epoch: 3
+  epoch: 4
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"
@@ -140,7 +140,7 @@ subpackages:
 
           # Install Boost Python library
           mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libboost_python${{range.value}}*.so* "${{targets.contextdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libboost_python${{range.value}}*.so.* "${{targets.contextdir}}"/usr/lib/
       - uses: strip
     test:
       environment:
@@ -189,7 +189,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libboost_${{range.key}}*.so* "${{targets.contextdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libboost_${{range.key}}*.so.* "${{targets.contextdir}}"/usr/lib/
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
By switching the order of packages, while I fixed boost-static, I introduced a regression in boost-dev where library symlinks were no longer present