### PR TITLE
fix(graph-tool): Build for arm64 and for every supported Python version

### DIFF
--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -88,9 +88,19 @@ subpackages:
           # Only link when needed
           sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
 
-          # Unfortunately cuts the number of threads used in
-          # half, but we need lots of memory per job
-          make -C . -j$(( $(nproc) / 2 ))
+          # Grab available memory
+          MEM_KB=$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo)
+          MEM_MB=$(( MEM_KB / 1024 ))
+
+          # Arbitrary amount of memory to reserve per-thread
+          # https://salsa.debian.org/python-team/packages/graph-tool/-/blob/master/debian/rules?ref_type=heads
+          MEM_PER_JOB=13000
+
+          # Calculate number of jobs
+          NJOBS=$(( MEM_MB / MEM_PER_JOB ))
+
+          # Build graph tool
+          make -C . -j$NJOBS
       - uses: autoconf/make-install
       - runs: find ${{targets.contextdir}} -name "*.so" -exec strip -g {} \;
     test:

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,13 +1,11 @@
 package:
   name: py3-graph-tool
   version: 2.97
-  epoch: 1
+  epoch: 2
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
     memory: 128Gi
-  target-architecture:
-    - x86_64
   copyright:
     - license: GPL-3.0-only
 
@@ -18,23 +16,20 @@ vars:
 data:
   - name: py-versions
     items:
-      # 3.10: '310'
-      # 3.11: '311'
-      # 3.12: '312'
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
       3.13: '313'
 
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
       - bash
       - boost-dev
-      - build-base
       - busybox
-      - ca-certificates-bundle
       - cairo-dev
       - cairomm-1.16-dev
+      - ccache
       - cgal-dev
       - eigen-dev
       - expat-dev
@@ -46,13 +41,20 @@ environment:
       - libtool
       - mpfr-dev
       - pkgconf-dev
+      - py3-supported-build-base-dev
       - py3-supported-cairo
       - py3-supported-gobject3
+      - py3-supported-libboost
       - py3-supported-numpy
-      - py3-supported-python-dev
       - py3-supported-scipy
       - sparsehash-dev
       - zlib-dev
+  environment:
+    # Use ccache
+    CC: ccache gcc
+    CXX: ccache g++
+    # Silence literal gigabytes of warnings
+    CXXFLAGS: '-Wno-attributes -Wno-maybe-uninitialized -Wno-uninitialized -Wno-psabi'
 
 pipeline:
   - uses: git-checkout
@@ -61,10 +63,12 @@ pipeline:
       tag: release-${{package.version}}
       expected-commit: cd15650ec9fb6807b4536b523a059354f231fcb1
 
+  - runs: ccache -F 0 -M 0
+
 subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
-    description: python${{range.key}} version of ${{vars.pypi-package}}
+    description: "${{vars.pypi-package}} for Python ${{range.key}}"
     dependencies:
       runtime:
         - py${{range.key}}-cairo
@@ -78,13 +82,15 @@ subpackages:
       - uses: autoconf/configure
         with:
           opts: |
-            --enable-openmp \
             --includedir=/usr/lib/cairomm-1.16 \
-            --disable-debug \
-            --disable-dependency-tracking \
             PYTHON=python${{range.key}}
       - runs: |
-          make -C . -j$(nproc) V=1
+          # Only link when needed
+          sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+
+          # Unfortunately cuts the number of threads used in
+          # half, but we need lots of memory per job
+          make -C . -j$(( $(nproc) / 2 ))
       - uses: autoconf/make-install
       - runs: find ${{targets.contextdir}} -name "*.so" -exec strip -g {} \;
     test:
@@ -158,16 +164,30 @@ subpackages:
             assert list(deg) == [1, 2, 1]
             EOF
 
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-doc
+    description: "Documentation for ${{vars.pypi-package}} with Python ${{range.key}}"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share
+          mv ${{targets.outdir}}/py${{range.key}}-${{vars.pypi-package}}/usr/share/doc \
+             ${{targets.contextdir}}/usr/share/
+    test:
+      pipeline:
+        - uses: test/docs
+
   - name: py3-supported-${{vars.pypi-package}}
-    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    description: Meta-package providing ${{vars.pypi-package}} for supported Python versions.
     dependencies:
       runtime:
-        # TODO: Add other python versions
-        # - py3.12-${{vars.pypi-package}}
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
 
   - range: py-versions
-    name: ${{package.name}}-dev
+    name: py${{range.key}}-${{vars.pypi-package}}-dev
+    description: "${{vars.pypi-package}} development files for Python ${{range.key}}"
     pipeline:
       - uses: split/dev
         with:
@@ -181,3 +201,7 @@ update:
   enabled: true
   git:
     strip-prefix: release-
+
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
Builds graph tool for supported versions of Python and enables support for arm64. Additionally, splits away documentation