### PR TITLE
airflow: fix: GHSA-r244-wg5g-6w2r

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: "2.11.0"
-  epoch: 0
+  epoch: 1
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -96,10 +96,12 @@ pipeline:
       pip3.12 uninstall --yes setuptools
 
       #GHSA-8w49-h785-mj3c/GHSA-8495-4g3g-x7pr/GHSA-27mf-ghqm-j3j8 fixes
+      #GHSA-r244-wg5g-6w2r (redshift-connector>=2.1.6)
       pip3.12 install --verbose \
         --force-reinstall --prefix=/opt/airflow --root="${{targets.contextdir}}" \
         aiohttp>=3.10.11 tornado>=6.5.0 statsd packaging pyparsing \
-        apache-airflow==${{package.version}} apache-airflow-providers-celery==3.10.0 "flask>=2.2.1,<2.3"
+        apache-airflow==${{package.version}} apache-airflow-providers-celery==3.10.0 "flask>=2.2.1,<2.3" \
+        redshift-connector>=2.1.6
       # NOTE: apache-airflow-providers-celery is pinned to 3.10.0 because 3.10.3 introduced a regresssion.
       # https://github.com/apache/airflow/issues/47781 details more about it.
       # NOTE: flask is pinned to < 2.3 as required by apache-airflow-providers-fab:


### PR DESCRIPTION
Bumps redshift-connector>=2.1.6 which contains the CVE fix