### PR TITLE
[Shard 1] Add output redirection to tests

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: "2.4.0"
-  epoch: 1
+  epoch: 2
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
@@ -158,7 +158,7 @@ test:
   pipeline:
     - runs: |
         # Use the same start script as the container image uses as its entrypoint
-        /usr/share/nifi/scripts/start.sh &
+        /usr/share/nifi/scripts/start.sh > /dev/null 2>&1 &
 
         # wait until we know the server has started. Does require quite a bit of time to fully boot up.
         sleep 40

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: "2.4.63"
-  epoch: 42
+  epoch: 43
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -293,7 +293,7 @@ subpackages:
 
             # Start httpd using the custom configuration
             echo "Starting httpd..."
-            httpd -DFOREGROUND &
+            httpd -DFOREGROUND > /dev/null 2>&1 &
             httpd_pid=$!
 
             # Give httpd some time to start
@@ -338,7 +338,7 @@ test:
 
         # Start httpd using the custom configuration
         echo "Starting httpd..."
-        httpd -DFOREGROUND &
+        httpd -DFOREGROUND > /dev/null 2>&1 &
         httpd_pid=$!
 
         # Give httpd some time to start

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: "0.16.3"
-  epoch: 0
+  epoch: 1
   description: helm chart repository server
   copyright:
     - license: Apache-2.0
@@ -69,7 +69,7 @@ test:
                 return
             fi
 
-            nohup "$CHARTMUSEUM_BINARY" --port=8080 --storage="$CHARTMUSEUM_STORAGE" --storage-local-rootdir="$CHARTMUSEUM_STORAGE_ROOTDIR" &> chartmuseum.log &
+            nohup "$CHARTMUSEUM_BINARY" --port=8080 --storage="$CHARTMUSEUM_STORAGE" --storage-local-rootdir="$CHARTMUSEUM_STORAGE_ROOTDIR" &> chartmuseum.log 2>&1 &
             echo $! > "$CHARTMUSEUM_PID_FILE"
             echo "ChartMuseum started."
         }

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: 1.4.2
-  epoch: 42
+  epoch: 43
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -387,7 +387,7 @@ subpackages:
         - name: "Test init"
           uses: test/daemon-check-output
           with:
-            setup: /usr/local/bin/clamdcheck.sh &
+            setup: /usr/local/bin/clamdcheck.sh > /dev/null 2>&1 &
             start: "exec tini -s /init > /proc/1/fd/1 2>&1 & sleep 10 && echo 'ok' && sleep 5"
             timeout: 60
             expected_output: |

--- a/cloud-sql-proxy-2.16.yaml
+++ b/cloud-sql-proxy-2.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy-2.16
   version: "2.16.0"
-  epoch: 1
+  epoch: 2
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0
@@ -55,7 +55,7 @@ test:
         export GOOGLE_APPLICATION_CREDENTIALS=fake-creds.json
         export FAKE_INSTANCE="project:region:instance"
 
-        cloud-sql-proxy "$FAKE_INSTANCE" --address 127.0.0.1 --port 9999 --credentials-file "$GOOGLE_APPLICATION_CREDENTIALS" 2>&1 | grep "oauth2: cannot fetch token" || exit 1 &
+        cloud-sql-proxy "$FAKE_INSTANCE" --address 127.0.0.1 --port 9999 --credentials-file "$GOOGLE_APPLICATION_CREDENTIALS" 2>&1 | grep "oauth2: cannot fetch token" || exit 1 > /dev/null 2>&1 &
         pid=$!
         trap "kill \$pid" EXIT
 

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: "1.12.1"
-  epoch: 2
+  epoch: 3
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -109,7 +109,7 @@ test:
         foo.wolfi.dev  IN TXT "hi"
         EOF
 
-        coredns &
+        coredns > /dev/null 2>&1 &
         sleep 2
 
         # validates intree plugins can be successfully loaded

--- a/cpp-httplib.yaml
+++ b/cpp-httplib.yaml
@@ -2,7 +2,7 @@
 package:
   name: cpp-httplib
   version: "0.20.1"
-  epoch: 0
+  epoch: 1
   description: C++ header-only HTTP/HTTPS server and client library
   copyright:
     - license: MIT
@@ -61,7 +61,7 @@ test:
         }
         EOF
         g++ server.cpp -o server
-        ./server &
+        ./server > /dev/null 2>&1 &
 
         [ "$(curl --fail http://127.0.0.1:8080/hi)" = "Hello World!" ]
 

--- a/dapr-1.15.yaml
+++ b/dapr-1.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: dapr-1.15
   version: "1.15.5"
-  epoch: 0
+  epoch: 1
   description: Portable, event-driven, runtime for building distributed applications across cloud and edge.
   dependencies:
     provides:
@@ -225,7 +225,7 @@ test:
           EOF
 
 
-          python3 /tmp/fake-subscriber.py &
+          python3 /tmp/fake-subscriber.py > /dev/null 2>&1 &
           echo $! > /tmp/subscriber.pid
 
           wait-for-it localhost:8080 --timeout=60

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,7 +1,7 @@
 package:
   name: distribution
   version: 3.0.0
-  epoch: 36
+  epoch: 37
   description: The toolkit to pack, ship, store, and deliver container content
   copyright:
     - license: Apache-2.0
@@ -126,7 +126,7 @@ test:
             interval: 10s
             threshold: 3
         EOF
-        registry serve /etc/docker/registry/config.yml &
+        registry serve /etc/docker/registry/config.yml > /dev/null 2>&1 &
         REGISTRY_PID=$!
         check_success "Failed to start local Docker registry"
 

--- a/envoy-1.34.yaml
+++ b/envoy-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy-1.34
   version: "1.34.1"
-  epoch: 1
+  epoch: 2
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -203,7 +203,7 @@ test:
         post: |
           #!/bin/sh -e
           first_pid=$(pgrep -f "restart-epoch 0")
-          envoy --config-path /tmp/minimal.yaml --restart-epoch 1 &
+          envoy --config-path /tmp/minimal.yaml --restart-epoch 1 > /dev/null 2>&1 &
           sleep 2
 
           # Verify both processes exist


### PR DESCRIPTION
PR 1 in the `Add output redirection to tests` series.

We were applying redirection inconsistently for a handful of tests. These may cause issues with QEMU so I'm going to open a series of PRs to address this with a manageable number of packages per PR.

If we were already redirecting to a file, I just added `2>&1` to match what we do elsewhere. For commands that just used `&`, I replaced this with `> /dev/null 2>&1 &`.