### PR TITLE
Unpin `gcc-14-default` from packages that build with GCC 15

### DIFF
--- a/cmake-bootstrap.yaml
+++ b/cmake-bootstrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-bootstrap
   version: 3.31.7
-  epoch: 1
+  epoch: 2
   description: "Bootstrap CMake without using system libraries, enabling to use CMake to build system libraries used by CMake"
   dependencies:
     provider-priority: 5
@@ -15,7 +15,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - gcc-14-default
       - openssl-dev
       - samurai
 

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.31.7
-  epoch: 1
+  epoch: 2
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10
@@ -17,7 +17,6 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - expat-dev
-      - gcc-14-default
       - jsoncpp-dev
       - libarchive-dev
       - libuv-dev

--- a/cxxopts.yaml
+++ b/cxxopts.yaml
@@ -2,7 +2,7 @@
 package:
   name: cxxopts
   version: "3.3.1"
-  epoch: 1
+  epoch: 2
   description: Lightweight C++ command line option parser as a header only library
   copyright:
     - license: MIT
@@ -14,7 +14,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      - gcc-14-default
       - ninja
 
 pipeline:

--- a/duckdb.yaml
+++ b/duckdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: duckdb
   version: "1.3.0"
-  epoch: 1
+  epoch: 2
   description: "DuckDB is an analytical in-process SQL database management system"
   copyright:
     - license: MIT
@@ -14,7 +14,6 @@ environment:
       - build-base
       - ca-certificates-bundle
       - cmake
-      - gcc-14-default
       - git
       - ninja
       - openssl-dev

--- a/iperf3.yaml
+++ b/iperf3.yaml
@@ -1,7 +1,7 @@
 package:
   name: iperf3
   version: "3.19"
-  epoch: 1
+  epoch: 2
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: BSD-3-Clause-LBNL
@@ -17,7 +17,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - openssl-dev
 
 pipeline:

--- a/m4.yaml
+++ b/m4.yaml
@@ -1,7 +1,7 @@
 package:
   name: m4
   version: "1.4.20"
-  epoch: 1
+  epoch: 2
   description: "GNU macro processor"
   copyright:
     - license: GPL-3.0
@@ -12,7 +12,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: "0.22.0"
-  epoch: 1
+  epoch: 2
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"
@@ -14,7 +14,6 @@ environment:
       - build-base
       - cmake
       - flex
-      - gcc-14-default
       - glib-dev
       - libevent-dev
       - openssl-dev

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.1"
-  epoch: 2
+  epoch: 3
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - libtool
       - libunwind-dev
       - m4

--- a/yazi.yaml
+++ b/yazi.yaml
@@ -1,7 +1,7 @@
 package:
   name: yazi
   version: "25.5.31"
-  epoch: 0
+  epoch: 1
   description: Blazing fast terminal file manager written in Rust, based on async I/O.
   copyright:
     - license: MIT
@@ -16,7 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - gcc-14-default
       - rust
 
 pipeline:


### PR DESCRIPTION
These packages now build fine with GCC 15, so we don't need to use gcc-14-default on them anymore.