### PR TITLE
[Shard 4] Add output redirection to tests

### DIFF
--- a/keycloak-config-cli.yaml
+++ b/keycloak-config-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-config-cli
   version: 6.4.0
-  epoch: 40
+  epoch: 41
   description: Import YAML/JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
     KEYCLOAK_VERSION: "26.1.0"
     KEYCLOAK_CLIENT_VERSION: "26.0.4"
-    MAVEN_CLI_OPTS: '-ntp --batch-mode --errors --fail-at-end --show-version -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3 -Dstyle.color=always'
+    MAVEN_CLI_OPTS: "-ntp --batch-mode --errors --fail-at-end --show-version -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3 -Dstyle.color=always"
 
 pipeline:
   - uses: git-checkout
@@ -155,7 +155,7 @@ subpackages:
         - working-directory: /opt/bitnami/${{package.name}}
           runs: |
             # Start dev Keycloak to interact with
-            kc.sh start-dev --features=admin-fine-grained-authz &
+            kc.sh start-dev --features=admin-fine-grained-authz > /dev/null 2>&1 &
 
             # Wait for keycloak to start
             wait-for-it localhost:8080 --timeout=60
@@ -191,7 +191,7 @@ test:
     - name: Startup ${{package.name}}
       runs: |
         # Start dev Keycloak to interact with
-        kc.sh start-dev --features=admin-fine-grained-authz &
+        kc.sh start-dev --features=admin-fine-grained-authz > /dev/null 2>&1 &
 
         # Wait for keycloak to start
         wait-for-it localhost:8080 --timeout=60

--- a/keydb.yaml
+++ b/keydb.yaml
@@ -1,7 +1,7 @@
 package:
   name: keydb
   version: 6.3.4
-  epoch: 1
+  epoch: 2
   description: A Multithreaded Fork of Redis
   copyright:
     - license: BSD-3-Clause
@@ -97,7 +97,7 @@ test:
         - keydb-cli
   pipeline:
     - runs: |
-        keydb-server &
+        keydb-server > /dev/null 2>&1 &
         sleep 2 # wait for keydb to start
         keydb-cli SET bike:1 "Process 134" || exit 1
         keydb-cli GET bike:1 | grep 'Process 134' || exit 1

--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-modelmesh-serving
   version: 0.12.0
-  epoch: 11
+  epoch: 12
   description: ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
   copyright:
     - license: Apache-2.0
@@ -94,7 +94,7 @@ test:
         kubectl get secrets modelmesh-webhook-server-cert -o jsonpath='{.data.tls\.key}' | base64 -d > ${certdir}/tls.key
     - name: Verify installation
       runs: |
-        manager &
+        manager > /dev/null 2>&1 &
         sleep 5
         # We're using this as a proxy for "is the controller up and serving"
         curl -s localhost:8080/metrics

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 38
+  epoch: 39
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -215,7 +215,7 @@ test:
         EOF
 
         # Start Fluentd in daemon mode
-        fluentd -c conf/fluent.conf &
+        fluentd -c conf/fluent.conf > /dev/null 2>&1 &
         sleep 2
 
         # Send a test message to Fluentd

--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.5.0"
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -84,7 +84,7 @@ test:
         # start the server
         export HOME=/usr/share/app
         cd $HOME
-        /usr/bin/python server.py &
+        /usr/bin/python server.py > /dev/null 2>&1 &
         sleep 5
 
         # simulate the upstream unit test suite: https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/visualization/test_server.py

--- a/kuberay-operator.yaml
+++ b/kuberay-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kuberay-operator
   version: "1.3.2"
-  epoch: 2
+  epoch: 3
   description: A toolkit to run Ray applications on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -65,7 +65,7 @@ test:
         sleep 5
 
         # let's start the operator
-        /usr/bin/manager --leader-election-namespace=default &
+        /usr/bin/manager --leader-election-namespace=default > /dev/null 2>&1 &
 
         # let's wait a couple of seconds for the operator to start
         sleep 10

--- a/kubernetes-csi-driver-hostpath.yaml
+++ b/kubernetes-csi-driver-hostpath.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-driver-hostpath
   version: "1.16.1"
-  epoch: 3
+  epoch: 4
   description: A sample (non-production) CSI Driver that creates a local directory as a volume on a single node
   copyright:
     - license: Apache-2.0
@@ -54,7 +54,7 @@ test:
     - runs: |
         mkdir -p /csi
 
-        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" &
+        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" > /dev/null 2>&1 &
         sleep 5
 
         livenessprobe --csi-address /csi/csi.sock --health-port 9898 &

--- a/kubernetes-csi-external-snapshotter-8.2.yaml
+++ b/kubernetes-csi-external-snapshotter-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter-8.2
   version: "8.2.1"
-  epoch: 4
+  epoch: 5
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -73,7 +73,7 @@ test:
     - uses: test/kwok/cluster
     - runs: |
         mkdir -p /csi
-        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" &
-        csi-snapshotter --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" &
+        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" > /dev/null 2>&1 &
+        csi-snapshotter --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" > /dev/null 2>&1 &
         sleep 10
         curl -Lk localhost:8080/metrics

--- a/kubernetes-dashboard-api.yaml
+++ b/kubernetes-dashboard-api.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-api
   version: "1.13.0"
-  epoch: 0
+  epoch: 1
   description: Go module handling authentication to the Kubernetes API
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ test:
     - uses: test/kwok/cluster
     - name: Verify kubernetes-dashboard-api installation
       runs: |
-        dashboard-api  --bind-address=0.0.0.0 --kubeconfig=/root/.kube/config &> dashboard-api.log &
+        dashboard-api  --bind-address=0.0.0.0 --kubeconfig=/root/.kube/config &> dashboard-api.log 2>&1 &
         sleep 5
         grep "Starting Kubernetes Dashboard API" dashboard-api.log || exit 1
     - name: Check version in logs

--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-auth
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: Stateless Go module, which could be referred to as a Kubernetes API extension
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ test:
     - uses: test/kwok/cluster
     - name: Verify kubernetes-dashboard-auth installation
       runs: |
-        dashboard-auth --address=0.0.0.0 --apiserver-host="https://accounts.google.com" --kubeconfig=/root/.kube/config &> dashboard-auth.log &
+        dashboard-auth --address=0.0.0.0 --apiserver-host="https://accounts.google.com" --kubeconfig=/root/.kube/config &> dashboard-auth.log 2>&1 &
         sleep 5
         grep "Starting Kubernetes Dashboard Auth" dashboard-auth.log || exit 1
     - name: Check version in logs


### PR DESCRIPTION
PR 4 in the `Add output redirection to tests` series.

We were applying redirection inconsistently for a handful of tests. These may cause issues with QEMU so I'm going to open a series of PRs to address this with a manageable number of packages per PR.

If we were already redirecting to a file, I just added `2>&1` to match what we do elsewhere. For commands that just used &, I replaced this with `> /dev/null 2>&1 &`.
