### PR TITLE
[Shard 10] Add output redirection to tests

### DIFF
--- a/tigera-operator-1.37.yaml
+++ b/tigera-operator-1.37.yaml
@@ -1,7 +1,7 @@
 package:
   name: tigera-operator-1.37
   version: "1.37.2"
-  epoch: 2
+  epoch: 3
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0
@@ -88,7 +88,7 @@ test:
           # NOTE: While test/kwok/cluster was initially considered for this test it failed to capture the required logs.
           # due to which we prefer using k3s ensures the operator starts reliably, logs are captured as expected.
 
-          k3s server --disable-agent &
+          k3s server --disable-agent > /dev/null 2>&1 &
           K3S_PID=$!
           for i in {1..20}; do
             if [ -f /etc/rancher/k3s/k3s.yaml ]; then

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 1
+  epoch: 2
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -161,7 +161,7 @@ test:
         - tileserver-gl-compat
   pipeline:
     - runs: |
-        /usr/src/app/docker-entrypoint.sh &
+        /usr/src/app/docker-entrypoint.sh > /dev/null 2>&1 &
         SERVER_PID=$!
 
         for attempt in 1 2 3 4 5; do

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: "1.7.2"
-  epoch: 0
+  epoch: 1
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0
@@ -62,7 +62,7 @@ test:
 
         mkdir -p /var/lib/mysql /run/mysqld
         mysqld --initialize-insecure
-        mysqld --user=root &
+        mysqld --user=root > /dev/null 2>&1 &
         wait-for-it -t 10 --strict localhost:3306 -- echo "Server is up"
 
         ./scripts/resetdb.sh --force

--- a/vault-env.yaml
+++ b/vault-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-env
   version: "1.21.9"
-  epoch: 0
+  epoch: 1
   description: Minimalistic init system for containers with Hashicorp Vault secrets support
   copyright:
     - license: Apache-2.0
@@ -54,12 +54,12 @@ test:
       VAULT_TOKEN: root
       VAULT_ADDR: http://127.0.0.1:8200
       VAULT_API_ADDR: http://127.0.0.1:8200
-      TEST_VARIABLE: 'vault:kvv2/data/webapp/config#Username is: ${.username}'
+      TEST_VARIABLE: "vault:kvv2/data/webapp/config#Username is: ${.username}"
   pipeline:
     - uses: test/kwok/cluster
     - name: Install, configure, and add a secret to vault
       runs: |
-        vault server -dev -dev-root-token-id $VAULT_TOKEN -dev-listen-address="0.0.0.0:8200" &
+        vault server -dev -dev-root-token-id $VAULT_TOKEN -dev-listen-address="0.0.0.0:8200" > /dev/null 2>&1 &
         sleep 3s # vault startup
         vault auth enable approle
         vault secrets enable -path=kvv2 kv-v2

--- a/vault-secrets-webhook.yaml
+++ b/vault-secrets-webhook.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-secrets-webhook
   version: "1.21.4"
-  epoch: 2
+  epoch: 3
   description: A Kubernetes mutating webhook that makes direct secret injection into Pods possible.
   copyright:
     - license: Apache-2.0
@@ -70,7 +70,7 @@ test:
     - name: Install, configure, and add a secret to vault
       runs: |
         git clone https://github.com/bank-vaults/vault-secrets-webhook
-        vault server -dev -dev-root-token-id $VAULT_TOKEN -dev-listen-address="0.0.0.0:8200" &
+        vault server -dev -dev-root-token-id $VAULT_TOKEN -dev-listen-address="0.0.0.0:8200" > /dev/null 2>&1 &
         sleep 3s # vault startup
         vault auth enable approle
         vault secrets enable -path=kvv2 kv-v2

--- a/vcluster.yaml
+++ b/vcluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: vcluster
   version: "0.25.0"
-  epoch: 0
+  epoch: 1
   description: Create fully functional virtual Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,8 @@ environment:
     packages:
       - curl
       - helm
+      - jq
+      - zip
 
 pipeline:
   - uses: git-checkout
@@ -73,7 +75,7 @@ test:
     - name: Test cluster list
       runs: |
         # Create won't work on virtual kubelets, but we can at least register for listing
-        vcluster create foo &
+        vcluster create foo > /dev/null 2>&1 &
 
         sleep 5
 

--- a/victoriametrics-operator.yaml
+++ b/victoriametrics-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-operator
   version: "0.59.1"
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for Victoria Metrics
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,7 @@ test:
         app --version
         app --help
         # Start the operator
-        app &
+        app > /dev/null 2>&1 &
         sleep 15
         cat << EOF | kubectl apply -f -
         apiVersion: operator.victoriametrics.com/v1beta1

--- a/wait-for-it.yaml
+++ b/wait-for-it.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-it
   version: 0.20200823
-  epoch: 5
+  epoch: 6
   description: Pure bash script to test and wait on the availability of a TCP host and port
   copyright:
     - license: MIT
@@ -42,7 +42,7 @@ test:
     - name: "Success when netcat listens on port"
       runs: |
         # Have netcat listen on port 80, and wait for it to become available.
-        nc -lvp 8080 &
+        nc -lvp 8080 > /dev/null 2>&1 &
         if ! /usr/bin/wait-for-it --host=localhost --port=8080 --strict --timeout=2 -- echo Success; then
           echo "Expected to see netcat listening on a port, but did not."
           exit 1

--- a/wait-for-port.yaml
+++ b/wait-for-port.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-port
   version: 1.0.8
-  epoch: 5
+  epoch: 6
   description: CLI tool for waiting until a TCP port reaches the desired state
   copyright:
     - license: Apache-2.0
@@ -33,5 +33,5 @@ test:
   pipeline:
     - runs: |
         wait-for-port --help 2>&1 | grep wait-for-port
-        nc -l -p 2568 &
+        nc -l -p 2568 > /dev/null 2>&1 &
         wait-for-port 2568

--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: "1.31.0"
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause
@@ -39,7 +39,7 @@ test:
         - curl
   pipeline:
     - runs: |
-        weaviate --host 0.0.0.0 --port 8080 --scheme http &
+        weaviate --host 0.0.0.0 --port 8080 --scheme http > /dev/null 2>&1 &
         sleep 5 # wait for weaviate to start
         WEAVITE_URL="http://127.0.0.1:8080"
         # Check the status using the HTTP API


### PR DESCRIPTION
PR 10 in the `Add output redirection to tests` series.

We were applying redirection inconsistently for a handful of tests. These may cause issues with QEMU so I'm going to open a series of PRs to address this with a manageable number of packages per PR.

If we were already redirecting to a file, I just added `2>&1` to match what we do elsewhere. For commands that just used &, I replaced this with `> /dev/null 2>&1 &`.
