### PR TITLE
[Shard 11] Add output redirection to tests

### DIFF
--- a/wildfly.yaml
+++ b/wildfly.yaml
@@ -71,40 +71,25 @@ subpackages:
             /usr/share/wildfly/bin/domain.sh --version | grep ${{package.version}}
             /usr/share/wildfly/bin/jboss-cli.sh version
         - name: Test Wildfly with OpenJDK ${{range.key}}
-          uses: test/daemon-check-output
-          with:
-            start: |
-              sh -c "
-              /usr/share/wildfly/bin/standalone.sh > /dev/null 2>&1 &
-              sleep 10
-              "
-            timeout: 60
-            expected_output: |
-              Started server
-              Http management interface listening on http://127.0.0.1:9990/management
-              Admin console listening on http://127.0.0.1:9990
-              JBoss Bootstrap Environment
-              JBoss Modules version
-              JBOSS_HOME
-              WildFly
-            post: |
-              #!/bin/sh -e
-              url=http://localhost:8080
-              response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
-              if [ "$response" -ne 200 ]; then
-                echo "WildFly instance is not responding correctly"
-                exit 1
-              fi
-              html=$(curl -s "$url")
-              if [ -z "$html" ]; then
-                echo "Got empty HTML content from $url"
-                exit 1
-              fi
-              echo "$html" | grep -q "Welcome to WildFly" || {
-                echo "response from $url did not contain \"Welcome to WildFly\""
-                exit 1
-              }
-              echo "WildFly instance is up"
+          runs: |
+            /usr/share/wildfly/bin/standalone.sh > /dev/null 2>&1 &
+            sleep 10
+            url=http://localhost:8080
+            response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            if [ "$response" -ne 200 ]; then
+              echo "WildFly instance is not responding correctly"
+              exit 1
+            fi
+            html=$(curl -s "$url")
+            if [ -z "$html" ]; then
+              echo "Got empty HTML content from $url"
+              exit 1
+            fi
+            echo "$html" | grep -q "Welcome to WildFly" || {
+              echo "response from $url did not contain \"Welcome to WildFly\""
+              exit 1
+            }
+            echo "WildFly instance is up"
 
   - range: openjdk-versions
     name: ${{package.name}}-openjdk-${{range.key}}-compat

--- a/wildfly.yaml
+++ b/wildfly.yaml
@@ -1,7 +1,7 @@
 package:
   name: wildfly
   version: "36.0.1"
-  epoch: 2
+  epoch: 3
   description: WildFly Application Server
   copyright:
     - license: Apache-2.0
@@ -75,7 +75,7 @@ subpackages:
           with:
             start: |
               sh -c "
-              /usr/share/wildfly/bin/standalone.sh &
+              /usr/share/wildfly/bin/standalone.sh > /dev/null 2>&1 &
               sleep 10
               "
             timeout: 60

--- a/xcover.yaml
+++ b/xcover.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcover
   version: "0.1.0"
-  epoch: 1
+  epoch: 2
   description: "Profile coverage of functional tests without instrumenting your binaries."
   copyright:
     - license: MIT
@@ -112,7 +112,7 @@ test:
           --exclude "^(runtime\.|internal\/)" \
           --log-level=debug \
           --verbose=false \
-          --status &
+          --status > /dev/null 2>&1 &
 
         # Wait for the xcover profiler to be ready,
         # which means that the tracee that we are

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.0"
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -119,7 +119,7 @@ test:
         cp conf/zoo_sample.cfg conf/zoo.cfg
 
         # Start Zookeeper
-        bin/zkServer.sh start-foreground &
+        bin/zkServer.sh start-foreground > /dev/null 2>&1 &
 
         # Grab PID
         ZOOKEEPER_PID=$!


### PR DESCRIPTION
PR 11 in the `Add output redirection to tests` series.

We were applying redirection inconsistently for a handful of tests. These may cause issues with QEMU so I'm going to open a series of PRs to address this with a manageable number of packages per PR.

If we were already redirecting to a file, I just added 2>&1 to match what we do elsewhere. For commands that just used &, I replaced this with > /dev/null 2>&1 &.
