### PR TITLE
zlib-ng-compat: new package

### DIFF
--- a/zlib-ng-compat.yaml
+++ b/zlib-ng-compat.yaml
@@ -1,0 +1,77 @@
+package:
+  name: zlib-ng-compat
+  version: 2.2.4
+  epoch: 0
+  description: "zlib replacement with optimizations for next generation systems"
+  copyright:
+    - license: Zlib
+  dependencies:
+    replaces:
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - cmake
+      - gtest-dev
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 860e4cff7917d93f54f5d7f0bc1d0e8b1a3cb988
+      repository: https://github.com/zlib-ng/zlib-ng.git
+      tag: ${{package.version}}
+
+  - uses: cmake/configure
+    with:
+      output-dir: build
+      opts: |
+        -DZLIB_COMPAT=ON
+
+  - uses: cmake/build
+    with:
+      output-dir: build
+
+  - runs: ctest --test-dir build
+
+  - uses: cmake/install
+    with:
+      output-dir: build
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-static"
+    description: "zlib-ng-compat static library"
+    pipeline:
+      - uses: split/static
+    dependencies:
+      replaces:
+        - zlib-static
+
+  - name: "${{package.name}}-dev"
+    description: "zlib-ng-compat development headers"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      replaces:
+        - zlib-dev
+      runtime:
+        - ${{package.name}}
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: zlib-ng/zlib-ng
+    use-tag: true


### PR DESCRIPTION
Related: #53551

### Pre-review Checklist

#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
