### PR TITLE
datadog-agent: remediate cve

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.66.0"
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -360,6 +360,9 @@ subpackages:
                 "./datadog_checks_base[deps, http]" \
                 "./datadog_checks_downloader" \
                 $(echo ${checks} | xargs -n1 echo | sed 's|^|./|')
+
+              # Remediate GHSA-5rjg-fvgr-3xxf
+              .venv/bin/pip${{vars.py-version}} install --upgrade setuptools
 
               find .venv -name "*.pyc" -delete
               find .venv -name "__pycache__" -exec rm -rf {} +


### PR DESCRIPTION
bump setuptools on subpackage datadog-agent-core-integrations to remediate GHSA-5rjg-fvgr-3xxf
