### PR TITLE
fix(protobuf grpc compatibility): Rebuilding all the grps with the new version of protobuf

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,12 +1,12 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 9
+  epoch: 10
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
   resources:
-    cpu: 24
+    cpu: "24"
     memory: 24Gi
   dependencies:
     provides:

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,12 +1,12 @@
 package:
   name: grpc-1.67 # On update, please check if -fdelete-null-pointer-checks is still required
   version: 1.67.1
-  epoch: 10
+  epoch: 11
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
   resources:
-    cpu: 24
+    cpu: "24"
     memory: 24Gi
   dependencies:
     provides:
@@ -25,10 +25,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:

--- a/grpc-1.68.yaml
+++ b/grpc-1.68.yaml
@@ -1,12 +1,12 @@
 package:
   name: grpc-1.68
   version: 1.68.2
-  epoch: 6
+  epoch: 7
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
   resources:
-    cpu: 24
+    cpu: "24"
     memory: 24Gi
   dependencies:
     provides:
@@ -25,10 +25,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:

--- a/grpc-1.69.yaml
+++ b/grpc-1.69.yaml
@@ -1,12 +1,12 @@
 package:
   name: grpc-1.69
   version: 1.69.0
-  epoch: 6
+  epoch: 7
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
   resources:
-    cpu: 24
+    cpu: "24"
     memory: 24Gi
   dependencies:
     provides:
@@ -25,10 +25,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:

--- a/grpc-1.70.yaml
+++ b/grpc-1.70.yaml
@@ -1,12 +1,12 @@
 package:
   name: grpc-1.70
   version: "1.70.2"
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
   resources:
-    cpu: 24
+    cpu: "24"
     memory: 24Gi
   dependencies:
     provides:
@@ -25,10 +25,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:


### PR DESCRIPTION
There is a new version of protobuf available(https://github.com/wolfi-dev/os/pull/54579) we need to rebuild all the grpc with this new version this required otherwise we will get a conflict to use both in a single build env

And some lint.