### PR TITLE
glibc: drop most per-locale packages, add -locale-extra

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 4
+  epoch: 5
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -146,217 +146,15 @@ pipeline:
   - uses: strip
 
 data:
-  - name: locales
+  # This is the list of the most popular locale which get their own subpackages.
+  # All the rest ends up in the glibc-locale-extra package.
+  - name: locales-main
     items:
-      aa: Afar
-      af: Afrikaans
-      agr: Aguaruna
-      ak: Akan
-      am: Amharic
-      anp: Angika
-      an: Aragonese
-      ar: Arabic
-      as: Assamese
-      ast: Asturian
-      ayc: Southern Aymara
-      az: Azerbaijani
-      be: Belarusian
-      bem: Bemba
-      ber: Berber
-      bg: Bulgarian
-      bhb: Bhili
-      bho: Bhojpuri
-      bi: Bislama
-      bn: Bangla
-      bo: Tibetan
-      br: Breton
-      brx: Bodo
-      bs: Bosnian
-      byn: Blin
       ca: Catalan
-      ce: Chechen
-      chr: Cherokee
-      ckb: Central Kurdish
-      cmn: Mandarin Chinese
-      crh: Crimean Turkish
-      csb: Kashubian
-      cs: Czech
-      cv: Chuvash
-      cy: Welsh
-      da: Danish
       de: German
-      doi: Dogri
-      dsb: Lower Sorbian
-      dv: Divehi
-      dz: Dzongkha
-      el: Greek
       en: English
-      eo: Esperanto
       es: Spanish
-      et: Estonian
-      eu: Basque
-      fa: Persian
-      ff: Fulah
-      fi: Finnish
-      fil: Filipino
-      fo: Faroese
       fr: French
-      fur: Friulian
-      fy: Western Frisian
-      ga: Irish
-      gbm: Garhwali
-      gd: Scottish Gaelic
-      gez: Geez
-      gl: Galician
-      gu: Gujarati
-      gv: Manx
-      hak: Hakka Chinese
-      ha: Hausa
-      he: Hebrew
-      hif: Fiji Hindi
-      hi: Hindi
-      hne: Chhattisgarhi
-      hr: Croatian
-      hsb: Upper Sorbian
-      ht: Haitian Creole
-      hu: Hungarian
-      hy: Armenian
-      ia: Interlingua
-      id: Indonesian
-      ig: Igbo
-      ik: Inupiaq
-      is: Icelandic
-      it: Italian
-      iu: Inuktitut
-      ja: Japanese
-      kab: Kabyle
-      ka: Georgian
-      kk: Kazakh
-      kl: Kalaallisut
-      km: Khmer
-      kn: Kannada
-      kok: Konkani
-      ko: Korean
-      ks: Kashmiri
-      ku: Kurdish
-      kv: Komi
-      kw: Cornish
-      ky: Kyrgyz
-      lb: Luxembourgish
-      lg: Ganda
-      lij: Ligurian
-      ltg: Latgalian
-      li: Limburgish
-      ln: Lingala
-      lo: Lao
-      lt: Lithuanian
-      lv: Latvian
-      lzh: Literary Chinese
-      mag: Magahi
-      mai: Maithili
-      mdf: Moksha
-      mfe: Morisyen
-      mg: Malagasy
-      mhr: Meadow Mari
-      miq: Miskito
-      mi: Maori
-      mjw: Karbi
-      mk: Macedonian
-      ml: Malayalam
-      mni: Manipuri
-      mnw: Mon
-      mn: Mongolian
-      mr: Marathi
-      ms: Malay
-      mt: Maltese
-      my: Burmese
-      nan: Min Nan Chinese
-      nb: Norwegian BokmÃ¥l
-      nds: Low German
-      ne: Nepali
-      nhn: Tlaxcala-Puebla Nahuatl
-      niu: Niuean
-      nl: Dutch
-      nn: Norwegian Nynorsk
-      nr: South Ndebele
-      nso: Northern Sotho
-      oc: Occitan
-      om: Oromo
-      or: Odia
-      os: Ossetic
-      pap: Papiamento
-      pa: Punjabi
-      pl: Polish
-      ps: Pashto
-      pt: Portuguese
-      quz: Cusco Quechua
-      raj: Rajasthani
-      rif: Tarifit
-      ro: Romanian
-      ru: Russian
-      rw: Kinyarwanda
-      sah: Sakha
-      sat: Santali
-      sa: Sanskrit
-      sc: Sardinian
-      scn: Sicilian
-      sd: Sindhi
-      se: Northern Sami
-      sgs: Samogitian
-      shn: Shan
-      shs: Shuswap
-      sid: Sidamo
-      si: Sinhala
-      sk: Slovak
-      sl: Slovenian
-      sm: Samoan
-      so: Somali
-      sq: Albanian
-      sr: Serbian
-      ss: Swati
-      ssy: Swaho
-      st: Southern Sotho
-      su: Sundanese
-      sv: Swedish
-      sw: Swahili
-      syr: Syriac
-      szl: Silesian
-      ta: Tamil
-      tcy: Tulu
-      te: Telugu
-      tg: Tajik
-      the: Chitwania Tharu
-      th: Thai
-      tig: Tigre
-      ti: Tigrinya
-      tk: Turkmen
-      tl: Tagalog
-      tn: Tswana
-      to: Tongan
-      tok: Toki Pona
-      tpi: Tok Pisin
-      tr: Turkish
-      ts: Tsonga
-      tt: Tatar
-      ug: Uyghur
-      uk: Ukrainian
-      unm: Unami language
-      ur: Urdu
-      uz: Uzbek
-      ve: Venda
-      vi: Vietnamese
-      wae: Walser
-      wal: Wolaytta
-      wa: Walloon
-      wo: Wolof
-      xh: Xhosa
-      yi: Yiddish
-      yo: Yoruba
-      yue: Cantonese
-      yuw: Yau
-      zgh: Moroccan Berber
-      zh: Mandarin Chinese
-      zu: Zulu
 
 subpackages:
   - name: "glibc-testresults"
@@ -734,7 +532,7 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - range: locales
+  - range: locales-main
     name: "glibc-locale-${{range.key}}"
     description: "${{range.value}} locale data for glibc"
     pipeline:
@@ -745,7 +543,7 @@ subpackages:
           [ -d "${{targets.destdir}}"/usr/lib/locale/${{range.key}} ] \
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
 
-          # glibc-locale-en is ~18x as big as it should be due to duplicate files.
+          # Some locale can be ~18x as big as it should be due to duplicate files.
           # rdfind replaces redundant files with hardlinks.
           rdfind -makehardlinks true "${{targets.subpkgdir}}"/usr/lib/locale/
     dependencies:
@@ -773,6 +571,47 @@ subpackages:
               exit 1
             }
             echo "PASS: $pkg shipped" $matches
+
+  - name: "glibc-locale-extra"
+    description: "All other extra locale data for glibc"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/locale
+          mv "${{targets.destdir}}"/usr/lib/locale/* "${{targets.subpkgdir}}"/usr/lib/locale/
+
+          # Some locale can be ~18x as big as it should be due to duplicate files.
+          # rdfind replaces redundant files with hardlinks.
+          rdfind -makehardlinks true "${{targets.subpkgdir}}"/usr/lib/locale/
+    dependencies:
+      runtime:
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+      provides:
+    test:
+      environment:
+        contents:
+          packages:
+            - posix-libc-utils
+      pipeline:
+        - runs: |
+            set +x
+            pkg=glibc-locale-extra
+            out=$(locale --all-locales) || {
+              echo "FAIL: locale --all-locales failed for $pkg"
+              exit 1
+            }
+            # XXX: the list of locales to check here needs to be kept in sync with
+            #  the locales-main range
+            for lang in ca de en es fr; do
+              matches=$(echo "$out" | grep "^$lang") && {
+                echo "FAIL: $pkg installs one of the stand-alone-package locales"
+                echo "$ locale --all-locales"
+                echo "$out"
+                exit 1
+              }
+            done
+            echo "PASS: $pkg correctly does not ship main locales"
 
   # Similar to https://packages.debian.org/bookworm/libc-bin
   - name: "libc-bin"
@@ -803,7 +642,7 @@ test:
 
         if [[ -n "${locales}" ]]; then
           for locale in "${locales}"; do
-            echo "Error: locale $locale found in main package, please add to locale list"
+            echo "Error: locale $locale found in main glibc package"
           done
           exit 1
         fi


### PR DESCRIPTION
Generating locale subpackages per language causes the glibc package count to go up to 211 for just the locale ones. This is unnecessary and causes issues with the apk copier everytime a new release is performed. We actually only use like 5 main locales + posix. Create an locale-extra package for the rest.