### PR TITLE
llvm-18: bump epoch to provide newer clang packages

### DIFF
--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-18
   version: "18.1.8"
-  epoch: 8
+  epoch: 9
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Between final testing and merge, an update landed into the clang-18
package which had version equivalence with the clang-* packages
provided by llvm-18; bump the epoch to superseed with the new
ones from llvm-18.
