### PR TITLE
patchelf: pick fix for for alignment problems

### DIFF
--- a/patchelf.yaml
+++ b/patchelf.yaml
@@ -1,7 +1,7 @@
 package:
   name: patchelf
   version: 0.18.0
-  epoch: 1
+  epoch: 2
   description: Small utility to modify the dynamic linker and RPATH of ELF executables
   copyright:
     - license: GPL-3.0-or-later
@@ -22,6 +22,8 @@ pipeline:
       expected-commit: 99c24238981b7b1084313aca8f5c493bb46f302c
       repository: https://github.com/NixOS/patchelf
       tag: ${{package.version}}
+      cherry-picks: |
+        master/0e338941fc730c1e7080ca04fc1ee18b9ae2854b: Fix alignment problem when rewriting sections
 
   - runs: |
       autoreconf -fiv


### PR DESCRIPTION
Cherry pick fix to resolve an issue related to aligment problems
after rewriting sections, resolving issues related to segfaults
in native Python extensions.
