### PR TITLE
fix(CVE): Update commons-beanutils transitive dependency to 1.11.0 to address GHSA-wxr5-93ph-8wr9

### DIFF
--- a/kafka-4.0.yaml
+++ b/kafka-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-4.0
   version: "4.0.0"
-  epoch: 41
+  epoch: 42
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,10 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 985bc99521dd22bbf620591b8db8613c54f596b2
+
+  - uses: patch
+    with:
+      patches: fix-GHSA-wxr5-93ph-8wr9-update-common-beanutils.patch
 
   - runs: |
       gradle clean releaseTarGz

--- a/kafka-4.0/fix-GHSA-wxr5-93ph-8wr9-update-common-beanutils.patch
+++ b/kafka-4.0/fix-GHSA-wxr5-93ph-8wr9-update-common-beanutils.patch
@@ -1,0 +1,77 @@
+From 83c3f16a0ffe35707a7c4526cc8b270274d567c6 Mon Sep 17 00:00:00 2001
+From: Debasish Biswas <debasishbsws.dev@gmail.com>
+Date: Mon, 2 Jun 2025 10:27:19 +0000
+Subject: [PATCH] fix(CVE): Update commons-beanutils transitive dependency to
+ 1.11.0 to address GHSA-wxr5-93ph-8wr9
+
+* commons-beanutils is a transitive dependency of commons-validator: https://commons.apache.org/proper/commons-validator/index.html
+* This patch enforces commons-beanutils version 1.11.0 explicitly to mitigate the CVE.
+* Can be removed once Kafka upstream upgrades commons-validator to a version that depends on commons-beanutils <= 1.11.0.
+  - Current commons-validator version in use: https://github.com/apache/kafka/blob/${{package.version}}/gradle/dependencies.gradle#L60
+  - Future validator versions can be checked for dependency updates: https://github.com/apache/commons-validator/blob/<commons-validator version>/pom.xml#L159-L163 in plugins
+
+Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>
+---
+ LICENSE-binary             | 2 +-
+ build.gradle               | 5 ++++-
+ gradle/dependencies.gradle | 2 ++
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 030f62b967..605528c2c8 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -206,7 +206,7 @@ This project bundles some components that are also licensed under the Apache
+ License Version 2.0:
+ 
+ - caffeine-3.1.1
+-- commons-beanutils-1.9.4
++- commons-beanutils-1.11.0
+ - commons-collections-3.2.2
+ - commons-digester-2.1
+ - commons-lang3-3.12.0
+diff --git a/build.gradle b/build.gradle
+index 388a85aa85..b6cccfb821 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -197,7 +197,9 @@ allprojects {
+           // ensure we have a single version in the classpath despite transitive dependencies
+           libs.scalaLibrary,
+           libs.scalaReflect,
+-          libs.jacksonAnnotations
++          libs.jacksonAnnotations,
++          // Enforce the updated commons-beanutils to address CVE
++          libs.commonsBeanutils
+         )
+       }
+     }
+@@ -1084,6 +1086,7 @@ project(':core') {
+     implementation project(':share-coordinator')
+ 
+     implementation libs.argparse4j
++    implementation libs.commonsBeanutils // Explicitly adding commons-beanutils to override transitive dependency
+     implementation libs.commonsValidator
+     implementation libs.jacksonDatabind
+     implementation libs.jacksonDataformatCsv
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index 66eca369aa..cae785a015 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -60,6 +60,7 @@ versions += [
+   caffeine: "3.1.1",
+   bndlib: "7.0.0",
+   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "10.20.2",
++  commonsBeanutils: "1.11.0", // Added to address CVE GHSA-wxr5-93ph-8wr9
+   commonsValidator: "1.9.0",
+   classgraph: "4.8.173",
+   gradle: "8.10.2",
+@@ -148,6 +149,7 @@ libs += [
+   bndlib:"biz.aQute.bnd:biz.aQute.bndlib:$versions.bndlib",
+   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
+   classgraph: "io.github.classgraph:classgraph:$versions.classgraph",
++  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
+   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
+   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
+   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
+-- 
+2.49.0


### PR DESCRIPTION

- commons-beanutils is a transitive dependency of commons-validator: https://commons.apache.org/proper/commons-validator/index.html
- This patch enforces commons-beanutils version 1.11.0 explicitly to mitigate the CVE.
- Can be removed once Kafka upstream upgrades commons-validator to a version that depends on commons-beanutils <= 1.11.0.
  - Current commons-validator version in use: https://github.com/apache/kafka/blob/${{package.version}}/gradle/dependencies.gradle#L60
  - Future validator versions can be checked for dependency updates: https://github.com/apache/commons-validator/blob/<version>/pom.xml#L159-L163
