### PR TITLE
glibc: fix shellcheck errors

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 4
+  epoch: 5
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -406,7 +406,11 @@ subpackages:
       pipeline:
         - name: Check lib64 and apk audit locations of ld-linux
           runs: |
-            [ -e /lib64/ld-linux-* ]
+            ld_linux_found=false
+            for f in /lib64/ld-linux-*; do
+              [ -e "$f" ] && ld_linux_found=true
+            done
+            [ "$ld_linux_found" = "true" ]
             [ -z "$(apk audit --full | grep ld-linux)" ]
         - name: Test usage of /etc/ld.so.conf.d/ snippets
           runs: |
@@ -802,7 +806,7 @@ test:
         locales=$(ls | grep -v C.utf8 || true)
 
         if [[ -n "${locales}" ]]; then
-          for locale in "${locales}"; do
+          for locale in ${locales}; do
             echo "Error: locale $locale found in main package, please add to locale list"
           done
           exit 1


### PR DESCRIPTION
In glibclc2vpwo_ line 4:
	for locale in "${locales}"; do
                      ^----------^ SC2066 (error): Since you double quoted this, it will not word split, and the loop will only run once.

In glibc1ae0s0em line 1:
[ -e /lib64/ld-linux-* ]
     ^---------------^ SC2144 (error): -e doesn't work with globs. Use a for loop.

For more information:
  https://www.shellcheck.net/wiki/SC2066 -- Since you double quoted this, it ...
  https://www.shellcheck.net/wiki/SC2144 -- -e doesn't work with globs. Use a...

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
