### PR TITLE
gcc: Update `--with-glibc-version` parameter

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 15.1.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -87,7 +87,7 @@ pipeline:
         --disable-nls \
         --disable-werror \
         --with-pkgversion='Wolfi ${{package.full-version}}' \
-        --with-glibc-version=2.39 \
+        --with-glibc-version=2.41 \
         --enable-initfini-array \
         --disable-nls \
         --disable-multilib \


### PR DESCRIPTION
This is a minor thing that slipped when GCC 15 got merged.