### PR TITLE
connect-proxy-1.105: new package

### DIFF
--- a/connect-proxy.yaml
+++ b/connect-proxy.yaml
@@ -2,7 +2,7 @@ package:
   name: connect-proxy
   version: "1.105"
   epoch: 0
-  description: Simple relaying command via proxy to make network connection via SOCKS and https proxy.
+  description: Simple relaying command to make network connection via SOCKS and https proxy.
   target-architecture:
     - aarch64
     - arm64

--- a/connect-proxy.yaml
+++ b/connect-proxy.yaml
@@ -1,0 +1,46 @@
+package:
+  name: connect-proxy
+  version: "1.105"
+  epoch: 0
+  description: Simple relaying command via proxy to make network connection via SOCKS and https proxy.
+  target-architecture:
+    - aarch64
+    - arm64
+    - x86_64
+  copyright:
+    - license: GPL-2.0-or-later
+      paths: 
+        - connect.c
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - gcc
+      - busybox
+      - sed
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/gotoh/ssh-connect
+      expected-commit: da7ff7660fe09cb3fc8c749dd0b10f62fc5ea8cd
+      tag: ${{package.version}}
+
+  - runs: |
+      sed -i 's/SOCKLEN_T/socklen_t/g' connect.c && gcc connect.c -o connect-proxy
+
+update:
+  enabled: true
+  github:
+    identifier: gotoh/ssh-connect
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Verify connect-proxy installation
+      runs: |
+        connect-proxy || exit 1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/55028

Related:
https://github.com/gotoh/ssh-connect
https://tracker.debian.org/pkg/connect-proxy

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
