### PR TITLE
Renames ffmpeg for version streaming

### DIFF
--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -2,11 +2,13 @@
 package:
   name: ffmpeg-7
   version: "7.1.1"
-  epoch: 4
+  epoch: 5
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
   dependencies:
+    provides:
+      - ffmpeg=${{package.full-version}}
     provider-priority: 5
     runtime:
       - libavcodec61=${{package.full-version}}
@@ -120,9 +122,11 @@ data:
 
 subpackages:
   - range: libraries
-    name: ${{range.key}}
+    name: ${{package.name}}-${{range.key}}
     description: "${{range.value}} library"
     dependencies:
+      provides:
+        - ${{range.key}}=${{package.full-version}}
       provider-priority: 5
     pipeline:
       - runs: |
@@ -132,16 +136,21 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: ffmpeg-static
+  - name: ${{package.name}}-static
+    dependencies:
+      provides:
+        - ffmpeg-static=${{package.full-version}}
     pipeline:
       - uses: split/static
     description: ffmpeg static libraries
 
-  - name: ffmpeg-dev
+  - name: ${{package.name}}-dev
     dependencies:
       runtime:
-        - ffmpeg
-        - ffmpeg-static
+        - ${{package.name}}
+        - ${{package.name}}-static
+      provides:
+        - ffmpeg-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
     description: ffmpeg development headers
@@ -150,12 +159,18 @@ subpackages:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
 
-  - name: ffmpeg-doc
+  - name: ${{package.name}}-doc
+    dependencies:
+      provides:
+        - ffmpeg-doc=${{package.full-version}}
     pipeline:
       - uses: split/manpages
     description: ffmpeg manpages
 
-  - name: ffmpeg-qt-faststart
+  - name: ${{package.name}}-qt-faststart
+    dependencies:
+      provides:
+        - ffmpeg-qt-faststart=${{package.full-version}}
     description: "Utility for optimizing MP4 files for HTTP streaming"
     pipeline:
       - uses: autoconf/make
@@ -167,7 +182,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - ffmpeg
+            - ${{package.name}}
       pipeline:
         - runs: |
             ffmpeg -f lavfi -i testsrc=size=640x480:duration=10:rate=30 -c:v libx264 -pix_fmt yuv420p sample_video.mp4
@@ -189,3 +204,15 @@ test:
         ffmpeg --help
         ffprobe --help
         ffplay --help
+
+        # Generate and verify a 1-second, 128x128 color test video using libx264 (H.264 encoder)
+        ffmpeg -f lavfi -i testsrc=duration=1:size=128x128:rate=30 \
+           -c:v libx264 -pix_fmt yuv420p out.mp4
+        test -f out.mp4
+
+        # Generate and confirm a 1-second 1000Hz sine wave and encode it to MP3 using libmp3lame
+        ffmpeg -f lavfi -i sine=frequency=1000:duration=1 -c:a libmp3lame test.mp3
+        test -f test.mp3
+
+        # Inspect the video file metadata
+        ffprobe -v error -show_format -show_streams out.mp4

--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -1,6 +1,6 @@
 #nolint:git-checkout-must-use-github-updates
 package:
-  name: ffmpeg
+  name: ffmpeg-7
   version: "7.1.1"
   epoch: 4
   description: ffmpeg multimedia library


### PR DESCRIPTION
#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
