### PR TITLE
chore: bump otel-cpp to build against new protobuf

### DIFF
--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: "1.21.0"
-  epoch: 0
+  epoch: 1
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
`ingres-nginx-controller` needs headers from both protobuf and otel-cpp.

This epoch bump ensures the otel-cpp proto-bits are built against our current protobuf-dev and should fix the build failures we're seeing in https://github.com/wolfi-dev/os/pull/55105.