### PR TITLE
Fix liburing macro regression

### DIFF
--- a/liburing.yaml
+++ b/liburing.yaml
@@ -1,7 +1,7 @@
 package:
   name: liburing
   version: "2.10"
-  epoch: 0
+  epoch: 1
   description: Linux kernel io_uring access library.
   copyright:
     - license: MIT OR LGPL-2.1-or-later
@@ -24,9 +24,12 @@ pipeline:
       repository: https://github.com/axboe/liburing.git
       tag: liburing-${{package.version}}
 
+  # TODO remove macro.patch once 2.11 lands
   - uses: patch
     with:
-      patches: realpath-flag.patch
+      patches: |
+        macro.patch
+        realpath-flag.patch
 
   - runs: |
       ./configure \

--- a/liburing/macro.patch
+++ b/liburing/macro.patch
@@ -1,0 +1,26 @@
+https://github.com/axboe/liburing/pull/1414
+diff --git a/src/include/liburing.h b/src/include/liburing.h
+index abaf75dde..487b1ccbe 100644
+--- a/src/include/liburing.h
++++ b/src/include/liburing.h
+@@ -379,15 +379,15 @@ IOURINGINLINE bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
+ }
+
+ /*
+- * NOTE: we should just get rid of the 'head' being passed in here, it doesn't
++ * NOTE: we should just get rid of the '__head__' being passed in here, it doesn't
+  * serve a purpose anymore. The below is a bit of a work-around to ensure that
+- * the compiler doesn't complain about 'head' being unused (or only written,
++ * the compiler doesn't complain about '__head__' being unused (or only written,
+  * never read), as we use a local iterator for both the head and tail tracking.
+  */
+-#define io_uring_for_each_cqe(ring, head, cqe)					\
++#define io_uring_for_each_cqe(ring, __head__, cqe)					\
+ 	for (struct io_uring_cqe_iter __ITER__ = io_uring_cqe_iter_init(ring);	\
+-	     (head) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
+-	     (void)(head))
++	     (__head__) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
++	     (void)(__head__))
+
+ /*
+  * Must be called after io_uring_for_each_cqe()


### PR DESCRIPTION
Relates to the failures seen in #55000. This should be resolved for good once 2.11 lands but in the meantime we'll want this patch to prevent build errors elsewhere.