### PR TITLE
argo-workflows: make updates manual, withdraw 3.6.8 packages

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -155,6 +155,9 @@ subpackages:
 
 update:
   enabled: true
+  # The most recent releases have been marked "do not use": ensure we should be
+  # using releases before landing
+  manual: true
   github:
     identifier: argoproj/argo-workflows
     strip-prefix: v

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -51,3 +51,12 @@ lld-static-19.1.7-r5.apk
 lld-static-19.1.7-r6.apk
 lld-static-19.1.7-r7.apk
 lld-static-19.1.7-r8.apk
+
+argo-workflow-cli-3.6.8-r0.apk
+argo-workflow-controller-3.6.8-r0.apk
+argo-workflow-controller-compat-3.6.8-r0.apk
+argo-workflow-executor-3.6.8-r0.apk
+argo-workflow-executor-compat-3.6.8-r0.apk
+argo-workflows-3.6.8-r0.apk
+argo-workflows-known-hosts-3.6.8-r0.apk
+argo-workflows-ui-3.6.8-r0.apk


### PR DESCRIPTION
Upstream have marked recent releases as "DO NOT USE", so let's not autoland them for now.