### PR TITLE
luajit: bump to latest

### DIFF
--- a/luajit.yaml
+++ b/luajit.yaml
@@ -1,7 +1,7 @@
 package:
   name: luajit
-  version: 2.1_p20210510
-  epoch: 12
+  version: 2.1_git20250117
+  epoch: 0
   description: OpenResty's branch of LuaJIT
   copyright:
     - license: MIT
@@ -15,16 +15,27 @@ environment:
       - busybox
       - ca-certificates-bundle
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\_git\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: "_git"
+    replace: "-"
+    to: mangled-package-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1ee6dad809a5bb22efb45e6dac767f7ce544ad652d353a93d7f26b605f69fe3f
-      uri: https://github.com/openresty/luajit2/archive/v2.1-20210510/luajit${{package.version}}.tar.gz
+      repository: https://github.com/openresty/luajit2
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: 93162f34e7424cd0ea3c4046a9ffacce621626bc
 
   - runs: |
       export LUAJIT_LIB=/usr/lib
       export LUA_LIB_DIR="$LUAJIT_LIB/lua"
-      export LUAJIT_INC=/usr/include/luajit-2.1
+      export LUAJIT_INC=/usr/include/luajit-${{vars.major-minor-version}}
 
       make CCDEBUG=-g PREFIX=/usr -j $(nproc)
       make DESTDIR="${{targets.destdir}}" install PREFIX=/usr
@@ -63,5 +74,5 @@ test:
     - runs: |
         lua -v
         luajit -v
-        luajit-2.1.0-beta3 -v
+        luajit-${{vars.major-minor-version}}.0-beta3 -v
     - uses: test/tw/ldd-check

--- a/luajit.yaml
+++ b/luajit.yaml
@@ -1,6 +1,6 @@
 package:
   name: luajit
-  version: 2.1_git20250117
+  version: 2.1_p20250117
   epoch: 0
   description: OpenResty's branch of LuaJIT
   copyright:
@@ -17,11 +17,11 @@ environment:
 
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+\.\d+)\_git\d+$
+    match: ^(\d+\.\d+)\_p\d+$
     replace: "$1"
     to: major-minor-version
   - from: ${{package.version}}
-    match: "_git"
+    match: "_p"
     replace: "-"
     to: mangled-package-version
 
@@ -65,8 +65,11 @@ subpackages:
         - uses: test/docs
 
 update:
-  enabled: false
-  exclude-reason: package uses special versioning
+  enabled: true
+  github:
+    identifier: openresty/luajit2
+    strip-prefix: v
+    use-tag: true
 
 test:
   pipeline:
@@ -74,5 +77,4 @@ test:
     - runs: |
         lua -v
         luajit -v
-        luajit-${{vars.major-minor-version}}.0-beta3 -v
     - uses: test/tw/ldd-check


### PR DESCRIPTION
Bump to latest: https://github.com/openresty/luajit2/releases/tag/v2.1-20250117