### PR TITLE
libxml2-13: add shim compat package

### DIFF
--- a/libxml2-13.yaml
+++ b/libxml2-13.yaml
@@ -1,0 +1,66 @@
+package:
+  name: libxml2-13
+  version: "2.13.6"
+  epoch: 4
+  description: XML parsing library, version 2
+  copyright:
+    - license: MIT
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 2.10.1 will create a new var mangled-package-version=2.10
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - pkgconf-dev
+      - python3-dev
+      - xz-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.gnome.org/GNOME/libxml2.git
+      tag: v${{package.version}}
+      expected-commit: 66453240c94b5cbd3e9ae9b32016fdafb13cdf18
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        PYTHON=/usr/bin/python3 \
+        --with-lzma \
+        --with-zlib \
+        --without-python \
+        --without-docs
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      rm -rf ${{targets.destdir}}/usr/include ${{targets.destdir}}/usr/share ${{targets.destdir}}/usr/man ${{targets.destdir}}/usr/bin
+      rm -rf ${{targets.destdir}}/usr/lib/libxml2.so ${{targets.destdir}}/usr/lib/cmake ${{targets.destdir}}/usr/lib/pkgconfig
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1783
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
Provide a versioned libxml2 package providing the .2 ABI only which
is co-installable with libxml2 latest; this should fix dependency
resolution issues while we work through remaining packages that
have not been transitioned.
