### PR TITLE
Empty package fix

### DIFF
--- a/bat.yaml
+++ b/bat.yaml
@@ -1,7 +1,7 @@
 package:
   name: bat
   version: 0.25.0
-  epoch: 2
+  epoch: 3
   description: "A cat(1) clone with wings"
   copyright:
     - license: MIT OR Apache-2.0
@@ -23,6 +23,11 @@ pipeline:
       repository: https://github.com/sharkdp/bat
       tag: v${{package.version}}
       expected-commit: 25f4f96ea3afb6fe44552f3b38ed8b1540ffa1b3
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man1"
+      cp assets/manual/bat.1.in "${{targets.destdir}}/usr/share/man/man1/"
+
 
   - uses: rust/cargobump
 

--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: benchmark
   version: "1.9.4"
-  epoch: 0
+  epoch: 1
   description: "microbenchmark support library"
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,11 @@ pipeline:
       DESTDIR="${{targets.destdir}}" cmake --install build
 
   - uses: strip
+  
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/"
+      cp -r docs/* "${{targets.destdir}}/usr/share/man/"
 
 subpackages:
   - name: benchmark-dev

--- a/bison.yaml
+++ b/bison.yaml
@@ -1,7 +1,7 @@
 package:
   name: bison
   version: 3.8.2
-  epoch: 6
+  epoch: 7
   description: "The GNU general-purposes parser generator"
   copyright:
     - license: GPL-3.0-or-later
@@ -148,6 +148,7 @@ subpackages:
     description: bison documentation
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     test:
       pipeline:
         - uses: test/docs

--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -38,7 +38,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-doc
+  - name: dhcping-doc
     description: "dhcping manpages"
     pipeline:
       - uses: split/manpages

--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: "2.3.1"
-  epoch: 1
+  epoch: 2
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT
@@ -79,6 +79,10 @@ pipeline:
       for p in $d/usr/bin/amazon-efs-mount-watchdog $d/usr/bin/mount.efs ; do
          sed -i -e '1s,^#!.*python3$,#!/usr/bin/python${{vars.py-version}},' "$p"
       done
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man8"
+      cp man/mount.efs.8 "${{targets.destdir}}/usr/share/man/man8/"
 
 # This package exists separately because aws-efs-csi-driver requires a custom efs-utils.
 # Upstream moves /etc/amazon/efs to /etc/amazon/efs-static-files
@@ -150,6 +154,14 @@ subpackages:
       pipeline:
         - runs: |
             efs-proxy --help
+
+  - name: efs-utils-doc
+    description: efs-utils doc
+    pipeline: 
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/exim.yaml
+++ b/exim.yaml
@@ -1,7 +1,7 @@
 package:
   name: exim
   version: "4.98.2"
-  epoch: 42
+  epoch: 43
   description: Message Transfer Agent
   copyright:
     - license: GPL-2.0-or-later
@@ -85,6 +85,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: exim-doc
+    description: exim docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
   - range: exim-lookups-with-deps
     name: exim-${{range.key}}
     description: "EXIM extension: ${{range.key}}"

--- a/fatrace.yaml
+++ b/fatrace.yaml
@@ -2,7 +2,7 @@
 package:
   name: fatrace
   version: 0.17.0
-  epoch: 3
+  epoch: 4
   description: Report system wide file access events
   copyright:
     - license: GPL-3.0-or-later
@@ -28,11 +28,19 @@ pipeline:
 
   - uses: strip
 
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man8"
+      cp fatrace.8 "${{targets.destdir}}/usr/share/man/man8/"
+
 subpackages:
   - name: fatrace-doc
     pipeline:
       - uses: split/manpages
     description: fatrace manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   release-monitor:

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs
   version: "1.15"
-  epoch: 0
+  epoch: 1
   description: FUSE implementation for overlayfs
   copyright:
     - license: GPL-2.0-or-later
@@ -42,6 +42,17 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+
+subpackages:
+  - name: fuse-overlayfs-doc
+    description: fuse-overlayfs docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs  
+
 
 update:
   enabled: true

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -1,7 +1,7 @@
 package:
   name: gawk
   version: "5.3.2"
-  epoch: 0
+  epoch: 1
   description: "GNU awk pattern-matching language"
   copyright:
     - license: GPL-3.0-or-later
@@ -37,6 +37,7 @@ subpackages:
   - name: ${{package.name}}-doc
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     description: ${{package.name}} manpages
     test:
       pipeline:

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.0"
-  epoch: 1
+  epoch: 2
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -90,6 +90,14 @@ pipeline:
       chmod a+x scripts/*
 
 subpackages:
+  - name: gdal-doc
+    description: gdal docs
+    pipeline:
+      - uses: split/manpages
+    test:
+       pipeline:
+         - uses: test/docs 
+         
   - range: py-versions
     name: gdal-py${{range.key}}
     description: ${{package.name}} for Python ${{range.key}}
@@ -177,6 +185,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/bin
           mv ${{targets.outdir}}/gdal-py${{range.key}}/usr/bin/* ${{targets.contextdir}}/usr/bin/
           cp -r scripts/* ${{targets.contextdir}}/usr/bin/
+
     test:
       pipeline:
         - runs: |

--- a/gh.yaml
+++ b/gh.yaml
@@ -1,7 +1,7 @@
 package:
   name: gh
   version: "2.74.0"
-  epoch: 0
+  epoch: 1
   description: GitHub's official command line tool
   copyright:
     - license: MIT
@@ -25,6 +25,16 @@ pipeline:
   - runs: make install prefix=${{targets.destdir}}/usr
 
   - uses: strip
+
+
+subpackages:
+  - name: gh-doc
+    description: gh docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/gi-docgen.yaml
+++ b/gi-docgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: gi-docgen
   version: "2025.3"
-  epoch: 0
+  epoch: 1
   description: A documentation generator for GObject-based libraries
   copyright:
     - license: Apache-2.0 OR GPL-3.0-or-later
@@ -41,8 +41,20 @@ pipeline:
     with:
       expected-sha256: 6c8174716b2dab9ecf87a96de54be11303f7bcd50456795bfc0f020a5a07347d
       uri: https://gitlab.gnome.org/GNOME/gi-docgen/-/archive/${{package.version}}/gi-docgen-${{package.version}}.tar.gz
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man1"
+      cp docs/gi-docgen.1 "${{targets.destdir}}/usr/share/man/man1/"
 
 subpackages:
+  - name: gi-docgen-doc
+    description: gi-docgen docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+          
   - range: py-versions
     name: gi-docgen-py${{range.key}}
     description: gi-docgen for Python ${{range.key}}

--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
   version: "2.85.0"
-  epoch: 0
+  epoch: 1
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later
@@ -74,6 +74,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: glib-doc
+    description: glib docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+        
   - name: glib-static
     pipeline:
       - uses: split/static

--- a/grep.yaml
+++ b/grep.yaml
@@ -1,7 +1,7 @@
 package:
   name: grep
   version: "3.12"
-  epoch: 0
+  epoch: 1
   description: "GNU grep implementation"
   copyright:
     - license: GPL-3.0-or-later
@@ -33,6 +33,16 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: grep-doc
+    description: grep docs
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/htop.yaml
+++ b/htop.yaml
@@ -1,7 +1,7 @@
 package:
   name: htop
   version: "3.4.1"
-  epoch: 0
+  epoch: 1
   description: "A cross-platform interactive process viewer."
   copyright:
     - license: GPL-2.0-or-later
@@ -44,6 +44,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: htop-doc
+    description: htop docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/httpie.yaml
+++ b/httpie.yaml
@@ -1,7 +1,7 @@
 package:
   name: httpie
   version: 3.2.4
-  epoch: 1
+  epoch: 2
   description: "HTTPie for Terminal — modern, user-friendly command-line HTTP client for the API era. JSON support, colors, sessions, downloads, plugins & more."
   copyright:
     - license: BSD-3-Clause
@@ -35,6 +35,15 @@ pipeline:
     uses: python/build-wheel
 
   - uses: strip
+
+subpackages:
+  - name: httpie-doc
+    description: httpie docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: i2c-tools
   version: "4.4"
-  epoch: 4
+  epoch: 5
   description: Tools for monitoring I2C devices
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -42,6 +42,22 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: i2c-tools-doc
+    description: i2c-tools docs
+    pipeline:
+      - runs: |
+          PACKAGE_DIR="${{targets.outdir}}/i2c-tools"
+          if [ -d "$PACKAGE_DIR/usr/local/share/man" ]; then
+            mkdir -p "$PACKAGE_DIR/usr/share"
+            mv "$PACKAGE_DIR/usr/local/share/man" "$PACKAGE_DIR/usr/share/"
+          fi
+      - uses: split/manpages
+        with:
+          package: i2c-tools
+    test:
+      pipeline:
+        - uses: test/docs
+
   - name: i2c-tools-dev
     pipeline:
       - uses: split/dev
@@ -49,11 +65,6 @@ subpackages:
       runtime:
         - i2c-tools
     description: i2c-tools dev
-
-  - name: i2c-tools-doc
-    pipeline:
-      - uses: split/manpages
-    description: i2c-tools manpages
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}

--- a/ipvsadm.yaml
+++ b/ipvsadm.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipvsadm
   version: "1.31"
-  epoch: 40
+  epoch: 41
   description: The IP Virtual Server administration utility
   copyright:
     - license: GPL-2.0-or-later
@@ -42,6 +42,15 @@ pipeline:
         install
 
   - uses: strip
+
+subpackages:
+  - name: ipvsadm-doc
+    description: ipvsadm docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/ldns.yaml
+++ b/ldns.yaml
@@ -1,7 +1,7 @@
 package:
   name: ldns
   version: 1.8.4
-  epoch: 2
+  epoch: 3
   description: Lowlevel DNS(SEC) library
   copyright:
     - license: BSD-3-Clause
@@ -61,6 +61,14 @@ subpackages:
         - runs: |
             drill version
             drill help
+
+  - name: ldns-doc
+    description: ldns docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/liblogging.yaml
+++ b/liblogging.yaml
@@ -1,7 +1,7 @@
 package:
   name: liblogging
   version: 1.0.7
-  epoch: 2
+  epoch: 3
   description: an easy to use and lightweight signal-safe logging library
   copyright:
     - license: BSD-2-Clause
@@ -52,6 +52,14 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: liblogging-doc
+    description: liblogging docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/libpcap.yaml
+++ b/libpcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpcap
   version: 1.10.5
-  epoch: 1
+  epoch: 2
   description: A system-independent interface for user-level packet capture
   copyright:
     - license: BSD-3-Clause
@@ -62,6 +62,14 @@ subpackages:
             pcap-config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: libcap-doc
+    description: libcap docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/libtelnet.yaml
+++ b/libtelnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtelnet
   version: 0.23
-  epoch: 2
+  epoch: 3
   description: Simple RFC-complient TELNET implementation as a C library.
   copyright:
     - license: CC-PDDC
@@ -36,6 +36,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: libtelnet-doc
+    description: libtelnet docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/libxkbcommon.yaml
+++ b/libxkbcommon.yaml
@@ -2,7 +2,7 @@
 package:
   name: libxkbcommon
   version: "1.10.0"
-  epoch: 0
+  epoch: 1
   description: keyboard handling library
   copyright:
     - license: MIT
@@ -58,6 +58,14 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: libxkbcommon-doc
+    description: libxkbcommon docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/lshw.yaml
+++ b/lshw.yaml
@@ -1,7 +1,7 @@
 package:
   name: lshw
   version: "02.20"
-  epoch: 40
+  epoch: 41
   description: "Provide detailed information about a machine's hardware configuration"
   copyright:
     - license: GPL-2.0-or-later
@@ -32,6 +32,15 @@ pipeline:
       opts: SBINDIR=/usr/bin
 
   - uses: strip
+
+subpackages:
+  - name: lshw-doc
+    description: lshw docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/luit.yaml
+++ b/luit.yaml
@@ -1,7 +1,7 @@
 package:
   name: luit
   version: "20240910"
-  epoch: 1
+  epoch: 2
   description: Filter that can be run between an arbitrary application and a UTF-8 terminal emulator
   copyright:
     - license: MIT
@@ -42,6 +42,14 @@ subpackages:
       runtime:
         - luit
     description: luit dev
+
+  - name: luit-doc
+    description: luit docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/m4.yaml
+++ b/m4.yaml
@@ -1,7 +1,7 @@
 package:
   name: m4
   version: "1.4.20"
-  epoch: 1
+  epoch: 2
   description: "GNU macro processor"
   copyright:
     - license: GPL-3.0
@@ -31,6 +31,16 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: m4-doc
+    description: m4 docs
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/make.yaml
+++ b/make.yaml
@@ -1,7 +1,7 @@
 package:
   name: make
   version: 4.4.1
-  epoch: 5
+  epoch: 6
   description: "GNU make"
   copyright:
     - license: GPL-3.0-or-later
@@ -33,6 +33,17 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+
+subpackages:
+  - name: make-doc
+    description: make docs
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/meson.yaml
+++ b/meson.yaml
@@ -1,7 +1,7 @@
 package:
   name: meson
   version: "1.8.1"
-  epoch: 0
+  epoch: 1
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0
@@ -57,6 +57,12 @@ pipeline:
     with:
       expected-sha256: b4e3b80e8fa633555abf447a95a700aba1585419467b2710d5e5bf88df0a7011
       uri: https://github.com/mesonbuild/meson/releases/download/${{package.version}}/meson-${{package.version}}.tar.gz
+      
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man1"
+      cp man/meson.1 "${{targets.destdir}}/usr/share/man/man1/"
+
 
 subpackages:
   - range: py-versions
@@ -136,7 +142,10 @@ subpackages:
   - name: meson-doc
     pipeline:
       - uses: split/manpages
-    description: meson manpages
+    description: meson docs
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/nano.yaml
+++ b/nano.yaml
@@ -1,7 +1,7 @@
 package:
   name: nano
   version: "8.4"
-  epoch: 0
+  epoch: 1
   description: "The Nano package contains a small, simple text editor which aims to replace Pico, the default editor in the Pine package."
   copyright:
     - license: GPL-3.0
@@ -77,6 +77,7 @@ subpackages:
     description: nano documentation
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     test:
       pipeline:
         - uses: test/docs

--- a/ndctl.yaml
+++ b/ndctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: ndctl
   version: "81"
-  epoch: 0
+  epoch: 1
   description: "Utility library for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel."
   copyright:
     - license: "GPL-2.0-only AND LGPL-2.1-only"
@@ -54,6 +54,14 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: ndctl-doc
+    description: ndctl docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/netcat-openbsd.yaml
+++ b/netcat-openbsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: netcat-openbsd
   version: "1.229"
-  epoch: 0
+  epoch: 1
   description: The TCP/IP swiss army knife. OpenBSD variant from debian.
   copyright:
     - license: BSD-3-Clause
@@ -50,6 +50,16 @@ pipeline:
       install -Dm644 nc.1 "${{targets.destdir}}"/usr/share/man/man1/nc.openbsd.1
 
   - uses: strip
+
+
+subpackages:
+  - name: netcat-openbsd-doc
+    description: netcat-openbsd docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: "20.19.2"
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -89,6 +89,15 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/node_modules
       rm "${{targets.destdir}}"/usr/bin/npm
       rm "${{targets.destdir}}"/usr/bin/npx
+
+subpackages:
+  - name: nodejs-20-doc
+    description: nodejs-20 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: "22.16.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -92,6 +92,15 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/node_modules
       rm "${{targets.destdir}}"/usr/bin/npm
       rm "${{targets.destdir}}"/usr/bin/npx
+
+subpackages:
+  - name: nodejs-22-doc
+    description: nodejs-22 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/ocamlbuild.yaml
+++ b/ocamlbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: ocamlbuild
   version: "0.16.1"
-  epoch: 0
+  epoch: 1
   description: "Generic build tool with built-in rules for building OCaml library and programs"
   copyright:
     - license: LGPL-2.0-only WITH OCaml-LGPL-linking-exception
@@ -41,6 +41,16 @@ pipeline:
       mv ocamlbuild.native ocamlbuild
 
   - uses: strip
+
+
+subpackages:
+  - name: ocamlbuild-doc
+    description: ocamlbuild docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/patch.yaml
+++ b/patch.yaml
@@ -1,7 +1,7 @@
 package:
   name: patch
   version: "2.8"
-  epoch: 0
+  epoch: 1
   description: "GNU patch"
   copyright:
     - license: GPL-3.0-or-later
@@ -39,6 +39,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: patch-doc
+    description: patch docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/pkcs11-helper.yaml
+++ b/pkcs11-helper.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkcs11-helper
   version: 1.30.0
-  epoch: 1
+  epoch: 2
   description: PKCS#11 Helper library that simplifies the interaction with PKCS#11 providers for end-user applications
   copyright:
     - license: GPL-2.0-or-later
@@ -52,6 +52,14 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: pkcs11-helper-dev-doc
+    description: pkcs11-helper-dev docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/rdfind.yaml
+++ b/rdfind.yaml
@@ -1,7 +1,7 @@
 package:
   name: rdfind
   version: "1.7.0"
-  epoch: 0
+  epoch: 1
   description: a redundant file finder
   copyright:
     - license: GPL-2.0-or-later
@@ -29,6 +29,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: rdfind-doc
+    description: rdfind docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: "8.2504.0"
-  epoch: 0
+  epoch: 1
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0
@@ -240,6 +240,14 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: rsyslog-doc
+    description: rsyslog docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.70
   version: 1.70.0
-  epoch: 2
+  epoch: 3
   description: "Empowering everyone to build reliable and efficient software. (version 1.70.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -127,6 +127,15 @@ vars:
   CFLAGS: "$CFLAGS -I/home/build/sysroot/include"
   CPPFLAGS: "$CPPFLAGS -I/home/build/sysroot/include"
   CXXFLAGS: "$CXXFLAGS -I/home/build/sysroot/include"
+
+subpackages:
+  - name: rust-1.70-doc
+    description: rust-1.70 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: false

--- a/scap-security-guide.yaml
+++ b/scap-security-guide.yaml
@@ -1,7 +1,7 @@
 package:
   name: scap-security-guide
   version: "0.1.76"
-  epoch: 0
+  epoch: 1
   description: Security automation content in SCAP, Bash, Ansible, and other formats
   copyright:
     - license: BSD-3-Clause
@@ -54,6 +54,15 @@ pipeline:
       output-dir: build
 
   - uses: strip
+
+subpackages:
+  - name: scap-security-guide-doc
+    description: scap-security-guide docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/sl.yaml
+++ b/sl.yaml
@@ -2,7 +2,7 @@
 package:
   name: sl
   version: "5.02"
-  epoch: 0
+  epoch: 1
   description: Cure your bad habit of mistyping
   copyright:
     - license: MIT
@@ -26,13 +26,18 @@ pipeline:
 
   - runs: |
       install -Dm755 sl "${{targets.destdir}}/usr/bin/sl"
+  
+  - runs: |
+          install -Dm644 sl.1 "${{targets.destdir}}/usr/share/man/man1/sl.1"
 
 subpackages:
   - name: sl-doc
     pipeline:
-      - runs: |
-          install -Dm644 sl.1 "${{targets.destdir}}/usr/share/man/man1/sl.1"
+      - uses: split/manpages
     description: sl manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/slirp4netns.yaml
+++ b/slirp4netns.yaml
@@ -1,7 +1,7 @@
 package:
   name: slirp4netns
   version: "1.3.2"
-  epoch: 0
+  epoch: 1
   description: User-mode networking for unprivileged network namespaces
   copyright:
     - license: GPL-2.0-or-later
@@ -40,6 +40,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: slirp4netns-doc
+    description: slirp4netns docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/texinfo.yaml
+++ b/texinfo.yaml
@@ -1,7 +1,7 @@
 package:
   name: texinfo
   version: "7.2"
-  epoch: 1
+  epoch: 2
   description: "GNU documentation tool"
   copyright:
     - license: GPL-3.0-or-later
@@ -82,6 +82,7 @@ subpackages:
     description: texinfo documentation
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     test:
       pipeline:
         - uses: test/docs

--- a/udns.yaml
+++ b/udns.yaml
@@ -1,7 +1,7 @@
 package:
   name: udns
   version: "0.6"
-  epoch: 1
+  epoch: 2
   description: DNS Resolver Library
   copyright:
     - license: LGPL-2.1-or-later
@@ -32,6 +32,15 @@ pipeline:
       ln -s libudns.so.0 "${{targets.contextdir}}"/usr/lib/libudns.so
 
   - uses: strip
+  
+  - name: install manpages
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/man/man1"
+      mkdir -p "${{targets.destdir}}/usr/share/man/man3"
+      cp dnsget.1 "${{targets.destdir}}/usr/share/man/man1/"
+      cp rblcheck.1 "${{targets.destdir}}/usr/share/man/man1/"
+      cp udns.3 "${{targets.destdir}}/usr/share/man/man3/"
+
 
 subpackages:
   - name: udns-dev
@@ -49,6 +58,9 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: udns manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 test:
   pipeline:

--- a/udunits.yaml
+++ b/udunits.yaml
@@ -2,7 +2,7 @@
 package:
   name: udunits
   version: 2.2.28
-  epoch: 1
+  epoch: 2
   description: Library for handling of units of physical quantities
   copyright:
     - license: UCAR
@@ -45,7 +45,11 @@ subpackages:
   - name: udunits-doc
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     description: udunits manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.1"
-  epoch: 2
+  epoch: 3
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause
@@ -62,6 +62,14 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: varnish-doc
+    description: varnish docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/vim.yaml
+++ b/vim.yaml
@@ -1,7 +1,7 @@
 package:
   name: vim
   version: "9.1.1420"
-  epoch: 0
+  epoch: 1
   description: "Improved vi-style text editor"
   copyright:
     - license: Vim
@@ -65,6 +65,15 @@ test:
         vimdiff --version
         vimdiff --help
         xxd --version
+
+subpackages:
+  - name: vim-doc
+    description: vim docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/wireguard-tools.yaml
+++ b/wireguard-tools.yaml
@@ -5,7 +5,7 @@
 package:
   name: wireguard-tools
   version: "1.0.20250521"
-  epoch: 0
+  epoch: 1
   description: "Next generation secure network tunnel: userspace tools"
   copyright:
     - license: GPL-2.0-only
@@ -41,6 +41,15 @@ pipeline:
       cp -rf contrib "${{targets.destdir}}"/usr/share/doc/${{package.name}}/
 
   - uses: strip
+
+subpackages:
+  - name: wireguard-tools-doc
+    description: wireguard-tools docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/xdpyinfo.yaml
+++ b/xdpyinfo.yaml
@@ -2,7 +2,7 @@
 package:
   name: xdpyinfo
   version: 1.3.4
-  epoch: 2
+  epoch: 3
   description: display information utility for X
   copyright:
     - license: MIT-open-group
@@ -49,6 +49,14 @@ subpackages:
       runtime:
         - xdpyinfo
     description: xdpyinfo dev
+
+  - name: xdpyinfo-doc
+    description: xdpyinfo docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/xterm.yaml
+++ b/xterm.yaml
@@ -1,7 +1,7 @@
 package:
   name: xterm
   version: "399"
-  epoch: 0
+  epoch: 1
   description: X Terminal Emulator
   copyright:
     - license: MIT
@@ -77,6 +77,15 @@ pipeline:
       install -m644 "$builddir"/uxterm.desktop "${{targets.destdir}}"/usr/share/applications/
 
   - uses: strip
+
+subpackages:
+  - name: xterm-doc
+    description: xterm docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION
I reviewed a total of 53 empty "-doc" packages and fixed some of them that were incorrectly defined. The remaining packages require further investigation. 

Notes:

pax-utils – Uses .docbook files for manpage generation.
bind – Manpages are generated from .rst sources using Sphinx.
rustsec – No explicit manpages or generation sources in the upstream repository.
cppunit – Uses Doxygen and a Doxyfile to generate manpages.
ffmpeg – Contains many .texi files, which can generate info files via the Texinfo toolchain.
git-crypt – Has man/git-crypt.xml, a .docbook-compatible file suitable for generating a manpage.
gst-plugins-bad – Documentation can be built using Meson.
ldb – Manpages should be generated from XML sources.
libasyncns – Uses Doxygen to generate manpages.
libatasmart – Does not include explicit manpages or documentation.
libatomic_ops – No explicit manpages or documentation available.
libcmis – Contains XML (docbook) files that can be used to generate manpages.
libexif – Uses Doxygen to generate API-specific documentation.
libhtp – Uses Doxygen for documentation generation.
liblangtag – No manpages, but includes HTML documentation.
libmodbus – Includes many Markdown files in /docs, but no explicit manpages.
libogg – Contains HTML documentation in /doc, but no manpages.
libpciaccess – Has a .man template; manpages can be generated using make.
libsamplerate – Markdown files exist under /docs, but no explicit manpages.
libsdl2 – Extensive Markdown documentation in /docs, but lacks manpages.
libtheora – Uses Doxygen to generate manpages.
libvorbis – Uses Doxygen to generate manpages and has extensive HTML docs under /doc.
libxfont2 – Manpages generated via Makefiles.
libxi – Manpages are generated using Makefiles.
libxtst – Uses Makefiles to generate manpages.
linux-pam – Generates manpages using Meson.
opus – Uses Doxygen to generate manpages.
qt5-qtbase / qt6-qtbase – Contains many .qdocconf files but lacks explicit manpages.
vectorscan – Includes several .rst files as references, but no explicit manpages.