### PR TITLE
elfutils: New packages `debuginfod` and `libdebuginfod{,-dev}`

### DIFF
--- a/elfutils.yaml
+++ b/elfutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: elfutils
   version: "0.193"
-  epoch: 0
+  epoch: 1
   description: Utilities and DSOs to handle ELF files and DWARF data
   copyright:
     - license: GPL-3.0-or-later AND ( GPL-2.0-or-later OR LGPL-3.0-or-later )
@@ -17,9 +17,15 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      - curl-dev
       - flex-dev
+      - json-c-dev
+      - libarchive-dev
+      - libmicrohttpd-dev
       - libtool
       - linux-headers
+      - openssl-dev
+      - sqlite-dev
       - xz-dev
       - zlib-dev
       - zstd-dev
@@ -43,8 +49,8 @@ pipeline:
         --program-prefix=eu- \
         --enable-deterministic-archives \
         --disable-nls \
-        --disable-libdebuginfod \
-        --disable-debuginfod \
+        --enable-libdebuginfod \
+        --enable-debuginfod \
         --with-zstd
 
   - uses: autoconf/make
@@ -54,6 +60,38 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: debuginfod
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/debuginfod* "${{targets.subpkgdir}}"/usr/bin
+    dependencies:
+      runtime:
+        - libdebuginfod=${{package.full-version}}
+
+  - name: libdebuginfod
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libdebuginfod.so.* "${{targets.subpkgdir}}"/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: libdebuginfod-dev
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/include/elfutils "${{targets.subpkgdir}}"/usr/lib/pkgconfig
+          mv "${{targets.destdir}}"/usr/include/elfutils/debuginfod.h "${{targets.subpkgdir}}"/usr/include/elfutils
+          mv "${{targets.destdir}}"/usr/lib/libdebuginfod*.so "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/pkgconfig/libdebuginfod.pc "${{targets.subpkgdir}}"/usr/lib/pkgconfig
+    dependencies:
+      runtime:
+        - libdebuginfod=${{package.full-version}}
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
   - name: libelf
     pipeline:
       - runs: |


### PR DESCRIPTION
Add new `debuginfod` and `libdebuginfod{,-dev}` packages.

Closes: https://github.com/chainguard-dev/internal-dev/issues/12757