### PR TITLE
systemd: cherry-pick dbebba11c3b80549ef80bd9005abe0c78a0dfdfe

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,8 @@
 package:
   name: systemd
+  # 35712.patch can be dropped when 258 releases
   version: "257.6"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -89,6 +90,10 @@ pipeline:
       repository: https://github.com/systemd/systemd
       tag: v${{package.version}}
       expected-commit: 00a12c234e2506f5cab683460199575f13c454db
+
+  - uses: patch
+    with:
+      patches: 35712.patch
 
   - uses: meson/configure
     with:

--- a/systemd/35712.patch
+++ b/systemd/35712.patch
@@ -1,0 +1,25 @@
+From dbebba11c3b80549ef80bd9005abe0c78a0dfdfe Mon Sep 17 00:00:00 2001
+From: Daan De Meyer <daan.j.demeyer@gmail.com>
+Date: Sat, 21 Dec 2024 17:01:27 +0100
+Subject: [PATCH] units: Order systemd-oomd after systemd-sysusers
+
+systemd-sysusers might create the systemd-oom system user that
+systemd-oomd runs under so let's order systemd-oomd after
+systemd-sysusers.
+---
+ units/systemd-oomd.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/systemd-oomd.service.in b/units/systemd-oomd.service.in
+index 670d5e6140814..6838ddccef46a 100644
+--- a/units/systemd-oomd.service.in
++++ b/units/systemd-oomd.service.in
+@@ -20,7 +20,7 @@ ConditionPathExists=/proc/pressure/cpu
+ ConditionPathExists=/proc/pressure/io
+ ConditionPathExists=/proc/pressure/memory
+ Requires=systemd-oomd.socket
+-After=systemd-oomd.socket
++After=systemd-oomd.socket systemd-sysusers.service
+ 
+ [Service]
+ AmbientCapabilities=CAP_KILL CAP_DAC_OVERRIDE


### PR DESCRIPTION
This commit didn't make it into the 257 release, but we need it for chainguard VMs. We do need sysusers to create systemd-oom before this unit runs.
