### PR TITLE
code-server: drop resource requirements

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -6,8 +6,8 @@ package:
   copyright:
     - license: Apache-2.0
   resources:
-    cpu: 65
-    memory: 128Gi
+    cpu: 6
+    memory: 30Gi
   dependencies:
     runtime:
       - glibc-locales


### PR DESCRIPTION
This job is overprovisioned.

- https://console.cloud.google.com/kubernetes/pod/us-central1/elastic-pre-a/pre-wolfi/code-server-amd64-t8pdc/details?project=prod-wolfi-os&inv=1&invt=AbzPig
- https://console.cloud.google.com/monitoring/metrics-explorer;duration=P14D?pageState=%7B%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%22Used%22,%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metric.label.%5C%22memory_type%5C%22%3D%5C%22non-evictable%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22prod-wolfi-os%5C%22%20metadata.user_labels.%5C%22melange.chainguard.dev%2Fpackage%5C%22%3D%5C%22code-server%5C%22%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=prod-wolfi-os
