### PR TITLE
Rebuild repmgr-17 with libxml2

### DIFF
--- a/repmgr-17.yaml
+++ b/repmgr-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: repmgr-17
   version: 5.5.0
-  epoch: 41
+  epoch: 42
   description: "A lightweight replication manager for PostgreSQL"
   copyright:
     - license: GPL-3.0-only
@@ -26,7 +26,7 @@ environment:
       - automake
       - build-base
       - ca-certificates-bundle
-      - clang
+      - clang-19
       - curl-dev
       - docbook-xml
       - flex


### PR DESCRIPTION
repmgr-17 also fails to build with llvm20 as it is looking for `llvm-lto`.

```
2025/06/04 20:50:47 INFO Building against PostgreSQL 17
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/lib/postgre
sql17'
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/share/postg
resql17/extension'
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/share/postg
resql17/extension'
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/libexec/pos
tgresql17'
2025/06/04 20:50:47 INFO /usr/bin/install -c -m 755  repmgr.so '/home/build/melange-out/repmgr-17/usr/lib/postgresql17/repmgr.so'
2025/06/04 20:50:47 INFO /usr/bin/install -c -m 644 .//repmgr.control '/home/build/melange-out/repmgr-17/usr/share/postgresql17/extension/'
2025/06/04 20:50:47 INFO /usr/bin/install -c -m 644 .//repmgr--unpackaged--4.0.sql .//repmgr--unpackaged--5.1.sql .//repmgr--unpackaged--5.2.sql .//repmgr
--unpackaged--5.3.sql .//repmgr--4.0.sql .//repmgr--4.0--4.1.sql .//repmgr--4.1.sql .//repmgr--4.1--4.2.sql .//repmgr--4.2.sql .//repmgr--4.2--4.3.sql .//
repmgr--4.3.sql .//repmgr--4.3--4.4.sql .//repmgr--4.4.sql .//repmgr--4.4--5.0.sql .//repmgr--5.0.sql .//repmgr--5.0--5.1.sql .//repmgr--5.1.sql .//repmgr
--5.1--5.2.sql .//repmgr--5.2.sql .//repmgr--5.2--5.3.sql .//repmgr--5.3.sql .//repmgr--5.3--5.4.sql .//repmgr--5.4.sql .//repmgr--5.4--5.5.sql .//repmgr-
-5.5.sql  '/home/build/melange-out/repmgr-17/usr/share/postgresql17/extension/'
2025/06/04 20:50:47 INFO /usr/bin/install -c -m 755 repmgr repmgrd '/home/build/melange-out/repmgr-17/usr/libexec/postgresql17/'
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/lib/postgre
sql17/bitcode/repmgr'
2025/06/04 20:50:47 INFO /bin/sh /usr/lib/postgresql17/pgxs/src/makefiles/../../config/install-sh -c -d '/home/build/melange-out/repmgr-17/usr/lib/postgre
sql17/bitcode'/repmgr/
2025/06/04 20:50:47 INFO /usr/bin/install -c -m 644 repmgr.bc '/home/build/melange-out/repmgr-17/usr/lib/postgresql17/bitcode'/repmgr/./
2025/06/04 20:50:47 INFO cd '/home/build/melange-out/repmgr-17/usr/lib/postgresql17/bitcode' && /usr/lib/llvm-19/bin/llvm-lto -thinlto -thinlto-action=thi
nlink -o repmgr.index.bc repmgr/repmgr.bc
2025/06/04 20:50:47 WARN /bin/sh: /usr/lib/llvm-19/bin/llvm-lto: not found
2025/06/04 20:50:47 WARN make: *** [/usr/lib/postgresql17/pgxs/src/makefiles/pgxs.mk:242: install] Error 127
2025/06/04 20:50:47 INFO make: Leaving directory '/home/build'
2025/06/04 20:50:48 ERRO failed to build package: unable to run package repmgr-17 pipeline: unable to run pipeline: unable to run pipeline: exit status 2
make[1]: *** [Makefile:157: packages/x86_64/repmgr-17-5.5.0-r41.apk] Error 1
make[1]: Leaving directory '/home/user/src/wolfi-os'
make: *** [Makefile:151: package/repmgr-17] Error 2
```