### PR TITLE
empty package fix 3

### DIFF
--- a/i2c-tools.yaml
+++ b/i2c-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: i2c-tools
   version: "4.4"
-  epoch: 4
+  epoch: 5
   description: Tools for monitoring I2C devices
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -51,9 +51,18 @@ subpackages:
     description: i2c-tools dev
 
   - name: i2c-tools-doc
+    description: i2c-tools docs
     pipeline:
+      - runs: |
+          PACKAGE_DIR="${{targets.outdir}}/i2c-tools"
+          if [ -d "$PACKAGE_DIR/usr/local/share/man" ]; then
+            mkdir -p "$PACKAGE_DIR/usr/share"
+            mv "$PACKAGE_DIR/usr/local/share/man" "$PACKAGE_DIR/usr/share/"
+          fi
       - uses: split/manpages
-    description: i2c-tools manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}

--- a/kakoune.yaml
+++ b/kakoune.yaml
@@ -1,7 +1,7 @@
 package:
   name: kakoune
   version: "2025.06.03"
-  epoch: 0
+  epoch: 1
   description: Code editor heavily inspired by Vim, but with less keystrokes
   copyright:
     - license: Unlicense
@@ -27,9 +27,20 @@ pipeline:
 
 subpackages:
   - name: kakoune-doc
+    description: kakoune docs
     pipeline:
+      - runs: |
+          PACKAGE_DIR="${{targets.outdir}}/kakoune"
+          if [ -d "$PACKAGE_DIR/usr/local/share/man/" ]; then
+            mkdir -p "$PACKAGE_DIR/usr/share/"
+            mv "$PACKAGE_DIR/usr/local/share/man/" "$PACKAGE_DIR/usr/share/"
+          fi
+          if [ -d "$PACKAGE_DIR/usr/local/share/kak/doc" ]; then
+            mkdir -p "$PACKAGE_DIR/usr/share/info/"
+            mv "$PACKAGE_DIR/usr/local/share/kak/doc/" "$PACKAGE_DIR/usr/share/info/"
+          fi
       - uses: split/manpages
-    description: kakoune manpages
+      - uses: split/infodir
 
 test:
   pipeline:

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -2,7 +2,7 @@
 package:
   name: rtmpdump
   version: "2.6_git20250605"
-  epoch: 0
+  epoch: 1
   description: rtmpdump is a toolkit for RTMP streams
   copyright:
     - license: LGPL-2.0-only
@@ -63,12 +63,21 @@ subpackages:
   - name: ${{package.name}}-doc
     description: ${{package.name}} documentation
     pipeline:
+      - runs: |
+          PACKAGE_DIR="${{targets.outdir}}/rtmpdump"
+          if [ -d "$PACKAGE_DIR/usr/man/" ]; then
+            mkdir -p "$PACKAGE_DIR/usr/share"
+            mv "$PACKAGE_DIR/usr/man" "$PACKAGE_DIR/usr/share/"
+          fi
       - uses: split/manpages
       - uses: split/infodir
     dependencies:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+    test:
+      pipeline:
+        - uses: test/docs
 
   - name: librtmp
     description: RTMP library


### PR DESCRIPTION

The fix for these 3 packages was to ensure their existing man pages were placed in standard directories that "split/manpages" checks excluding non standard paths like:
   - /usr/local/share/man/
   - /usr/man/
