### PR TITLE
"-doc" package fix

### DIFF
--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: "20.19.2"
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -89,6 +89,15 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/node_modules
       rm "${{targets.destdir}}"/usr/bin/npm
       rm "${{targets.destdir}}"/usr/bin/npx
+
+subpackages:
+  - name: nodejs-20-doc
+    description: nodejs-20 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: "22.16.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -92,6 +92,15 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/node_modules
       rm "${{targets.destdir}}"/usr/bin/npm
       rm "${{targets.destdir}}"/usr/bin/npx
+
+subpackages:
+  - name: nodejs-22-doc
+    description: nodejs-22 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/ocamlbuild.yaml
+++ b/ocamlbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: ocamlbuild
   version: "0.16.1"
-  epoch: 0
+  epoch: 1
   description: "Generic build tool with built-in rules for building OCaml library and programs"
   copyright:
     - license: LGPL-2.0-only WITH OCaml-LGPL-linking-exception
@@ -41,6 +41,15 @@ pipeline:
       mv ocamlbuild.native ocamlbuild
 
   - uses: strip
+
+subpackages:
+  - name: ocamlbuild-doc
+    description: ocamlbuild docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/patch.yaml
+++ b/patch.yaml
@@ -1,7 +1,7 @@
 package:
   name: patch
   version: "2.8"
-  epoch: 0
+  epoch: 1
   description: "GNU patch"
   copyright:
     - license: GPL-3.0-or-later
@@ -39,6 +39,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: patch-doc
+    description: patch docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/pkcs11-helper.yaml
+++ b/pkcs11-helper.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkcs11-helper
   version: 1.30.0
-  epoch: 1
+  epoch: 2
   description: PKCS#11 Helper library that simplifies the interaction with PKCS#11 providers for end-user applications
   copyright:
     - license: GPL-2.0-or-later
@@ -52,6 +52,14 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: pkcs11-helper-dev-doc
+    description: pkcs11-helper-dev docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/rdfind.yaml
+++ b/rdfind.yaml
@@ -1,7 +1,7 @@
 package:
   name: rdfind
   version: "1.7.0"
-  epoch: 0
+  epoch: 1
   description: a redundant file finder
   copyright:
     - license: GPL-2.0-or-later
@@ -29,6 +29,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: rdfind-doc
+    description: rdfind docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION

Fixes:
'split/manpages', 'split/infodir' added to the appropriate packages