### PR TITLE
"-doc" package fix

### DIFF
--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: "8.2504.0"
-  epoch: 0
+  epoch: 1
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0
@@ -240,6 +240,14 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: rsyslog-doc
+    description: rsyslog docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.70
   version: 1.70.0
-  epoch: 2
+  epoch: 3
   description: "Empowering everyone to build reliable and efficient software. (version 1.70.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -127,6 +127,15 @@ vars:
   CFLAGS: "$CFLAGS -I/home/build/sysroot/include"
   CPPFLAGS: "$CPPFLAGS -I/home/build/sysroot/include"
   CXXFLAGS: "$CXXFLAGS -I/home/build/sysroot/include"
+
+subpackages:
+  - name: rust-1.70-doc
+    description: rust-1.70 docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: false

--- a/scap-security-guide.yaml
+++ b/scap-security-guide.yaml
@@ -1,7 +1,7 @@
 package:
   name: scap-security-guide
   version: "0.1.76"
-  epoch: 0
+  epoch: 1
   description: Security automation content in SCAP, Bash, Ansible, and other formats
   copyright:
     - license: BSD-3-Clause
@@ -54,6 +54,15 @@ pipeline:
       output-dir: build
 
   - uses: strip
+
+subpackages:
+  - name: scap-security-guide-doc
+    description: scap-security-guide docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/slirp4netns.yaml
+++ b/slirp4netns.yaml
@@ -1,7 +1,7 @@
 package:
   name: slirp4netns
   version: "1.3.3"
-  epoch: 0
+  epoch: 1
   description: User-mode networking for unprivileged network namespaces
   copyright:
     - license: GPL-2.0-or-later
@@ -40,6 +40,15 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: slirp4netns-doc
+    description: slirp4netns docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/texinfo.yaml
+++ b/texinfo.yaml
@@ -1,7 +1,7 @@
 package:
   name: texinfo
   version: "7.2"
-  epoch: 1
+  epoch: 2
   description: "GNU documentation tool"
   copyright:
     - license: GPL-3.0-or-later
@@ -82,6 +82,7 @@ subpackages:
     description: texinfo documentation
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     test:
       pipeline:
         - uses: test/docs

--- a/varnish.yaml
+++ b/varnish.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish
   version: "7.7.1"
-  epoch: 3
+  epoch: 4
   description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
   copyright:
     - license: BSD-2-Clause
@@ -61,6 +61,14 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: varnish-doc
+    description: varnish docs
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION

Fixes:
'split/manpages', 'split/infodir' added to the appropriate packages