### PR TITLE
Fix(update): Use Gitlab repo sourcecode and our toolchain to build

### DIFF
--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -2,7 +2,7 @@
 package:
   name: cryptsetup
   version: 2.7.5
-  epoch: 21
+  epoch: 22
   description: Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi
   copyright:
     - license: GPL-2.0-or-later WITH cryptsetup-OpenSSL-exception
@@ -10,12 +10,6 @@ package:
     runtime:
       - merged-sbin
       - wolfi-baselayout
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: major-minor-version
 
 environment:
   contents:
@@ -29,19 +23,31 @@ environment:
       - busybox
       - ca-certificates-bundle
       - coreutils
+      - gettext-dev
       - json-c-dev
       - libssh
       - libssh-dev
+      - libtool
       - lvm2-dev
       - openssl-dev
+      - pkgconf-dev
       - popt-dev
       - util-linux-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f2c6d22e53435de5d35dc9fdc86600d3e5e2227d27970b07a8e6a0f9f7bd42ac
-      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v${{vars.major-minor-version}}/cryptsetup-${{package.version}}.tar.gz
+      expected-commit: 3c3a8210e4927b5ce06481f91468c6ad9779b3aa
+      repository: https://gitlab.com/cryptsetup/cryptsetup.git
+      tag: v${{package.version}}
+
+  - runs: |
+      # Extract the current gettext version
+      GETTEXT_VERSION=$(gettext --version | head -1 | awk '{print $4}')
+      # Update the configure.ac file with the current version
+      sed -i "s/AM_GNU_GETTEXT_VERSION(\[[0-9.]*\])/AM_GNU_GETTEXT_VERSION([$GETTEXT_VERSION])/g" configure.ac
+
+      ./autogen.sh
 
   - uses: autoconf/configure
     with:
@@ -96,8 +102,10 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 13709
+  ignore-regex-patterns:
+    - '\d+_\d+_\d+' # Ignore v1 version as they contain _
+  git:
+    strip-prefix: v
 
 test:
   environment:


### PR DESCRIPTION
- We can use our GitMonitor now which is much accurate that release monitor
- Even the tar and the gitlab source is not an exact match they result in the same artifact

Fix: https://github.com/chainguard-dev/internal-dev/issues/12692

using this will result in less tickets of update bot failures in future.