### PR TITLE
zipkin: remediate cve

### DIFF
--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -1,7 +1,7 @@
 package:
   name: zipkin
   version: "3.5.1"
-  epoch: 1
+  epoch: 2
   description: Zipkin distributed tracing system
   copyright:
     - license: Apache-2.0
@@ -36,6 +36,8 @@ pipeline:
       repository: https://github.com/openzipkin/zipkin
       tag: ${{package.version}}
       expected-commit: b7e22588e8d978939f2c8c7da5bb13d1467facbd
+      cherry-picks: |
+        master/429de5235bda69fa701ea844fda1cdc4a01c39eb: Update to Spring Boot 3.5.0 - remediate CVE- CVE-2025-22233
 
   - uses: patch
     with:


### PR DESCRIPTION
remediate CVE-2025-22233 by doing a cherry-pick from upstream that bumps Spring Boot to 3.5.0.
