### PR TITLE
util-linux: fix chainguard-2.28 ftbfs

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.41"
-  epoch: 41
+  epoch: 42
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -65,7 +65,8 @@ pipeline:
         --with-vendordir=/usr/lib \
         --without-python \
         --without-econf \
-        --disable-asciidoc
+        --disable-asciidoc \
+        $([ -d /usr/lib/oldglibc ] && echo ac_cv_func_close_range='no' ac_cv_func_strnchr='no' ac_cv_func_open_tree='no' ac_cv_func_move_mount='no' ac_cv_func_mount_setattr='no' ac_cv_func_landlock_add_rule='no' ac_cv_func_landlock_create_ruleset='no' ac_cv_func_landlock_restrict_self='no' ac_cv_func_fsconfig='no' ac_cv_func_fsopen='no' ac_cv_func_fsmount='no' ac_cv_func_fspick='no' ac_cv_func_cachestat='no' ac_cv_func_sched_setattr='no' ac_cv_header_linux_btrfs_h='no')
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Using debuging builds instructions
https://chainguard.engineering/docs/technical/services/elastic-build/dependencies/
fix FTBFS of util-linux in chainguard-2.28 builds.

Somehow autoconf manages to find system libc, instead of toolchain
libc, and thus tries to enable and use features that we don't want to
use.

Likely these would need to be externalised elsewhere later on, but
this should do it for now.
