### PR TITLE
curl: fix FTBFS with chainguard-2.28

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.14.1"
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -63,7 +63,8 @@ pipeline:
         --enable-ldap \
         --disable-ntlm \
         --without-libssh2 \
-        --with-libpsl
+        --with-libpsl \
+        $([ -d /usr/lib/oldglibc ] && echo --without-libgsasl ac_cv_func_getpass_r='no' ac_cv_header_stdatomic_h='no')
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
In chainguard-2.28 gsasl.h doesn't exist, nor does libxcrypt or
stdatomic.h header, instruct autoconf to pretend they don't exist
(rather than managing to fallthrough oldglibc path to find these in
system path).

This fixes FTBFS in chaingaurd-2.28 repo.
