### PR TITLE
tileserver-gl: remediate cve

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 2
+  epoch: 3
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -60,7 +60,7 @@ pipeline:
     pipeline:
       - uses: patch
         with:
-          patches: ../CVE-2024-12905.patch
+          patches: ../CVE-2025-48387.patch
 
   # install packages
   - working-directory: app

--- a/tileserver-gl/CVE-2025-48387.patch
+++ b/tileserver-gl/CVE-2025-48387.patch
@@ -16,7 +16,7 @@ index c56f024..fdc77ab 100644
          "rc": "^1.2.7",
          "simple-get": "^4.0.0",
 -        "tar-fs": "^2.0.0",
-+        "tar-fs": "^2.1.2",
++        "tar-fs": "^2.1.3",
          "tunnel-agent": "^0.6.0"
        },
        "bin": {


### PR DESCRIPTION
remediate CVE-2025-48387 by bumping tar-fs to v2.1.3.
