### PR TITLE
fix(CVE): [confluent-kafka] Update commons-beanutils transitive dependency to 1.11.0 to address GHSA-wxr5-93ph-8wr9

### DIFF
--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -9,7 +9,7 @@ package:
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
   version: "8.1.0.11"
-  epoch: 0
+  epoch: 1
   description: Community edition of Confluent Kafka.
   copyright:
     - license: Apache-2.0

--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -50,6 +50,10 @@ pipeline:
       repository: https://github.com/confluentinc/kafka
       tag: v${{vars.mangled-package-version}}
 
+  - uses: patch
+    with:
+      patches: fix-GHSA-wxr5-93ph-8wr9-force-update-common-beanutils.patch
+
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 

--- a/confluent-kafka/fix-GHSA-wxr5-93ph-8wr9-force-update-common-beanutils.patch
+++ b/confluent-kafka/fix-GHSA-wxr5-93ph-8wr9-force-update-common-beanutils.patch
@@ -1,0 +1,72 @@
+From 83c3f16a0ffe35707a7c4526cc8b270274d567c6 Mon Sep 17 00:00:00 2001
+From: Debasish Biswas <debasishbsws.dev@gmail.com>
+Date: Mon, 2 Jun 2025 10:27:19 +0000
+Subject: [PATCH] fix(CVE): Update commons-beanutils transitive dependency to
+ 1.11.0 to address GHSA-wxr5-93ph-8wr9
+
+* commons-beanutils is a transitive dependency of commons-validator: https://commons.apache.org/proper/commons-validator/index.html
+* This patch enforces commons-beanutils version 1.11.0 explicitly to mitigate the CVE.
+* Can be removed once Kafka upstream upgrades commons-validator to a version that depends on commons-beanutils <= 1.11.0.
+  - Current commons-validator version in use: https://github.com/apache/kafka/blob/${{package.version}}/gradle/dependencies.gradle#L60
+  - Future validator versions can be checked for dependency updates: https://github.com/apache/commons-validator/blob/<commons-validator version>/pom.xml#L159-L163 in plugins
+
+Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 7456e7fc60..53a311f023 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -206,7 +206,7 @@ This project bundles some components that are also licensed under the Apache
+ License Version 2.0:
+ 
+ - caffeine-3.1.8
+-- commons-beanutils-1.9.4
++- commons-beanutils-1.11.0
+ - commons-collections-3.2.2
+ - commons-digester-2.1
+ - commons-lang3-3.12.0
+diff --git a/build.gradle b/build.gradle
+index 1c8e4e2871..36cb21ac88 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -214,7 +214,9 @@ allprojects {
+           // ensure we have a single version in the classpath despite transitive dependencies
+           libs.scalaLibrary,
+           libs.scalaReflect,
+-          libs.jacksonAnnotations
++          libs.jacksonAnnotations,
++          // Enforce the updated commons-beanutils to address CVE
++          libs.commonsBeanutils,
+         )
+       }
+     }
+@@ -1074,6 +1076,7 @@ project(':core') {
+     implementation project(':share-coordinator')
+ 
+     implementation libs.argparse4j
++    implementation libs.commonsBeanutils // Explicitly adding commons-beanutils to override transitive dependency
+     implementation libs.commonsValidator
+     implementation libs.jacksonDatabind
+     implementation libs.jacksonDataformatCsv
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index edde8a4e13..1559af3e12 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -57,6 +57,7 @@ versions += [
+   caffeine: "3.1.8",
+   bndlib: "7.0.0",
+   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "10.20.2",
++  commonsBeanutils: "1.11.0", // Added to address CVE GHSA-wxr5-93ph-8wr9
+   commonsValidator: "1.9.0",
+   classgraph: "4.8.173",
+   gradle: "8.14.1",
+@@ -147,6 +148,7 @@ libs += [
+   bndlib:"biz.aQute.bnd:biz.aQute.bndlib:$versions.bndlib",
+   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
+   classgraph: "io.github.classgraph:classgraph:$versions.classgraph",
++  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
+   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
+   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
+   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
+--
+2.49.0


### PR DESCRIPTION
- address GHSA-wxr5-93ph-8wr9

- It was marked pending upstream fix but even it is a transitive dependency it is fixable by forcing the version
