### PR TITLE
kubernetes-1.33: make kubelet-1.33 subpackage provide kubelet

### DIFF
--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.33
   version: "1.33.1"
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -174,6 +174,8 @@ subpackages:
   - name: kubelet-${{vars.kubernetes-version}}
     description: An agent that runs on each node in a Kubernetes cluster making sure that containers are running in a Pod
     dependencies:
+      provides:
+        - kubelet=${{package.full-version}}
       runtime:
         - ip6tables
     pipeline:


### PR DESCRIPTION
Add a `provides` for the `kubelet-1.33` subpackage so that it may be installed as `kubelet`.