### PR TITLE
fix(CVE): [jenkins-plugin-manager] Update commons-beanutils transitive dependency to   1.11.0

### DIFF
--- a/jenkins-plugin-manager.yaml
+++ b/jenkins-plugin-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-plugin-manager
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: Plugin Manager CLI tool for Jenkins
   copyright:
     - license: MIT
@@ -23,6 +23,14 @@ pipeline:
       repository: https://github.com/jenkinsci/plugin-installation-manager-tool
       tag: ${{package.version}}
       expected-commit: d3a6ba3f84bf0223870ad9632b0f74bd861b7539
+
+  - uses: maven/pombump
+    with:
+      pom: plugin-management-cli/pom.xml
+
+  - uses: maven/pombump
+    with:
+      pom: plugin-management-library/pom.xml
 
   - runs: |
       mvn clean package -DskipTests

--- a/jenkins-plugin-manager/pombump-deps.yaml
+++ b/jenkins-plugin-manager/pombump-deps.yaml
@@ -1,0 +1,7 @@
+patches:
+    - groupId: commons-beanutils
+      artifactId: commons-beanutils
+      version: 1.11.0
+    - groupId: commons-logging
+      artifactId: commons-logging
+      version: 1.3.5

--- a/jenkins-plugin-manager/pombump-deps.yaml
+++ b/jenkins-plugin-manager/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
-    - groupId: commons-beanutils
-      artifactId: commons-beanutils
-      version: 1.11.0
-    - groupId: commons-logging
-      artifactId: commons-logging
-      version: 1.3.5
+  - groupId: commons-beanutils
+    artifactId: commons-beanutils
+    version: 1.11.0
+  - groupId: commons-logging
+    artifactId: commons-logging
+    version: 1.3.5


### PR DESCRIPTION
-address GHSA-wxr5-93ph-8wr9

- It was marked pending upstream fix but even it is a transitive dependency it is fixable by forcing the version

- There are total 3 pom.xml file and we need to apply the patch for two of them
