### PR TITLE
chor: Nginx Update the mainline to 1.28 and change the stable to 1.27

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,8 +1,8 @@
 package:
   name: nginx-mainline
   # Must also bump njs at the same time
-  version: "1.27.5"
-  epoch: 3
+  version: "1.28.0"
+  epoch: 0
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -57,7 +57,7 @@ pipeline:
     with:
       repository: https://github.com/nginx/nginx.git
       tag: release-${{package.version}}
-      expected-commit: 6ac8b69f06bc10d5503f636da888fa70095b151c
+      expected-commit: 481d28cb4e04c8096b9b6134856891dc52ecc68f
       destination: nginx-mainline
   - name: configure
     working-directory: nginx-mainline
@@ -320,5 +320,5 @@ update:
   github:
     identifier: nginx/nginx
     use-tag: true
-    tag-filter: release-1.27
+    tag-filter: release-1.28
     strip-prefix: release-

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
-  version: "1.26.3"
-  epoch: 43
+  version: "1.27.5"
+  epoch: 0
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/nginx/nginx.git
       tag: release-${{package.version}}
-      expected-commit: 1be0fb0c9f9bc3489c7b40576efd6afe6b2eccd5
+      expected-commit: 6ac8b69f06bc10d5503f636da888fa70095b151c
       destination: nginx-stable
   - name: configure
     working-directory: nginx-stable
@@ -128,7 +128,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: nginx-stable-config
+  - name: ${{package.name}}-config
     description: Creates nginx config step that can then be overridden by users
     dependencies:
       runtime:
@@ -149,7 +149,7 @@ subpackages:
           # and both access logs to stdout
           sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
 
-  - name: nginx-stable-package-config
+  - name: ${{package.name}}-package-config
     description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
     dependencies:
       runtime:
@@ -180,7 +180,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/etc/nginx/templates
 
   - range: modules
-    name: nginx-stable-mod-${{range.key}}
+    name: ${{package.name}}-mod-${{range.key}}
     description: Nginx third-party module ${{range.key}}
     dependencies:
       provides:
@@ -219,7 +219,7 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: nginx-stable-src
+  - name: ${{package.name}}-src
     description: Nginx source code
     dependencies:
       provides:
@@ -269,5 +269,5 @@ update:
   github:
     identifier: nginx/nginx
     use-tag: true
-    tag-filter: release-1.26
+    tag-filter: release-1.27
     strip-prefix: release-


### PR DESCRIPTION
There is new version available in upstream.
 it's an odd one.