### PR TITLE
falco-no-driver: pin build deps to llvm 19

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: "0.41.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,9 @@ package:
     cpu: 20
     memory: 20Gi
 
+vars:
+  llvm-vers: 19
+
 environment:
   contents:
     packages:
@@ -23,7 +26,7 @@ environment:
       - build-base
       - busybox
       - c-ares-dev
-      - clang
+      - clang-${{vars.llvm-vers}}
       - cmake
       - cpp-httplib
       - curl-dev


### PR DESCRIPTION
Match [upstream](https://github.com/falcosecurity/falco/pull/3537) and use clang-19 for our toolchain.

clang-20 leads to run time failures like this when using the `modern-ebpf` driver:
```
Wed Jun  4 22:44:36 2025: One ring buffer every '2' CPUs.
Wed Jun  4 22:44:36 2025: [libs]: Trying to open the right engine!
Wed Jun  4 22:44:37 2025: [libs]: libbpf: prog 'sys_enter': BPF program load failed: Permission denied
Wed Jun  4 22:44:37 2025: [libs]: libbpf: prog 'sys_enter': -- BEGIN PROG LOAD LOG --
...
-- END PROG LOAD LOG --
Wed Jun  4 22:44:37 2025: [libs]: libbpf: prog 'sys_enter': failed to load: -13
Wed Jun  4 22:44:37 2025: [libs]: libbpf: failed to load object 'bpf_probe'
Wed Jun  4 22:44:37 2025: [libs]: libbpf: failed to load BPF skeleton 'bpf_probe': -13
```

Related: https://github.com/chainguard-dev/image-release-stats/issues/5738