### PR TITLE
falco: right size build resources

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: "0.41.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,10 @@ package:
     runtime:
       - falco-rules
       - falcoctl
+  resources:
+    # https://go/wolfi-rsc/falco
+    cpu: 20
+    memory: 20Gi
 
 vars:
   llvm-vers: 19


### PR DESCRIPTION
Match resources set in [falco-no-driver](https://github.com/wolfi-dev/os/blob/main/falco-no-driver.yaml#L11-L14).

See: https://go/wolfi-rsc/falco