### PR TITLE
sqlpad: bump tar-fs to 2.1.3 to fix GHSA-8cj5-5rvv-wf4v

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: "7.5.3" # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 1
+  epoch: 2
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -32,7 +32,7 @@ pipeline:
     runs: |
       # Create "resolutions" section of package.json
       jq '.resolutions |= (if . then . else {} end)' package.json > temp.json && mv temp.json package.json
-      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"' '"cookie"="0.7.0"' '"path-to-regexp"="0.1.12"' '"xml-crypto"="3.2.1"' '"tar-fs"="^2.1.2"'; do
+      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"' '"cookie"="0.7.0"' '"path-to-regexp"="0.1.12"' '"xml-crypto"="3.2.1"' '"tar-fs"="^2.1.3"'; do
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 


### PR DESCRIPTION
## Summary

Fixes GHSA-8cj5-5rvv-wf4v by updating tar-fs from 2.1.2 to 2.1.3.

## CVE Details
- **ID**: GHSA-8cj5-5rvv-wf4v
- **Component**: tar-fs
- **Fixed Version**: 2.1.3

## Testing
- Package builds successfully
- Tests pass
- CVE scan confirms vulnerability is fixed

## Checklist
- [x] Package builds successfully
- [x] Tests pass
- [x] CVE is resolved
- [x] Epoch incremented