### PR TITLE
auth pipelines: fully qualify GCS metadata server name

### DIFF
--- a/pipelines/auth/github.yaml
+++ b/pipelines/auth/github.yaml
@@ -32,7 +32,7 @@ pipeline:
         ghtoken=$(cat .github-token)
       else
         echo "Using OctoSTS to get a token for ${{inputs.repo}} as ${{inputs.identity}}"
-        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=octo-sts.dev)
+        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=octo-sts.dev)
         ghtoken=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${idtoken}" "https://octo-sts.dev/sts/exchange?scope=${{inputs.repo}}&identity=${{inputs.identity}}" | jq -r .token)
       fi
 

--- a/pipelines/auth/gradle.yaml
+++ b/pipelines/auth/gradle.yaml
@@ -24,7 +24,7 @@ pipeline:
       if [ -f /var/cache/melange/.libraries_token.txt ]; then
         cgtoken=$(cat /var/cache/melange/.libraries_token.txt)
       else
-        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=issuer.enforce.dev)
+        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=issuer.enforce.dev)
         cgtoken=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${idtoken}" 'https://issuer.enforce.dev/sts/exchange?aud=libraries.cgr.dev&scope=${{inputs.group}}&identity=${{inputs.identity}}' | jq -r '.token')
       fi
 

--- a/pipelines/auth/maven.yaml
+++ b/pipelines/auth/maven.yaml
@@ -24,7 +24,7 @@ pipeline:
       if [ -f /var/cache/melange/.libraries_token.txt ]; then
         cgtoken=$(cat /var/cache/melange/.libraries_token.txt)
       else
-        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=issuer.enforce.dev)
+        idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=issuer.enforce.dev)
         cgtoken=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${idtoken}" 'https://issuer.enforce.dev/sts/exchange?aud=libraries.cgr.dev&scope=${{inputs.group}}&identity=${{inputs.identity}}' | jq -r '.token')
       fi
 


### PR DESCRIPTION
Builds that use the auth pipelines are failing in QEMU because the google metadata server cannot be resolved; e.g. with the auth/github pipeline:

```
running step "auth/github"
Using OctoSTS to get a token for chainguard-dev/iamguarded-tools as elastic-build
curl: (6) Could not resolve host: metadata
```

This is likely because the QEMU guest in melange is not getting the google.internal domain to search by default set in its resolv.conf

Ref: https://github.com/chainguard-dev/prodsec/issues/271