### PR TITLE
php: add sysvmsg, shmop and ffi

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.32"
-  epoch: 44
+  epoch: 45
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -36,6 +36,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libsodium-dev
@@ -139,8 +140,11 @@ pipeline:
         --enable-posix=shared \
         --with-pgsql=shared \
         --with-zip=shared \
+        --enable-shmop=shared \
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared \
         --with-apxs2=/usr/bin/apxs \
         --enable-phpdbg=shared
 
@@ -199,6 +203,7 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: Shmop
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -208,8 +213,10 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
       sysvsem: System V Semaphores
       sysvshm: System V Shared Memory
+      sysvmsg: System V Messages
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.28"
-  epoch: 44
+  epoch: 45
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -36,6 +36,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -134,8 +135,11 @@ pipeline:
         --enable-posix=shared \
         --with-pgsql=shared \
         --with-zip=shared \
+        --enable-shmop=shared \
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared \
         --with-apxs2=/usr/bin/apxs \
         --enable-phpdbg=shared
 
@@ -194,6 +198,7 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: Shmop
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -203,8 +208,10 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
       sysvsem: System V Semaphores
       sysvshm: System V Shared Memory
+      sysvmsg: System V Messages
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.22"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -42,6 +42,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -139,8 +140,11 @@ pipeline:
         --enable-posix=shared \
         --with-pgsql=shared \
         --with-zip=shared \
+        --enable-shmop=shared \
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared \
         --with-apxs2=/usr/bin/apxs \
         --enable-phpdbg=shared
 
@@ -199,6 +203,7 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: Shmop
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -208,8 +213,10 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
       sysvsem: System V Semaphores
       sysvshm: System V Shared Memory
+      sysvmsg: System V Messages
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.8"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -42,6 +42,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -139,8 +140,11 @@ pipeline:
         --enable-posix=shared \
         --with-pgsql=shared \
         --with-zip=shared \
+        --enable-shmop=shared \
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared \
         --with-apxs2=/usr/bin/apxs \
         --enable-phpdbg=shared
 
@@ -199,6 +203,7 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: Shmop
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -208,8 +213,10 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
       sysvsem: System V Semaphores
       sysvshm: System V Shared Memory
+      sysvmsg: System V Messages
 
 subpackages:
   - name: ${{package.name}}-config


### PR DESCRIPTION
Adds PHP extensions:

- https://www.php.net/manual/en/book.shmop.php
- https://www.php.net/manual/en/book.sysvmsg.php
- https://www.php.net/manual/en/book.ffi.php

shmop and sysvmsg are required for PHP Sync Library https://github.com/amphp/sync

and ffi is required for libvips https://github.com/libvips/php-vips, libvips is an enhanced image processor for things like thumbnail generation.

The PHP Team directly maintains all three extensions

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
