### PR TITLE
nginx-s3-gateway: add stream_geoip to runtime deps

### DIFF
--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -2,7 +2,7 @@
 package:
   name: nginx-s3-gateway
   version: 0_git20250605
-  epoch: 2
+  epoch: 3
   description: NGINX S3 Gateway
   copyright:
     - license: Apache-2.0
@@ -12,18 +12,11 @@ package:
       - nginx-stable-config
     runtime:
       - njs
-      - gzip
-      - libzstd1
-      - liblz4-1
-      - libwebp
-      - lz4
-      - zlib
-      - lerc
-      - libdeflate
       - nginx-stable
       - nginx-mod-http_xslt_filter
       - nginx-mod-http_image_filter
       - nginx-mod-http_geoip
+      - nginx-mod-stream_geoip
 
 # Based off of https://github.com/nginx/nginx-s3-gateway/blob/main/Dockerfile.oss
 environment:
@@ -88,6 +81,10 @@ subpackages:
       - name: Create module directory
         runs: |
           mkdir -p ${{targets.subpkgdir}}/var/cache/nginx/s3_proxy
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/var/log/nginx
+          ln -sf /dev/stdout ${{targets.contextdir}}/var/log/nginx/access.log
+          ln -sf /dev/stderr ${{targets.contextdir}}/var/log/nginx/error.log
     test:
       pipeline:
         - name: Check if all scripts exist, are executable, and owned by root
@@ -109,6 +106,7 @@ subpackages:
         - nginx-mod-http_xslt_filter
         - nginx-mod-http_image_filter
         - nginx-mod-http_geoip
+        - nginx-mod-stream_geoip
     pipeline:
       - name: Copy and modify configurations for unprivileged operation
         runs: |


### PR DESCRIPTION
few more things:
- compresssion libraries are shared so removed from main runtime and kept it inside oci-entrypoint.
- logs file are linked to stdout and stderr