### PR TITLE
Enable update for Yajl

### DIFF
--- a/yajl.yaml
+++ b/yajl.yaml
@@ -64,4 +64,7 @@ test:
     - uses: test/tw/ldd-check
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: lloyd/yajl
+    use-tag: true


### PR DESCRIPTION
**This do not required an epoch bump** as this do not change anything in the build apk

Even the repo is almost dead and no new commit or new version in last 10 years, but enabling update is a better approach as we are trying to reduce the number of packages with manual update or update not enabled
