### PR TITLE
curl: rebuild without overlinking

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.14.1"
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -22,6 +22,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cyrus-sasl-dev
+      - git-bootstrap
       - krb5-dev
       - libpsl-dev
       - libtool
@@ -64,7 +65,7 @@ pipeline:
         --disable-ntlm \
         --without-libssh2 \
         --with-libpsl \
-        $([ -d /usr/lib/oldglibc ] && echo --without-libgsasl ac_cv_func_getpass_r='no' ac_cv_header_stdatomic_h='no')
+        $([ -d /usr/lib/oldglibc ] && echo ac_cv_func_getpass_r='no' ac_cv_header_stdatomic_h='no')
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
The 2.28 build of curl linked and references symbols that are not
present in any of the dependencies. This leads to libcurl failures at
runtime. This this with a rebuild against reverted toolchain.
