### PR TITLE
glibc: stop shipping /etc/ld.so.cache

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 7
+  epoch: 8
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -180,6 +180,12 @@ pipeline:
       cp vendor/ld.so.conf.d/*.conf "${{targets.destdir}}"/etc/ld.so.conf.d
       mkdir -p ${{targets.destdir}}/etc/apk/commit_hooks.d
       cp ldconfig-commit.sh -p ${{targets.destdir}}/etc/apk/commit_hooks.d/
+
+  - name: "Clean up /etc/ld.so.cache"
+    runs: |
+      # Having a package own a file that will be different in most
+      # every image poisons our layering mechanism
+      rm ${{targets.destdir}}/etc/ld.so.cache
 
   - name: "Clean up documentation"
     runs: |

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -300,6 +300,12 @@ subpackages:
             LIBRARY_PATH="$tmplibdir" \
               gcc "$tmpdir/test.c" -o "$tmpdir/test" -lldsoconfdotd
             "$tmpdir"/test
+        - name: Confirm that we do not ship/own /etc/ld.so.cache
+          runs: |
+            if apk info -L "${{context.name}}" | grep '^etc/ld\.so\.cache$'; then
+              exit 1
+            fi
+            exit 0
 
   - name: "glibc-dev"
     description: "GLIBC development headers"


### PR DESCRIPTION
Avoids poisoning our layering scheme, which expects files owned by
a package to remain static after the image build. `apko` will
regenerate this file.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
