### PR TITLE
perl-command-runner: init package at 0.201 + dependencies

### DIFF
--- a/perl-command-runner.yaml
+++ b/perl-command-runner.yaml
@@ -1,0 +1,93 @@
+package:
+  name: perl-command-runner
+  version: "0.201"
+  epoch: 0
+  description: run external commands and Perl code refs
+  copyright:
+    - license: Artistic-1.0-Perl OR GPL-1.0-or-later
+  dependencies:
+    runtime:
+      - perl
+      - perl-capture-tiny
+      - perl-file-pushd
+      - perl-string-shellquote
+      - perl-win32-shellquote
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - perl
+      - perl-capture-tiny
+      - perl-extutils-config
+      - perl-extutils-helpers
+      - perl-extutils-installpaths
+      - perl-file-pushd
+      - perl-module-build-tiny
+      - perl-string-shellquote
+      - perl-win32-shellquote
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 38e3294ae9ffd015625d7746a0803cc329de92fb0f0edae9a29cd8232cf458d3
+      uri: https://cpan.metacpan.org/authors/id/S/SK/SKAJI/Command-Runner-${{package.version}}.tar.gz
+
+  - name: Build and Test
+    runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      perl Build.PL --installdirs=vendor
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      perl Build
+      perl Build test
+
+  - runs: |
+      perl Build install --destdir=${{targets.destdir}}
+      find ${{targets.destdir}} \( -name perllocal.pod -o -name .packlist \) -delete
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 17233
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: ${{package.name}} documentation
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - name: Smoke test
+      runs: echo "use Command::Runner;" | perl
+    - name: Ensure command runner works
+      runs: |
+        {
+        perl <<'EOF' || exit 0
+        use Command::Runner;
+        use Data::Dumper;
+
+        my $cmd = Command::Runner->new(
+          command => ['ls', '-al'],
+          timeout => 10,
+          stdout  => sub { warn "out: $_[0]\n" },
+          stderr  => sub { warn "err: $_[0]\n" },
+        );
+        my $res = $cmd->run;
+        my $cmd = Command::Runner->new(
+          command => ['ls', '-al', '/fail'],
+          timeout => 10,
+          stdout  => sub { warn "out: $_[0]\n" },
+          stderr  => sub { warn "err: $_[0]\n" },
+        );
+        my $res = $cmd->run;
+        EOF
+        } 2>&1 | tee output.txt
+
+        grep 'out: drwxrwxrwx' ./output.txt
+        grep 'err: ls: /fail: No such file or directory' ./output.txt

--- a/perl-command-runner.yaml
+++ b/perl-command-runner.yaml
@@ -73,7 +73,7 @@ test:
         use Data::Dumper;
 
         my $cmd = Command::Runner->new(
-          command => ['ls', '-al'],
+          command => ['touch', 'success.txt'],
           timeout => 10,
           stdout  => sub { warn "out: $_[0]\n" },
           stderr  => sub { warn "err: $_[0]\n" },
@@ -89,5 +89,5 @@ test:
         EOF
         } 2>&1 | tee output.txt
 
-        grep 'out: drwxrwxrwx' ./output.txt
-        grep 'err: ls: /fail: No such file or directory' ./output.txt
+        grep '/fail: No such file or directory' ./output.txt
+        stat success.txt

--- a/perl-file-pushd.yaml
+++ b/perl-file-pushd.yaml
@@ -1,0 +1,73 @@
+package:
+  name: perl-file-pushd
+  version: "1.016"
+  epoch: 0
+  description: change directory temporarily for a limited scope
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d73a7f09442983b098260df3df7a832a5f660773a313ca273fa8b56665f97cdc
+      uri: https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/File-pushd-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2899
+
+subpackages:
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: ${{package.name}} manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - name: Smoke test
+      runs: echo "use File::pushd;" | perl
+    - name: Ensure pushd works
+      runs: |
+        mkdir -p mytests
+        mkdir -p mytests2
+
+        echo "test1" > mytests/test1.txt
+        echo "test2" > mytests2/test2.txt
+
+        perl <<'EOF' > output.txt
+        use File::pushd;
+        chdir $ENV{HOME};
+        {
+           my $dir = pushd( "/home/build/mytests" );
+           open(fh, "test1.txt") or die "File test1.txt can't be opened";
+           $firstline = <fh>;
+           print "$firstline";
+        }
+        {
+           my $dir = pushd( "/home/build/mytests2" );
+           open(fh, "test2.txt") or die "File test2.txt can't be opened";
+           $firstline = <fh>;
+           print "$firstline";
+        }
+        EOF
+        get_line() { cat output.txt | sed -n "${1}p"; }
+
+        get_line 1 | grep "^test1$"
+        get_line 2 | grep "^test2$"

--- a/perl-string-shellquote.yaml
+++ b/perl-string-shellquote.yaml
@@ -1,0 +1,60 @@
+package:
+  name: perl-string-shellquote
+  version: "1.04"
+  epoch: 0
+  description: quote strings for passing through the shell
+  copyright:
+    # License shows up as "unknown" on metacpan but README redistrubites as "the same terms as Perl itself."
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e606365038ce20d646d255c805effdd32f86475f18d43ca75455b00e4d86dd35
+      uri: https://cpan.metacpan.org/authors/id/R/RO/ROSCH/String-ShellQuote-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11899
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: ${{package.name}} documentation
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - name: Smoke test
+      runs: echo "use String::ShellQuote" | perl
+    - name: Ensure quoting works
+      runs: |
+        perl -l <<'EOF' > output.txt
+        use String::ShellQuote;
+        my $list = "hello world, hello, world!";
+        print shell_quote $list;
+        print shell_quote_best_effort $list;
+        print shell_comment_quote $list;
+        EOF
+        get_line() { cat output.txt | sed -n "${1}p"; }
+
+        get_line 1 | grep "^'hello world, hello, world!'$"
+        get_line 2 | grep "^'hello world, hello, world!'$"
+        get_line 3 | grep "^hello world, hello, world!$"

--- a/perl-win32-shellquote.yaml
+++ b/perl-win32-shellquote.yaml
@@ -1,0 +1,72 @@
+package:
+  name: perl-win32-shellquote
+  version: "0.003001"
+  epoch: 0
+  description: Quote argument lists for Win32
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: aa74b0e3dc2d41cd63f62f853e521ffd76b8d823479a2619e22edb4049b4c0dc
+      uri: https://cpan.metacpan.org/authors/id/H/HA/HAARG/Win32-ShellQuote-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: haarg/Win32-ShellQuote
+    use-tag: true
+    strip-prefix: v
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: ${{package.name}} documentation
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - name: Smoke test
+      runs: echo "use Win32::ShellQuote qw(:all);" | perl
+    - name: Ensure quoting works
+      runs: |
+        perl -l <<'EOF' > output.txt
+        use strict;
+        use Win32::ShellQuote qw(:all);
+
+        print quote_native('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_cmd('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_system_list('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_system_string('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_system('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_system_cmd('program.exe', '--switch', 'argument with spaces or other special characters');
+        print quote_literal('program.exe', '--switch', 'argument with spaces or other special characters');
+        print cmd_escape('program.exe', '--switch', 'argument with spaces or other special characters');
+        EOF
+        get_line() { cat output.txt | sed -n "${1}p"; }
+
+        get_line 1 | grep 'exe" "--s'
+        get_line 2 | grep '.exe^" ^"--s'
+        get_line 3 | grep 'exe""--s'
+        get_line 4 | grep '.exe" "--s'
+        get_line 5 | grep '.exe""--s'
+        get_line 6 | grep '^\%PATH\:\~0,0\%\^\"program.exe^\"'
+        get_line 7 | grep '^\"program.exe\"$'
+        get_line 8 | grep "^program.exe$"


### PR DESCRIPTION
Signed-off-by: Arthur Exaltação <arthur.exaltacao@chainguard.dev>

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
