### PR TITLE
lvm-driver: fix update/checkout configuration

### DIFF
--- a/lvm-driver.yaml
+++ b/lvm-driver.yaml
@@ -25,7 +25,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openebs/lvm-localpv
-      tag: lvm-localpv-${{package.version}}
+      tag: v${{package.version}}
       expected-commit: 45e0fbdd6af38f3025132fff5b6d10c3c2eec1fb
 
   - uses: go/bump
@@ -57,7 +57,7 @@ update:
   enabled: true
   github:
     identifier: openebs/lvm-localpv
-    strip-prefix: lvm-localpv-
+    strip-prefix: v
 
 test:
   environment:


### PR DESCRIPTION
The latest release tag is v-prefixed.

(I'll let automation perform the actual version bump.)