### PR TITLE
elixir: Maintenance

### DIFF
--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.17
   version: 1.17.3
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -20,8 +20,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.18
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -20,8 +20,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
- **elixir: Rebuild elixir to use erlang 28**
  Here I rebuild elixir so that erlang 28 is the runtime used.
  

- **elixir: Compile with erlang 26 instead of 25**
  The Elixir project specifies Erlang 26 as the minimum supported version.
  See
  - https://elixir-lang.org/install.html#installing-erlang
  - https://hexdocs.pm/elixir/1.17.3/introduction.html#installation
  - https://hexdocs.pm/elixir/1.18.4/introduction.html#installation
  