### PR TITLE
Update to Trino 476

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
-  version: "475"
-  epoch: 6
+  version: "476"
+  epoch: 0
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -34,14 +34,14 @@ pipeline:
     with:
       repository: https://github.com/trinodb/trino.git
       tag: ${{package.version}}
-      expected-commit: fd2b81e86ba1c288684746d0842c0ffc3a709598
+      expected-commit: 7f3746a7fa0b27ace2470340e848feaf3ee73f48
 
   - uses: git-checkout
     working-directory: ./airlift/launcher
     with:
       repository: https://github.com/airlift/launcher.git
-      tag: 303
-      expected-commit: 82aded83e695f028e906f129f05400f503fe3031
+      tag: 304
+      expected-commit: 9e51bc34915c11230f2c233404a039f824334f0f
 
   - working-directory: ./airlift/launcher
     runs: |
@@ -82,7 +82,6 @@ data:
       delta-lake: delta-lake
       druid: druid
       elasticsearch: elasticsearch
-      example-http: example-http
       exasol: exasol
       exchange-filesystem: exchange-filesystem
       exchange-hdfs: exchange-hdfs


### PR DESCRIPTION
Fixes:

Update to latest Trino release, remove Example HTTP connector like upstream, also update launcher like upstream

Related:

https://trino.io/docs/current/release/release-476.html

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
