### PR TITLE
tensorflow-cpu-jupyter: bump epoch to 3 for jupyter-core vulnerability GHSA-33p9-3p43-82vq

### DIFF
--- a/tensorflow-cpu-jupyter.yaml
+++ b/tensorflow-cpu-jupyter.yaml
@@ -2,7 +2,7 @@
 package:
   name: tensorflow-cpu-jupyter
   version: "2.19.0"
-  epoch: 2
+  epoch: 3
   description: tensorflow-cpu with jupyter support
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump epoch to address jupyter-core vulnerability GHSA-33p9-3p43-82vq.

Related CVE ticket: https://github.com/chainguard-dev/CVE-Dashboard/issues/24419