### PR TITLE
Enable version update for videolan/x264

### DIFF
--- a/ffmpeg-7.1.yaml
+++ b/ffmpeg-7.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ffmpeg-7.1
   version: "7.1.1"
-  epoch: 7
+  epoch: 8
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -2,7 +2,7 @@
 package:
   name: ffmpeg-7
   version: "7.1.1"
-  epoch: 6
+  epoch: 7
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/x264.yaml
+++ b/x264.yaml
@@ -1,4 +1,4 @@
-#nolint:git-checkout-must-use-github-updates
+#nolint:valid-pipeline-git-checkout-tag
 # Generated from https://git.alpinelinux.org/aports/plain/community/x264/APKBUILD
 package:
   name: x264

--- a/x264.yaml
+++ b/x264.yaml
@@ -1,9 +1,10 @@
+#nolint:git-checkout-must-use-github-updates
 # Generated from https://git.alpinelinux.org/aports/plain/community/x264/APKBUILD
 package:
   name: x264
-  # When bumping this, also bump the URL in the fetch step below. The version scheme is complicated here so we can't use our normal tooling.
-  version: 0_git20191217
-  epoch: 2
+  # We are using the stable branch of x264, which is not tagged. Need to update the commit hash manually.
+  version: 2023.10.01
+  epoch: 0
   description: Free library for encoding H264/AVC video streams
   copyright:
     - license: GPL-2.0-or-later
@@ -23,10 +24,11 @@ environment:
       - perl
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: b2495c8f2930167d470994b1ce02b0f4bfb24b3317ba36ba7f112e9809264160
-      uri: https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20191217-2245-stable.tar.bz2
+      repository: https://code.videolan.org/videolan/x264.git
+      branch: stable
+      expected-commit: 31e19f92f00c7003fa115047ce50978bc98c3a0d
 
   - runs: |
       ./configure \
@@ -59,7 +61,9 @@ subpackages:
         - uses: test/tw/ldd-check
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 369388
 
 test:
   environment:


### PR DESCRIPTION
- Moved to use GitLab repo for the source code
- The repo does not release any version, we are using the stable version, the latest commit for update
- Using release monitor as it tracks the latest commit by date as a version

_ Bumping epoch of ffmpeg-7.1 to rebuild with this new version of x264, otherwise there will be a conflict with provides. 
