### PR TITLE
erlang: align -dev and package versions

### DIFF
--- a/erlang-25.yaml
+++ b/erlang-25.yaml
@@ -2,7 +2,7 @@
 package:
   name: erlang-25
   version: "25.3.2.21"
-  epoch: 1
+  epoch: 2
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -56,13 +56,13 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "erlang-25-dev"
+  - name: ${{package.name}}-dev
     description: "headers for erlang"
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - erlang
+        - ${{package.name}}
       provides:
         - erlang-dev=${{package.full-version}}
 

--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-26
   version: "26.2.5.12"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -65,7 +65,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - erlang
+        - ${{package.name}}
       provides:
         - erlang-dev=${{package.full-version}}
 

--- a/erlang-27.yaml
+++ b/erlang-27.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-27
   version: "27.3.4"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -62,7 +62,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - erlang
+        - ${{package.name}}
       provides:
         - erlang-dev=${{package.full-version}}
 

--- a/erlang-28.yaml
+++ b/erlang-28.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-28
   version: "28.0"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -62,7 +62,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - erlang
+        - ${{package.name}}
       provides:
         - erlang-dev=${{package.full-version}}
 


### PR DESCRIPTION
Installing a -dev package for a specific version stream of
erlang should automatically select the aligned erlang package.

Make it so.
