### PR TITLE
DNM: fix: add support for cap add/drop in QEMU's SSH session

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - attr
+      - bubblewrap
       - busybox
       - coreutils
       - gnutar
@@ -17,7 +18,6 @@ package:
       - openssh-server
       - util-linux-misc
       - xfsprogs
-      - bubblewrap
 
 environment:
   contents:

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 8
+  epoch: 9
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,7 @@ package:
     runtime:
       - attr
       - busybox
+      - coreutils
       - gnutar
       - iproute2
       - kmod
@@ -16,6 +17,7 @@ package:
       - openssh-server
       - util-linux-misc
       - xfsprogs
+      - bubblewrap
 
 environment:
   contents:
@@ -51,7 +53,6 @@ pipeline:
       Port 22
       Port 2223
       Protocol 2
-      ChrootDirectory /mount
       AcceptEnv *
       AddressFamily inet
       UseDNS no
@@ -69,9 +70,11 @@ pipeline:
       AllowStreamLocalForwarding no
       HostKeyAlgorithms ssh-ed25519
       Ciphers aes128-gcm@openssh.com
-      Match LocalPort 2223
-          ChrootDirectory none
+      Match LocalPort 22
+          ForceCommand /usr/bin/bwrap-shell.sh
       EOF
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      cp bwrap-shell.sh ${{targets.destdir}}/usr/bin/
 
 update:
   enabled: false

--- a/microvm-init/bwrap-shell.sh
+++ b/microvm-init/bwrap-shell.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -x
+
+cap_add=""
+cap_drop=""
+
+OLDIFS=$IFS
+IFS=","
+for capadd in $CAP_ADD; do
+	cap_add="$cap_add --cap-add $capadd"
+done
+for capdrop in $CAP_DROP; do
+	cap_drop="$cap_drop --cap-drop $capdrop"
+done
+IFS=$OLDIFS
+
+bwrap \
+	--bind /mount / \
+	--bind /proc /proc \
+	--bind /sys /sys \
+	--bind /sys/fs/cgroup /sys/fs/cgroup \
+	--tmpfs /tmp \
+	--tmpfs /run \
+	--dev /dev \
+	--bind /dev/pts /dev/pts \
+	--uid $(id -u) \
+	--gid $(id -g) \
+	${cap_add} ${cap_drop} \
+	-- ${SHELL} -i

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -1,7 +1,34 @@
 #!/bin/busybox sh
 set -e
+set -x
 
 PATH=/usr/bin:/usr/sbin:/sbin:/bin
+
+# ramfs is not an actual mountpoint, hence we cannot pivot_root
+# into it, so we use this workaround instead.
+if [ "$1" != "remounted" ]; then
+	mkdir /initrd
+	mount -t tmpfs tmpfs /initrd
+	for i in "
+		bin
+		etc
+		home
+		lib
+		lib64
+		opt
+		root
+		sbin
+		usr
+		var
+		init
+	"; do
+		cp -a $i /initrd/
+	done
+	for i in $(ls -1 /); do
+		[ -e /initrd/"$i" ] || mkdir /initrd/"$i"
+	done
+	exec switch_root /initrd/ /init remounted
+fi
 
 # Default is 777 which creates problems
 chmod 0755 /
@@ -19,6 +46,7 @@ mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
 mkdir -p -m 0755 /dev/shm
 mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
+mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /sys/fs/cgroup
 
 # Setup tty/pty
 mkdir /dev/pts
@@ -98,13 +126,11 @@ mount -t 9p \
 # Allow the user we are running as to copy things to the shared dir
 chmod 0777 /mount/mnt
 
-mount --bin /proc /mount/proc
-mount --bin /dev /mount/dev
-mount --bin /sys /mount/sys
-mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /mount/sys/fs/cgroup
-mkdir -p /mount/dev/pts
-mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /mount/dev/pts/
-mount --bind /mount/dev/pts/ptmx /mount/dev/ptmx
+mount --bind /proc /mount/proc
+mount --bind /dev /mount/dev
+mount --bind /dev/pts /mount/dev/pts
+mount --bind /sys /mount/sys
+mount --bind /sys/fs/cgroup /mount/sys/fs/cgroup
 
 # Set default hard limit of open file descriptors to match systemd init
 # behavior. The pam_limit module uses the settings in /proc/1/limit as


### PR DESCRIPTION
chroot will break nested unshares
bwrap uses pivot_root which works for unshares, but will not work inside a ramfs

as a workaround, we switch_root from ramfs into a tmpfs, then pivot_root will work, and we can use `bwrap-shell` instead of the `ChrootDirectory` option of sshd

This needs to be tested thoroughly as it's a potentially big change compared to the "simple" ssh+chroot current situation 

Fixes: https://github.com/chainguard-dev/prodsec/issues/282

Goes in hand with Melange PR: https://github.com/chainguard-dev/melange/pull/2032
for passing the caps add/drop via env variables