### PR TITLE
calico-3.30: replace harbor-2.9-portal-nginx-config to apk addable

### DIFF
--- a/calico-3.30.yaml
+++ b/calico-3.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.30
   version: "3.30.1"
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -756,6 +756,7 @@ subpackages:
     dependencies:
       replaces:
         - nginx-mainline-config
+        - harbor-2.9-portal-nginx-config # It conflicts with nginx-mainline-config when installed together
       provides:
         - calico-whisker=${{package.full-version}}
       runtime:


### PR DESCRIPTION
Fixes:

```
installing calico-whisker-3.30 (ver:3.30.1-r0 arch:aarch64): unable to install files for pkg calico-whisker-3.30: writing header for "etc/nginx/nginx.conf": packages map[calico-whisker-3.30:calico-3.30 harbor-2.9-portal-nginx-config:harbor-2.9] has conflicting file: "etc/nginx/nginx.conf"
```

Similar to `calico-whisker-fips` package: https://github.com/chainguard-dev/enterprise-packages/blob/e2af6445350959cc86fe008d1bfea10c19c43444/calico-fips-3.30.yaml#L734