### PR TITLE
update kaniko to use the chainguard-dev one for updates and bump the package

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
-  version: "1.24.0"
-  epoch: 1
+  version: "1.25.0"
+  epoch: 0
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0
@@ -18,13 +18,13 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/kaniko
       tag: v${{package.version}}
-      expected-commit: 1d2bff595903b1887220a522a5a43c67db2da553
+      expected-commit: 37afb27d847300f5baeef648b0bafcf31e35a178
 
   - uses: go/build
     with:
       output: executor
       packages: ./cmd/executor
-      ldflags: -X github.com/GoogleContainerTools/kaniko/pkg/version.Version=v${{package.version}}
+      ldflags: -X github.com/chainguard-dev/kaniko/pkg/version.Version=v${{package.version}}
 
 subpackages:
   - name: kaniko-warmer
@@ -33,7 +33,7 @@ subpackages:
         with:
           output: warmer
           packages: ./cmd/warmer
-          ldflags: -X github.com/GoogleContainerTools/kaniko/pkg/version.Version=v${{package.version}}
+          ldflags: -X github.com/chainguard-dev/kaniko/pkg/version.Version=v${{package.version}}
     test:
       pipeline:
         - runs: |

--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -56,7 +56,7 @@ subpackages:
 update:
   enabled: true
   github:
-    identifier: GoogleContainerTools/kaniko
+    identifier: chainguard-dev/kaniko
     strip-prefix: v
     use-tag: true
     tag-filter: v


### PR DESCRIPTION
follow up of https://github.com/wolfi-dev/os/pull/55395


also as we have a new tag, bump the package