### PR TITLE
Add the missing files to the package and improve the test

### DIFF
--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-network-policy-agent
   version: "1.2.1"
-  epoch: 0
+  epoch: 1
   description: Amazon EKS Network Policy Agent is a daemonset that is responsible for enforcing configured network policies on the cluster.
   copyright:
     - license: Apache-2.0

--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -84,23 +84,22 @@ subpackages:
         - "${{package.name}}"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"
+          mkdir -p "${{targets.contextdir}}"/usr/bin
           # https://github.com/aws/aws-network-policy-agent/blob/b3d2257ca51e859f6f559760dc6ddc2772e29499/Dockerfile#L61
           ln -sf /usr/bin/controller ${{targets.contextdir}}/controller
           for btf in tc.v4ingress.bpf.o tc.v4egress.bpf.o tc.v6ingress.bpf.o tc.v6egress.bpf.o v4events.bpf.o v6events.bpf.o
           do
+            mv pkg/ebpf/c/${btf} ${{targets.contextdir}}/usr/bin
             ln -sf /usr/bin/$btf ${{targets.contextdir}}/$btf
           done
     test:
       pipeline:
         - runs: |
-            ls -l /controller
-            ls -l /tc.v4ingress.bpf.o
-            ls -l /tc.v4egress.bpf.o
-            ls -l /tc.v6ingress.bpf.o
-            ls -l /tc.v6egress.bpf.o
-            ls -l /v4events.bpf.o
-            ls -l /v6events.bpf.o
+            for file in controller tc.v4ingress.bpf.o tc.v4egress.bpf.o tc.v6ingress.bpf.o tc.v6egress.bpf.o v4events.bpf.o v6events.bpf.o
+            do
+              test -s /${file} 
+              test -L /${file}
+            done
 
 update:
   enabled: true

--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -97,7 +97,7 @@ subpackages:
         - runs: |
             for file in controller tc.v4ingress.bpf.o tc.v4egress.bpf.o tc.v6ingress.bpf.o tc.v6egress.bpf.o v4events.bpf.o v6events.bpf.o
             do
-              test -s /${file} 
+              test -s /${file}
               test -L /${file}
             done
 


### PR DESCRIPTION
The .o files are missing from the finished package. There are links to nothing.

This PR adds the .o files and improves the test to make sure they are links and links to something that is non-zero sized.

Should the files be put in /usr/bin in compat or the main package???