### PR TITLE
perl-io-gzip: use correct release-monitoring ID

### DIFF
--- a/perl-io-gzip.yaml
+++ b/perl-io-gzip.yaml
@@ -49,4 +49,4 @@ test:
 update:
   enabled: true
   release-monitor:
-    identifier: 375129
+    identifier: 5988


### PR DESCRIPTION
The previous ID must have been identified as a duplicate: this one points at the appropriate CPAN URL.