### PR TITLE
Add a runtime dep on xz

### DIFF
--- a/ruby3.2-systemd-journal.yaml
+++ b/ruby3.2-systemd-journal.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-systemd-journal
   version: "2.1.0"
-  epoch: 0
+  epoch: 1
   description: Provides the ability to navigate and read entries from the systemd journal in ruby, as well as write events to the journal.
   copyright:
     - license: MIT
@@ -10,6 +10,7 @@ package:
       - libsystemd # libsystemd.so.0 is dlopened
       - ruby${{vars.rubyMM}}-ffi
       - ruby-${{vars.rubyMM}}
+      - xz
 
 environment:
   contents:


### PR DESCRIPTION
systemd journals can have portions that are compressed by xz. When xz is not installed the application will crash when trying to read some journals.

Here's part of an example crash:

```
[1970-01-01 00:00:00 +0000] : time="2025-06-04T20:29:19.528866865Z" level=info msg="loading plugin \"io.containerd.grpc.v1.cri\"..." type=io.containerd.grpc.v1
/usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:317: [BUG] Segmentation fault at 0x0000000000000000
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) [x86_64-linux-gnu]

-- Control frame information -----------------------------------------------
c:0007 p:---- s:0040 e:000039 CFUNC  :sd_journal_enumerate_data
c:0006 p:0031 s:0033 e:000032 METHOD /usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:317
c:0005 p:0053 s:0024 e:000023 METHOD /usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:124
c:0004 p:0026 s:0016 e:000015 METHOD /usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:84 [FINISH]
c:0003 p:---- s:0012 e:000011 CFUNC  :each_entry
c:0002 p:0049 s:0008 E:000020 EVAL   test.rb:13 [FINISH]
c:0001 p:0000 s:0003 E:0002c0 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:13:in `<main>'
test.rb:13:in `each_entry'
/usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:84:in `each'
/usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:124:in `current_entry'
/usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:317:in `enumerate_helper'
/usr/lib/ruby/gems/3.2.0/gems/systemd-journal-2.1.0/lib/systemd/journal.rb:317:in `sd_journal_enumerate_data'
```