### PR TITLE
py3-langchain: convert to git update backend

### DIFF
--- a/py3-langchain.yaml
+++ b/py3-langchain.yaml
@@ -74,10 +74,9 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: langchain-ai/langchain
+  git:
     strip-prefix: langchain==
-    tag-filter: langchain==
+    tag-filter-prefix: langchain==
 
 # Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
 test:


### PR DESCRIPTION
The `github` backend can't look far enough back to find the most recent `langchain` release (as the repo has releases for multiple different projects).