### PR TITLE
py3-astunparse: Add test/tw/pip-check

### DIFF
--- a/py3-astunparse.yaml
+++ b/py3-astunparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-astunparse
   version: 1.6.3
-  epoch: 6
+  epoch: 7
   description: An AST unparser for Python
   copyright:
     - license: BSD-3-Clause
@@ -43,6 +43,7 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-six
+        - py${{range.key}}-wheel
       provides:
         - py3-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
@@ -53,6 +54,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.1"
-  epoch: 0
+  epoch: 1
   description: "built-package format for Python"
   copyright:
     - license: MIT
@@ -40,12 +40,16 @@ subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-packaging
     pipeline:
       - uses: py/pip-build-install-bootstrap
         with:
           python: python${{range.key}}
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             import: wheel


### PR DESCRIPTION
Fixes an error it found:

`INFO astunparse 1.6.3 requires wheel, which is not installed`

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
