### PR TITLE
py3-stevedore: ignore `-eol` releases

### DIFF
--- a/py3-stevedore.yaml
+++ b/py3-stevedore.yaml
@@ -68,6 +68,7 @@ update:
     use-tag: true
   ignore-regex-patterns:
     - -eom
+    - -eol
 
 test:
   pipeline:


### PR DESCRIPTION
They're date-based releases, presumably related to OpenStack versioning rather than stevedore's own versioning.

Closes: #55751 