### PR TITLE
melange: incorporate v0.26.8 release

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.26.7"
+  version: "0.26.8"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,14 +13,9 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 6418f7c66370d9058a152e1022f2ef48b5c4661a
+      expected-commit: f203105284d1c09bceec3719dc99a45c5b991c5b
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
-
-  - uses: go/bump
-    with:
-      deps: |-
-        github.com/containerd/containerd/v2@v2.0.5
 
   - uses: go/build
     with:


### PR DESCRIPTION
Intended to address the test failures in:
- https://github.com/wolfi-dev/os/pull/55716
- https://github.com/wolfi-dev/os/pull/55813

v2: drop gobump of containerd dependency, addressed in uptream melange
  in https://github.com/chainguard-dev/melange/pull/2034

