### PR TITLE
DNM WIP elixir & rebar

### DIFF
--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -44,7 +44,15 @@ update:
     tag-filter-prefix: v1.17
 
 test:
+  environment:
+    environment:
+      # Suppresses message about latin1 encoding which may cause Elixir to malfunction as it expects utf8.
+      ELIXIR_ERL_OPTIONS: "+fnu"
+    contents:
+      packages:
+        - erlang-28-dev # Test with latest erlang
   pipeline:
+    - name: "Version & Help"
     - runs: |
         elixir --version
 
@@ -57,3 +65,7 @@ test:
         iex --version
         mix --version
         mix --help
+    - runs: |
+        cp myapp.exs /usr/local/bin/myapp.exs
+
+        elixir /usr/local/bin/myapp.exs

--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.17
   version: 1.17.3
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -20,8 +20,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout

--- a/elixir-1.17/myapp.exs
+++ b/elixir-1.17/myapp.exs
@@ -1,0 +1,25 @@
+Mix.install([
+  {:plug_cowboy, "~> 2.5"}
+])
+
+defmodule HelloWorld.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/" do
+    send_resp(conn, 200, "Hello, Elixir!")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not Found")
+  end
+end
+
+port = 8080
+
+IO.puts("Starting server on http://localhost:#{port}")
+{:ok, _pid} = Plug.Cowboy.http(HelloWorld.Router, [], port: port)
+
+Process.sleep(10)

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.18
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -20,8 +20,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -19,7 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
+      # compile Elixir with oldest supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
       - erlang-26
       - erlang-26-dev
 
@@ -44,8 +44,16 @@ update:
     tag-filter-prefix: v1.18
 
 test:
+  environment:
+    environment:
+      # Suppresses message about latin1 encoding which may cause Elixir to malfunction as it expects utf8.
+      ELIXIR_ERL_OPTIONS: "+fnu"
+    contents:
+      packages:
+        - erlang-28-dev # Test with latest erlang
   pipeline:
-    - runs: |
+    - name: "Version & Help"
+      runs: |
         elixir --version
 
         cat <<'EOF' >> /tmp/hello.exs
@@ -57,3 +65,7 @@ test:
         iex --version
         mix --version
         mix --help
+    - runs: |
+        cp myapp.exs /usr/local/bin/myapp.exs
+
+        elixir /usr/local/bin/myapp.exs

--- a/elixir-1.18/myapp.exs
+++ b/elixir-1.18/myapp.exs
@@ -1,0 +1,25 @@
+Mix.install([
+  {:plug_cowboy, "~> 2.5"}
+])
+
+defmodule HelloWorld.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/" do
+    send_resp(conn, 200, "Hello, Elixir!")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not Found")
+  end
+end
+
+port = 8080
+
+IO.puts("Starting server on http://localhost:#{port}")
+{:ok, _pid} = Plug.Cowboy.http(HelloWorld.Router, [], port: port)
+
+Process.sleep(10)

--- a/rebar3.yaml
+++ b/rebar3.yaml
@@ -13,7 +13,7 @@ environment:
   contents:
     packages:
       - busybox
-      - erlang-dev
+      - erlang-26-dev # Build with oldest erlang.
 
 pipeline:
   - uses: git-checkout
@@ -37,7 +37,8 @@ test:
   environment:
     contents:
       packages:
-        - erlang
+        - erlang-28-dev # Test with latest erlang
+        - elixir-1.17
   pipeline:
     - name: Smoke tests
       runs: |
@@ -48,5 +49,10 @@ test:
       runs: |
         rebar3 new app myapp
         cd myapp
+        cp ../myapp.exs .
         rebar3 compile
         rebar3 new release myrel
+    - name: zzz
+      runs: |
+        cp ./myapp.exs /usr/local/bin/
+        elixir /usr/local/bin/myapp.exs

--- a/rebar3/myapp.exs
+++ b/rebar3/myapp.exs
@@ -1,0 +1,25 @@
+Mix.install([
+  {:plug_cowboy, "~> 2.5"}
+])
+
+defmodule HelloWorld.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/" do
+    send_resp(conn, 200, "Hello, Elixir!")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not Found")
+  end
+end
+
+port = 8080
+
+IO.puts("Starting server on http://localhost:#{port}")
+{:ok, _pid} = Plug.Cowboy.http(HelloWorld.Router, [], port: port)
+
+Process.sleep(10)


### PR DESCRIPTION
- **elixir: Rebuild elixir to use erlang 28**
  Here I rebuild elixir so that erlang 28 is the runtime used.
  

- **elixir: Compile with erlang 26 instead of 25**
  The Elixir project specifies Erlang 26 as the minimum supported version.
  See
  - https://elixir-lang.org/install.html#installing-erlang
  - https://hexdocs.pm/elixir/1.17.3/introduction.html#installation
  - https://hexdocs.pm/elixir/1.18.4/introduction.html#installation
  

- **DNM WIP**
  