### PR TITLE
Enable version update for temporal-docker-builds amd schedule it mont…

### DIFF
--- a/temporal-docker-builds.yaml
+++ b/temporal-docker-builds.yaml
@@ -1,9 +1,8 @@
 package:
   name: temporal-docker-builds
   # This project doesn't do releases and everything is commit based.
-  # This corresponds to commit 70f8b8bbda3723fe7c8f822cc8aa379598ac8c86
-  version: 0.0_git20231116
-  epoch: 2
+  version: 0.0_git20250611
+  epoch: 0
   description: Temporal service Docker images build
   copyright:
     - license: MIT
@@ -22,10 +21,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 5cea800b194c364ce182a2f917f8736476ef60a6e1ef8a830665a1a7bdec2cd6
-      uri: https://github.com/temporalio/docker-builds/archive/${{vars.commit}}.tar.gz
+      repository: https://github.com/temporalio/docker-builds.git
+      branch: main
+      expected-commit: 6860f846c49072d9fedc53e4e33e8fd34f3fd468
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/temporal
@@ -43,4 +43,10 @@ pipeline:
       chmod +x "${{targets.destdir}}"/etc/temporal/auto-setup.sh
 
 update:
-  enabled: false
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: |
+      Temporal server releases have an irregular cadence (averaging every 1-2 months).
+      Monthly checks ensure we don't miss updates while avoiding excessive build triggers.

--- a/temporal-docker-builds.yaml
+++ b/temporal-docker-builds.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: temporal-docker-builds
   # This project doesn't do releases and everything is commit based.


### PR DESCRIPTION
…hly using Git monitor

- Update the version to take today's latest commit, and we want it to update monthly.
- Use git checkout instead of fetch

- We are using the main branch as there is no tags
- temporal-docker-builds is required by the temporal-server that has an irregular release cadence (averaging every 1-2 months). Monthly checks ensure we don't miss updates while avoiding excessive build triggers.