### PR TITLE
feat(zookeeper-3.9): add iamguarded compat package

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.0"
-  epoch: 1
+  epoch: 2
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ var-transforms:
     match: ^(\d+\.\d+\.\d+)\.\d+$
     replace: "$1"
     to: short-package-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -97,6 +101,53 @@ subpackages:
           ln -sf /opt/bitnami/scripts/zookeeper/run.sh "${{targets.subpkgdir}}"/run.sh
     test:
       pipeline:
+        - runs: |
+            run-script --version
+            run-script --help
+
+  - name: ${{package.name}}-iamguarded-compat
+    description: "Compatibility package for iamguarded variant of Zookeeper"
+    dependencies:
+      provides:
+        - zookeeper-iamguarded-compat=${{package.full-version}}
+      runtime:
+        - busybox
+        - coreutils
+        - glibc-locale-en
+        - merged-usrsbin
+        - netcat-openbsd
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: zookeeper
+          version: ${{vars.major-minor-version}}
+      - runs: |
+          mkdir -p /opt/iamguarded/zookeeper/
+          mkdir -p /opt/iamguarded/zookeeper/bin
+          mkdir -p /opt/iamguarded/zookeeper/conf
+          mkdir -p /opt/iamguarded/zookeeper/conf.default
+          mkdir -p /opt/iamguarded/zookeeper/logs
+          mkdir -p /opt/iamguarded/scripts/zookeeper/
+
+          cp -r ${{targets.destdir}}/usr/share/java/zookeeper/bin/* /opt/iamguarded/zookeeper/bin
+          ln -s /usr/share/java/zookeeper/lib /opt/iamguarded/zookeeper/lib
+          cp -r conf/* /opt/iamguarded/zookeeper/conf/
+          cp -r conf/* /opt/iamguarded/zookeeper/conf.default
+
+          # create symlinks for both /entrypoint.sh and /run.sh to make it compatible with iamguarded/zookeeper helm chart
+          ln -sf /opt/iamguarded/scripts/zookeeper/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
+          ln -sf /opt/iamguarded/scripts/zookeeper/run.sh ${{targets.contextdir}}/run.sh
+      - uses: iamguarded/finalize-compat
+        with:
+          package: zookeeper
+          version: ${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: zookeeper
+            version: ${{vars.major-minor-version}}
         - runs: |
             run-script --version
             run-script --help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
