### PR TITLE
az/CVE-2024-47081: bump epoch to trigger rebuild

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.74.0"
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT


### PR DESCRIPTION
`az` depends on `requests`. 

https://github.com/advisories/GHSA-9hjg-9r4m-mvj7 is fixed in `requests` 2.32.4, so rebuild to remediate

