### PR TITLE
jupyter-base-notebook/GHSA-9hjg-9r4m-mvj7: Rebuild to remediate

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: "7.4.3"
-  epoch: 0
+  epoch: 1
   description: Jupyter Notebook
   dependencies:
     runtime:

--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -103,7 +103,7 @@ test:
     - name: Run and test jupyter server
       uses: test/daemon-check-output
       with:
-        start: jupyter server
+        start: jupyter server >/dev/null 2>&1
         timeout: 30
         expected_output: |
           extension was successfully linked


### PR DESCRIPTION
`jupyter-base-notebook` includes `requests` which is affected by [CVE-2024-47081](https://github.com/advisories/GHSA-9hjg-9r4m-mvj7)

