### PR TITLE
fix: gcc15 build error with bat,kdash,delta,oranda,spin

### DIFF
--- a/bat.yaml
+++ b/bat.yaml
@@ -1,7 +1,7 @@
 package:
   name: bat
   version: 0.25.0
-  epoch: 2
+  epoch: 3
   description: "A cat(1) clone with wings"
   copyright:
     - license: MIT OR Apache-2.0
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - gcc-14-default
       - rust
       - zlib-dev
 

--- a/bat/cargobump-deps.yaml
+++ b/bat/cargobump-deps.yaml
@@ -9,3 +9,6 @@ packages:
   # Newer version of url pulls in newer version of idna necesary to fix GHSA-h97m-ww89-6jmq CVE
   - name: url
     version: 2.5.4
+  # fix build error with gcc 15
+  - name: onig
+    version: 6.5.1

--- a/delta.yaml
+++ b/delta.yaml
@@ -1,7 +1,7 @@
 package:
   name: delta
   version: 0.18.2
-  epoch: 2
+  epoch: 3
   description: Syntax-highlighting pager for git and diff output
   copyright:
     - license: MIT
@@ -12,7 +12,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - rust
 
 pipeline:
@@ -21,6 +20,8 @@ pipeline:
       repository: https://github.com/dandavison/delta
       tag: ${{package.version}}
       expected-commit: a589ff9debaefdd3992384434120f5a03a103481
+
+  - uses: rust/cargobump
 
   - runs: |
       cargo build --release

--- a/delta/cargobump-deps.yaml
+++ b/delta/cargobump-deps.yaml
@@ -1,0 +1,5 @@
+packages:
+    # fix build error with gcc 15
+    # https://github.com/dandavison/delta/issues/1990
+    - name: onig
+      version: 6.5.1

--- a/kdash.yaml
+++ b/kdash.yaml
@@ -1,7 +1,7 @@
 package:
   name: kdash
   version: "0.6.2"
-  epoch: 5
+  epoch: 6
   description: "A simple and fast dashboard for Kubernetes"
   copyright:
     - license: MIT
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - gcc-14-default
       - libxcb
       - libxcb-dev
       - openssl

--- a/kdash/cargobump-deps.yaml
+++ b/kdash/cargobump-deps.yaml
@@ -11,3 +11,5 @@ packages:
       version: 0.17.13
     - name: tokio
       version: 1.43.1
+    - name: onig
+      version: 6.5.1

--- a/oranda.yaml
+++ b/oranda.yaml
@@ -1,7 +1,7 @@
 package:
   name: oranda
   version: 0.6.5
-  epoch: 7
+  epoch: 8
   description: generate beautiful landing pages for your developer tools
   copyright:
     - license: MIT
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - gcc-14-default
       - openssl-dev
       - rust
 

--- a/oranda/cargobump-deps.yaml
+++ b/oranda/cargobump-deps.yaml
@@ -7,3 +7,5 @@ packages:
       version: 1.38.2
     - name: crossbeam-channel
       version: 0.5.15
+    - name: onig
+      version: 6.5.1

--- a/spin.yaml
+++ b/spin.yaml
@@ -1,7 +1,7 @@
 package:
   name: spin
   version: "3.2.0"
-  epoch: 2
+  epoch: 3
   description: "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
   copyright:
     - license: Apache-2.0
@@ -19,8 +19,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargobump
       - cmake
-      - gcc-14-default
       - openssl-dev
       - rustup
       - wolfi-base
@@ -53,6 +53,8 @@ pipeline:
           echo '[build]' >> .cargo/config
           echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> .cargo/config
       fi
+
+      cargobump --run-update=false --bump-file ./cargobump-deps.yaml
 
       cargo build --release
 

--- a/spin/cargobump-deps.yaml
+++ b/spin/cargobump-deps.yaml
@@ -1,0 +1,6 @@
+packages:
+    # fix build error with gcc 15
+    # https://github.com/spinframework/spin/issues/3128
+    - name: onig
+      version: 6.5.1
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/54955 https://github.com/wolfi-dev/os/issues/54921 https://github.com/wolfi-dev/os/issues/54883 https://github.com/wolfi-dev/os/issues/54866 https://github.com/wolfi-dev/os/issues/54853

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
