### PR TITLE
test redpanda build args

### DIFF
--- a/redpanda.yaml
+++ b/redpanda.yaml
@@ -62,7 +62,7 @@ pipeline:
     runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/
       mkdir -p ${{targets.destdir}}/usr/lib/redpanda
-      bazel build --verbose_failures --action_env=STABLE_GIT_LATEST_TAG=${{package.version}} --show_loading_progress --config=release --strategy=sandboxed --jobs=$(nproc) //...
+      bazel build --verbose_failures --action_env=STABLE_GIT_LATEST_TAG=${{package.version}} --show_loading_progress --config=release //...
       mv bazel-bin/src/v/redpanda/redpanda ${{targets.destdir}}/usr/bin/
       mv bazel-bin/src/go/rpk/cmd/rpk/rpk_/rpk ${{targets.destdir}}/usr/bin/
       # Copy redpanda config file to default location /etc/redpanda

--- a/redpanda.yaml
+++ b/redpanda.yaml
@@ -1,0 +1,122 @@
+package:
+  name: redpanda
+  version: "25.1.4"
+  epoch: 50
+  description: "Redpanda is a streaming platform based on Apache Kafka API"
+  copyright:
+    - license: "Apache-2.0"
+  dependencies:
+    runtime:
+      - bash
+
+vars:
+  java-version: 21
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - bazelisk-default
+      - binutils
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang
+      - coreutils
+      - crane
+      - e2fsprogs-dev
+      - git
+      - glibc-locale-en
+      - go
+      - krb5-dev
+      - libtool
+      - liburing-dev
+      - libxml2-dev
+      - openjdk-${{vars.java-version}}-default-jdk
+      - openssl-dev
+      - ragel
+      - samurai
+      - yamllint
+      - zlib
+      - zstd
+  environment:
+    STABLE_GIT_LATEST_TAG: ${{package.version}}
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: "https://github.com/redpanda-data/redpanda.git"
+      expected-commit: "6cd1d4ef6b8424ee4fd219df94a90abe839a36bc"
+      tag: "v${{package.version}}"
+      destination: redpanda
+
+  - working-directory: redpanda
+    uses: patch
+    with:
+      patches: ../0001-build-update-krb5-configuration-to-include-system-er.patch
+
+  - working-directory: redpanda
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mkdir -p ${{targets.destdir}}/usr/lib/redpanda
+      bazel build --verbose_failures --action_env=STABLE_GIT_LATEST_TAG=${{package.version}} --show_loading_progress --config=release --strategy=sandboxed --jobs=$(nproc) //...
+      mv bazel-bin/src/v/redpanda/redpanda ${{targets.destdir}}/usr/bin/
+      mv bazel-bin/src/go/rpk/cmd/rpk/rpk_/rpk ${{targets.destdir}}/usr/bin/
+      # Copy redpanda config file to default location /etc/redpanda
+      mkdir -p ${{targets.destdir}}/etc/redpanda
+      cp conf/redpanda.yaml ${{targets.destdir}}/etc/redpanda/redpanda.yaml
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          tag=v${{package.version}}
+          crane export redpandadata/redpanda:${tag} - | tar -xvf - entrypoint.sh
+          mkdir -p ${{targets.subpkgdir}}/
+          mv entrypoint.sh ${{targets.subpkgdir}}/
+
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+  pipeline:
+    - uses: test/tw/ldd-check
+    - name: "Verify binary versions"
+      runs: |
+        redpanda --version
+        rpk --version
+    - name: "Test rpk commands"
+      runs: |
+        # A full blown redpanda cluster requires resources that the CI cluster cannot provide
+        rpk redpanda start --mode dev-container --smp 1 --memory 1G --node-id 0 &
+        sleep 5
+        rpk cluster health | grep -iE '^Healthy:[[:space:]]+true$'
+        rpk topic create tutorial
+        rpk topic list | grep tutorial
+    - name: "Test rpk cluster commands"
+      runs: |
+        rpk cluster --help
+        rpk cluster info --help
+    - name: "test entrypoint usage"
+      runs: |
+        /entrypoint.sh --help
+
+update:
+  enabled: true
+  github:
+    identifier: "redpanda-data/redpanda"
+    strip-prefix: "v"
+    use-tag: true

--- a/redpanda.yaml
+++ b/redpanda.yaml
@@ -71,7 +71,7 @@ pipeline:
 
   - uses: strip
 
-
+subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev

--- a/redpanda.yaml
+++ b/redpanda.yaml
@@ -71,14 +71,6 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: ${{package.name}}-compat
-    pipeline:
-      - runs: |
-          tag=v${{package.version}}
-          crane export redpandadata/redpanda:${tag} - | tar -xvf - entrypoint.sh
-          mkdir -p ${{targets.subpkgdir}}/
-          mv entrypoint.sh ${{targets.subpkgdir}}/
 
   - name: ${{package.name}}-dev
     pipeline:

--- a/redpanda/0001-build-update-krb5-configuration-to-include-system-er.patch
+++ b/redpanda/0001-build-update-krb5-configuration-to-include-system-er.patch
@@ -1,0 +1,24 @@
+From 0d34201b0ac11c35681a580cfac80f4c901cda44 Mon Sep 17 00:00:00 2001
+From: uti <uti.edun@chainguard.dev>
+Date: Thu, 29 May 2025 18:29:46 +0000
+Subject: [PATCH] remove unused library dependency  from krb5 build
+ configuration
+
+---
+ bazel/thirdparty/krb5.BUILD | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/bazel/thirdparty/krb5.BUILD b/bazel/thirdparty/krb5.BUILD
+index c7aa78b1bc..a899643725 100644
+--- a/bazel/thirdparty/krb5.BUILD
++++ b/bazel/thirdparty/krb5.BUILD
+@@ -57,7 +57,6 @@ configure_make(
+     },
+     lib_source = ":srcs",
+     out_shared_libs = [
+-        "libcom_err.so.3",
+         "libgssapi_krb5.so.2",
+         "libk5crypto.so.3",
+         "libkrb5.so.3",
+--
+2.49.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
