### PR TITLE
zfs: mix fixups

### DIFF
--- a/zfs.yaml
+++ b/zfs.yaml
@@ -2,7 +2,7 @@
 package:
   name: zfs
   version: "2.3.2"
-  epoch: 0
+  epoch: 1
   description: Advanced filesystem and volume manager
   copyright:
     - license: CDDL-1.0
@@ -26,6 +26,7 @@ environment:
       - libtirpc-dev
       - libtool
       - linux-headers
+      - linux-pam-dev
       - openssl-dev
       - util-linux-dev
 
@@ -43,11 +44,14 @@ pipeline:
       ./configure \
         --prefix=/usr \
         --sbindir=/usr/bin \
-        --with-udevdir=/lib/udev \
-        --disable-systemd \
+        --with-udevdir=/usr/lib/udev \
         --disable-static \
+        --enable-systemd \
+        --disable-sysvinit \
+        --enable-pam \
         --with-python=3 \
         --with-tirpc \
+        --libexecdir=/usr/lib \
         --sysconfdir=/etc \
         --mandir=/usr/share/man \
         --infodir=/usr/share/info \
@@ -98,8 +102,8 @@ subpackages:
   - name: zfs-udev
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/lib/udev
-          mv ${{targets.destdir}}/lib/udev/* ${{targets.subpkgdir}}/lib/udev/
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/udev
+          mv ${{targets.destdir}}/usr/lib/udev/* ${{targets.subpkgdir}}/usr/lib/udev/
     description: zfs udev
     dependencies:
       runtime:


### PR DESCRIPTION
zfs was added as a required dep to docker, I believe most other distros have it marked as optional. As a result it's showing up everywhere docker does and I've noticed warnings in systemd about it not having service files. Alpine, where this came from does not use systemd but we do so this swaps to systemd . Also updates the udev location to be in /usr/lib instead of lib. And explictly set the libexec location and adds PAM support.

