### PR TITLE
Elixir Improvements

### DIFF
--- a/elixir-1.17.yaml
+++ b/elixir-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.17
   version: 1.17.3
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -19,9 +19,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      # compile Elixir with oldest supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout
@@ -44,7 +44,12 @@ update:
     tag-filter-prefix: v1.17
 
 test:
+  environment:
+    environment:
+      # Suppresses message about latin1 encoding which may cause Elixir to malfunction as it expects utf8.
+      ELIXIR_ERL_OPTIONS: "+fnu"
   pipeline:
+    - name: "Version & Help"
     - runs: |
         elixir --version
 

--- a/elixir-1.18.yaml
+++ b/elixir-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir-1.18
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -19,9 +19,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      # compile Elixir with older supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
-      - erlang-25
-      - erlang-25-dev
+      # compile Elixir with oldest supported version of Erlang. Reason: if we compile with the latest version of Erlang, the compiled Elixir will not work with the older Erlang versions.
+      - erlang-26
+      - erlang-26-dev
 
 pipeline:
   - uses: git-checkout
@@ -44,8 +44,18 @@ update:
     tag-filter-prefix: v1.18
 
 test:
+  environment:
+    environment:
+      # Suppresses message about latin1 encoding which may cause Elixir to malfunction as it expects utf8.
+      ELIXIR_ERL_OPTIONS: "+fnu"
+    contents:
+      packages:
+        - curl
+        - erlang-28-dev # Test with latest erlang
+        - rebar3
   pipeline:
-    - runs: |
+    - name: "Version & Help"
+      runs: |
         elixir --version
 
         cat <<'EOF' >> /tmp/hello.exs
@@ -57,3 +67,11 @@ test:
         iex --version
         mix --version
         mix --help
+    - runs: |
+        cd zzz
+        mix local.rebar rebar3 /usr/bin/rebar3
+        mix deps.get
+        mix release
+        _build/dev/rel/zzz/bin/zzz daemon
+        sleep 3  # Just to get the daemon started
+        curl -s localhost:8080 | grep "Hello, Elixir!"

--- a/elixir-1.18/zzz/lib/zzz.ex
+++ b/elixir-1.18/zzz/lib/zzz.ex
@@ -1,0 +1,14 @@
+defmodule Zzz.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/" do
+    send_resp(conn, 200, "Hello, Elixir!")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not Found")
+  end
+end

--- a/elixir-1.18/zzz/lib/zzz/application.ex
+++ b/elixir-1.18/zzz/lib/zzz/application.ex
@@ -1,0 +1,24 @@
+defmodule Zzz.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    # children = [
+    #   # Starts a worker by calling: Zzz.Worker.start_link(arg)
+    #   # {Zzz.Worker, arg}
+    # ]
+    children = [
+      {Plug.Cowboy, scheme: :http, plug: Zzz.Router, options: [port: 8080]}
+    ]
+
+    IO.puts("Starting server on http://localhost:8080")
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Zzz.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/elixir-1.18/zzz/mix.exs
+++ b/elixir-1.18/zzz/mix.exs
@@ -1,0 +1,30 @@
+defmodule Zzz.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :zzz,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Zzz.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:plug_cowboy, "~> 2.7"}
+    ]
+  end
+end

--- a/elixir-1.18/zzz/test/test_helper.exs
+++ b/elixir-1.18/zzz/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/rebar3.yaml
+++ b/rebar3.yaml
@@ -1,7 +1,7 @@
 package:
   name: rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 0
+  epoch: 1
   version: 3.25.0
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
   contents:
     packages:
       - busybox
-      - erlang-dev
+      - erlang-26-dev # Build with oldest erlang.
 
 pipeline:
   - uses: git-checkout
@@ -37,7 +37,8 @@ test:
   environment:
     contents:
       packages:
-        - erlang
+        - erlang-28-dev # Test with latest erlang
+        - elixir-1.17
   pipeline:
     - name: Smoke tests
       runs: |


### PR DESCRIPTION
- **elixir-1.18: Improve test & use Erlang 26**
  Here I add a useful test to exercise mix and elixir. I also add env var
  to tests to suppress a warning.  I also moved to use Erlang 26 in the
  build which is the minimum supported by the upstream.
  

- **elixir-1.17: Add env var to test & use Erlang 26**
  Here I an env var to the tests to suppress a warning.  I also moved to
  use Erlang 26 in the build which is the minimum supported by the
  upstream.
  

- **rebar3: Use old Erlang for build**
  