### PR TITLE
proj: update cmake flags, expand tests

### DIFF
--- a/proj.yaml
+++ b/proj.yaml
@@ -2,7 +2,7 @@
 package:
   name: proj
   version: "9.6.2"
-  epoch: 0
+  epoch: 1
   description: PROJ coordinate transformation software library
   copyright:
     - license: MIT
@@ -31,6 +31,12 @@ pipeline:
       expected-commit: 7c3d4a1fa9c1d5a3941b5eaee7c8d149f5936f54
 
   - uses: cmake/configure
+    with:
+      opts: |
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DBUILD_TESTING=OFF \
 
   - uses: cmake/build
 
@@ -42,6 +48,9 @@ subpackages:
   - name: proj-doc
     pipeline:
       - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc/ "${{targets.subpkgdir}}"/usr/share
     description: proj manpages
     test:
       pipeline:
@@ -73,8 +82,38 @@ subpackages:
         - uses: test/tw/ldd-check
 
 test:
+  environment:
+    contents:
+      packages:
+        - proj-util
+        - proj-dev
+        - curl
   pipeline:
     - uses: test/tw/ldd-check
+    - name: Smoke test binaries
+      runs: |
+        which cct
+        which gie
+        which cs2cs
+        which projinfo
+        set -e
+        projinfo -h 2>&1 | grep -qi "usage"
+        cs2cs 2>&1 | grep -qi "usage"
+        set +e
+    - name: Test coordinate transformation using cs2cs
+      runs: |
+        echo "2 49" | cs2cs +proj=latlong +datum=WGS84 +to +proj=utm +zone=31 +datum=WGS84 | grep -q -E "[0-9]+\s+[0-9]+"
+    - name: Test projinfo for EPSG conversion
+      runs: |
+        projinfo EPSG:4326 | grep -qi "World Geodetic System"
+    - name: Test gie scripting
+      runs: |
+        cat <<EOF > test.gie
+        operation +proj=utm +zone=32 +datum=WGS84
+        forward
+        12 55
+        EOF
+        gie < test.gie | grep -q "success"
 
 update:
   enabled: true


### PR DESCRIPTION
Expand tests, update cmake flags to sync with how upstream does.

* https://github.com/OSGeo/PROJ/blob/d87fcea05ed78271ab6210a71ab128bde0f51b61/Dockerfile#L21
* https://github.com/OSGeo/gdal/blob/v3.11.0/docker/ubuntu-full/bh-proj.sh