### PR TITLE
py3-pip: patch CVE-2024-47081 in vendored requests

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.1.1"
-  epoch: 1
+  epoch: 2
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
@@ -32,6 +32,10 @@ pipeline:
       repository: https://github.com/pypa/pip
       expected-commit: 01857ef79f59a98db592bacb6e7b48f354528c80
       tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: fix-CVE-2024-47081.patch
 
 subpackages:
   - range: py-versions

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -143,3 +143,37 @@ update:
   github:
     identifier: pypa/pip
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import pip
+    - name: "Verify CVE-2024-47081 fix"
+      uses: py/one-python
+      with:
+        content: |
+          #!/usr/bin/env python3
+          import sys
+          # Import from pip's vendored requests
+          from pip._vendor.requests.utils import get_netrc_auth
+          import inspect
+
+          # Get the source code of get_netrc_auth function
+          source = inspect.getsource(get_netrc_auth)
+
+          # Verify that the security fix is applied
+          if 'host = ri.hostname' in source:
+              print('✓ CVE-2024-47081 fix verified: using ri.hostname for netrc lookups')
+              sys.exit(0)
+          elif 'host = ri.netloc' in source or 'ri.netloc.split' in source:
+              print('✗ VULNERABLE: still using ri.netloc for netrc lookups')
+              sys.exit(1)
+          else:
+              print('? Unable to verify CVE fix - code structure may have changed')
+              # Print relevant part of the source for debugging
+              for line in source.split('\n'):
+                  if 'host =' in line or 'ri.' in line:
+                      print(f'  Found: {line.strip()}')
+              sys.exit(1)

--- a/py3-pip/fix-CVE-2024-47081.patch
+++ b/py3-pip/fix-CVE-2024-47081.patch
@@ -1,0 +1,26 @@
+Fix CVE-2024-47081: requests .netrc credential leak via malicious URLs
+
+This patch fixes GHSA-9hjg-9r4m-mvj7 where .netrc credentials could be
+leaked to unintended hosts. The fix changes from using netloc (which
+could be manipulated) to using hostname for netrc lookups.
+
+Based on upstream commit 96ba401c1296ab1dda74a2365ef36d88f7d144ef
+
+--- a/src/pip/_vendor/requests/utils.py
++++ b/src/pip/_vendor/requests/utils.py
+@@ -233,14 +233,7 @@ def get_netrc_auth(url, raise_errors=False):
+             return
+ 
+         ri = urlparse(url)
+-
+-        # Strip port numbers from netloc. This weird `if...encode`` dance is
+-        # used for Python 3.2, which doesn't support unicode literals.
+-        splitstr = b":"
+-        if isinstance(url, str):
+-            splitstr = splitstr.decode("ascii")
+-        host = ri.netloc.split(splitstr)[0]
+-
++        host = ri.hostname
+         try:
+             _netrc = netrc(netrc_path).authenticators(host)
+             if _netrc:


### PR DESCRIPTION
## Summary

This PR patches CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7) in pip's vendored requests library.

## Details

- **Vulnerability**: Requests < 2.32.4 may leak .netrc credentials via malicious URLs
- **Fix**: Apply the security patch from requests 2.32.4 that changes from using `netloc` to `hostname` for netrc lookups
- **Approach**: Patch the vulnerability without updating the entire vendored requests library

## Changes

1. Added `py3-pip/fix-CVE-2024-47081.patch` that applies the security fix
2. Updated `py3-pip.yaml` to apply the patch during build
3. Added a test that verifies the fix is properly applied

## Testing

- Built all py3-pip packages successfully
- Verified the patch is applied in the built packages
- Confirmed the vulnerability is fixed (using `ri.hostname` instead of `ri.netloc`)
- Added automated test that verifies the security fix

## Notes

The vulnerability scanner will still flag this as requests 2.32.3 because we didn't update the full library, only applied the security fix. This is intentional to minimize changes and potential breakage.

## References

- [GHSA-9hjg-9r4m-mvj7](https://github.com/advisories/GHSA-9hjg-9r4m-mvj7)
- [Upstream fix commit](https://github.com/psf/requests/commit/96ba401c1296ab1dda74a2365ef36d88f7d144ef)