### PR TITLE
py3-arrow: add missing dep on types-python-dateutil

### DIFF
--- a/py3-arrow.yaml
+++ b/py3-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-arrow
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: Arrow is a Python library that offers a sensible and human-friendly approach to creating, manipulating, formatting and converting dates, times and timestamps.
   annotations:
     cgr.dev/ecosystem: python
@@ -45,6 +45,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-python-dateutil
+        - py${{range.key}}-types-python-dateutil
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -52,6 +53,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -1,8 +1,8 @@
-# Generated from https://pypi.org/project/python-dateutil/
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 7
+  epoch: 8
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0
@@ -14,12 +14,15 @@ environment:
     packages:
       - busybox
       - py3-supported-build-base
+      - py3-supported-requests
       - py3-supported-six
       - tzutils
       - wolfi-base
 
 vars:
   pypi-package: dateutil
+  typeshed-package: types-python-dateutil
+  typeshed-import: types.python.dateutil
 
 data:
   - name: py-versions
@@ -35,6 +38,20 @@ pipeline:
       expected-commit: db9d018944c41ddc740015cf5f64717c2ba64a5c
       repository: https://github.com/dateutil/dateutil
       tag: ${{package.version}}
+
+  - uses: git-checkout
+    with:
+      destination: typeshed
+      repository: https://github.com/python/typeshed
+      branch: main
+      expected-commit: 126768408a69b7a3a09b7d3992970b289f92937e
+
+  - uses: git-checkout
+    with:
+      destination: stub_uploader
+      repository: https://github.com/typeshed-internal/stub_uploader
+      branch: main
+      expected-commit: 04eaed4de5c857937a6711cc51145fe4484834ca
 
   - runs: |
       python3.13 ./updatezinfo.py
@@ -79,6 +96,32 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.typeshed-package}}
+    description: python${{range.key}} version of ${{vars.typeshed-package}}
+    pipeline:
+      - working-directory: stub_uploader
+        runs: |
+          export PYTHONPATH=$(pwd)
+          builddir="build/${{range.key}}"
+          mkdir -p "$builddir"
+          python3.13 ./stub_uploader/build_wheel.py --build-dir "$builddir" \
+            ../typeshed python-dateutil ${{package.version}}
+          pip${{range.key}} install --no-index --no-build-isolation --no-deps \
+            --prefix=/usr --root=${{targets.subpkgdir}} "$builddir"/dist/*.whl
+    test:
+      pipeline:
+        - uses: test/tw/pip-check
+
+  - name: py3-supported-${{vars.typeshed-package}}
+    description: meta package providing ${{vars.typeshed-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.typeshed-package}}
+        - py3.11-${{vars.typeshed-package}}
+        - py3.12-${{vars.typeshed-package}}
+        - py3.13-${{vars.typeshed-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
py3-arrow: add missing dep on `types-python-dateutil`

Noticed by `test/tw/pip-check`.

This package contains the typestubs for python-dateutil, it does not include any importable modules. `typeshed` is an upstream project with type stubs for lots of stuff, including this package. This repository does not have tags, and the pypi release model is for each stubs whl is to match the version of the corresponding upstream project + a datestamp. Our -rX number should satisfy the same needs as the datestamp.
