### PR TITLE
Add exclude reason and Enable update for multiple packages

### DIFF
--- a/ruby3.4-openid_connect-1.1.8.yaml
+++ b/ruby3.4-openid_connect-1.1.8.yaml
@@ -54,6 +54,8 @@ vars:
 
 update:
   enabled: false
+  exclude-reason: |
+    This is a pinned version of the OpenID Connect library. We do not want to update it.
 
 test:
   environment:

--- a/ruby3.4-quantile.yaml
+++ b/ruby3.4-quantile.yaml
@@ -38,10 +38,11 @@ vars:
   gem: quantile
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: matttproud/ruby_quantile_estimation
     strip-prefix: v
+    use-tag: true
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.4-snaky_hash.yaml
+++ b/ruby3.4-snaky_hash.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-snaky_hash
-  version: 2.0.0
-  epoch: 3
+  version: 2.0.3
+  epoch: 0
   description: 'A Hashie::Mash joint to make #snakelife better'
   copyright:
     - license: MIT
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 63628366fa881b8f5de66799e715f28664210a83
+      expected-commit: fa841e326ec205802ee98662f66143125abb09d7
       tag: v${{package.version}}
       repository: https://gitlab.com/oauth-xx/snaky_hash
 
@@ -43,7 +43,9 @@ vars:
   gem: snaky_hash
 
 update:
-  enabled: false
+  enabled: true
+  git:
+    strip-prefix: v
 
 var-transforms:
   - from: ${{package.name}}

--- a/ssdeep.yaml
+++ b/ssdeep.yaml
@@ -40,7 +40,9 @@ pipeline:
   - uses: autoconf/make-install
 
 update:
-  enabled: false
+  enabled: true
+  git:
+    strip-prefix: release-
 
 test:
   pipeline:

--- a/ssh-import-id.yaml
+++ b/ssh-import-id.yaml
@@ -41,8 +41,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
-  exclude-reason: Need support for git.launchpad.net
+  enabled: true
+  git: {}
 
 test:
   pipeline:

--- a/tcptraceroute.yaml
+++ b/tcptraceroute.yaml
@@ -26,10 +26,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/mct/tcptraceroute/archive/tcptraceroute-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: ad5588e62a56f1b5fa851b68280a88e66a900777fe4fd67587262245cd9da17b536b7dc972abe540fc124a93ac76abcabbc55bc32f9f8ee872d5df57b08f7222
+      repository: https://github.com/mct/tcptraceroute.git
+      expected-commit: 086a47f75f271fd55d4104a7bfc31bf1c960dd1d
+      tag: tcptraceroute-${{vars.mangled-package-version}}
 
   - uses: autoconf/configure
     with:
@@ -57,7 +58,10 @@ subpackages:
 
 update:
   enabled: false
-  manual: true
+  exclude-reason: |
+    Upstream have not have any new commits since 2007. Probably no updates will be there anymore.
+    We are building the beta7 which is the last version, as our automation skips tags with "beta" in them
+    we can't configure automatic updates.
 
 test:
   pipeline:


### PR DESCRIPTION
- Add exclude reason for tcptraceroute
- Enable update for
  - ssh-import-id.yaml
  - ssdeep.yaml
  - ruby3.4-snaky_hash.yaml (also package update to latest)
  - ruby3.4-quantile.yaml