### PR TITLE
fix(jitsucom-jitsu): re-add runtime dependencies and add tests

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.10.0"
-  epoch: 0
+  epoch: 1
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -62,6 +62,9 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-console
+    dependencies:
+      runtime:
+        - ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/app
@@ -93,6 +96,16 @@ subpackages:
 
           # Remove musl shared libraries
           find ${{targets.contextdir}} -type f -name '*musl*.so*' -delete
+    test:
+      pipeline:
+        - name: Verify runtime dependencies exist
+          runs: |
+            bash --version
+            node --version
+        - name: Verify image entrypoint exists
+          runs: |
+            [ -f /app/docker-start-console.sh ] || exit 1
+            [ -x /app/docker-start-console.sh ] || exit 1
 
   - name: ${{package.name}}-rotor
     pipeline:


### PR DESCRIPTION
Runtime dependencies were accidentally removed in a recent commit: https://github.com/wolfi-dev/os/commit/a275e19620a0cbce20186a02ab871352ab05db43, this PR re-adds them and adds some basic checks

Related: https://github.com/chainguard-dev/image-release-stats/issues/5776