### PR TITLE
No change rebuild of rust & uv

### DIFF
--- a/rust-1.87.yaml
+++ b/rust-1.87.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.87
   version: "1.87.0"
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/uv.yaml
+++ b/uv.yaml
@@ -1,7 +1,7 @@
 package:
   name: uv
   version: "0.7.12"
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python package installer and resolver, written in Rust.
   copyright:
     - license: MIT


### PR DESCRIPTION
No change rebuild of rust and uv, such that broken builds can be flushed from chainguard-2.28 repo.
