### PR TITLE
add missing azurefile-proxy scripts and binary

### DIFF
--- a/azurefile-csi-1.33.yaml
+++ b/azurefile-csi-1.33.yaml
@@ -1,13 +1,23 @@
 package:
   name: azurefile-csi-1.33
   version: "1.33.1"
-  epoch: 1
+  epoch: 2
   description: Azure File CSI Driver
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - azurefile-csi=${{package.full-version}}
+    runtime:
+      # https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/a9797b4447144d7d5d0ebfa354b1d023b14cae62/pkg/azurefileplugin/Dockerfile#L36
+      - azcopy
+      - cifs-utils
+      - e2fsprogs
+      - mount
+      - nfs-utils
+      - udev
+      - util-linux
+      - xfsprogs
 
 pipeline:
   - uses: git-checkout
@@ -30,6 +40,11 @@ pipeline:
       output: azurefileplugin
       packages: ./pkg/azurefileplugin
 
+  - uses: go/build
+    with:
+      output: azurefile-proxy
+      packages: ./pkg/azurefile-proxy
+
 subpackages:
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
@@ -37,6 +52,13 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/azurefileplugin ${{targets.subpkgdir}}/azurefileplugin
+
+          # https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/a9797b4447144d7d5d0ebfa354b1d023b14cae62/pkg/azurefileplugin/Dockerfile#L38-L41
+          mkdir -p "${{targets.contextdir}}"/azurefile-proxy/
+          install -Dm755 ./pkg/azurefile-proxy/init.sh "${{targets.contextdir}}"/azurefile-proxy/
+          install -Dm755 ./pkg/azurefile-proxy/install-proxy.sh "${{targets.contextdir}}"/azurefile-proxy/
+          install -Dm755 ./pkg/azurefile-proxy/azurefile-proxy.service "${{targets.contextdir}}"/azurefile-proxy/
+          ln -sf /usr/bin/azurefile-proxy "${{targets.contextdir}}"/azurefile-proxy/azurefile-proxy
     dependencies:
       provides:
         - azurefile-csi-compat=${{package.full-version}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

