### PR TITLE
fix: make unshare optional when not needed

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.66.1"
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -181,8 +181,13 @@ pipeline:
 
       # Build once to correctly setup links/generates. The system-probe we end
       # up using will be part of the multicall below.
-      unshare --user --map-root-user \
-        invoke -e system-probe.build
+      if [ "$(id -u)" -gt 0 ]; then
+        # on rootless systems let's use unshare to build
+        unshare --user --map-root-user \
+          invoke -e system-probe.build
+        else
+          invoke -e system-probe.build
+      fi
         #--bundle-ebpf # This makes oom-kill.o to fail because it expects it to be embedded in the Go binary at /build, because
         # of this: https://github.com/DataDog/datadog-agent/blob/eab078f2e713852de8e4f4c168ea009065841903/pkg/ebpf/co_re.go#L71
         # where c.coreDir is by default: /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re


### PR DESCRIPTION
Right now the `unshare` command is used as a workaround to a limitation of the bubblewrap runner, this will break on both QEMU and Docker

Make this optional, and skip unshare if not needed

Workaround for: https://github.com/chainguard-dev/prodsec/issues/282