### PR TITLE
npm: remediate GHSA-v6h2-p8h4-qcjw

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -2,7 +2,7 @@
 package:
   name: npm
   version: "11.4.1"
-  epoch: 1
+  epoch: 2
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -20,6 +20,13 @@ pipeline:
       uri: https://registry.npmjs.org/npm/-/npm-${{package.version}}.tgz
       expected-sha512: fcee43884166b6f9c5d04535fb95650e9708b6948a1f797eddf40e9778646778a518dfa32651b1c62ff36f4ac42becf177ca46ca27d53f24b539190c8d91802b
       delete: true
+
+  # This can probably be removed after
+  # upstream releases a version after 11.4.1
+  - uses: patch
+    with:
+      patches: |
+        brace-expansion-2.0.2.patch
 
   - runs: |
       # Wrapper scripts written in Bash and CMD.

--- a/npm/brace-expansion-2.0.2.patch
+++ b/npm/brace-expansion-2.0.2.patch
@@ -1,0 +1,46 @@
+From 9a342a4afb40d0668ab6a2c3820be7cacb4b79f7 Mon Sep 17 00:00:00 2001
+From: Gar <gar+gh@danger.computer>
+Date: Wed, 11 Jun 2025 09:00:23 -0700
+Subject: [PATCH] deps: brace-expansion@2.0.2
+
+also updated dev deps for brace-expansion@1.1.12
+---
+ node_modules/brace-expansion/index.js     |  2 +-
+ node_modules/brace-expansion/package.json |  5 +-
+ 3 files changed, 44 insertions(+), 41 deletions(-)
+
+diff --git a/node_modules/brace-expansion/index.js b/node_modules/brace-expansion/index.js
+index 4af9ddee4..a27f81ce0 100644
+--- a/node_modules/brace-expansion/index.js
++++ b/node_modules/brace-expansion/index.js
+@@ -116,7 +116,7 @@ function expand(str, isTop) {
+     var isOptions = m.body.indexOf(',') >= 0;
+     if (!isSequence && !isOptions) {
+       // {a},b}
+-      if (m.post.match(/,.*\}/)) {
++      if (m.post.match(/,(?!,).*\}/)) {
+         str = m.pre + '{' + m.body + escClose + m.post;
+         return expand(str);
+       }
+diff --git a/node_modules/brace-expansion/package.json b/node_modules/brace-expansion/package.json
+index 7097d41e3..c7eee3451 100644
+--- a/node_modules/brace-expansion/package.json
++++ b/node_modules/brace-expansion/package.json
+@@ -1,7 +1,7 @@
+ {
+   "name": "brace-expansion",
+   "description": "Brace expansion as known from sh/bash",
+-  "version": "2.0.1",
++  "version": "2.0.2",
+   "repository": {
+     "type": "git",
+     "url": "git://github.com/juliangruber/brace-expansion.git"
+@@ -42,5 +42,8 @@
+       "iphone/6.0..latest",
+       "android-browser/4.2..latest"
+     ]
++  },
++  "publishConfig": {
++    "tag": "2.x"
+   }
+ }


### PR DESCRIPTION
We remediated the vulnerability GHSA-v6h2-p8h4-qcjw by applying the upstream patch to bump the dependency brace-expansion to version v2.0.2

More information:
https://github.com/npm/cli/commit/9a342a4afb40d0668ab6a2c3820be7cacb4b79f7