### PR TITLE
Update melange to 0.26.10

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.26.8"
+  version: "0.26.10"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: f203105284d1c09bceec3719dc99a45c5b991c5b
+      expected-commit: 5e64256882e19c9e9f565cb92ca655df2b5a96ae
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR bumps melange to `0.26.10` to pull in additional build fixes.