### PR TITLE
fuse3: don't install init scripts

### DIFF
--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse3
   version: "3.17.2"
-  epoch: 0
+  epoch: 1
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only
@@ -32,7 +32,8 @@ pipeline:
   - uses: meson/configure
     with:
       opts: |
-        --sbindir /usr/bin
+        --sbindir /usr/bin \
+        -Dinitscriptdir='' \
 
   - uses: meson/compile
 


### PR DESCRIPTION
These are written for sys-v init, which we don't have.

