### PR TITLE
chainguard-security-guide: update to stig 3.2.3

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "3.2.2"
+  version: "3.2.3"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: cbeaacf878bcdf6647f2d0bcc5082cd1290a811f
+      expected-commit: 11d3a1cb7e3d46f6e988c1bb97cc62979efee4b9
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
Key item: add missing rule iand rationale for V-259333 / SRG-OS-000439-GPOS-00195.

Ref: https://github.com/chainguard-dev/prodsec/issues/285
