### PR TITLE
fix: rebuild postfix to pick up permissions fixes

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.2"
-  epoch: 1
+  epoch: 2
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0


### PR DESCRIPTION
This PR bumps the `postfix` epoch to rebuild the package with correct permissions.

Looks better:

`aarch64`:
```
$ tar tvf aarch64/postfix-3.10.2-r2.apk 2>/dev/null | grep -E "var/lib/postfix|var/spool/postfix"
drwxr-xr-x 100/root          0 2025-06-12 17:42 var/lib/postfix
drwxr-xr-x root/root         0 2025-06-12 17:42 var/spool/postfix
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/active
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/bounce
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/corrupt
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/defer
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/deferred
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/flush
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/hold
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/incoming
drwxr-xr-x 100/101           0 2025-06-12 17:42 var/spool/postfix/maildrop
drwxr-xr-x root/100          0 2025-06-12 17:42 var/spool/postfix/pid
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/private
drwxr-xr-x 100/101           0 2025-06-12 17:42 var/spool/postfix/public
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/saved
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/trace
```
`x86_64`:
```
$ tar tvf x86_64/postfix-3.10.2-r2.apk 2>/dev/null | grep -E "var/lib/postfix|var/spool/postfix"
drwxr-xr-x 100/root          0 2025-06-12 17:42 var/lib/postfix
drwxr-xr-x root/root         0 2025-06-12 17:42 var/spool/postfix
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/active
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/bounce
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/corrupt
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/defer
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/deferred
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/flush
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/hold
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/incoming
drwxr-xr-x 100/101           0 2025-06-12 17:42 var/spool/postfix/maildrop
drwxr-xr-x root/100          0 2025-06-12 17:42 var/spool/postfix/pid
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/private
drwxr-xr-x 100/101           0 2025-06-12 17:42 var/spool/postfix/public
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/saved
drwx------ 100/root          0 2025-06-12 17:42 var/spool/postfix/trace
```

Testing install in a container:
```
e0dfc1f7c536:/# apk add --allow-untrusted /workspace/postfix-3.10.2-r2.apk
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/20) Installing libbz2-1 (1.0.8-r13)
(2/20) Installing perl (5.40.2-r1)
(3/20) Installing libstdc++ (15.1.0-r1)
(4/20) Installing icu (75.1-r0)
(5/20) Installing lmdb (0.9.31-r4)
(6/20) Installing krb5-conf (1.0-r6)
(7/20) Installing libcom_err (1.47.2-r22)
(8/20) Installing keyutils-libs (1.6.3-r33)
(9/20) Installing libverto (0.3.2-r5)
(10/20) Installing krb5-libs (1.21.3-r42)
(11/20) Installing libtirpc (1.3.6-r1)
(12/20) Installing libnsl (2.0.1-r2)
(13/20) Installing gdbm (1.25-r1)
(14/20) Installing ncurses-terminfo-base (6.5_p20241228-r2)
(15/20) Installing ncurses (6.5_p20241228-r2)
(16/20) Installing readline (8.2.13-r4)
(17/20) Installing sqlite-libs (3.50.1-r0)
(18/20) Installing heimdal (7.8.0-r6)
(19/20) Installing cyrus-sasl (2.1.28-r42)
(20/20) Installing postfix (3.10.2-r2)
Executing postfix-3.10.2-r2.pre-install
Executing busybox-1.37.0-r40.trigger
OK: 113 MiB in 35 packages
e0dfc1f7c536:/# ls -hal /var/lib/postfix/
total 12K
drwxr-xr-x    2 postfix  root        4.0K Jun 12 23:01 .
drwxr-xr-x    1 root     root        4.0K Jun 12 23:01 ..
e0dfc1f7c536:/# ls -hal /var/spool/postfix/
total 64K
drwxr-xr-x   16 root     root        4.0K Jun 12 23:01 .
drwxr-xr-x    1 root     root        4.0K Jun 12 23:01 ..
drwx------    2 postfix  root        4.0K Jun 12 23:01 active
drwx------    2 postfix  root        4.0K Jun 12 23:01 bounce
drwx------    2 postfix  root        4.0K Jun 12 23:01 corrupt
drwx------    2 postfix  root        4.0K Jun 12 23:01 defer
drwx------    2 postfix  root        4.0K Jun 12 23:01 deferred
drwx------    2 postfix  root        4.0K Jun 12 23:01 flush
drwx------    2 postfix  root        4.0K Jun 12 23:01 hold
drwx------    2 postfix  root        4.0K Jun 12 23:01 incoming
drwxr-xr-x    2 postfix  postdrop    4.0K Jun 12 23:01 maildrop
drwxr-xr-x    2 root     postfix     4.0K Jun 12 23:01 pid
drwx------    2 postfix  root        4.0K Jun 12 23:01 private
drwxr-xr-x    2 postfix  postdrop    4.0K Jun 12 23:01 public
drwx------    2 postfix  root        4.0K Jun 12 23:01 saved
drwx------    2 postfix  root        4.0K Jun 12 23:01 trace
```
