### PR TITLE
dependency-track: use cg libraries

### DIFF
--- a/dependency-track.yaml
+++ b/dependency-track.yaml
@@ -27,6 +27,8 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 948b6cb5c905168d4d3a68ba13a16bba57d0d2d1
 
+  - uses: auth/maven
+
   - uses: maven/pombump
 
   - runs: |

--- a/dependency-track.yaml
+++ b/dependency-track.yaml
@@ -1,7 +1,7 @@
 package:
   name: dependency-track
   version: "4.13.2"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
use chainguard libraries. 