### PR TITLE
datadog-agent/GHSA-9hjg-9r4m-mvj7 fix

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.66.1"
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -346,7 +346,7 @@ subpackages:
               expected-commit: 3040577a9e2f266b8202294db17da354dcb41c47 # needs to be updated with each new release
           - uses: patch
             with:
-              patches: /home/build/int-core-datadog_checks_dev-pyproject-toml.patch /home/build/int-core-datadog_checks_base-pyproject-toml.patch /home/build/int-core-mysql-hatch-toml.patch /home/build/int-core-singlestore-hatch-toml.patch /home/build/int-core-agent_requirements-in.patch
+              patches: /home/build/int-core-datadog_checks_dev-pyproject-toml.patch /home/build/int-core-datadog_checks_base-pyproject-toml.patch /home/build/int-core-mysql-hatch-toml.patch /home/build/int-core-singlestore-hatch-toml.patch /home/build/int-core-agent_requirements-in.patch /home/build/int-core-requests-upgrade.patch
           - runs: |
               # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
               SOURCE_DATE_EPOCH=315532800

--- a/datadog-agent/int-core-requests-upgrade.patch
+++ b/datadog-agent/int-core-requests-upgrade.patch
@@ -1,0 +1,63 @@
+From 83ef84ab78b4bb99506c7c8a26616115d7b4e5a7 Mon Sep 17 00:00:00 2001
+From: Dorran Howell <dorran.howell@gmail.com>
+Date: Thu, 12 Jun 2025 16:55:58 +0200
+Subject: [PATCH] chore: Bump requests to newer patch version (#20494)
+
+* chore: Bump requests to newer patch version
+
+Updated the pinned version of requests in datadog_checks_base to a
+version without known CVEs.
+
+* Run ddev dep freeze
+
+Updated agent requirements based on the new checks_base dependencies.
+
+* Add changelog entry
+
+* Update changelog entry name
+
+* Update datadog_checks_base/changelog.d/20494.security
+
+---------
+
+Co-authored-by: Kyle Neale <kyle.a.neale@gmail.com>
+---
+ agent_requirements.in                          | 2 +-
+ datadog_checks_base/changelog.d/20494.security | 1 +
+ datadog_checks_base/pyproject.toml             | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+ create mode 100644 datadog_checks_base/changelog.d/20494.security
+
+diff --git a/agent_requirements.in b/agent_requirements.in
+index 8e73f21f11732..d0df18fbb9ad7 100644
+--- a/agent_requirements.in
++++ b/agent_requirements.in
+@@ -58,7 +58,7 @@ requests-ntlm==1.3.0
+ requests-oauthlib==2.0.0
+ requests-toolbelt==1.0.0
+ requests-unixsocket2==0.4.2
+-requests==2.32.3
++requests==2.32.4
+ rethinkdb==2.4.10.post1
+ securesystemslib[crypto,pynacl]==0.28.0
+ semver==3.0.4
+diff --git a/datadog_checks_base/changelog.d/20494.security b/datadog_checks_base/changelog.d/20494.security
+new file mode 100644
+index 0000000000000..262d47bf50376
+--- /dev/null
++++ b/datadog_checks_base/changelog.d/20494.security
+@@ -0,0 +1 @@
++Updates `requests` to 2.32.4
+diff --git a/datadog_checks_base/pyproject.toml b/datadog_checks_base/pyproject.toml
+index 7d9df3ea9549b..7746c0c8b8c11 100644
+--- a/datadog_checks_base/pyproject.toml
++++ b/datadog_checks_base/pyproject.toml
+@@ -46,7 +46,7 @@ "pywin32==308; sys_platform == 'win32'",
+     "pyyaml==6.0.2",
+     "requests-toolbelt==1.0.0",
+     "requests-unixsocket2==0.4.2",
+-    "requests==2.32.3",
++    "requests==2.32.4",
+     "simplejson==3.19.3",
+     "uptime==3.0.1",
+     "wrapt==1.17.2",


### PR DESCRIPTION
# Fix GHSA-9hjg-9r4m-mvj7: Upgrade requests to 2.32.4

## Summary
This PR is part of the fixes GHSA-9hjg-9r4m-mvj7 (CVE-2024-47081) by upgrading the requests library to version 2.32.4 or higher across 20 packages.

## Vulnerability Details
- **CVE**: CVE-2024-47081
- **GHSA**: GHSA-9hjg-9r4m-mvj7
- **Severity**: Medium
- **Description**: The `python-requests` library leaks Proxy-Authorization headers to destination servers when following HTTP redirects with an explicit proxy server.

## Changes by Repository

### OS Repository (13 packages)
**Direct + Vendored (need dependency upgrade + epoch bump):**
- datadog-agent-core-integrations (via patch)
- katib-earlystopping
- py3-cassandra-medusa

**Direct Only (need dependency upgrade + epoch bump):**
- dask-kubernetes
- kserve-storage-controller
- kubeflow-jupyter-web-app
- kubeflow-pipelines-apiserver
- kubeflow-volumes-web-app
- mlflow
- py3-semgrep
- superset

**Vendored Only (epoch bump only):**
- tensorflow-cpu-jupyter

### Enterprise Repository (7 packages)
**Direct + Vendored:**
- ansible-operator
- datadog-agent-core-integrations-fips (via patch)
- pgadmin4
- request-1276

**Direct Only:**
- apache-beam-python-3.11-sdk
- barman-cloudnative-pg
- tritonserver-backend-vllm-24.04

### Extra Repository (1 package)
**Vendored Only:**
- tensorflow-gpu-jupyter

## Testing
All packages have been:
- [x] Modified to upgrade requests to >= 2.32.4 where direct dependency exists
- [x] Epoch bumped to ensure updates are applied
- [x] Linted with `yam` or `./lint.sh`
- [ ] Built locally (pending)
- [ ] Scanned to verify CVE is fixed (pending)

## Notes
- For packages with vendored pip, the epoch bump will pick up the fixed pip from the cloud APK index
- Datadog packages use a patch to upgrade requests in their requirements file
- All changes follow existing patterns in each package's ecosystem (pip, pipenv, poetry)