### PR TITLE
prism/vitess-21.0/lerna: remediate cve

### DIFF
--- a/lerna.yaml
+++ b/lerna.yaml
@@ -1,7 +1,7 @@
 package:
   name: lerna
   version: "8.2.2"
-  epoch: 1
+  epoch: 2
   description: "Lerna is a fast, modern build system for managing and publishing multiple JavaScript/TypeScript packages from the same repository."
   copyright:
     - license: MIT

--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: "5.14.2"
-  epoch: 1
+  epoch: 2
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:

--- a/prism/CVE-2025-1302.patch
+++ b/prism/CVE-2025-1302.patch
@@ -2,7 +2,7 @@ diff --git a/package.json b/package.json
 index 26135a8..f89a71a 100644
 --- a/package.json
 +++ b/package.json
-@@ -23,7 +23,11 @@
+@@ -23,7 +23,12 @@
    },
    "resolutions": {
      "sanitize-html": "2.12.1",
@@ -11,7 +11,8 @@ index 26135a8..f89a71a 100644
 +    "braces": "3.0.3",
 +    "micromatch": "4.0.8",
 +    "axios": "1.8.2",
-+    "cross-spawn": "7.0.6"
++    "cross-spawn": "7.0.6",
++    "brace-expansion": "2.0.2"
    },
    "devDependencies": {
      "@stoplight/types": "^14.1.0",

--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -86,6 +86,8 @@ pipeline:
       npm pkg set overrides['@babel/helpers']=7.26.10
       npm pkg set overrides['@babel/runtime']=7.26.10
       npm pkg set overrides['@babel/runtime-corejs3']=7.26.10
+      # Fix CVE CVE-2025-5889
+      npm pkg set overrides['brace-expansion']=2.0.2
 
   - name: Build web UI
     working-directory: web/vtadmin

--- a/vitess-21.0.yaml
+++ b/vitess-21.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-21.0
   version: "21.0.4"
-  epoch: 3
+  epoch: 4
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
bump epoch in order to to remediate CVE GHSA-v6h2-p8h4-qcjw
