### PR TITLE
opensearch-3/GHSA-vgq5-3255-v292 bump kafka-client version in security plugin

### DIFF
--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -77,7 +77,7 @@ data:
       observability: ""
       performance-analyzer: ""
       reporting: ""
-      security: ""
+      security: "security-plugin-GHSA-vgq5-3255-v292.patch"
       security-analytics: ""
       sql: ""
 

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.0.0"
-  epoch: 1
+  epoch: 2
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0

--- a/opensearch-3/security-plugin-GHSA-vgq5-3255-v292.patch
+++ b/opensearch-3/security-plugin-GHSA-vgq5-3255-v292.patch
@@ -1,0 +1,26 @@
+From c10fd10fe90003a17ecf9d18c0ee3009ed946d3f Mon Sep 17 00:00:00 2001
+From: Ben Tasker <2900301+bentasker@users.noreply.github.com>
+Date: Fri, 13 Jun 2025 14:40:40 +0100
+Subject: [PATCH] feat: upgrade kafa client to 3.9.1
+
+Signed-off-by: Ben Tasker <2900301+bentasker@users.noreply.github.com>
+---
+ build.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index df8a05f1..ae596d5a 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -26,7 +26,7 @@ buildscript {
+ 
+         common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-beta1-SNAPSHOT')
+ 
+-        kafka_version  = '3.7.1'
++        kafka_version  = '3.9.1'
+         open_saml_version = '5.1.4'
+         open_saml_shib_version = "9.1.4"
+         one_login_java_saml = '2.9.0'
+-- 
+2.43.0
+


### PR DESCRIPTION
This bumps the kafka client version to 3.9.1 to remediate [CVE-2025-27817](https://github.com/advisories/GHSA-vgq5-3255-v292)