### PR TITLE
xorg-server: fix install conflict w/ xkeyboard-config

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: "21.1.16"
-  epoch: 2
+  epoch: 3
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -84,6 +84,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Remove xkb dir to avoid conflicts w/ xkeyboard-config symlink
+    runs: |
+      # Do it pedantically so we fail if upstream has changed something
+      rm ${{targets.destdir}}/usr/share/X11/xkb/compiled/README.compiled
+      rmdir ${{targets.destdir}}/usr/share/X11/xkb/compiled
+      rmdir ${{targets.destdir}}/usr/share/X11/xkb
 
   - uses: strip
 


### PR DESCRIPTION
Conflict introduced upstream by switching the directory to a symlink in:
      https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/commit/fd1d8d2d4f07ac494109b1a9e72d7fe777f6757a
