### PR TITLE
opensearch-dashboards-3: remediate cve

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.0.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 0
+  epoch: 1
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -74,8 +74,8 @@ pipeline:
       # unset our global flags to allow the build to succeed.
       unset LDFLAGS
 
-      # fix CVE-2024-47764, CVE-2025-27789
-      resolutions='{"**/cookie": "^0.7.0", "@babel/runtime": "^7.26.10", "@babel/runtime-corejs3": "^7.26.10"}'
+      # fix CVE-2024-47764, CVE-2025-27789, CVE-2025-5889
+      resolutions='{"**/cookie": "^0.7.0", "@babel/runtime": "^7.26.10", "@babel/runtime-corejs3": "^7.26.10", "brace-expansion": "1.1.12"}'
       jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
       # fix CVE-2023-28155

--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -127,8 +127,8 @@ subpackages:
       - runs: |
           cd ./plugins/${{range.value}}
 
-          # fix CVE-2025-27789, CVE-2025-25977
-          resolutions='{"@babel/runtime": "^7.26.10", "canvg": "^4.0.3"}'
+          # fix CVE-2025-27789, CVE-2025-25977, CVE-2025-5889
+          resolutions='{"@babel/runtime": "^7.26.10", "canvg": "^4.0.3", "brace-expansion": "1.1.12"}'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
           dependencies='{"cypress": "^13.5.1"}'


### PR DESCRIPTION
We remediated the cve CVE-2025-5889 by bumping dependency brace-expansion to version 1.1.12
