### PR TITLE
cve-remediation: add a new service account

### DIFF
--- a/.github/chainguard/lifecycle-cve-remediation.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-remediation.sts.yaml
@@ -3,7 +3,8 @@ issuer: https://accounts.google.com
 # have more than one service account
 # staging-images: cve-remediation-sa@staging-images-183e.iam.gserviceaccount.com (115001090278325569140)
 # prod-images: cve-remediation-sa@prod-images-c6e5.iam.gserviceaccount.com (103318643747916563750)
-subject_pattern: "(115001090278325569140|103318643747916563750)"
+# staging-new-cve-remediation: cve-remediation-sa@staging-enforce-cd1e.iam.gserviceaccount.com (114095860907513056796)
+subject_pattern: "(114095860907513056796|115001090278325569140|103318643747916563750)"
 
 permissions:
   pull_requests: write


### PR DESCRIPTION
Add the service account of the new cve-remediation service migrated to mono.