### PR TITLE
fix: ease hardening of tmpfs on QEMU runner

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 8
+  epoch: 9
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -16,9 +16,9 @@ SSHKEY="$(tr ' ' '\n' < /proc/cmdline | grep "sshkey=" | cut -d'=' -f2- | base64
 
 mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
 mount -t sysfs sys -o nodev,nosuid,noexec /sys
-mount -t tmpfs -o nodev,nosuid tmpfs /tmp
+mount -t tmpfs tmpfs /tmp
 mkdir -p -m 0755 /dev/shm
-mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
+mount -t tmpfs -o mode=1777 tmpfs /dev/shm
 
 # Setup tty/pty
 mkdir /dev/pts


### PR DESCRIPTION
Some packages will need to use /tmp to compile correctly, remove nodev nosuid to ease package compilation

