### PR TITLE
Apply /dev/shm fix to melange/init

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.26.12"
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -9,7 +9,7 @@ mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
 mount -t sysfs sys -o nodev,nosuid,noexec /sys
 mount -t tmpfs -o nodev,nosuid tmpfs /tmp
 mkdir -p -m 0755 /dev/shm
-mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /dev/shm
+mount -t tmpfs -o mode=1777 tmpfs /dev/shm
 mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /sys/fs/cgroup
 
 # Fix /dev/fd


### PR DESCRIPTION
Relates to: #56731

This applies the change from the aforementioned PR to the Melange `init` script.