### PR TITLE
fix: QEMU: correctly propagate mounts in chroot

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 9
+  epoch: 10
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -98,9 +98,10 @@ mount -t 9p \
 # Allow the user we are running as to copy things to the shared dir
 chmod 0777 /mount/mnt
 
-mount --bin /proc /mount/proc
-mount --bin /dev /mount/dev
-mount --bin /sys /mount/sys
+mount --rbind /dev /mount/dev
+mount --rbind /proc /mount/proc
+mount --rbind /sys /mount/sys
+mount --rbind /tmp /mount/tmp
 mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /mount/sys/fs/cgroup
 mkdir -p /mount/dev/pts
 mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /mount/dev/pts/


### PR DESCRIPTION
We need `rbind` to correctly propagate nested mount inside the chroot
