### PR TITLE
spark-3.5: add iamguarded compat

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5
   version: "3.5.6"
-  epoch: 1
+  epoch: 2
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -149,6 +149,50 @@ subpackages:
       runtime:
         - merged-usrsbin
         - wolfi-baselayout
+
+  - name: ${{package.name}}-scala-2.12-iamguarded-compat
+    description: Compatibility package for Spark 3.5 with Scala 2.12 and Iamguarded chart
+    dependencies:
+      runtime:
+        - coreutils # needed for cp -nr command
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: spark
+          version: ${{vars.major-minor-version}}
+      - runs: |
+          mkdir -p \
+            /opt/iamguarded/spark/ \
+            /opt/iamguarded/spark/logs \
+            /opt/iamguarded/spark/tmp \
+            /opt/iamguarded/spark/conf.default \
+            /opt/iamguarded/spark/conf
+
+          cp -r ${{targets.outdir}}/${{package.name}}-scala-2.12/usr/lib/spark/conf/* \
+            /opt/iamguarded/spark/conf.default/
+          # We copy conf instead of symlinking to avoid issues with the volume mount.
+          cp -r ${{targets.outdir}}/${{package.name}}-scala-2.12/usr/lib/spark/conf/* \
+            /opt/iamguarded/spark/conf/
+
+          ln -s /usr/lib/spark/jars /opt/iamguarded/spark/jars
+          ln -s /usr/lib/spark/bin /opt/iamguarded/spark/bin
+          ln -s /usr/lib/spark/data /opt/iamguarded/spark/data
+          ln -s /usr/lib/spark/python /opt/iamguarded/spark/python
+          ln -s /usr/lib/spark/licenses /opt/iamguarded/spark/licenses
+          ln -s /usr/lib/spark/kubernetes /opt/iamguarded/spark/kubernetes
+          ln -s /usr/lib/spark/sbin /opt/iamguarded/spark/sbin
+          ln -s /usr/lib/spark/yarn /opt/iamguarded/spark/yarn
+      - uses: iamguarded/finalize-compat
+        with:
+          package: spark
+          version: ${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: spark
+            version: ${{vars.major-minor-version}}
 
   - name: ${{package.name}}-scala-2.12-bitnami-compat
     description: Bitnami compat for Spark 3.5 with Scala 2.12


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
