### PR TITLE
logstash-8: bump logstash-integration-kafka to 11.6.3 to fix GHSA-vgq5-3255-v292

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: "8.18.2"
-  epoch: 1
+  epoch: 2
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -97,7 +97,7 @@ pipeline:
       echo "gem 'rexml', '3.4.1'" >> Gemfile.template
       echo "gem 'puma', '6.6.0'" >> Gemfile.template
       echo "gem 'sinatra', '4.1.1'" >> Gemfile.template
-      echo "gem 'logstash-integration-kafka', '11.6.0'" >> Gemfile.template
+      echo "gem 'logstash-integration-kafka', '11.6.3'" >> Gemfile.template
       echo "gem 'rack', '3.1.16'" >> Gemfile.template
       echo "gem 'rack-session', '2.1.1'" >> Gemfile.template
       echo "gem 'net-imap', '0.5.8'" >> Gemfile.template


### PR DESCRIPTION
## Summary

This PR fixes CVE [GHSA-vgq5-3255-v292](https://github.com/advisories/GHSA-vgq5-3255-v292) in logstash-8 by updating the bundled kafka-clients from 3.8.1 to 3.9.1.

## Changes

- Updated `logstash-integration-kafka` gem from 11.6.0 to 11.6.3
- Incremented epoch from 1 to 2

## Vulnerability Details

**CVE**: GHSA-vgq5-3255-v292  
**Severity**: Moderate  
**Description**: Apache Kafka Client Arbitrary File Read and Server Side Request Forgery Vulnerability

The vulnerability allows attackers to:
- Read arbitrary files from disk via `sasl.oauthbearer.token.endpoint.url` and `sasl.oauthbearer.jwks.endpoint.url` configurations
- Make requests to unintended locations (SSRF)
- Access filesystem/environment/URL in Apache Kafka Connect environments

## Fix

The logstash-integration-kafka gem version 11.6.3 bundles Apache Kafka clients version 3.9.1, which includes the security fix for this vulnerability.

## Testing

- ✅ Package builds successfully with `make package/logstash-8`
- ✅ All tests pass with `make test/logstash-8`
- ✅ CVE scan confirms the vulnerability is fixed

## References

- [GitHub Advisory GHSA-vgq5-3255-v292](https://github.com/advisories/GHSA-vgq5-3255-v292)
- [logstash-integration-kafka 11.6.3 release](https://rubygems.org/gems/logstash-integration-kafka/versions/11.6.3)