### PR TITLE
gcc-14: Add libatomic-14 subpackage

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -87,7 +87,6 @@ pipeline:
             --enable-initfini-array \
             --disable-nls \
             --disable-multilib \
-            --disable-libatomic \
             --disable-libsanitizer \
             --enable-host-shared \
             --enable-shared \
@@ -154,6 +153,17 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: 'libatomic-14'
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
+          mv "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/libatomic*.so.* "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/
+    options:
+      no-provides: true
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: 'libstdc++-14'
     pipeline:


### PR DESCRIPTION
Certain packages that are failing to build with GCC 15 require `libatomic`.  Let's provide that for GCC 14, at least until the FTBFSes are fixed.