### PR TITLE
kubeflow-centraldashboard: fix GHSA-v6h2-p8h4-qcjw in vendored protobufjs deps

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 0
+  epoch: 1
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -81,6 +81,15 @@ pipeline:
       # Build the frontend and copy the common package into it
       npm rebuild && \
       npm install --force --legacy-peer-deps && \
+      # Fix brace-expansion vulnerability in protobufjs dependency
+      if [ -d "node_modules/protobufjs/cli/node_modules/brace-expansion" ]; then \
+        sed -i 's/"version": "1.1.11"/"version": "1.1.12"/' node_modules/protobufjs/cli/node_modules/brace-expansion/package.json && \
+        rm -rf node_modules/protobufjs/cli/node_modules/brace-expansion/node_modules && \
+        cd node_modules/protobufjs/cli/node_modules && \
+        rm -rf brace-expansion && \
+        npm install brace-expansion@1.1.12 --no-save && \
+        cd -; \
+      fi && \
       npm run build --force --legacy-peer-deps && \
       npm prune --production --force --legacy-peer-deps
       # Now move it all into place


### PR DESCRIPTION
## Summary
- Fixes CVE GHSA-v6h2-p8h4-qcjw (brace-expansion ReDoS vulnerability)
- The vulnerable brace-expansion@1.1.11 is vendored inside protobufjs's CLI dependencies
- Applied manual replacement during build to update to brace-expansion@1.1.12

## Details
The vulnerability exists in a vendored dependency chain:
```
kubeflow-centraldashboard
└── @google-cloud/monitoring@1.2.0
    └── google-gax@1.3.0
        └── protobufjs@6.11.2
            └── cli/node_modules/ (vendored)
                └── espree@7.3.1
                    └── glob@7.2.3
                        └── minimatch@3.1.2
                            └── brace-expansion@1.1.11 (vulnerable)
```

Since protobufjs 6.x vendors its CLI dependencies, npm overrides don't work. The fix manually replaces the vendored brace-expansion during the build process.

## Test plan
- [x] Built package successfully
- [x] Tests pass
- [x] Scanned with wolfictl - CVE is no longer present
- [x] Only two unrelated CVEs remain (taffydb and request)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>