### PR TITLE
code-server/GHSA-v6h2-p8h4-qcjw fix

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.100.3"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -59,7 +59,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: node-memory.patch GHSA-pq67-2wwv-3xjx.patch fix-CVE-2025-47279.patch
+      patches: node-memory.patch GHSA-pq67-2wwv-3xjx.patch fix-CVE-2025-47279.patch fix-GHSA-v6h2-p8h4-qcjw.patch
 
   - runs: |
       mkdir -p "${{targets.contextdir}}"/usr/lib/code-server

--- a/code-server/fix-GHSA-v6h2-p8h4-qcjw.patch
+++ b/code-server/fix-GHSA-v6h2-p8h4-qcjw.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Albert <jamie.albert@chainguard.dev>
+Date: Sun, 16 Jun 2025 12:49:00 -0700
+Subject: [PATCH] bump brace-expansion to 1.1.12 to fix GHSA-v6h2-p8h4-qcjw
+
+---
+ package-lock.json | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/package-lock.json b/package-lock.json
+index 1111111111..2222222222 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -1305,9 +1305,9 @@
+
+       }
+     },
+     "node_modules/brace-expansion": {
+-      "version": "1.1.11",
+-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
++      "version": "1.1.12",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
++      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+       "license": "MIT",
+       "dependencies": {
+         "balanced-match": "^1.0.0",
+-- 
+2.49.0


### PR DESCRIPTION
  ## Summary
  - Fixes CVE GHSA-v6h2-p8h4-qcjw (brace-expansion ReDoS vulnerability)
  - Updates brace-expansion from 1.1.11 to 1.1.12 in code-server's dependency tree
  - Low severity Regular Expression Denial of Service (ReDoS) vulnerability

  ## Details
  The vulnerable brace-expansion@1.1.11 is a transitive dependency brought in through:
  code-server
  └── mailto:rimraf@3.0.2
      └── mailto:glob@7.2.3
          └── mailto:minimatch@3.1.2
              └── mailto:brace-expansion@1.1.11 (vulnerable)

  Applied a patch to update the package-lock.json to use brace-expansion@1.1.12 which contains the fix for the ReDoS vulnerability.

  ## Test plan
  - [x] Built package successfully with `make package/code-server`
  - [x] Tests pass with `make test/code-server`
  - [x] Scanned with `wolfictl scan` - CVE no longer present in scan results