### PR TITLE
Add redirection to remaining packages

### DIFF
--- a/grafana-oncall.yaml
+++ b/grafana-oncall.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-oncall
   version: "1.16.1"
-  epoch: 2
+  epoch: 3
   description: "Developer-friendly incident response with brilliant Slack integration"
   copyright:
     - license: AGPL-3.0-or-later
@@ -202,7 +202,7 @@ test:
         pidfile /tmp/redis_6379.pid
         dir /tmp/
         EOF
-        redis-server /tmp/redis.conf &
+        redis-server /tmp/redis.conf > out.log 2>&1 &
         wait-for-it localhost:6379 --timeout=60
         redis-cli -p 6379 ping
     - name: "start celery"

--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: "2.16.0"
-  epoch: 0
+  epoch: 1
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0
@@ -42,6 +42,8 @@ test:
     - uses: test/kwok/cluster
     - runs: |
         mkdir -p /csi
-        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" & sleep 5
-        livenessprobe --csi-address /csi/csi.sock --health-port 8080 & sleep 10
+        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" > hostpathplugin.log 2>&1 &
+        sleep 5
+        livenessprobe --csi-address /csi/csi.sock --health-port 8080 > livenessprobelog 2>&1 &
+        sleep 10
         curl -Lk localhost:8080/healthz

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.1.0"
-  epoch: 1
+  epoch: 2
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -98,7 +98,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: mlflow
-          version-path: 2/debian-12
+          version-path: 3/debian-12
       - runs: |
           # Restore virtual env paths
           sed -i "s|/usr/share/mlflow|/home/build/venv|g" venv/pyvenv.cfg
@@ -149,10 +149,10 @@ test:
   pipeline:
     - runs: |
         export PATH="/usr/share/mlflow/bin:${PATH}"
-        python3 ./test-mlflow.py > /dev/null 2>&1
+        python3 ./test-mlflow.py > /dev/null 2>&1 &
         mlflow ui > /dev/null 2>&1 &
-        sleep 5 > /dev/null 2>&1
-        curl -vsL localhost:5000 > /dev/null 2>&1
+        sleep 5
+        curl -vsL localhost:5000
     # Will fail see https://github.com/wolfi-dev/os/issues/34358
     # - uses: test/pkgconf
     - uses: test/tw/ldd-check

--- a/pgpool2_exporter.yaml
+++ b/pgpool2_exporter.yaml
@@ -65,14 +65,29 @@ test:
     - name: "Set up PostgreSQL"
       runs: |
         useradd -m $PG_USER
-        sudo -u $PG_USER initdb -D $PG_DATA --username=$PG_USER
+
+        # Initialize DB
+        sudo -u $PG_USER initdb -D $PG_DATA --username=$PG_USER > useradd.log 2>&1
+
+        cat <<EOF >> $PG_DATA/postgresql.conf
+        listen_addresses = '*'
+        port = $PG_PORT
+        EOF
+
+        cat <<EOF >> $PG_DATA/pg_hba.conf
+        host all all 127.0.0.1/32 trust
+        host all all ::1/128 trust
+        EOF
+
         # Start PostgreSQL in the background
-        sudo -u $PG_USER pg_ctl -D $PG_DATA -o "-p $PG_PORT" -w start
-        # Grant privileges to DB
-        psql -U $PG_USER -h "$PGHOST" -p "$PG_PORT" -d ${PG_DB} -c "GRANT ALL PRIVILEGES ON DATABASE $PG_DB TO $PG_USER;"
+        sudo -u $PG_USER pg_ctl -D $PG_DATA -w start > pgstart.log 2>&1
+
+        # Grant privileges
+        psql -U $PG_USER -h localhost -p "$PG_PORT" -d ${PG_DB} -c "GRANT ALL PRIVILEGES ON DATABASE $PG_DB TO $PG_USER;" > pggrant.log 2>&1
     - name: "Start Pgpool2"
       runs: |
         mkdir -p /etc/pgpool2 /var/log/pgpool /tmp/pgpool
+        touch /tmp/pgpool_status
         # Pgpool config
         cat <<EOF > /etc/pgpool2/pgpool.conf
         backend_hostname0 = 'localhost'
@@ -93,14 +108,14 @@ test:
       uses: test/daemon-check-output
       with:
         start: |
-          sh -c 'DATA_SOURCE_NAME="postgres://${PG_USER}:${PG_PASSWORD}@localhost:${PGPOOL_PORT}/${PG_DB}?sslmode=disable" pgpool2_exporter --web.listen-address=":${EXPORTER_PORT}" --log.level=debug'
+          sh -c 'DATA_SOURCE_NAME="postgres://${PG_USER}:${PG_PASSWORD}@localhost:${PGPOOL_PORT}/${PG_DB}?sslmode=disable" pgpool2_exporter --web.listen-address=":${EXPORTER_PORT}" --log.level=debug' 2>&1
         expected_output: |
           Querying namespace
           Starting pgpool2_exporter
           Listening on address
         timeout: 10
         post: |
-          curl -sf http://localhost:${EXPORTER_PORT}/metrics 2>&1 | tee metrics.txt
+          curl -sf http://localhost:${EXPORTER_PORT}/metrics > metrics.txt 2>&1 &
           grep -q "pgpool2_backend_used 1" metrics.txt
           grep -q "pgpool2_frontend_total 32" metrics.txt
           grep -q "pgpool2_up 1" metrics.txt
@@ -108,7 +123,7 @@ test:
           echo "Updating DB by running 5 queries through Pgpool"
           for i in $(seq 1 5); do
             echo "- Running query $i"
-            PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h localhost -p ${PGPOOL_PORT} -d $PG_DB -c "SELECT generate_series(1, 100);" > /dev/null 2>&1
+            PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h localhost -p ${PGPOOL_PORT} -d $PG_DB -c "SELECT generate_series(1, 100);" > /dev/null 2>&1 &
             sleep 1
           done
           echo "Validating updated Pgpool metrics (5 queries)"

--- a/pgpool2_exporter.yaml
+++ b/pgpool2_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2_exporter
   version: "1.2.2"
-  epoch: 2
+  epoch: 3
   description: Prometheus exporter for Pgpool-II metrics.
   copyright:
     - license: MIT

--- a/sops.yaml
+++ b/sops.yaml
@@ -49,8 +49,10 @@ test:
         sops --help
     - name: decrypt
       runs: |
-        gpg-agent --no-options --daemon > /dev/null 2>&1 &
-        gpg --no-options --import pgp/sops_functional_tests_key.asc
+        mkdir -p /tmp/.gnupg
+        chmod 0600 /tmp/.gnupg
+        gpg-agent --homedir /tmp/.gnupg --daemon > /dev/null 2>&1 &
+        gpg --homedir /tmp/.gnupg --import pgp/sops_functional_tests_key.asc
 
         cd examples/all_in_one
         sops decrypt config/secret.enc.json > /dev/null 2>&1 &

--- a/sops.yaml
+++ b/sops.yaml
@@ -1,7 +1,7 @@
 package:
   name: sops
   version: "3.10.2"
-  epoch: 1
+  epoch: 2
   description: Simple and flexible tool for managing secrets
   copyright:
     - license: MPL-2.0
@@ -49,8 +49,8 @@ test:
         sops --help
     - name: decrypt
       runs: |
-        gpg-agent --daemon > /dev/null 2>&1
-        gpg --import pgp/sops_functional_tests_key.asc > /dev/null 2>&1
+        gpg-agent --no-options --daemon > /dev/null 2>&1 &
+        gpg --no-options --import pgp/sops_functional_tests_key.asc
 
         cd examples/all_in_one
-        sops decrypt config/secret.enc.json > /dev/null 2>&1
+        sops decrypt config/secret.enc.json > /dev/null 2>&1 &


### PR DESCRIPTION
This PR adds test redirection to the remaining packages that were not covered in recent CVE remediation PRs.

For the most part, we're now redirecting output to a file rather than `/dev/null` with a few exceptions.