### PR TITLE
rancher-api-ui: fix GHSA-v6h2-p8h4-qcjw brace-expansion vulnerability

### DIFF
--- a/rancher-api-ui.yaml
+++ b/rancher-api-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-api-ui
   version: "1.2.3"
-  epoch: 0
+  epoch: 1
   description: Embedded UI for any service that implements the Rancher API spec
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: CVE-2024-4068.patch
+      patches: CVE-2024-4068.patch fix-GHSA-v6h2-p8h4-qcjw.patch
 
   - runs: |
       yarn build --omit=dev

--- a/rancher-api-ui.yaml
+++ b/rancher-api-ui.yaml
@@ -85,4 +85,4 @@ test:
           serving
           Available on
         post: |
-          curl http://localhost:8080/index.html | grep -qi "${{vars.VERSION_SUFFIX}}-api-ui"
+          curl http://localhost:8080/index.html | grep -qi "${{vars.VERSION_SUFFIX}}-api-ui" > /dev/null 2>&1

--- a/rancher-api-ui/fix-GHSA-v6h2-p8h4-qcjw.patch
+++ b/rancher-api-ui/fix-GHSA-v6h2-p8h4-qcjw.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Albert <jamie.albert@chainguard.dev>
+Date: Mon, 16 Jun 2025 15:16:00 -0700
+Subject: [PATCH] Fix GHSA-v6h2-p8h4-qcjw brace-expansion vulnerability
+
+Update brace-expansion from 1.1.11 to 1.1.12 to fix ReDoS vulnerability
+
+Signed-off-by: Jamie Albert <jamie.albert@chainguard.dev>
+---
+ yarn.lock | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/yarn.lock b/yarn.lock
+index 1234567..abcdefg 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -26,9 +26,9 @@ bootstrap@3.4.1:
+   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+ 
+ brace-expansion@^1.1.7:
+-  version "1.1.11"
+-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
++  version "1.1.12"
++  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
++  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+   dependencies:
+     balanced-match "^1.0.0"
+     concat-map "0.0.1"
+EOF < /dev/null


### PR DESCRIPTION
## Summary
- Fixes CVE GHSA-v6h2-p8h4-qcjw (brace-expansion ReDoS vulnerability)
- Updates brace-expansion from 1.1.11 to 1.1.12 in yarn.lock
- Low severity Regular Expression Denial of Service (ReDoS) vulnerability

## Details
The vulnerable brace-expansion@1.1.11 is a transitive dependency brought in through:
```
rancher-api-ui
└── minimatch@3.1.2
    └── brace-expansion@1.1.11 (vulnerable)
```

Applied a patch to the yarn.lock file to update brace-expansion to version 1.1.12 which contains the fix for the ReDoS vulnerability.

## Test plan
- [x] Built package successfully with `make package/rancher-api-ui`
- [x] Tests pass with `make test/rancher-api-ui`
- [x] Scanned with `wolfictl scan` - CVE no longer present in scan results
- [x] Only one unrelated CVE remains (bootstrap XSS)