### PR TITLE
aws-application-networking-k8s: fix released version

### DIFF
--- a/aws-application-networking-k8s.yaml
+++ b/aws-application-networking-k8s.yaml
@@ -1,6 +1,6 @@
 package:
   name: aws-application-networking-k8s
-  version: "1.2.0"
+  version: "1.1.2"
   epoch: 0
   description: A Kubernetes controller for Amazon VPC Lattice
   copyright:
@@ -12,7 +12,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0de30baee7a5e8292f8089d5faef060b4d2edc9d
+      expected-commit: 1efa8f6101fafe3c579c5fc957d9a7040a8d1d7d
       repository: https://github.com/aws/aws-application-networking-k8s
       tag: v${{package.version}}
 

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -25,3 +25,5 @@ sonarqube-10-25.5.0.107428-r1.apk
 sonarqube-10-scripts-25.5.0.107428-r2.apk
 sonarqube-10-docker-compat-25.5.0.107428-r2.apk
 sonarqube-10-25.5.0.107428-r2.apk
+aws-application-networking-k8s-1.2.0-r0.apk
+aws-application-networking-k8s-compat-1.2.0-r0.apk


### PR DESCRIPTION
Seems that our automation caught a mistake upstream of a tag/release that doesn't exist anymore and now we can't build the package as it is relying on a tag that doesn't exist.

This aims to fix the package version and withdraw the bogus package version from our repositories.
