### PR TITLE
chainguard-2.28: Test build libunistring

### DIFF
--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527
-      uri: https://ftp.gnu.org/gnu/libunistring/libunistring-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/libunistring/libunistring-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
     with:

--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunistring
   version: "1.3"
-  epoch: 2
+  epoch: 3
   description: Library for manipulating Unicode strings and C strings
   copyright:
     - license: GPL-2.0-or-later OR LGPL-3.0-or-later


### PR DESCRIPTION
Picked up host glibc symbol somehow for

> /home/build/lib/struniq.h:98:(.text+0xef): undefined reference to `__libc_single_threaded'