### PR TITLE
chainguard-2.28: Fix failure to build harfbuzz from source

### DIFF
--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -1,7 +1,7 @@
 package:
   name: harfbuzz
   version: "11.2.1"
-  epoch: 0
+  epoch: 1
   description: Text shaping library
   copyright:
     - license: MIT

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -33,6 +33,10 @@ pipeline:
       expected-sha256: 093714c8548a285094685f0bdc999e202d666b59eeb3df2ff921ab68b8336a49
       uri: https://github.com/harfbuzz/harfbuzz/releases/download/${{package.version}}/harfbuzz-${{package.version}}.tar.xz
 
+  # oldglibc has redundant declarations, which is harmless
+  - runs: |
+      [ -d /usr/lib/oldglibc ] && sed -i '/-Wredundant-decls/d' src/hb.hh
+
   - uses: meson/configure
     with:
       opts: |


### PR DESCRIPTION
For oldglibc: make redundant declarations non-fatal, this fixes failure to build harfbuzz from source in chainguard-2.28.