### PR TITLE
chainguard-2.28: Fix failure to build libxdmcp from source

### DIFF
--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxdmcp
   version: 1.1.5
-  epoch: 6
+  epoch: 7
   description: X11 Display Manager Control Protocol library
   copyright:
     - license: MIT

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -31,6 +31,8 @@ pipeline:
   - runs: ./autogen.sh
 
   - uses: autoconf/configure
+    with:
+      opts: $([ -d /usr/lib/oldglibc ] && echo ac_cv_func_arc4random_buf='no')
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Fix:
> Key.c:96:5: error: implicit declaration of function 'arc4random_buf' [-Wimplicit-function-declaration]

In 2.28 builds, by hinting autoconf to not use arc4random_buf. 12 successful checks, including the eco-2.28 build.