### PR TITLE
sbom/binutils tarball check

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 7
+  epoch: 8
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 44
+  epoch: 45
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.1"
-  epoch: 1
+  epoch: 2
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
- **binutils: no change rebuild to publish upstream tarball.**
- **busybox: no change rebuild to regenerate archive for SBOM.**
- **haproxy-3.2: no change rebuild to replace zero size archive for SBOM.**
