### PR TITLE
fix: renamed package and added installed container entrypoint scripts

### DIFF
--- a/ipfs.yaml
+++ b/ipfs.yaml
@@ -7,10 +7,10 @@ package:
     - license: MIT
   dependencies:
     runtime:
+      - busybox
+      - gosu
       - "posix-libc-utils" # "getent" required
       - tini
-      - gosu
-      - busybox
     provides:
       - kubo:${{package.full-version}}
 
@@ -61,7 +61,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/data/ipfs
       mkdir -p ${{targets.destdir}}/ipfs ${{targets.destdir}}/ipns
       mkdir -p ${{targets.destdir}}/container-init.d
-      
+
       # Install container entrypoint scripts
       install -Dm755 bin/container_daemon ${{targets.destdir}}/usr/local/bin/start_ipfs
       install -Dm755 bin/container_init_run ${{targets.destdir}}/usr/local/bin/container_init_run

--- a/ipfs.yaml
+++ b/ipfs.yaml
@@ -1,15 +1,18 @@
 package:
   name: ipfs
   version: "0.35.0"
-  epoch: 2
+  epoch: 3
   description: An IPFS implementation in Go
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - "posix-libc-utils" # "getent" required
+      - tini
+      - gosu
+      - busybox
     provides:
-      - kubo
+      - kubo:${{package.full-version}}
 
 environment:
   contents:
@@ -46,15 +49,22 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
         github.com/pion/interceptor@v0.1.39
 
-  - runs: |
-      CGO_ENABLED=1 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GOFLAGS=-buildvcs=false make build GOTAGS=openssl
-      install -m755 -D ./cmd/ipfs/ipfs "${{targets.destdir}}"/usr/bin/ipfs
+  - uses: go/build
+    with:
+      packages: ./cmd/ipfs
+      output: ipfs
+      tags: openssl
+      ldflags: |
+        -X 'github.com/ipfs/kubo/version.CurrentCommit=$(git rev-parse HEAD)'
 
   - runs: |
-      # create fs-repo directory
-      mkdir -p /data/ipfs
-      # create mount points
-      mkdir /ipfs /ipns
+      mkdir -p ${{targets.destdir}}/data/ipfs
+      mkdir -p ${{targets.destdir}}/ipfs ${{targets.destdir}}/ipns
+      mkdir -p ${{targets.destdir}}/container-init.d
+      
+      # Install container entrypoint scripts
+      install -Dm755 bin/container_daemon ${{targets.destdir}}/usr/local/bin/start_ipfs
+      install -Dm755 bin/container_init_run ${{targets.destdir}}/usr/local/bin/container_init_run
 
   - uses: strip
 

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -91,10 +91,6 @@ subpackages:
             test -x /usr/bin/container_init_run
 
 test:
-  environment:
-    contents:
-      packages:
-        - ${{package.name}}-compat
   pipeline:
     - name: Test IPFS installation
       runs: |

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -1,18 +1,15 @@
 package:
-  name: ipfs
+  name: kubo
   version: "0.35.0"
-  epoch: 3
+  epoch: 0
   description: An IPFS implementation in Go
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - busybox
       - gosu
       - "posix-libc-utils" # "getent" required
       - tini
-    provides:
-      - kubo:${{package.full-version}}
 
 environment:
   contents:
@@ -62,19 +59,42 @@ pipeline:
       mkdir -p ${{targets.destdir}}/ipfs ${{targets.destdir}}/ipns
       mkdir -p ${{targets.destdir}}/container-init.d
 
-      # Install container entrypoint scripts
-      install -Dm755 bin/container_daemon ${{targets.destdir}}/usr/local/bin/start_ipfs
-      install -Dm755 bin/container_init_run ${{targets.destdir}}/usr/local/bin/container_init_run
+      install -Dm755 bin/container_daemon ${{targets.destdir}}/usr/bin/start_ipfs
+      install -Dm755 bin/container_init_run ${{targets.destdir}}/usr/bin/container_init_run
 
   - uses: strip
 
-update:
-  enabled: true
-  github:
-    identifier: ipfs/kubo
-    strip-prefix: v
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility symlinks for IPFS container entrypoint scripts
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          ln -sf /usr/bin/start_ipfs ${{targets.contextdir}}/usr/local/bin/start_ipfs
+          ln -sf /usr/bin/container_init_run ${{targets.contextdir}}/usr/local/bin/container_init_run
+    test:
+      pipeline:
+        - runs: |
+            # Verify symlinks exist and point to correct targets
+            stat /usr/local/bin/start_ipfs
+            stat /usr/local/bin/container_init_run
+            
+            # Check that symlinks point to the right locations
+            test "$(readlink /usr/local/bin/start_ipfs)" = "/usr/bin/start_ipfs"
+            test "$(readlink /usr/local/bin/container_init_run)" = "/usr/bin/container_init_run"
+            
+            # Verify the targets are executable
+            test -x /usr/bin/start_ipfs
+            test -x /usr/bin/container_init_run
 
 test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Test IPFS installation
       runs: |
@@ -109,3 +129,9 @@ test:
         DAEMON_PID=$!
         echo "IPFS daemon started with PID $DAEMON_PID."
         kill $DAEMON_PID
+
+update:
+  enabled: true
+  github:
+    identifier: ipfs/kubo
+    strip-prefix: v

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubo
   version: "0.35.0"
-  epoch: 0
+  epoch: 3
   description: An IPFS implementation in Go
   copyright:
     - license: MIT

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -10,6 +10,8 @@ package:
       - gosu
       - "posix-libc-utils" # "getent" required
       - tini
+    provides:
+      - ipfs=${{package.full-version}}
 
 environment:
   contents:
@@ -94,6 +96,7 @@ test:
   environment:
     contents:
       packages:
+        - ${{package.name}}
         - ${{package.name}}-compat
   pipeline:
     - name: Test IPFS installation

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -81,11 +81,11 @@ subpackages:
             # Verify symlinks exist and point to correct targets
             stat /usr/local/bin/start_ipfs
             stat /usr/local/bin/container_init_run
-            
+
             # Check that symlinks point to the right locations
             test "$(readlink /usr/local/bin/start_ipfs)" = "/usr/bin/start_ipfs"
             test "$(readlink /usr/local/bin/container_init_run)" = "/usr/bin/container_init_run"
-            
+
             # Verify the targets are executable
             test -x /usr/bin/start_ipfs
             test -x /usr/bin/container_init_run


### PR DESCRIPTION
We're creating new package and image named `kubo` upstream project [`ipfs/kubo.`](https://github.com/ipfs/kubo)
The existing images use the `go-ipfs `and package `ipfs` naming for historical reasons, but adopting the correct upstream name improves clarity and consistency.
So renaming the packege `ipfs` to `kubo`
For more context refer to this thread [here](https://chainguard-dev.slack.com/archives/C062D52J3T9/p1750169806574819) 