### PR TITLE
tarball-uploads: no-change rebuilds to generate upstream archive tarballs.

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: "3.12.1"
-  epoch: 3
+  epoch: 4
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 8
+  epoch: 9
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 45
+  epoch: 46
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 17
+  epoch: 18
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/giflib.yaml
+++ b/giflib.yaml
@@ -1,7 +1,7 @@
 package:
   name: giflib
   version: 5.2.2
-  epoch: 8
+  epoch: 9
   description: "A library for reading and writing GIF images"
   copyright:
     - license: MIT

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 8
+  epoch: 9
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.1"
-  epoch: 2
+  epoch: 3
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later

--- a/isl.yaml
+++ b/isl.yaml
@@ -1,7 +1,7 @@
 package:
   name: isl
   version: 0.27
-  epoch: 2
+  epoch: 3
   description: "an integer set library for the polyhedral model"
   copyright:
     - license: MIT

--- a/keyutils.yaml
+++ b/keyutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: keyutils
   version: 1.6.3
-  epoch: 34
+  epoch: 35
   description: Linux Key Management Utilities
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.76"
-  epoch: 3
+  epoch: 4
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/npth.yaml
+++ b/npth.yaml
@@ -1,7 +1,7 @@
 package:
   name: npth
   version: "1.8"
-  epoch: 7
+  epoch: 8
   description: The New GNU Portable Threads library
   copyright:
     - license: LGPL-2.1


### PR DESCRIPTION
The tarball-upload service in production received fixes today to improve resilience and deal with large tarballs (such as binutils and glibc) which failed in prior rebuilds.

This is triggered from the publication of APK's to the Wolfi archive post merge and build; rebuild selected core packages that make use of this service to publish an upstream tarball to use in SBOM downloadLocation references.

For reference this is a smaller subset of the packages in Wolfi that don't use github, gitlab or upstream release tarballs to build.