### PR TITLE
qemu: use autoconf pipeline, explicit build options for aio/io-uring and ensure dummy --version  tests arent broken

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: "10.0.2"
-  epoch: 1
+  epoch: 2
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -28,7 +28,6 @@ environment:
       - liburing-dev
       - ncurses
       - ncurses-dev
-      - ninja-build
       - perl
       - pixman-dev
       - py3-packaging
@@ -47,12 +46,22 @@ pipeline:
       expected-commit: ff3419cbacdc9ad0715c716afeed65bb21a2bbbc
       tag: v${{package.version}}
 
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-system \
+        --enable-slirp \
+        --enable-linux-aio \
+        --enable-linux-io-uring \
+        --enable-vnc \
+        --target-list=x86_64-softmmu,aarch64-softmmu \
+        --prefix=/usr
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
   - runs: |
-      mkdir build
-      cd build
-      ../configure --enable-system --enable-slirp --enable-vnc --target-list=x86_64-softmmu,aarch64-softmmu --prefix=${{targets.destdir}}/usr
-      make -j$(nproc)
-      make install
       # Remove this firmware file, which we don't need, but requires so:dld.sl, which we don't have
       rm -f ${{targets.destdir}}/usr/share/qemu/hppa-firmware64.img
       # Can't use strip pipeline; there are some binaries that melange can't strip,
@@ -64,11 +73,17 @@ subpackages:
     description: "QEMU iPXE roms"
     pipeline:
       - runs: |
-          set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu/
           for i in e1000 e1000e eepro100 ne2k_pci pcnet rtl8139 virtio vmxnet3; do
             mv "${{targets.destdir}}"/usr/share/qemu/efi-$i.rom "${{targets.subpkgdir}}"/usr/share/qemu/
           done
+    test:
+      pipeline:
+        - name: Ensure that ROMs got properly moved
+          runs: |
+            for i in e1000 e1000e eepro100 ne2k_pci pcnet rtl8139 virtio vmxnet3; do
+              stat "/usr/share/qemu/efi-$i.rom"
+            done
 
   - name: ${{package.name}}-utils # in Alpine this is qemu-img
     description: "QEMU utils"
@@ -82,15 +97,16 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            qemu-img --version
-            qemu-img --help
+            qemu-img --version | grep "${{package.version}}"
+            qemu-img --help | grep "QEMU disk image utility"
+            qemu-io --version | grep "${{package.version}}"
+            qemu-io --help | grep "QEMU Disk exerciser"
+            qemu-nbd --version | grep "${{package.version}}"
+            qemu-nbd --help | grep "QEMU Disk Network Block Device Utility"
+            qemu-storage-daemon --version | grep "${{package.version}}"
+            qemu-storage-daemon --help | grep "QEMU storage daemon"
             qemu-img create -f qcow2 disk1.img 1G
-            qemu-io --version
-            qemu-io --help
-            qemu-nbd --version
-            qemu-nbd --help
-            qemu-storage-daemon --version
-            qemu-storage-daemon --help
+            stat disk1.img
 
   - name: ${{package.name}}-system-x86_64
     description: "QEMU x86 system"
@@ -99,7 +115,6 @@ subpackages:
         - ${{package.name}}-ipxe
     pipeline:
       - runs: |
-          set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/qemu-system-x86_64 "${{targets.subpkgdir}}"/usr/bin/
 
@@ -117,8 +132,8 @@ subpackages:
             - curl
       pipeline:
         - runs: |
-            qemu-system-x86_64 --version
-            qemu-system-x86_64 --help
+            qemu-system-x86_64 --version | grep "${{package.version}}"
+            qemu-system-x86_64 --help | grep "usage: qemu-system-x86_64"
 
             # Basic test to launch a kernel with QEMU
             #
@@ -150,7 +165,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/qemu/edk2-aarch64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
 
           # arm vars are same as format as aarch64, but this is easier for consumer.
-          cp "${{targets.destdir}}"/usr/share/qemu/edk2-arm-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-aarch64-vars.fd
+          install -Dpm0644 "${{targets.destdir}}"/usr/share/qemu/edk2-arm-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-aarch64-vars.fd
     test:
       environment:
         contents:
@@ -158,8 +173,8 @@ subpackages:
             - curl
       pipeline:
         - runs: |
-            qemu-system-aarch64 --version
-            qemu-system-aarch64 --help
+            qemu-system-aarch64 --version | grep "${{package.version}}"
+            qemu-system-aarch64 --help | grep "usage: qemu-system-aarch64"
             # Basic test to launch a kernel with QEMU
             #
             # First download a kernel from Alpine. Based on:
@@ -179,15 +194,18 @@ test:
     - uses: test/pkgconf
     - runs: |
         for i in /usr/bin/qemu-system-*; do
-          $i --help 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
-          $i --version 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
+          {
+            $i --help | grep "QEMU emulator"
+          } 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
+          {
+            $i --version | grep "${{package.version}}"
+          } 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
         done
-        qemu-edid version
-        qemu-edid help
-        qemu-ga --version
-        qemu-ga --help
-        qemu-pr-helper --version
-        qemu-pr-helper --help
+        qemu-edid -h | grep "test tool for the qemu edid generator"
+        qemu-ga --version | grep "${{package.version}}"
+        qemu-ga --help | grep "QEMU Guest Agent"
+        qemu-pr-helper --version | grep "${{package.version}}"
+        qemu-pr-helper --help | grep "Persistent Reservation helper program"
 
 update:
   enabled: true

--- a/qemu.yaml
+++ b/qemu.yaml
@@ -28,6 +28,7 @@ environment:
       - liburing-dev
       - ncurses
       - ncurses-dev
+      - ninja-build
       - perl
       - pixman-dev
       - py3-packaging
@@ -97,14 +98,15 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            qemu-img --version | grep "${{package.version}}"
-            qemu-img --help | grep "QEMU disk image utility"
-            qemu-io --version | grep "${{package.version}}"
-            qemu-io --help | grep "QEMU Disk exerciser"
-            qemu-nbd --version | grep "${{package.version}}"
-            qemu-nbd --help | grep "QEMU Disk Network Block Device Utility"
-            qemu-storage-daemon --version | grep "${{package.version}}"
-            qemu-storage-daemon --help | grep "QEMU storage daemon"
+            set -o pipefail
+            qemu-img --version | grep -F "${{package.version}}"
+            qemu-img --help | grep -F "QEMU disk image utility"
+            qemu-io --version | grep -F "${{package.version}}"
+            qemu-io --help | grep -F "QEMU Disk exerciser"
+            qemu-nbd --version | grep -F "${{package.version}}"
+            qemu-nbd --help | grep -F "QEMU Disk Network Block Device Utility"
+            qemu-storage-daemon --version | grep -F "${{package.version}}"
+            qemu-storage-daemon --help | grep -F "QEMU storage daemon"
             qemu-img create -f qcow2 disk1.img 1G
             stat disk1.img
 
@@ -173,8 +175,8 @@ subpackages:
             - curl
       pipeline:
         - runs: |
-            qemu-system-aarch64 --version | grep "${{package.version}}"
-            qemu-system-aarch64 --help | grep "usage: qemu-system-aarch64"
+            qemu-system-aarch64 --version | grep -F "${{package.version}}"
+            qemu-system-aarch64 --help | grep -F "usage: qemu-system-aarch64"
             # Basic test to launch a kernel with QEMU
             #
             # First download a kernel from Alpine. Based on:
@@ -195,17 +197,17 @@ test:
     - runs: |
         for i in /usr/bin/qemu-system-*; do
           {
-            $i --help | grep "QEMU emulator"
+            $i --help | grep -F "QEMU emulator"
           } 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
           {
-            $i --version | grep "${{package.version}}"
+            $i --version | grep -F "${{package.version}}"
           } 2>/dev/null && echo "$i --> OKAY" || echo "$i --> FAIL"
         done
-        qemu-edid -h | grep "test tool for the qemu edid generator"
-        qemu-ga --version | grep "${{package.version}}"
-        qemu-ga --help | grep "QEMU Guest Agent"
-        qemu-pr-helper --version | grep "${{package.version}}"
-        qemu-pr-helper --help | grep "Persistent Reservation helper program"
+        qemu-edid -h | grep -F "test tool for the qemu edid generator"
+        qemu-ga --version | grep -F "${{package.version}}"
+        qemu-ga --help | grep -F "QEMU Guest Agent"
+        qemu-pr-helper --version | grep -F "${{package.version}}"
+        qemu-pr-helper --help | grep -F "Persistent Reservation helper program"
 
 update:
   enabled: true

--- a/qemu.yaml
+++ b/qemu.yaml
@@ -90,7 +90,6 @@ subpackages:
     description: "QEMU utils"
     pipeline:
       - runs: |
-          set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           for i in img io nbd storage-daemon; do
             mv "${{targets.destdir}}"/usr/bin/qemu-$i "${{targets.subpkgdir}}"/usr/bin/
@@ -134,6 +133,7 @@ subpackages:
             - curl
       pipeline:
         - runs: |
+            set -o pipefail
             qemu-system-x86_64 --version | grep "${{package.version}}"
             qemu-system-x86_64 --help | grep "usage: qemu-system-x86_64"
 
@@ -158,7 +158,6 @@ subpackages:
         - ${{package.name}}-ipxe
     pipeline:
       - runs: |
-          set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/qemu-system-aarch64 "${{targets.subpkgdir}}"/usr/bin/
 
@@ -175,6 +174,7 @@ subpackages:
             - curl
       pipeline:
         - runs: |
+            set -o pipefail
             qemu-system-aarch64 --version | grep -F "${{package.version}}"
             qemu-system-aarch64 --help | grep -F "usage: qemu-system-aarch64"
             # Basic test to launch a kernel with QEMU
@@ -195,6 +195,7 @@ test:
     - uses: test/tw/ldd-check
     - uses: test/pkgconf
     - runs: |
+        set -o pipefail
         for i in /usr/bin/qemu-system-*; do
           {
             $i --help | grep -F "QEMU emulator"


### PR DESCRIPTION
Older title was too big, I believe this might be ok? 
- Also changed a few things to `install` instead of `cp`
- `qemu-edid` was displaying garbled data on the tests because the `help`/`version` options don't seem to exist
- Hopefully from now on we could specify what exactly we want on the build so we can clear up old dependencies easier in the future