### PR TITLE
daemon-check-output - fix output after timeout.

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -185,7 +185,7 @@ pipeline:
 
       while [ $# -ne 0 ]; do
           if grep -q "$1" "$OUT_F"; then
-              info "found within $n seconds: $line"
+              info "found within $n seconds: $1"
               found=$((found+1))
           else
               info "missing expected output: $1"


### PR DESCRIPTION
seen in a run of this pipeline for
https://github.com/wolfi-dev/os/pull/56442, the timeout was reached and then we saw 'found within 31 seconds:' repeated 5 times.

This will fix that and print what things _were_ found.
