### PR TITLE
feat: add tofu-controller package

### DIFF
--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,17 +1,19 @@
 package:
   name: tofu-controller
-  version: "0.16.0"
+  version: "0.16.0_rc5"
   epoch: 0
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0
 
-# only needed because of the rc tag, once we're not using that we can remove this
-# currently tracking tag: '-rc.5'
+# using apk-v2 friendly spec version format for package version string
+# need to transform version to match upstream rc tag: '0.16.0-rc.5'
+# this is only needed because of the rc tag, once we're not using that we can remove this
+# and change package version string to conventional 'X.Y.Z' format
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+).(\d+).(\d+).*
-    replace: ${1}.${2}.${3}-rc.5
+    match: ^(\d+)\.(\d+)\.(\d+)_([a-zA-Z]+)(\d+)$
+    replace: ${1}.${2}.${3}-${4}.${5}
     to: rc-package-version
 
 pipeline:
@@ -70,7 +72,6 @@ update:
     identifier: flux-iac/tofu-controller
     strip-prefix: v
     use-tag: true
-    tag-filter: ${{vars.rc-package-version}}
 
 test:
   pipeline:

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -74,6 +74,13 @@ update:
     use-tag: true
 
 test:
+  environment:
+    environment:
+      POD_NAMESPACE: default
+    contents:
+      packages:
+        - openssl
+        - ${{package.name}}-runner
   pipeline:
     - uses: test/kwok/cluster
     - name: "Install required CRD for tofu controller to pick up"
@@ -110,3 +117,43 @@ test:
         grep -q "starting server" /tmp/tofu-controller.log
         grep -q "Starting EventSource" /tmp/tofu-controller.log
         grep -q "Starting Controller" /tmp/tofu-controller.log
+    - name: "Startup tf-runner"
+      runs: |
+        # Generating a self-signed TLS cert key for use with tf-runner.
+        # Upstream code for tf-runner attempts to parse the private key using 'x509.ParsePKCS1PrivateKey', which
+        # only supports traditional PKCS#1 (RSA) key format.
+        # REF: https://github.com/flux-iac/tofu-controller/blob/67198a27f35b97119492965ea1fe7a9034cc4476/mtls/rotator.go#L521
+        #
+        # If the key is provided in PKCS#8 format (default in OpenSSL 3.x),
+        # tf-runner will fail at startup with: 
+        #     "failed to parse private key (use ParsePKCS8PrivateKey instead for this key format)"
+        #
+        # To avoid this error, we convert the PKCS#8 key to to PKCS#1
+
+        CERTDIR="$(mktemp -d)"
+        openssl genpkey -algorithm RSA -out "${CERTDIR}/tmp.key" -pkeyopt rsa_keygen_bits:2048
+        openssl pkey -in "${CERTDIR}/tmp.key" -out "${CERTDIR}/tls.key" -traditional
+        
+        openssl req -new -x509 -sha256 -days 365 \
+        -key "${CERTDIR}/tls.key" \
+        -out "${CERTDIR}/tls.crt" \
+        -subj "/CN=localhost/O=Test tfrunner./C=US"
+        
+        # Create secret for tf-runner
+        kubectl create secret generic tf-runner-tls \
+        --from-file=tls.crt="${CERTDIR}/tls.crt" \
+        --from-file=tls.key="${CERTDIR}/tls.key" \
+        --from-file=ca.crt="${CERTDIR}/tls.crt" \
+        --from-file=ca.key="${CERTDIR}/tls.key"
+        
+        # Startup tf-runner
+        tf-runner --tls-secret-name="tf-runner-tls" > /tmp/tf-runner.log 2>&1 &
+        sleep 3
+        ps aux | grep -q tf-runner
+    - name: "TF-Runner Validations"
+      runs: |
+        grep -q "Starting the runner" /tmp/tf-runner.log
+      
+
+        
+

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,16 +1,23 @@
 package:
   name: tofu-controller
-  version: "0.16.0-rc.5"
+  version: "0.16.0"
   epoch: 0
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0
 
+# only needed because of the rc tag, once we're not using that we can remove this
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).(\d+).(\d+).*
+    replace: ${1}.${2}.${3}-rc.5
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/flux-iac/tofu-controller.git
-      tag: v${{package.version}}
+      tag: v${{vars.mangled-package-version}}
       expected-commit: 01bbcd1540eb90d6f453739756ab43d092f241e4
 
   - uses: go/bump
@@ -23,7 +30,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/manager/main.go
-      output: tf-controller
+      output: tofu-controller
       ldflags: -X main.BuildSHA=$(git rev-parse HEAD) -X main.BuildVersion=$(git describe --tags $(git rev-list --tags --max-count=1))
 
 update:
@@ -36,4 +43,4 @@ test:
   pipeline:
     - name: "Basic smoke test"
       runs: |
-        tf-controller --help
+        tofu-controller --help

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,6 +1,6 @@
 package:
   name: tofu-controller
-  version: "0.15.1"
+  version: "0.16.0-rc.5"
   epoch: 0
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
@@ -11,7 +11,7 @@ pipeline:
     with:
       repository: https://github.com/flux-iac/tofu-controller.git
       tag: v${{package.version}}
-      expected-commit: a53488094851773978301511922c2ced1397cdf9
+      expected-commit: 01bbcd1540eb90d6f453739756ab43d092f241e4
 
   - uses: go/build
     with:
@@ -21,8 +21,6 @@ pipeline:
 
 update:
   enabled: true
-  ignore-regex-patterns:
-    - '-rc'
   github:
     identifier: flux-iac/tofu-controller
     strip-prefix: v

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -69,6 +69,8 @@ update:
   github:
     identifier: flux-iac/tofu-controller
     strip-prefix: v
+    use-tag: true
+    tag-filter: ${{vars.rc-package-version}}
 
 test:
   pipeline:

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,0 +1,34 @@
+package:
+  name: tofu-controller
+  version: "0.15.1"
+  epoch: 0
+  description: A GitOps OpenTofu and Terraform controller for Flux
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/flux-iac/tofu-controller.git
+      tag: v${{package.version}}
+      expected-commit: a53488094851773978301511922c2ced1397cdf9
+
+  - uses: go/build
+    with:
+      packages: ./cmd/manager/main.go
+      output: tf-controller
+      ldflags: -X main.BuildSHA=$(git rev-parse HEAD) -X main.BuildVersion=$(git describe --tags $(git rev-list --tags --max-count=1))
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '-rc'
+  github:
+    identifier: flux-iac/tofu-controller
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: "Basic smoke test"
+      runs: |
+        tf-controller --help

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -5,6 +5,15 @@ package:
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - git
+      - gnupg
+      - libcrypto3
+      - libretls
+      - libssl3
+      - openssh-client
+      - tini
 
 # using apk-v2 friendly spec version format for package version string
 # need to transform version to match upstream rc tag: '0.16.0-rc.5'
@@ -125,7 +134,7 @@ test:
         # REF: https://github.com/flux-iac/tofu-controller/blob/67198a27f35b97119492965ea1fe7a9034cc4476/mtls/rotator.go#L521
         #
         # If the key is provided in PKCS#8 format (default in OpenSSL 3.x),
-        # tf-runner will fail at startup with: 
+        # tf-runner will fail at startup with:
         #     "failed to parse private key (use ParsePKCS8PrivateKey instead for this key format)"
         #
         # To avoid this error, we convert the PKCS#8 key to to PKCS#1
@@ -133,19 +142,19 @@ test:
         CERTDIR="$(mktemp -d)"
         openssl genpkey -algorithm RSA -out "${CERTDIR}/tmp.key" -pkeyopt rsa_keygen_bits:2048
         openssl pkey -in "${CERTDIR}/tmp.key" -out "${CERTDIR}/tls.key" -traditional
-        
+
         openssl req -new -x509 -sha256 -days 365 \
         -key "${CERTDIR}/tls.key" \
         -out "${CERTDIR}/tls.crt" \
         -subj "/CN=localhost/O=Test tfrunner./C=US"
-        
+
         # Create secret for tf-runner
         kubectl create secret generic tf-runner-tls \
         --from-file=tls.crt="${CERTDIR}/tls.crt" \
         --from-file=tls.key="${CERTDIR}/tls.key" \
         --from-file=ca.crt="${CERTDIR}/tls.crt" \
         --from-file=ca.key="${CERTDIR}/tls.key"
-        
+
         # Startup tf-runner
         tf-runner --tls-secret-name="tf-runner-tls" > /tmp/tf-runner.log 2>&1 &
         sleep 3
@@ -153,7 +162,3 @@ test:
     - name: "TF-Runner Validations"
       runs: |
         grep -q "Starting the runner" /tmp/tf-runner.log
-      
-
-        
-

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -7,17 +7,18 @@ package:
     - license: Apache-2.0
 
 # only needed because of the rc tag, once we're not using that we can remove this
+# currently tracking tag: '-rc.5'
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+).(\d+).(\d+).*
     replace: ${1}.${2}.${3}-rc.5
-    to: mangled-package-version
+    to: rc-package-version
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/flux-iac/tofu-controller.git
-      tag: v${{vars.mangled-package-version}}
+      tag: v${{vars.rc-package-version}}
       expected-commit: 01bbcd1540eb90d6f453739756ab43d092f241e4
 
   - uses: go/bump
@@ -29,9 +30,39 @@ pipeline:
 
   - uses: go/build
     with:
+      extra-args: -gcflags="-N -l"
       packages: ./cmd/manager/main.go
       output: tofu-controller
-      ldflags: -X main.BuildSHA=$(git rev-parse HEAD) -X main.BuildVersion=$(git describe --tags $(git rev-list --tags --max-count=1))
+      ldflags: |
+        -X main.BuildSHA=$(git rev-parse HEAD)
+        -X main.BuildVersion=${{vars.rc-package-version}}
+
+subpackages:
+  - name: ${{package.name}}-runner
+    description: tf-runner binary for tofu-controller
+    pipeline:
+      - uses: go/build
+        with:
+          extra-args: -gcflags="-N -l"
+          packages: ./cmd/runner/main.go
+          output: tf-runner
+          ldflags: |
+            -X main.BuildSHA=$(git rev-parse HEAD)
+            -X main.BuildVersion=${{vars.rc-package-version}}
+
+  - name: ${{package.name}}-compat
+    description: Compat package for ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          ln -sf /usr/bin/tofu-controller "${{targets.contextdir}}"/usr/local/bin/tofu-controller
+
+  - name: ${{package.name}}-runner-compat
+    description: Compat package for ${{package.name}} runner
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          ln -sf /usr/bin/tf-runner "${{targets.contextdir}}"/usr/local/bin/tf-runner
 
 update:
   enabled: true
@@ -41,6 +72,38 @@ update:
 
 test:
   pipeline:
-    - name: "Basic smoke test"
+    - uses: test/kwok/cluster
+    - name: "Install required CRD for tofu controller to pick up"
       runs: |
-        tofu-controller --help
+        cat <<EOF | kubectl apply -f -
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: terraforms.infra.contrib.fluxcd.io
+        spec:
+          group: infra.contrib.fluxcd.io
+          names:
+            kind: Terraform
+            listKind: TerraformList
+            plural: terraforms
+            singular: terraform
+          scope: Namespaced
+          versions:
+            - name: v1alpha2
+              served: true
+              storage: true
+              schema:
+                openAPIV3Schema:
+                  type: object
+        EOF
+    - name: "Start tofu-controller"
+      runs: |
+        tofu-controller > /tmp/tofu-controller.log 2>&1 &
+        sleep 3
+        ps aux | grep -q tofu-controller
+    - name: "Validations"
+      runs: |
+        grep -q "Starting manager" /tmp/tofu-controller.log
+        grep -q "starting server" /tmp/tofu-controller.log
+        grep -q "Starting EventSource" /tmp/tofu-controller.log
+        grep -q "Starting Controller" /tmp/tofu-controller.log

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -13,6 +13,13 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 01bbcd1540eb90d6f453739756ab43d092f241e4
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
+
   - uses: go/build
     with:
       packages: ./cmd/manager/main.go


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

NOTES:
- Although the upstream docs indicate that multiple versions of tofu-controller are supported, versions `v0.12 - v0.15` haven't been updated in years. 
- The current upstream version that is being actively maintained is:`v0.16.0-rc.5`
- Provides packages for `tofu-controller` and `tf-runner` binaries

REF: https://github.com/flux-iac/tofu-controller

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
