### PR TITLE
Fix subpackage runtime deps, which were meant at the test level

### DIFF
--- a/aws-otel-collector.yaml
+++ b/aws-otel-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-otel-collector
   version: 0.43.3
-  epoch: 0
+  epoch: 1
   description: AWS distro for OpenTelemetry Collector
   copyright:
     - license: Apache-2.0

--- a/aws-otel-collector.yaml
+++ b/aws-otel-collector.yaml
@@ -52,16 +52,17 @@ subpackages:
             /usr/bin/healthcheck --help
 
   - name: ${{package.name}}-compat
-    dependencies:
-      runtime:
-        - ${{package.name}}
-        - ${{package.name}}-healthcheck
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/
           ln -sf /usr/bin/awscollector ${{targets.contextdir}}/awscollector
           ln -sf /usr/bin/healthcheck ${{targets.contextdir}}/healthcheck
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - ${{package.name}}-healthcheck
       pipeline:
         - name: Test root-level symlinks
           runs: |


### PR DESCRIPTION
Previously i'd defined runtime dependencies for the compat package at the package level, these should have been at the test level. As a result, this compat package could not be used across different variations of this image. Doesn't impact any current images - which load all the correct runtime deps.