### PR TITLE
fix(sqlpad): recreate client yarn env for 7.5.4

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: "7.5.4" # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 0
+  epoch: 1
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -40,6 +40,17 @@ pipeline:
         jq ".dependencies.${dep}" package.json > temp.json && mv temp.json package.json
       done
 
+      yarn install
+
+  - working-directory: /home/build/client
+    runs: |
+      # TODO(kwmonroe): v7.5.4 client yarn.lock is broken; recreate it with known good deps
+      # - upstream build failures started with: https://github.com/sqlpad/sqlpad/pull/1270
+      for dep in '"@types/prop-types"="^15.7.15"' '"@types/react"="^19.1.8"'; do
+        jq ".dependencies.${dep}" package.json > temp.json && mv temp.json package.json
+      done
+
+      rm yarn.lock
       yarn install
 
   - uses: patch
@@ -91,7 +102,7 @@ test:
           Migration finished
           Welcome to SQLPad!
         post: |
-          curl -s http://localhost:3000 | grep "<title>SQLPad</title>" > /dev/null 2>&1 &
+          curl -s http://localhost:3000 | grep "<title>SQLPad</title>"
 
 update:
   enabled: true


### PR DESCRIPTION
A recent package update masked failing tests, which happened as a result of broken sqlpad client deps upstream. This was initially noticed on the [package update pr](https://github.com/wolfi-dev/os/pull/55707#pullrequestreview-2931019389) post merge.

This PR fixes the issue by pinning the sqlpad client to a more recent react version and recreating the yarn environment.

Related: https://github.com/chainguard-dev/image-release-stats/issues/5842