### PR TITLE
gcc-14: enable gfortran

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -98,7 +98,7 @@ pipeline:
             --with-arch=$march \
             --with-tune=$mtune \
             --with-specs=$specs \
-            --enable-languages=c,c++ \
+            --enable-languages=c,c++,fortran \
             --enable-bootstrap \
             --enable-gnu-indirect-function \
             --enable-gnu-unique-object \
@@ -197,22 +197,63 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
+  - name: "libgfortran-14"
+    description: "Fortran runtime library provided by GCC"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
+          mv "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/libgfortran.so.* "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/
+    options:
+      no-provides: true
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: "gfortran-14"
+    description: "GNU Fortran Compiler"
+    pipeline:
+      - runs: |
+          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
+          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
+
+          for i in "$_libexecdir" "$_libdir" usr/lib usr/bin; do
+            mkdir -p "${{targets.subpkgdir}}"/$i
+          done
+          mv "${{targets.destdir}}"/usr/bin/*fortran* "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/libgfortran* "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/
+          [ -f "${{targets.destdir}}"/usr/lib/libquadmath* ] && mv "${{targets.destdir}}"/usr/lib/libquadmath* "${{targets.subpkgdir}}"/usr/lib
+
+          mv "${{targets.destdir}}"/$_libdir/finclude "${{targets.subpkgdir}}"/$_libdir
+          mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir
+    dependencies:
+      runtime:
+        - gcc-14
+        - libgfortran-14
+    test:
+      pipeline:
+        - runs: |
+            gfortran-14 --version
+            gfortran-14 --help
+
   - name: 'gcc-14-default'
     description: 'Use GCC 14 as system gcc'
     dependencies:
       provides:
         - gcc=${{package.full-version}}
+        - gfortran=${{package.full-version}}
       runtime:
         - gcc-14=${{package.full-version}}
+        - gfortran-14=${{package.full-version}}
+        - libgfortran
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
 
-          for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
+          for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib gfortran; do
             ln -sf "${{host.triplet.gnu}}-"$i"-14" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
           done
 
-          for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
+          for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gfortran gcov gcov-dump gcov-tool lto-dump; do
             ln -sf $i"-14" "${{targets.subpkgdir}}"/usr/bin/$i
           done
     test:
@@ -232,6 +273,8 @@ subpackages:
             gcc-nm --help
             gcc-ranlib --version
             gcc-ranlib --help
+            gfortran --version
+            gfortran --help
             gcov --version
             gcov --help
             gcov-dump --version


### PR DESCRIPTION
Enable versioned gfortran too. chainguard-2.28 is still on gcc-14 and some projects need gfortran and the 15 gfortran doesn't work with gcc 14 provided crt files and lto plugins. Instead of trying to provide 15 ctr files and lto plugins it is easier to just enable gfortran build in gcc-14 for now for consistent toolchain builds.
