### PR TITLE
py3-sphinxext-opengraph: add new package

### DIFF
--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -57,7 +57,6 @@ subpackages:
         - py${{range.key}}-sphinxcontrib-qthelp
         - py${{range.key}}-sphinxcontrib-serializinghtml
         - py${{range.key}}-tomli
-        - py${{range.key}}-sphinxext-opengraph
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: "8.2.3"
-  epoch: 0
+  epoch: 1
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -57,6 +57,7 @@ subpackages:
         - py${{range.key}}-sphinxcontrib-qthelp
         - py${{range.key}}-sphinxcontrib-serializinghtml
         - py${{range.key}}-tomli
+        - py${{range.key}}-sphinxext-opengraph
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: "8.2.3"
-  epoch: 1
+  epoch: 0
   description: Python Documentation Generator
   copyright:
     - license: MIT

--- a/py3-sphinxext-opengraph.yaml
+++ b/py3-sphinxext-opengraph.yaml
@@ -5,8 +5,6 @@ package:
   description: sphinxcontrib-devhelp is a sphinx extension to generate unique OpenGraph metadata
   copyright:
     - license: BSD-3-Clause
-  dependencies:
-    provider-priority: "0"
 
 vars:
   pypi-package: sphinxext-opengraph
@@ -15,10 +13,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
-      3.11: '311'
-      3.12: '312'
-      3.13: '313'
+      3.10: ''
+      3.11: ''
+      3.12: ''
+      3.13: ''
 
 environment:
   contents:
@@ -37,10 +35,6 @@ subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: python${{range.key}} version of ${{vars.pypi-package}}
-    dependencies:
-      provider-priority: ${{range.value}}
-      provides:
-        - py3-${{vars.pypi-package}}
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -48,6 +42,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}
@@ -65,10 +60,7 @@ subpackages:
 
 test:
   pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
+    - uses: test/emptypackage
 
 update:
   enabled: true

--- a/py3-sphinxext-opengraph.yaml
+++ b/py3-sphinxext-opengraph.yaml
@@ -1,0 +1,77 @@
+package:
+  name: py3-sphinxext-opengraph
+  version: 0.10.0
+  epoch: 0
+  description: sphinxcontrib-devhelp is a sphinx extension to generate unique OpenGraph metadata
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: "0"
+
+vars:
+  pypi-package: sphinxext-opengraph
+  import: sphinxext.opengraph
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-flit-core
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sphinx-doc/sphinxext-opengraph
+      expected-commit: 935e43463e4fc985e56462a6c66f03a540d6c105
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
+
+update:
+  enabled: true
+  github:
+    identifier: sphinx-doc/sphinxext-opengraph
+    strip-prefix: v

--- a/py3-sphinxext-opengraph.yaml
+++ b/py3-sphinxext-opengraph.yaml
@@ -35,6 +35,9 @@ subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+        runtime:
+          - py${{range.key}}-sphinx
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -42,12 +45,11 @@ subpackages:
       - uses: strip
     test:
       pipeline:
-        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}
             imports: |
-              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
+              import ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-sphinxext-opengraph.yaml
+++ b/py3-sphinxext-opengraph.yaml
@@ -36,8 +36,8 @@ subpackages:
     name: py${{range.key}}-${{vars.pypi-package}}
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
-        runtime:
-          - py${{range.key}}-sphinx
+      runtime:
+        - py${{range.key}}-sphinx
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
Add new package, required dependency of some other packages, like smartypants, which has some sphinx-based docs that somehow load this opengraph extension.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/pull/56819

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)