### PR TITLE
Modify package version so it can autoupdate

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,6 +1,6 @@
 package:
   name: ncurses
-  version: 6.5-20250104
+  version: 6.5_p20250104
   epoch: 0
   description: "console display library"
   copyright:
@@ -8,6 +8,12 @@ package:
   dependencies:
     runtime:
       - ncurses-terminfo-base
+
+var-transforms:
+  - from: ${{package.version}}
+    match: _p(\d+)$
+    replace: -$1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -20,7 +26,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}.tgz
+      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
       expected-sha512: 1430238829d52110d8cb4dccfaaf9ef8fdd37a7e9a1c7e7c7ef116971eb497ab7619e2a64552967dde36ac35f95666869667093aca6df7ade72bf5e8f337dee9
 
   - name: Configure
@@ -149,6 +155,9 @@ subpackages:
 
 update:
   enabled: true
+  version-transform:
+    - match: "-"
+      replace: "_p"
   release-monitor:
     identifier: 2057
 

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,6 +1,6 @@
 package:
   name: ncurses
-  version: 6.5_p20241228
+  version: 6.5-20241228
   epoch: 3
   description: "console display library"
   copyright:
@@ -17,17 +17,10 @@ environment:
       - ca-certificates-bundle
       - ncurses
 
-# Turn the date suffix in the version into something that is a valid apk version.
-var-transforms:
-  - from: ${{package.version}}
-    match: _p(\d+)$
-    replace: -$1
-    to: mangled-package-version
-
 pipeline:
   - uses: fetch
     with:
-      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
+      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}.tgz
       expected-sha512: 4ca73f46f598647dea24cbd89a5704eccdf7e52626f15f8271b08bf3bd2221f5bfb327c9b40532a6ebcc4cf1cd58e33bf4c149de9f8abaaafe1e2b0ce4cdf4d8
 
   - name: Configure
@@ -156,9 +149,6 @@ subpackages:
 
 update:
   enabled: true
-  version-transform:
-    - match: _p(\d+)$
-      replace: -$1
   release-monitor:
     identifier: 2057
 

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.5-20241228
-  epoch: 3
+  version: 6.5-20250104
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT
@@ -21,7 +21,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}.tgz
-      expected-sha512: 4ca73f46f598647dea24cbd89a5704eccdf7e52626f15f8271b08bf3bd2221f5bfb327c9b40532a6ebcc4cf1cd58e33bf4c149de9f8abaaafe1e2b0ce4cdf4d8
+      expected-sha512: 1430238829d52110d8cb4dccfaaf9ef8fdd37a7e9a1c7e7c7ef116971eb497ab7619e2a64552967dde36ac35f95666869667093aca6df7ade72bf5e8f337dee9
 
   - name: Configure
     runs: |

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.5_p20241228
-  epoch: 2
+  epoch: 3
   description: "console display library"
   copyright:
     - license: MIT


### PR DESCRIPTION
The ncurses package is currently out of date and it seems the package update config check has been failing silently for months. This PR drops the `_p` in the package version and all the transformations dealing with it and that results in the package update config check now failing because the package is out of date.