### PR TITLE
py3-sphinxcontrib-jsmath: disable version tagging

### DIFF
--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: "8.2.3"
-  epoch: 0
+  epoch: 1
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -68,6 +68,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -38,8 +38,8 @@ pipeline:
     runs: |
       # These greps will fail when this workaround is no longer needed,
       # expected to be the next upstream release.
-      grep tag_build setup.py
-      grep tag_date setup.py
+      grep tag_build setup.cfg
+      grep tag_date setup.cfg
       cat > "$DIST_EXTRA_CONFIG" <<EOF
       [egg_info]
       tag_build =

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 7
+  epoch: 8
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD-3-Clause
@@ -24,6 +24,8 @@ environment:
   contents:
     packages:
       - py3-supported-build-base
+  environment:
+    DIST_EXTRA_CONFIG: build_opts.cfg
 
 pipeline:
   - uses: git-checkout
@@ -31,6 +33,18 @@ pipeline:
       repository: https://github.com/sphinx-doc/sphinxcontrib-jsmath
       expected-commit: e4c69dd2180c7f18330d5c3fb9300ea0e8461911
       tag: ${{package.version}}
+
+  - name: Disable dev version tagging that causes pip-check failures in rdeps
+    runs: |
+      # These greps will fail when this workaround is no longer needed,
+      # expected to be the next upstream release.
+      grep tag_build setup.py
+      grep tag_date setup.py
+      cat > "$DIST_EXTRA_CONFIG" <<EOF
+      [egg_info]
+      tag_build =
+      tag_date  = false
+      EOF
 
 subpackages:
   - range: py-versions
@@ -47,6 +61,7 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}


### PR DESCRIPTION
The tagging breaks pip-check for py3-sphinx:

```
2025/06/20 16:02:55 INFO sphinx 8.2.3 has requirement sphinxcontrib-jsmath>=1.0.1, but you have sphinxcontrib-jsmath 1.0.1.dev20241212.
```

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
