### PR TITLE
Tofu-controller package addition

### DIFF
--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -36,6 +36,7 @@ update:
     - .*-rc.*
   github:
     identifier: flux-iac/tofu-controller
+    use-tag: true
     strip-prefix: v
 
 test:

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -18,7 +18,7 @@ pipeline:
       deps: |-
         github.com/cyphar/filepath-securejoin@v0.2.4
         github.com/hashicorp/go-retryablehttp@v0.7.7
-        golang.org/x/cryptov0.35.0
+        golang.org/x/crypto@v0.35.0
         golang.org/x/net@v0.38.0
         golang.org/x/oauth2@v0.27.0
         google.golang.org/grpc@v1.56.3

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,0 +1,81 @@
+package:
+  name: tofu-controller
+  version: "0.15.1"
+  epoch: 0
+  description: Tofu Controller (previously known as Weave TF-Controller) is a controller for Flux to reconcile OpenTofu and Terraform resources in the GitOps way.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/flux-iac/tofu-controller
+      tag: v${{package.version}}
+      expected-commit: a53488094851773978301511922c2ced1397cdf9
+
+  - uses: go/build
+    with:
+      extra-args: -gcflags="-N -l"
+      packages: ./cmd/manager
+      output: tofu-controller
+      ldflags: |
+        -X main.BuildVersion=${{package.version}} 
+        -X main.BuildSHA=$(git rev-parse HEAD)
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compat package for ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          ln -sf /usr/bin/tofu-controller "${{targets.contextdir}}"/usr/local/bin/tofu-controller
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - .*-rc.*
+  github:
+    identifier: flux-iac/tofu-controller
+    strip-prefix: v
+
+
+test:
+  environment:
+    contents:
+      packages:
+        - mkcert
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: "Install required CRD for tofu controller to pick up"
+      runs: |
+        cat <<EOF | kubectl apply -f -
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: terraforms.infra.contrib.fluxcd.io
+        spec:
+          group: infra.contrib.fluxcd.io
+          names:
+            kind: Terraform
+            listKind: TerraformList
+            plural: terraforms
+            singular: terraform
+          scope: Namespaced
+          versions:
+            - name: v1alpha2
+              served: true
+              storage: true
+              schema:
+                openAPIV3Schema:
+                  type: object
+        EOF
+    - name: "Start tofu-controller"
+      runs: |
+        tofu-controller > /tmp/tofu-controller.log 2>&1 &
+        sleep 3
+        ps aux | grep tofu-controller
+    - name: "Validation"
+      runs: |
+        grep -q "Starting manager" /tmp/tofu-controller.log
+        grep -q "Starting server" /tmp/tofu-controller.log
+        cat /tmp/tofu-controller.log

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -18,7 +18,7 @@ pipeline:
       deps: |-
         github.com/cyphar/filepath-securejoin@v0.2.4
         github.com/hashicorp/go-retryablehttp@v0.7.7
-        golang.org/x/crypto@v0.35.0
+        golang.org/x/crypto@v0.36.0
         golang.org/x/net@v0.38.0
         golang.org/x/oauth2@v0.27.0
         google.golang.org/grpc@v1.56.3

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -33,7 +33,7 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '-rc'
+    - .*-rc.*
   github:
     identifier: flux-iac/tofu-controller
     use-tag: true

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -33,7 +33,7 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - .*-rc.*
+    - '-rc'
   github:
     identifier: flux-iac/tofu-controller
     use-tag: true

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -13,6 +13,17 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a53488094851773978301511922c2ced1397cdf9
 
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/cyphar/filepath-securejoin@v0.2.4
+        github.com/hashicorp/go-retryablehttp@v0.7.7
+        golang.org/x/cryptov0.35.0
+        golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
+        google.golang.org/grpc@v1.56.3
+        google.golang.org/protobuf@v1.33.0
+
   - uses: go/build
     with:
       extra-args: -gcflags="-N -l"

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -19,7 +19,7 @@ pipeline:
       packages: ./cmd/manager
       output: tofu-controller
       ldflags: |
-        -X main.BuildVersion=${{package.version}} 
+        -X main.BuildVersion=${{package.version}}
         -X main.BuildSHA=$(git rev-parse HEAD)
 
 subpackages:
@@ -38,12 +38,7 @@ update:
     identifier: flux-iac/tofu-controller
     strip-prefix: v
 
-
 test:
-  environment:
-    contents:
-      packages:
-        - mkcert
   pipeline:
     - uses: test/kwok/cluster
     - name: "Install required CRD for tofu controller to pick up"
@@ -73,9 +68,10 @@ test:
       runs: |
         tofu-controller > /tmp/tofu-controller.log 2>&1 &
         sleep 3
-        ps aux | grep tofu-controller
-    - name: "Validation"
+        ps aux | grep -q tofu-controller
+    - name: "Validations"
       runs: |
         grep -q "Starting manager" /tmp/tofu-controller.log
         grep -q "Starting server" /tmp/tofu-controller.log
-        cat /tmp/tofu-controller.log
+        grep -q "Starting EventSource" /tmp/tofu-controller.log
+        grep -q "Starting Controller" /tmp/tofu-controller.log


### PR DESCRIPTION
**tofu-controller package** `Current version: v0.15.1`
- Tofu Controller (previously known as Weave TF-Controller) is a controller for Flux to reconcile OpenTofu and Terraform resources in the GitOps way.

**Type**: Go binary
**REF**: https://github.com/flux-iac/tofu-controller

**Tests:**
- Validation tests against k8s cluster for components: `manager`, `server`, `EventSource` and `Controller`.