### PR TITLE
openssl: build without jitterentropy on 2.28

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: "3.5.0"
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -76,7 +76,7 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
-         enable-jitter \
+         $([ -d /usr/lib/oldglibc ] || echo enable-jitter) \
          shared \
          enable-pie \
          no-zlib \


### PR DESCRIPTION
jitterentropy is compiled to 2.34 glibc ABI level, thus for 2.28
configuration build openssl without it.
