### PR TITLE
Replace ftp.gnu.org with ftpmirror.gnu.org

### DIFF
--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -2,7 +2,7 @@
 package:
   name: autoconf-archive
   version: 2023.02.20
-  epoch: 0
+  epoch: 1
   description: Collection of re-usable GNU Autoconf macros
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33
-      uri: https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
 

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: autoconf
   version: "2.72"
-  epoch: 2
+  epoch: 3
   description: "GNU tool for generating configure scripts"
   copyright:
     - license: GPL-2.0
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/autoconf/autoconf-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/autoconf/autoconf-${{package.version}}.tar.gz
       expected-sha256: afb181a76e1ee72832f6581c0eddf8df032b83e2e0239ef79ebedc4467d92d6e
 
   - runs: |

--- a/automake.yaml
+++ b/automake.yaml
@@ -1,7 +1,7 @@
 package:
   name: automake
   version: "1.18"
-  epoch: 0
+  epoch: 1
   description: "GNU tool for generating makefiles"
   copyright:
     - license: GPL-2.0
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/automake/automake-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/automake/automake-${{package.version}}.tar.xz
       expected-sha256: 5bdccca96b007a7e344c24204b9b9ac12ecd17f5971931a9063bdee4887f4aaf
 
   - runs: |

--- a/bc.yaml
+++ b/bc.yaml
@@ -2,7 +2,7 @@
 package:
   name: bc
   version: "1.08.2"
-  epoch: 0
+  epoch: 1
   description: An arbitrary precision numeric processing language (calculator)
   copyright:
     - license: GPL-3.0-or-later
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: ae470fec429775653e042015edc928d07c8c3b2fc59765172a330d3d87785f86
-      uri: https://ftp.gnu.org/gnu/bc/bc-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/bc/bc-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.7"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -30,7 +30,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/coreutils/coreutils-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${{package.version}}.tar.xz
       expected-sha256: e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf
 
   - runs: |

--- a/cpio.yaml
+++ b/cpio.yaml
@@ -1,7 +1,7 @@
 package:
   name: cpio
   version: "2.15"
-  epoch: 1
+  epoch: 2
   description: tool to copy files into or out of a cpio or tar archive
   copyright:
     - license: GPL-3.0-or-later
@@ -18,7 +18,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 937610b97c329a1ec9268553fb780037bcfff0dcffe9725ebc4fd9c1aa9075db
-      uri: https://ftp.gnu.org/gnu/cpio/cpio-${{package.version}}.tar.bz2
+      uri: https://ftpmirror.gnu.org/gnu/cpio/cpio-${{package.version}}.tar.bz2
 
   - uses: autoconf/configure
 

--- a/diffutils.yaml
+++ b/diffutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: diffutils
   version: "3.12"
-  epoch: 0
+  epoch: 1
   description: "GNU diff utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/diffutils/diffutils-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/diffutils/diffutils-${{package.version}}.tar.xz
       expected-sha256: 7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd
 
   - runs: |

--- a/ed.yaml
+++ b/ed.yaml
@@ -1,7 +1,7 @@
 package:
   name: ed
   version: "1.21.1"
-  epoch: 0
+  epoch: 1
   description: Line-oriented text editor used to create, display, modify and otherwise manipulate text files
   copyright:
     - license: GPL-2.0-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: d6d0c7192b02b0519c902a93719053e865ade5a784a3b327d93d888457b23c4b
-      uri: https://ftp.gnu.org/gnu/ed/ed-${{package.version}}.tar.lz
+      uri: https://ftpmirror.gnu.org/gnu/ed/ed-${{package.version}}.tar.lz
       extract: false
 
   - runs: |

--- a/findutils.yaml
+++ b/findutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: findutils
   version: 4.10.0
-  epoch: 1
+  epoch: 2
   description: "GNU find utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/findutils/findutils-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/findutils/findutils-${{package.version}}.tar.xz
       expected-sha256: 1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5
 
   - runs: |

--- a/font-freefont.yaml
+++ b/font-freefont.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-freefont
   version: 20120503
-  epoch: 0
+  epoch: 1
   description: A set of free high-quality TrueType fonts covering the UCS character set
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 7c85baf1bf82a1a1845d1322112bc6ca982221b484e3b3925022e25b5cae89af
-      uri: https://ftp.gnu.org/gnu/freefont/freefont-ttf-${{package.version}}.zip
+      uri: https://ftpmirror.gnu.org/gnu/freefont/freefont-ttf-${{package.version}}.zip
       extract: false
 
   - runs: |

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -1,7 +1,7 @@
 package:
   name: gawk
   version: "5.3.2"
-  epoch: 1
+  epoch: 2
   description: "GNU awk pattern-matching language"
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gawk/gawk-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/gawk/gawk-${{package.version}}.tar.gz
       expected-sha256: 8639a1a88fb411a1be02663739d03e902a6d313b5c6fe024d0bfeb3341a19a11
 
   - name: Configure

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.3"
-  epoch: 0
+  epoch: 1
   description: The GNU Debugger
   copyright:
     - license: GPL-2.0
@@ -31,7 +31,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5
-      uri: https://ftp.gnu.org/gnu/gdb/gdb-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gdb/gdb-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
     with:

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: "1.25"
-  epoch: 1
+  epoch: 2
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gdbm/gdbm-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/gdbm/gdbm-${{package.version}}.tar.gz
       expected-sha256: d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec
 
   - name: Configure

--- a/gengetopt.yaml
+++ b/gengetopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: gengetopt
   version: 2.23
-  epoch: 0
+  epoch: 1
   description: "A tool to write command line option parsing code for C programs"
   copyright:
     - license: GPL-3.0-or-later
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gengetopt/gengetopt-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-${{package.version}}.tar.xz
       expected-sha256: b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac
 
   - uses: autoconf/configure

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,7 +1,7 @@
 package:
   name: gettext
   version: 0.22.5
-  epoch: 2
+  epoch: 3
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT
@@ -26,7 +26,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: fe10c37353213d78a5b83d48af231e005c4da84db5ce88037d88355938259640
-      uri: https://ftp.gnu.org/gnu/gettext/gettext-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gettext/gettext-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
     with:

--- a/glpk.yaml
+++ b/glpk.yaml
@@ -1,7 +1,7 @@
 package:
   name: glpk
   version: 5.0
-  epoch: 3
+  epoch: 4
   description: The GLPK (GNU Linear Programming Kit) package is intended for solving large-scale linear programming (LP), mixed integer programming (MIP), and other related problems
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15
-      uri: https://ftp.gnu.org/gnu/glpk/glpk-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/glpk/glpk-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 6
+  epoch: 7
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/gmp/gmp-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/gmp/gmp-${{package.version}}.tar.xz
       expected-sha256: a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
 
   - runs: |

--- a/gnu-libiconv.yaml
+++ b/gnu-libiconv.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnu-libiconv
   version: "1.18"
-  epoch: 1
+  epoch: 2
   description: GNU charset conversion library for libc which doesn't implement it
   copyright:
     - license: LGPL-2.1-or-later
@@ -19,7 +19,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8
-      uri: https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${{package.version}}.tar.gz
 
   - runs: |
       ./configure \

--- a/gnucobol.yaml
+++ b/gnucobol.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnucobol
   version: 3.2
-  epoch: 2
+  epoch: 3
   description: "compiler from COBOL to C"
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/pub/gnu/gnucobol/gnucobol-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${{package.version}}.tar.gz
       expected-sha256: 29f30a77176015847f0afb2e22939e39798bb4d98c7c7a26f6765930b4553c52
 
   - uses: autoconf/configure

--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutar
   version: "1.35"
-  epoch: 3
+  epoch: 4
   description: "The GNU Tar program"
   copyright:
     - license: GPL-3.0-or-later
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/tar/tar-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/tar/tar-${{package.version}}.tar.gz
       expected-sha256: 14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e
 
   - uses: autoconf/configure

--- a/gperf.yaml
+++ b/gperf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gperf
   version: "3.3"
-  epoch: 0
+  epoch: 1
   description: Perfect hash function generator.
   copyright:
     - license: GPL-3.0-or-later
@@ -19,7 +19,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8
-      uri: https://ftp.gnu.org/gnu/gperf/gperf-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/gperf/gperf-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/grep.yaml
+++ b/grep.yaml
@@ -1,7 +1,7 @@
 package:
   name: grep
   version: "3.12"
-  epoch: 1
+  epoch: 2
   description: "GNU grep implementation"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/grep/grep-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/grep/grep-${{package.version}}.tar.gz
       expected-sha256: badda546dfc4b9d97e992e2c35f3b5c7f20522ffcbe2f01ba1e9cdcbe7644cdc
 
   - name: Configure

--- a/groff.yaml
+++ b/groff.yaml
@@ -1,7 +1,7 @@
 package:
   name: groff
   version: 1.23.0
-  epoch: 5
+  epoch: 6
   description: GNU troff text-formatting system
   copyright:
     - license: GPL-3.0-or-later
@@ -27,7 +27,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 6b9757f592b7518b4902eb6af7e54570bdccba37a871fddb2d30ae3863511c13
-      uri: https://ftp.gnu.org/gnu/groff/groff-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/groff/groff-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/gsl.yaml
+++ b/gsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: gsl
   version: "2.8"
-  epoch: 1
+  epoch: 2
   description: Modern numerical library for C and C++ programmers
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190
-      uri: https://ftp.gnu.org/gnu/gsl/gsl-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/gsl/gsl-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/guile.yaml
+++ b/guile.yaml
@@ -1,7 +1,7 @@
 package:
   name: guile
   version: 3.0.10
-  epoch: 2
+  epoch: 3
   description: portable, embeddable Scheme implementation written in C
   copyright:
     - license: LGPL-3.0-or-later AND GPL-3.0-or-later
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 2dbdbc97598b2faf31013564efb48e4fed44131d28e996c26abe8a5b23b56c2a
-      uri: https://ftp.gnu.org/gnu/guile/guile-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/guile/guile-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/hello-wolfi.yaml
+++ b/hello-wolfi.yaml
@@ -1,7 +1,7 @@
 package:
   name: hello-wolfi
   version: "2.12.2"
-  epoch: 0
+  epoch: 1
   description: "the GNU hello world program"
   copyright:
     - paths:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
       expected-sha256: 5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab
 
   - uses: autoconf/configure

--- a/help2man.yaml
+++ b/help2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: help2man
   version: 1.49.3
-  epoch: 3
+  epoch: 4
   description: "Create simple man pages from --help output"
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/help2man/help2man-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/help2man/help2man-${{package.version}}.tar.xz
       expected-sha256: 4d7e4fdef2eca6afe07a2682151cea78781e0a4e8f9622142d9f70c083a2fd4f
 
   - runs: |

--- a/libidn.yaml
+++ b/libidn.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn
   version: "1.43"
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: LGPL-2.1-or-later
@@ -19,7 +19,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: bdc662c12d041b2539d0e638f3a6e741130cdb33a644ef3496963a443482d164
-      uri: https://ftp.gnu.org/gnu/libidn/libidn-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/libidn/libidn-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: "2.3.8"
-  epoch: 1
+  epoch: 2
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a
-      uri: https://ftp.gnu.org/gnu/libidn/libidn2-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/libidn/libidn2-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/libmicrohttpd.yaml
+++ b/libmicrohttpd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmicrohttpd
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: small C library that is supposed to make it easy to run an HTTP server as part of another application
   copyright:
     - license: LGPL-2.1-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94
-      uri: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/libtasn1.yaml
+++ b/libtasn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtasn1
   version: "4.20.0"
-  epoch: 3
+  epoch: 4
   description: The ASN.1 library used in GNUTLS
   copyright:
     - license: LGPL-2.1-or-later
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c
-      uri: https://ftp.gnu.org/gnu/libtasn1/libtasn1-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunistring
   version: "1.3"
-  epoch: 2
+  epoch: 3
   description: Library for manipulating Unicode strings and C strings
   copyright:
     - license: GPL-2.0-or-later OR LGPL-3.0-or-later
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527
-      uri: https://ftp.gnu.org/gnu/libunistring/libunistring-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/libunistring/libunistring-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
     with:

--- a/m4.yaml
+++ b/m4.yaml
@@ -1,7 +1,7 @@
 package:
   name: m4
   version: "1.4.20"
-  epoch: 3
+  epoch: 4
   description: "GNU macro processor"
   copyright:
     - license: GPL-3.0
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/m4/m4-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/m4/m4-${{package.version}}.tar.gz
       expected-sha256: 6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef
 
   - name: Configure

--- a/make.yaml
+++ b/make.yaml
@@ -1,7 +1,7 @@
 package:
   name: make
   version: 4.4.1
-  epoch: 6
+  epoch: 7
   description: "GNU make"
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/make/make-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/make/make-${{package.version}}.tar.gz
       expected-sha256: dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3
 
   - name: Configure

--- a/mtools.yaml
+++ b/mtools.yaml
@@ -1,7 +1,7 @@
 package:
   name: mtools
   version: "4.0.49"
-  epoch: 0
+  epoch: 1
   description: collection of utilities to access MS-DOS disks from Unix without mounting them
   copyright:
     - license: GPL-3.0-or-later
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/mtools/mtools-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/mtools/mtools-${{package.version}}.tar.gz
       expected-sha256: 10cd1111da87bf2400a380c1639a6cba8bfb937a24f9c51f5f88d393ae5f6f76
 
   - uses: autoconf/configure

--- a/nettle.yaml
+++ b/nettle.yaml
@@ -1,7 +1,7 @@
 package:
   name: nettle
   version: 3.10.1
-  epoch: 2
+  epoch: 3
   description: A low-level cryptographic library
   copyright:
     - license: LGPL-3.0
@@ -24,7 +24,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: b0fcdd7fc0cdea6e80dcf1dd85ba794af0d5b4a57e26397eee3bc193272d9132
-      uri: https://ftp.gnu.org/gnu/nettle/nettle-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/nettle/nettle-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/parallel.yaml
+++ b/parallel.yaml
@@ -1,7 +1,7 @@
 package:
   name: parallel
   version: "20250622"
-  epoch: 0
+  epoch: 1
   description: "GNU parallel is a shell tool for executing jobs in parallel using one or more computers"
   copyright:
     - license: GPL-3.0-or-later
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/parallel/parallel-${{package.version}}.tar.bz2
+      uri: https://ftpmirror.gnu.org/gnu/parallel/parallel-${{package.version}}.tar.bz2
       expected-sha256: 69f578cf11f1b124ba3c2b673a16641debe63aeb3d2ac4cec5ad65f8a53d489b
 
   - uses: autoconf/configure

--- a/patch.yaml
+++ b/patch.yaml
@@ -1,7 +1,7 @@
 package:
   name: patch
   version: "2.8"
-  epoch: 1
+  epoch: 2
   description: "GNU patch"
   copyright:
     - license: GPL-3.0-or-later
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/patch/patch-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/patch/patch-${{package.version}}.tar.gz
       expected-sha256: 308a4983ff324521b9b21310bfc2398ca861798f02307c79eb99bb0e0d2bf980
 
   - runs: |

--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: 8.2.13
-  epoch: 4
+  epoch: 5
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/readline/readline-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/readline/readline-${{package.version}}.tar.gz
       expected-sha256: 0e5be4d2937e8bd9b7cd60d46721ce79f88a33415dd68c2d738fb5924638f656
 
   - uses: patch

--- a/screen.yaml
+++ b/screen.yaml
@@ -2,7 +2,7 @@
 package:
   name: screen
   version: "5.0.1"
-  epoch: 0
+  epoch: 1
   description: Window manager that multiplexes a physical terminal
   copyright:
     - license: GPL-3.0-or-later
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d
-      uri: https://ftp.gnu.org/gnu/screen/screen-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/screen/screen-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/sed.yaml
+++ b/sed.yaml
@@ -1,7 +1,7 @@
 package:
   name: sed
   version: "4.9"
-  epoch: 4
+  epoch: 5
   description: "GNU stream editor"
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/sed/sed-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/sed/sed-${{package.version}}.tar.gz
       expected-sha256: d1478a18f033a73ac16822901f6533d30b6be561bcbce46ffd7abce93602282e
 
   - name: Configure

--- a/texinfo.yaml
+++ b/texinfo.yaml
@@ -1,7 +1,7 @@
 package:
   name: texinfo
   version: "7.2"
-  epoch: 2
+  epoch: 3
   description: "GNU documentation tool"
   copyright:
     - license: GPL-3.0-or-later
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/texinfo/texinfo-${{package.version}}.tar.xz
+      uri: https://ftpmirror.gnu.org/gnu/texinfo/texinfo-${{package.version}}.tar.xz
       expected-sha256: 0329d7788fbef113fa82cb80889ca197a344ce0df7646fe000974c5d714363a6
 
   - name: 'Configure texinfo'

--- a/unrtf.yaml
+++ b/unrtf.yaml
@@ -2,7 +2,7 @@
 package:
   name: unrtf
   version: 0.21.10
-  epoch: 2
+  epoch: 3
   description: Command-line program which converts RTF documents to other formats
   copyright:
     - license: GPL-3.0-or-later
@@ -21,7 +21,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: b49f20211fa69fff97d42d6e782a62d7e2da670b064951f14bbff968c93734ae
-      uri: https://ftp.gnu.org/gnu/unrtf/unrtf-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/unrtf/unrtf-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
 

--- a/wdiff.yaml
+++ b/wdiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: wdiff
   version: "1.2.2"
-  epoch: 1
+  epoch: 2
   description: "GNU diff utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -18,7 +18,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/wdiff/wdiff-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/wdiff/wdiff-${{package.version}}.tar.gz
       expected-sha256: 34ff698c870c87e6e47a838eeaaae729fa73349139fc8db12211d2a22b78af6b
 
   - runs: |

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.25.0
-  epoch: 1
+  epoch: 2
   description: "GNU wget"
   copyright:
     - license: GPL-3.0
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/wget/wget-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/wget/wget-${{package.version}}.tar.gz
       expected-sha256: 766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784
 
   - runs: |


### PR DESCRIPTION
https://ftpmirror.gnu.org is a CDN mirror,
https://ftp.gnu.org

per https://www.gnu.org/prep/ftp.en.html

> please try to use one of the many mirrors of our site listed below:
> the mirrors will give you faster response. Some mirrors also provide a
> copy of the rest of ftp.gnu.org; try the parent directory if you're
> interested. You can use the generic URLs https://ftpmirror.gnu.org and
> http://ftpmirror.gnu.org to automatically choose a nearby and up-to-date
> mirror.
