### PR TITLE
lz4 package: lz4-static fix

### DIFF
--- a/lz4.yaml
+++ b/lz4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lz4
   version: 1.10.0
-  epoch: 3
+  epoch: 4
   description: "lossless high performance compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -24,7 +24,7 @@ pipeline:
   - uses: cmake/configure
     with:
       opts: |
-        -S build/cmake
+        -S build/cmake -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
 
   - uses: cmake/build
 
@@ -46,6 +46,10 @@ subpackages:
     description: "lz4 static library"
     pipeline:
       - uses: split/static
+    test:
+      pipeline:
+        - runs: |
+            test -s /usr/lib/liblz4.a
 
   - name: "lz4-dev"
     description: "lz4 development headers"


### PR DESCRIPTION
 - Add `liblz4.a` [static library version of the LZ4 compression library].
 
 
 This builds both shared and static versions of the library:
- `liblz4.so` (for runtime linking)
- `liblz4.a` (for static linking)