### PR TITLE
sbom: misc no change rebuilds

### DIFF
--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.1"
-  epoch: 3
+  epoch: 4
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later

--- a/hardening-check.yaml
+++ b/hardening-check.yaml
@@ -1,7 +1,7 @@
 package:
   name: hardening-check
   version: "2.25.15"
-  epoch: 0
+  epoch: 1
   description: "Debian devscripts hardening-check"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Previous published tarballs to support SBOM downloadLocations had an
issue with broken symbolic links; these have now been flushed from
object storage to rebuild to retrigger new tarball generation.
