### PR TITLE
protobuf: update to 31.1

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,18 +1,10 @@
 package:
   name: protobuf
-  version: "3.29.5" # On update, please check if -fdelete-null-pointer-checks is still required
+  version: "31.1" # On update, please check if -fdelete-null-pointer-checks is still required
   epoch: 0
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
-
-var-transforms:
-  # 3.26.1 -> 26.1
-  # TODO: Figure out how to make this 26.1.0
-  - from: ${{package.version}}
-    match: \d+\.(\d+\.\d+)
-    replace: $1
-    to: mangled-package-version
 
 environment:
   contents:
@@ -37,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/protocolbuffers/protobuf
       tag: v${{package.version}}
-      expected-commit: f5de0a0495faa63b4186fc767324f8b9a7bf4fc4
+      expected-commit: 74211c0dfc2777318ab53c2cd2c317a2ef9012de
       cherry-picks: |
         main/ced605d0e6a7ad20985375b596b2ca6720e07737: utf8_range: add version marker to library
 
@@ -84,15 +76,15 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv ${{targets.destdir}}/usr/bin/protoc-${{vars.mangled-package-version}}.0 ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/protoc-${{package.version}}.0 ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/protoc ${{targets.subpkgdir}}/usr/bin/protoc
     test:
       pipeline:
         - name: Verify protoc installation
           runs: |
             protoc --version || exit 1
-            protoc-${{vars.mangled-package-version}}.0 --version
-            protoc-${{vars.mangled-package-version}}.0 --help
+            protoc-${{package.version}}.0 --version
+            protoc-${{package.version}}.0 --help
         - name: Compile sample proto file
           runs: |
             echo 'syntax = "proto3"; message Test { string name = 1; }' > test.proto


### PR DESCRIPTION
Update package to 31.1

Related: https://github.com/wolfi-dev/os/pull/56871

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0