### PR TITLE
Withdraw bad provides jdk

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,6 @@
 opa-envoy-1.1.0-r1-r0.apk
+openjdk-24-default-jdk-24.0.1-r5.apk
+openjdk-24-24.0.1-r5.apk
+openjdk-24-jre-24.0.1-r5.apk
+openjdk-24-demos-24.0.1-r5.apk
+openjdk-24-default-jvm-24.0.1-r5.apk


### PR DESCRIPTION
JDK with bad provides has been published, we should withdraw it:

https://github.com/wolfi-dev/os/runs/44622873988