### PR TITLE
rename dotty -> scala-3

### DIFF
--- a/scala-3.7.yaml
+++ b/scala-3.7.yaml
@@ -8,7 +8,7 @@ package:
   dependencies:
     runtime:
       - bash
-      - openjdk-17-default-jdk
+      - openjdk-24-default-jdk
     provides:
       - dotty=${{package.full-version}}
       - scala=${{package.full-version}}
@@ -17,7 +17,7 @@ environment:
   contents:
     packages:
       - busybox
-      - openjdk-17-default-jdk
+      - openjdk-24-default-jdk
       - sbt
 
 pipeline:
@@ -51,7 +51,7 @@ pipeline:
 test:
   environment:
     environment:
-      PATH: /usr/lib/jvm/default-jvm
+      PATH: /usr/lib/jvm/default-jvm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   pipeline:
     - name: Verify that the binaries are installed and executable
       runs: |

--- a/scala-3.7.yaml
+++ b/scala-3.7.yaml
@@ -13,13 +13,14 @@ package:
       - scala=${{package.full-version}}
 
 vars:
+  java-version: "8"
   runtime-java-version: "24"
 
 environment:
   contents:
     packages:
       - busybox
-      - openjdk-8-default-jdk
+      - openjdk-${{vars.java-version}}-default-jdk
       - sbt
   environment:
     RELEASEBUILD: "yes"

--- a/scala-3.7.yaml
+++ b/scala-3.7.yaml
@@ -1,5 +1,5 @@
 package:
-  name: scala-3
+  name: scala-3.7
   version: "3.7.1"
   epoch: 1
   description: The Scala 3 compiler, also known as Dotty.
@@ -11,6 +11,9 @@ package:
     provides:
       - dotty=${{package.full-version}}
       - scala=${{package.full-version}}
+
+vars:
+  runtime-java-version: "24"
 
 environment:
   contents:
@@ -40,9 +43,6 @@ pipeline:
       # Cleaning and removing windows batch files
       find dist/linux-${{build.arch}}/target/universal/stage -name '*.bat' -type f -delete
 
-      # Dropping -bin-SNAPSHOT from the package version
-      sed -i 's/-bin-SNAPSHOT//' dist/linux-${{build.arch}}/target/universal/stage/VERSION
-
       mv dist/linux-${{build.arch}}/target/universal/stage/* ${{targets.contextdir}}/usr/share/scala/
 
       ln -sf /usr/share/scala/bin/scala ${{targets.contextdir}}/usr/bin/scala
@@ -53,9 +53,7 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-24-default-jvm
-    environment:
-      PATH: /usr/lib/jvm/default-jvm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - openjdk-${{vars.runtime-java-version}}-default-jvm
   pipeline:
     - name: Verify that the binaries are installed and executable
       runs: |
@@ -119,3 +117,4 @@ update:
   enabled: true
   github:
     identifier: scala/scala3
+    tag-filter: 3.7.

--- a/scala-3.7.yaml
+++ b/scala-3.7.yaml
@@ -1,25 +1,24 @@
 package:
-  name: dotty
+  name: scala-3.7
   version: "3.7.1"
-  epoch: 0
+  epoch: 1
   description: The Scala 3 compiler, also known as Dotty.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
+      - openjdk-17-default-jdk
     provides:
+      - dotty=${{package.full-version}}
       - scala=${{package.full-version}}
 
 environment:
   contents:
     packages:
-      - build-base
       - busybox
-      - ca-certificates-bundle
-      - openjdk-11-default-jdk
+      - openjdk-17-default-jdk
       - sbt
-      - unzip
 
 pipeline:
   - uses: git-checkout
@@ -28,34 +27,31 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 92a8f3c53f18f27eb73ea305325aab87a6fa8cd2
 
-  - name: Build Dotty
-    runs: |
-      sbt dist/Universal/packageBin
+  - name: Build Scala
+    runs: ./project/scripts/sbt dist-linux-${{build.arch}}/Universal/stage
 
-  - name: Install Dotty
+  - name: Install Scala
     runs: |
       # Create the directories with the correct permissions
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -dm755 "${{targets.destdir}}"/usr/share/scala/
-
-      # Extract the zip file
-      unzip dist/target/universal/scala3-${{package.version}}-bin-SNAPSHOT.zip -d build
+      mkdir -p ${{targets.contextdir}}/usr/bin
+      install -dm755 "${{targets.contextdir}}"/usr/share/scala/
 
       # Cleaning and removing windows batch files
-      rm -rf build/scala3-${{package.version}}-bin-SNAPSHOT/bin/*.bat
-      rm -rf build/scala3-${{package.version}}-bin-SNAPSHOT/libexec/*.bat
+      find dist/linux-${{build.arch}}/target/universal/stage -name '*.bat' -type f -delete
 
-      mv build/scala3-${{package.version}}-bin-SNAPSHOT/* ${{targets.destdir}}/usr/share/scala/
+      # Dropping -bin-SNAPSHOT from the package version
+      sed -i 's/-bin-SNAPSHOT//' dist/linux-${{build.arch}}/target/universal/stage/VERSION
 
-      ln -sf /usr/share/scala/bin/scala ${{targets.destdir}}/usr/bin/scala
-      ln -sf /usr/share/scala/bin/scalac ${{targets.destdir}}/usr/bin/scalac
-      ln -sf /usr/share/scala/bin/scaladoc ${{targets.destdir}}/usr/bin/scaladoc
+      mv dist/linux-${{build.arch}}/target/universal/stage/* ${{targets.contextdir}}/usr/share/scala/
+
+      ln -sf /usr/share/scala/bin/scala ${{targets.contextdir}}/usr/bin/scala
+      ln -sf /usr/share/scala/bin/scalac ${{targets.contextdir}}/usr/bin/scalac
+      ln -sf /usr/share/scala/bin/scaladoc ${{targets.contextdir}}/usr/bin/scaladoc
 
 test:
   environment:
-    contents:
-      packages:
-        - openjdk-11-default-jvm
+    environment:
+      PATH: /usr/lib/jvm/default-jvm
   pipeline:
     - name: Verify that the binaries are installed and executable
       runs: |
@@ -65,7 +61,7 @@ test:
             exit 1
           fi
           # Run the --version command for each binary
-          $bin --version
+          $bin --version | grep ${{package.version}}
         done
     - name: "Test Scala compiler"
       runs: |

--- a/scala-3.yaml
+++ b/scala-3.yaml
@@ -1,5 +1,5 @@
 package:
-  name: scala-3.7
+  name: scala-3
   version: "3.7.1"
   epoch: 1
   description: The Scala 3 compiler, also known as Dotty.
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - bash
-      - openjdk-24-default-jdk
     provides:
       - dotty=${{package.full-version}}
       - scala=${{package.full-version}}
@@ -17,8 +16,10 @@ environment:
   contents:
     packages:
       - busybox
-      - openjdk-24-default-jdk
+      - openjdk-8-default-jdk
       - sbt
+  environment:
+    RELEASEBUILD: "yes"
 
 pipeline:
   - uses: git-checkout
@@ -50,6 +51,9 @@ pipeline:
 
 test:
   environment:
+    contents:
+      packages:
+        - openjdk-24-default-jvm
     environment:
       PATH: /usr/lib/jvm/default-jvm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

The Scala3 compiler is nicknamed "Dotty" however this causes confusion with what is being installed when asking for the latest version of Scala:

```
# apk add scala
...
(1/4) Installing ncurses-terminfo-base (6.5_p20241228-r2)
(2/4) Installing ncurses (6.5_p20241228-r2)
(3/4) Installing bash (5.2.37-r33)
(4/4) Installing dotty (3.7.1-r0)
Executing busybox-1.37.0-r46.trigger
OK: 166 MiB in 20 packages
```

Re-naming the package but keeping the virtual `provides` for `dotty`.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

Note: no current package or image builds are calling for the `dotty` package.