### PR TITLE
rebar3: multiversion depending on multiple erlang versions

### DIFF
--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -1,0 +1,66 @@
+package:
+  name: erl25-rebar3
+  description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
+  epoch: 0
+  version: 3.25.0
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - erlang-${{vars.erlMM}}
+  options:
+    # escript is not provided by any erlang version
+    no-depends: true
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - erlang-${{vars.erlMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/erlang/rebar3.git
+      tag: ${{package.version}}
+      expected-commit: 6243d3fb017c9759ba699850e8a6b57700fbfabd
+
+  - name: Build Rebar3
+    runs: ./bootstrap
+
+  - runs: |
+      install -Dpm0755 -t ${{targets.destdir}}/usr/bin/ ./rebar3
+
+update:
+  enabled: true
+  github:
+    identifier: erlang/rebar3
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^erl(\d\d+)-.*
+    replace: $1
+    to: erlMM
+
+test:
+  environment:
+    contents:
+      packages:
+        - erlang-${{vars.erlMM}}-dev
+  pipeline:
+    - name: Smoke tests
+      runs: |
+        rebar3 --version | grep ${{package.version}}
+        rebar3 help shell | grep "Start a shell"
+        rebar3 help unlock | grep "Unlock project dependencies"
+    - name: Ensure package installation works
+      runs: |
+        rebar3 new escript myscript
+        cd myscript
+        rebar3 escriptize
+        _build/default/bin/myscript "hello" | grep '^Args: \["hello"\]$'
+        rebar3 tree | grep '0.1.0 (project app)'
+        rebar3 compile
+        stat _build/default/lib/myscript/ebin/myscript.beam
+        rebar3 clean
+        { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"

--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -5,9 +5,6 @@ package:
   version: 3.25.0
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - erlang-${{vars.erlMM}}
   options:
     # escript is not provided by any erlang version
     no-depends: true

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -5,9 +5,6 @@ package:
   version: 3.25.0
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - erlang-${{vars.erlMM}}
   options:
     # escript is not provided by any erlang version
     no-depends: true

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -1,0 +1,66 @@
+package:
+  name: erl26-rebar3
+  description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
+  epoch: 0
+  version: 3.25.0
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - erlang-${{vars.erlMM}}
+  options:
+    # escript is not provided by any erlang version
+    no-depends: true
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - erlang-${{vars.erlMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/erlang/rebar3.git
+      tag: ${{package.version}}
+      expected-commit: 6243d3fb017c9759ba699850e8a6b57700fbfabd
+
+  - name: Build Rebar3
+    runs: ./bootstrap
+
+  - runs: |
+      install -Dpm0755 -t ${{targets.destdir}}/usr/bin/ ./rebar3
+
+update:
+  enabled: true
+  github:
+    identifier: erlang/rebar3
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^erl(\d\d+)-.*
+    replace: $1
+    to: erlMM
+
+test:
+  environment:
+    contents:
+      packages:
+        - erlang-${{vars.erlMM}}-dev
+  pipeline:
+    - name: Smoke tests
+      runs: |
+        rebar3 --version | grep ${{package.version}}
+        rebar3 help shell | grep "Start a shell"
+        rebar3 help unlock | grep "Unlock project dependencies"
+    - name: Ensure package installation works
+      runs: |
+        rebar3 new escript myscript
+        cd myscript
+        rebar3 escriptize
+        _build/default/bin/myscript "hello" | grep '^Args: \["hello"\]$'
+        rebar3 tree | grep '0.1.0 (project app)'
+        rebar3 compile
+        stat _build/default/lib/myscript/ebin/myscript.beam
+        rebar3 clean
+        { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -5,9 +5,6 @@ package:
   version: 3.25.0
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - erlang-${{vars.erlMM}}
   options:
     # escript is not provided by any erlang version
     no-depends: true

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -1,0 +1,66 @@
+package:
+  name: erl27-rebar3
+  description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
+  epoch: 0
+  version: 3.25.0
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - erlang-${{vars.erlMM}}
+  options:
+    # escript is not provided by any erlang version
+    no-depends: true
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - erlang-${{vars.erlMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/erlang/rebar3.git
+      tag: ${{package.version}}
+      expected-commit: 6243d3fb017c9759ba699850e8a6b57700fbfabd
+
+  - name: Build Rebar3
+    runs: ./bootstrap
+
+  - runs: |
+      install -Dpm0755 -t ${{targets.destdir}}/usr/bin/ ./rebar3
+
+update:
+  enabled: true
+  github:
+    identifier: erlang/rebar3
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^erl(\d\d+)-.*
+    replace: $1
+    to: erlMM
+
+test:
+  environment:
+    contents:
+      packages:
+        - erlang-${{vars.erlMM}}-dev
+  pipeline:
+    - name: Smoke tests
+      runs: |
+        rebar3 --version | grep ${{package.version}}
+        rebar3 help shell | grep "Start a shell"
+        rebar3 help unlock | grep "Unlock project dependencies"
+    - name: Ensure package installation works
+      runs: |
+        rebar3 new escript myscript
+        cd myscript
+        rebar3 escriptize
+        _build/default/bin/myscript "hello" | grep '^Args: \["hello"\]$'
+        rebar3 tree | grep '0.1.0 (project app)'
+        rebar3 compile
+        stat _build/default/lib/myscript/ebin/myscript.beam
+        rebar3 clean
+        { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -5,9 +5,6 @@ package:
   version: 3.25.0
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - erlang-${{vars.erlMM}}
   options:
     # escript is not provided by any erlang version
     no-depends: true

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -1,19 +1,22 @@
 package:
-  name: rebar3
+  name: erl28-rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 1
+  epoch: 0
   version: 3.25.0
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - erlang-${{vars.erlMM}}
   options:
-    # Automatic dependency on `cmd:escript`, but nothing provides it, just bring your own erlang
+    # escript is not provided by any erlang version
     no-depends: true
 
 environment:
   contents:
     packages:
       - busybox
-      - erlang-26-dev # Build with oldest erlang.
+      - erlang-${{vars.erlMM}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -33,12 +36,17 @@ update:
   github:
     identifier: erlang/rebar3
 
+var-transforms:
+  - from: ${{package.name}}
+    match: ^erl(\d\d+)-.*
+    replace: $1
+    to: erlMM
+
 test:
   environment:
     contents:
       packages:
-        - erlang-28-dev # Test with latest erlang
-        - elixir-1.17
+        - erlang-${{vars.erlMM}}-dev
   pipeline:
     - name: Smoke tests
       runs: |
@@ -47,7 +55,12 @@ test:
         rebar3 help unlock | grep "Unlock project dependencies"
     - name: Ensure package installation works
       runs: |
-        rebar3 new app myapp
-        cd myapp
+        rebar3 new escript myscript
+        cd myscript
+        rebar3 escriptize
+        _build/default/bin/myscript "hello" | grep '^Args: \["hello"\]$'
+        rebar3 tree | grep '0.1.0 (project app)'
         rebar3 compile
-        rebar3 new release myrel
+        stat _build/default/lib/myscript/ebin/myscript.beam
+        rebar3 clean
+        { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"


### PR DESCRIPTION
This allows us to use this with multiple different elixir versions since the erlang OTP support window can skew when we are using for example, a erl28-built rebar3 with erl25 on the system.
