### PR TITLE
refactor(openjdk-17): let the jdk provide jre

### DIFF
--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -174,6 +174,13 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - name: Ensure the java compiler is not present in the jre package
+          runs: |
+            export PATH="/usr/lib/jvm/java-17-openjdk/bin:$PATH"
+            if command -v javac; then
+              echo "javac should not be present in the jre"
+              exit 1
+            fi
         - uses: test/tw/ldd-check
           with:
             extra-library-paths: "/usr/lib/jvm/java-17-openjdk/lib/server/"
@@ -234,6 +241,14 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+    test:
+      pipeline:
+        - name: Ensure the jdk provides the jre
+          runs: |
+            if ! apk info --installed ${{package.name}}-jre | grep -q ${{package.name}}-default-jdk; then
+              echo "${{package.name}}-default-jdk should provide ${{package.name}}-jre"
+              exit 1
+            fi
 
 # OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK17u
 # The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk17u/tags

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: "17.0.15" # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -156,6 +156,7 @@ subpackages:
         - libxrender
         - libxtst
         - ttf-dejavu
+      provider-priority: 10
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-17-openjdk"
@@ -218,15 +219,17 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
-  - name: "openjdk-17-default-jdk"
+  - name: "${{package.name}}-default-jdk"
     description: "Use the openjdk-17 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
         - java-common
-        - openjdk-17
+        - ${{package.name}}
+      provider-priority: 5
       provides:
         - default-jdk=1.17
         - default-jdk-lts=1.17
+        - ${{package.name}}-jre=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm


### PR DESCRIPTION
The `openjdk-x-jre` package is known to conflict with `openjdk-x-default-jdk`. Since the jre is a subset of the jdk, use the 'provides' mechanism to ensure the jre does not get installed in an environment where the jdk already exists.

Note, we set the `provider-priority` higher in the jre definition so the actual `openjdk-x-jre` package will fulfill explicit requests for the jre.