### PR TITLE
Fix(Update): The version transform was resulting in 6.5.20250621 wher…

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -157,8 +157,8 @@ subpackages:
 update:
   enabled: true
   version-transform:
-    - match: _p
-      replace: \-
+    - match: \-
+      replace: _p
   release-monitor:
     identifier: 2057
 

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.5_p20241228
-  epoch: 3
+  version: 6.5_p20250621
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
-      expected-sha512: 4ca73f46f598647dea24cbd89a5704eccdf7e52626f15f8271b08bf3bd2221f5bfb327c9b40532a6ebcc4cf1cd58e33bf4c149de9f8abaaafe1e2b0ce4cdf4d8
+      expected-sha512: 1b665749b822133e7166c21e44e0cf0d94766a7ed4f96a6138de43c46c8ce85ed0c5d5230c050103de3830e7d2fc35c283262d30990b9de30851d1f999525b85
 
   - name: Configure
     runs: |
@@ -158,9 +158,7 @@ update:
   enabled: true
   version-transform:
     - match: _p
-      replace: .
-    - match: \-
-      replace: .
+      replace: \-
   release-monitor:
     identifier: 2057
 


### PR DESCRIPTION
…e it should be 6.5-20250621

this change replace the `_p` to `- `which matches the version used by the upstream.

Also package update to 6.5_p20250621

