### PR TITLE
az: add iamguarded compat subpackage

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.74.0"
-  epoch: 2
+  epoch: 3
   description: Azure CLI
   copyright:
     - license: MIT
@@ -112,3 +112,53 @@ test:
 
         echo "Expanded command tests passed!"
     - uses: test/tw/ldd-check
+
+subpackages:
+  - name: ${{package.name}}-iamguarded-compat
+    description: "compat package with iamguarded/azure-cli image"
+    dependencies:
+      runtime:
+        - az=${{package.full-version}}
+        - bash
+        - busybox
+        - merged-usrsbin
+        - python-3
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: azure-cli
+          version: "2"
+      - runs: |
+          mkdir -p /opt/iamguarded/azure-cli/bin
+          chmod g+rwX /opt/iamguarded
+
+          # Create symlink for az binary
+          ln -sf /usr/bin/az /opt/iamguarded/azure-cli/bin/az
+
+          # Create expected directories
+          mkdir -p /opt/iamguarded/azure-cli/tmp
+          mkdir -p /opt/iamguarded/azure-cli/logs
+          mkdir -p /iamguarded/azure-cli
+      - uses: iamguarded/finalize-compat
+        with:
+          package: azure-cli
+          version: "2"
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: azure-cli
+            version: "2"
+        - name: Verify iamguarded symlinks work
+          runs: |
+            # Test az command through symlink
+            /opt/iamguarded/azure-cli/bin/az --version
+
+            # Test basic command functionality
+            /opt/iamguarded/azure-cli/bin/az -h
+            /opt/iamguarded/azure-cli/bin/az version -o json


### PR DESCRIPTION
* "az: add iamguarded compat subpackage"

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
