### PR TITLE
basisu: Upgrade & improve version matching

### DIFF
--- a/basisu.yaml
+++ b/basisu.yaml
@@ -1,7 +1,7 @@
 package:
   name: basisu
-  version: 1.16.4
-  epoch: 2
+  version: 1.60
+  epoch: 0
   description: Basis Universal GPU Texture Codec
   copyright:
     - license: Apache-2.0
@@ -18,18 +18,28 @@ environment:
       - cmake
       - opencl-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/BinomialLLC/basis_universal
-      tag: ${{package.version}}
-      expected-commit: 900e40fb5d2502927360fe2f31762bdbb624455f
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: 323239a6a5ffa57d6570cfc403be99156e33a8b0
 
   - uses: cmake/configure
 
   - uses: cmake/build
 
   - uses: cmake/install
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mv bin/basisu "${{targets.contextdir}}"/usr/bin
 
   - uses: strip
 
@@ -40,9 +50,14 @@ subpackages:
 
 update:
   enabled: true
+  version-transform:
+    - match: _
+      replace: .
   github:
     identifier: BinomialLLC/basis_universal
-    tag-filter: 1.
+    tag-filter-prefix: v
+    strip-prefix: v
+    tag-filter-contains: _
 
 test:
   environment:


### PR DESCRIPTION
Upgrade package to 1.60.

Upstream decided to start using underscore instead of dot in version strings.