### PR TITLE
libreoffice-25.2: pin gpgme-dev<2, to fix FTBFS

### DIFF
--- a/libreoffice-25.2.yaml
+++ b/libreoffice-25.2.yaml
@@ -8,7 +8,7 @@ package:
     - license: GPL-3.0-only AND LGPL-3.0-only AND MPL-2.0
   resources:
     cpu: 65
-    memory: 32Gi
+    memory: 48Gi
   dependencies:
     runtime:
       - libnss

--- a/libreoffice-25.2.yaml
+++ b/libreoffice-25.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-25.2 # On update, please check if -fdelete-null-pointer-checks is still required
   version: "25.2.4.3"
-  epoch: 0
+  epoch: 1
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:
@@ -46,7 +46,7 @@ environment:
       - glib-dev
       - gnutar
       - gperf
-      - gpgme-dev
+      - gpgme-dev<2
       - gst-plugins-base-dev
       - gstreamer-dev
       - gtk-3-dev


### PR DESCRIPTION
Fixes: #56765