### PR TITLE
zeromq: switch from automake to cmake

### DIFF
--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -80,14 +80,6 @@ subpackages:
             pkg-config libzmq --cflags
             pkg-config libzmq --libs
 
-  - name: zeromq-doc
-    pipeline:
-      - uses: split/manpages
-    description: zeromq manpages
-    test:
-      pipeline:
-        - uses: test/docs
-
 update:
   enabled: true
   github:

--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -1,7 +1,7 @@
 package:
   name: zeromq
   version: 4.3.5
-  epoch: 2
+  epoch: 3
   description: The ZeroMQ messaging library and tools
   copyright:
     - license: MPL-2.0
@@ -9,10 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - automake
       - build-base
-      - busybox
-      - ca-certificates-bundle
+      - libbsd-dev
       - libsodium-dev
       - perl
       - util-linux-dev
@@ -24,13 +22,13 @@ pipeline:
       expected-sha256: 6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
       uri: https://github.com/zeromq/libzmq/releases/download/v${{package.version}}/zeromq-${{package.version}}.tar.gz
 
-  - uses: autoconf/configure
+  - uses: cmake/configure
     with:
-      opts: --with-libsodium --disable-Werror
+      opts: -DENABLE_CURVE=ON -DWITH_LIBSODIUM=ON
 
-  - uses: autoconf/make
+  - uses: cmake/build
 
-  - uses: autoconf/make-install
+  - uses: cmake/install
 
   - uses: strip
 

--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -22,6 +22,10 @@ pipeline:
       expected-sha256: 6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
       uri: https://github.com/zeromq/libzmq/releases/download/v${{package.version}}/zeromq-${{package.version}}.tar.gz
 
+  - uses: patch
+    with:
+      patches: 0001-cmake-add-curve_keygen-binary.patch
+
   - uses: cmake/configure
     with:
       opts: -DENABLE_CURVE=ON -DWITH_LIBSODIUM=ON

--- a/zeromq/0001-cmake-add-curve_keygen-binary.patch
+++ b/zeromq/0001-cmake-add-curve_keygen-binary.patch
@@ -1,0 +1,30 @@
+From dacde1f11aa4fcbf7571ea520e7b1b8ccee154ec Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 25 Jun 2025 17:42:39 +0100
+Subject: [PATCH] cmake: add curve_keygen binary
+
+When sodium is enabled, also build curve_keygen binary. This is to
+bring cmake builds to parity with autoconf.
+
+Fixes: https://github.com/zeromq/libzmq/issues/4675
+---
+ CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ab2259e..7caf2c87 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1915,3 +1915,9 @@ if(ENABLE_NO_EXPORT)
+   message(STATUS "Building with empty ZMQ_EXPORT macro")
+   add_definitions(-DZMQ_NO_EXPORT)
+ endif()
++
++if (ENABLE_CURVE)
++  add_executable(curve_keygen tools/curve_keygen.cpp)
++  target_link_libraries(curve_keygen libzmq)
++  install(TARGETS curve_keygen RUNTIME DESTINATION bin)
++endif()
+-- 
+2.48.1
+


### PR DESCRIPTION
This produces binaries that honor toolchain settings for
-static-libstdc++, as libtool generates flags that causes to ignore
them.

Doc subpackage is empty with either autoconf or cmake, drop it completely.

Cherrypick upstream contributed patch to build keygen binary with CMake:
- https://github.com/zeromq/libzmq/pull/4799
