### PR TITLE
DNM: openssl: test-build the 3.5 branch in anticipation of 3.5.1

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,8 +1,8 @@
 #nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
-  version: "3.5.0"
-  epoch: 3
+  version: "3.5.1" # NOTE: not released yet, only for testing purposes
+  epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -40,22 +40,11 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openssl/openssl
-      tag: openssl-${{package.version}}
-      expected-commit: 636dfadc70ce26f2473870570bfd9ec352806b1d
+      branch: openssl-3.5
 
   - uses: patch
     with:
-      # fix-cve-2025-4575.patch
-      # cannot be cherry-picked from master because of
-      # a merge conflict in the test file est/recipes/25-test_x509.t
-      # Had to modify from:
-      # `- plan tests => 136;`
-      # `+ plan tests => 140;`
-      # to
-      # `- plan tests => 134;`
-      # `+ plan tests => 138;`
-      # This patch can probably be removed in the next 3.5.1 openssl upstream release.
-      patches: fix-jitter.patch fix-cve-2025-4575.patch
+      patches: fix-jitter.patch
 
   - name: Create dbg sourcecode
     runs: |


### PR DESCRIPTION
Just for testing purposes.