### PR TITLE
gflags: Backport fix to support CMake 4.0

### DIFF
--- a/gflags.yaml
+++ b/gflags.yaml
@@ -1,7 +1,7 @@
 package:
   name: gflags
   version: 2.2.2
-  epoch: 2
+  epoch: 3
   description: "The gflags package contains a C++ library that implements commandline flags processing."
   copyright:
     - license: "BSD-3-Clause"
@@ -20,6 +20,8 @@ pipeline:
       repository: https://github.com/gflags/gflags/
       tag: v${{package.version}}
       expected-commit: e171aa2d15ed9eb17054558e0b3a6a413bb01067
+      cherry-picks: |
+        master/70c01a642f08734b7bddc9687884844ca117e080: build: support cmake 4.0
 
   - uses: cmake/configure
     with:


### PR DESCRIPTION
Unfortunately upstream hasn't released a new version since 2018, so we're stuck with cherry-picking fixes for now.