### PR TITLE
json-c: Don't build apps; fix build with CMake 4.0

### DIFF
--- a/json-c.yaml
+++ b/json-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: json-c
   version: "0.18"
-  epoch: 1
+  epoch: 2
   description: A JSON implementation in C
   copyright:
     - license: MIT
@@ -23,6 +23,9 @@ pipeline:
       uri: https://s3.amazonaws.com/json-c_releases/releases/json-c-${{package.version}}.tar.gz
 
   - uses: cmake/configure
+    with:
+      opts: |
+        -DBUILD_APPS=OFF
 
   - uses: cmake/build
 


### PR DESCRIPTION
We don't ship what's inside the "apps" directory, and it unfortunately introduces a breakage with CMake 4.0, so let's just not build it.