### PR TITLE
libgdiplus: Bump version, update upstream location

### DIFF
--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgdiplus
-  version: 6.1
-  epoch: 3
+  version: 6.2
+  epoch: 0
   description: "Open Source Implementation of the GDI+ API"
   copyright:
     - license: MIT
@@ -27,13 +27,15 @@ environment:
       - libtool
       - libxft-dev
       - pango-dev
+      - pkgconf-dev
       - tiff-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha512: 7f176d38024d5bde4a825ad00b907006f7dd3ff174e12aba6e91df0b624431cc9b536f1bcf206998bad11f6d03e6fe5122710591f58877de0f2c08e8cb4e46cd
-      uri: https://download.mono-project.com/sources/libgdiplus/libgdiplus-${{package.version}}.tar.gz
+      repository: https://gitlab.winehq.org/mono/libgdiplus
+      tag: ${{package.version}}
+      expected-commit: 5a6d5d7990a7a4955b4c856f89edaf4a366484ba
 
   - uses: autoconf/configure
     with:
@@ -67,10 +69,7 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: mono/libgdiplus
-    use-tag: true
-    tag-filter: 6.
+  git: {}
 
 test:
   pipeline:


### PR DESCRIPTION
Mono upstream changed hands to WineHQ (https://www.mono-project.com/).  Update libgdiplus to use the new upstream, bump its version, and fix the build for the upcoming CMake 4.0 package.