### PR TITLE
libical: Upgrade to latest version; enable auto-update

### DIFF
--- a/libical.yaml
+++ b/libical.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/libical/APKBUILD
 package:
   name: libical
-  version: 3.0.16
-  epoch: 7
+  version: 3.0.20
+  epoch: 0
   description: Reference implementation of the iCalendar format
   copyright:
     - license: LGPL-2.1-only OR MPL-2.0
@@ -27,10 +27,11 @@ environment:
       - vala
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: b44705dd71ca4538c86fb16248483ab4b48978524fb1da5097bd76aa2e0f0c33
-      uri: https://github.com/libical/libical/releases/download/v${{package.version}}/libical-${{package.version}}.tar.gz
+      repository: https://github.com/libical/libical
+      tag: v${{package.version}}
+      expected-commit: 57ce34025066935f356fd539e6deb7a7a9952618
 
   - uses: cmake/configure
     with:
@@ -61,8 +62,10 @@ subpackages:
         - uses: test/tw/ldd-check
 
 update:
-  release-monitor:
-    identifier: 1637
+  enabled: true
+  github:
+    identifier: libical/libical
+    strip-prefix: v
 
 test:
   pipeline:


### PR DESCRIPTION
For some reason auto-update was disabled for libical.  Enable it, and update the package to the latest upstream version.  This also fixes a build failure when using CMake 4.0.