### PR TITLE
libid3tag: Enable auto-update; backport fix to build with CMake 4

### DIFF
--- a/libid3tag.yaml
+++ b/libid3tag.yaml
@@ -1,7 +1,7 @@
 package:
   name: libid3tag
   version: 0.16.3
-  epoch: 1
+  epoch: 2
   description: MAD ID3 tagger for MP3 audio files
   copyright:
     - license: GPL-2.0-or-later
@@ -24,6 +24,8 @@ pipeline:
       repository: https://codeberg.org/tenacityteam/libid3tag
       tag: ${{package.version}}
       expected-commit: e02ecf1276b467a8a5dd20c55ce711e6f7116d3e
+      cherry-picks: |
+        main/eee94b22508a066f7b9bc1ae05d2d85982e73959: Allow build with CMake 4.0.0
 
   - runs: |
       cmake -B build -G Ninja \
@@ -51,11 +53,8 @@ subpackages:
         - uses: test/tw/ldd-check
 
 update:
-  enabled: false
-  manual: true
-  exclude-reason: >
-    we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.
-
+  enabled: true
+  git: {}
 
 test:
   pipeline:


### PR DESCRIPTION
Auto-update should be enabled for this package.  Also, unfortunately upstream hasn't made a release in quite some time, so we have to backport the fix to build the package with CMake 4.0.