### PR TITLE
libsndfile: Upgrade; enable auto-update; cherry-pick fix for CMake 4

### DIFF
--- a/libsndfile.yaml
+++ b/libsndfile.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/libsndfile/APKBUILD
 package:
   name: libsndfile
-  version: 1.2.0
-  epoch: 3
+  version: 1.2.2
+  epoch: 0
   description: C library for reading and writing files containing sampled sound
   copyright:
     - license: LGPL-2.1-or-later
@@ -28,10 +28,17 @@ environment:
       - speexdsp-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 0e30e7072f83dc84863e2e55f299175c7e04a5902ae79cfb99d4249ee8f6d60a
-      uri: https://github.com/libsndfile/libsndfile/releases/download/${{package.version}}/libsndfile-${{package.version}}.tar.xz
+      repository: https://github.com/libsndfile/libsndfile
+      tag: ${{package.version}}
+      expected-commit: 72f6af15e8f85157bd622ed45b979025828b7001
+      cherry-picks: |
+        master/5f87db67a10bda6c53edb8a23829eb7f26ed2c27: cmake: Bump supported policy version to 3.26
+        master/e486f20fd4b1c7490cde84f22635e1c267ae882b: cmake: Bump minimum required version to 3.5
+        master/17a19ab264fcf238f46104cea9af9a0a5ca3786d: cmake version min 3.12
+        master/ea9ff560b4c2086c2f1cae3f02287768a0de4673: fix cmake min...max syntax
+        master/52b803f57a1f4d23471f5c5f77e1a21e0721ea0e: Update for cmake 4
 
   - runs: |
       cmake -B build-shared -G Ninja \
@@ -86,8 +93,9 @@ subpackages:
         - uses: test/docs
 
 update:
-  release-monitor:
-    identifier: 13277
+  enabled: true
+  github:
+    identifier: libsndfile/libsndfile
 
 test:
   pipeline:


### PR DESCRIPTION
- Upgrade the package to the latest upstream version (1.2.2).
- Use git-checkout and fetch release directly from github.
- Cherry-pick commit to fix build with CMake 4.0.
- Enable auto-update via github.