### PR TITLE
libvncserver: Cherry-pick commit to fix build with CMake 4

### DIFF
--- a/libvncserver.yaml
+++ b/libvncserver.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvncserver
   version: 0.9.15
-  epoch: 2
+  epoch: 3
   description: Library to make writing a vnc server easy
   copyright:
     - license: GPL-2.0-or-later
@@ -35,6 +35,8 @@ pipeline:
       repository: https://github.com/LibVNC/libvncserver
       tag: LibVNCServer-${{package.version}}
       expected-commit: 9b54b1ec32731bd23158ca014dc18014db4194c3
+      cherry-picks: |
+        master/e64fa928170f22a2e21b5bbd6d46c8f8e7dd7a96: CMake: require at least CMake 3.5
 
   - runs: |
       cmake -B build -G Ninja \


### PR DESCRIPTION
Upstream hasn't cut a new release with the fix yet.