### PR TITLE
feat: add script subpackage

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.41.1"
-  epoch: 0
+  epoch: 1
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -93,6 +93,7 @@ data:
       mcookie: Generate random numbers for xauth from util-linux
       mount: Makes a file system available for use
       partx: Tell the kernel about disk partition changes from util-linux
+      script: make typescript of terminal session
       setarch: Change reported architecture in new program environment and/or set personality flags
       setpriv: Run a program with different Linux privilege settings
       sfdisk: Partition table manipulator from util-linux
@@ -363,12 +364,6 @@ subpackages:
             rename --help
             renice --version
             renice --help
-            script --version
-            script --help
-            scriptlive --version
-            scriptlive --help
-            scriptreplay --version
-            scriptreplay --help
             setpgid --version
             setpgid --help
             setsid --version


### PR DESCRIPTION
For some pipelines script is needed, but we don't want to bring all other binaries, hence we split the subpackage
