### PR TITLE
Add zstd support to qemu.

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: "10.0.2"
-  epoch: 1
+  epoch: 2
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -39,6 +39,7 @@ environment:
       - wolfi-base
       - zlib-dev
       - zlib-static
+      - zstd-dev
 
 pipeline:
   - uses: git-checkout
@@ -80,6 +81,10 @@ subpackages:
             mv "${{targets.destdir}}"/usr/bin/qemu-$i "${{targets.subpkgdir}}"/usr/bin/
           done
     test:
+      environment:
+        contents:
+          packages:
+            - jq
       pipeline:
         - runs: |
             qemu-img --version
@@ -91,6 +96,26 @@ subpackages:
             qemu-nbd --help
             qemu-storage-daemon --version
             qemu-storage-daemon --help
+        - name: "qemu-img zlib and zstd support"
+          runs: |
+            disk=disk1
+            qemu-img create -f raw $disk.raw 2G
+            for ctype in zlib zstd; do
+                t="convert raw to qcow with $comp"
+                qemu-img convert -f raw -O qcow2 -c -o compression_type=$ctype \
+                    $disk.raw $disk-$ctype.qcow2 ||
+                    { echo "FAIL: $t - qemu-img convert failed"; exit 1; }
+                jblob=$(qemu-img info --output=json $disk-$ctype.qcow2) ||
+                    { echo "FAIL: $t - qemu-img info --output=json failed"; exit 1; }
+                found=$(echo "$jblob" |
+                    jq -r '"\(.format)/\(.["format-specific"].data."compression-type")"')
+                expected="qcow2/$ctype"
+                [ "$found" = "qcow2/$ctype" ] || {
+                  echo "FAIL: $t - qemu-img info said '$found' expected '$expected'";
+                  exit 1;
+                }
+                echo "PASS: $t"
+            done
 
   - name: ${{package.name}}-system-x86_64
     description: "QEMU x86 system"


### PR DESCRIPTION
qemu-img convert can write zstd compression and then also read that and thus we can make images with 'qemu-img convert -c' that have zstd inside.
