### PR TITLE
oauth2-proxy: rebuild with new Go stdlib

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: "7.9.0"
-  epoch: 1
+  epoch: 2
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT


### PR DESCRIPTION
CVE-2025-4673