### PR TITLE
Add apisix package

### DIFF
--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -498,7 +498,7 @@ test:
         curl -X PUT -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes/100" -d "$payload"
         # wait for route to be available
         sleep 2
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:9080/hello")
+        HTTP_CODE=$(curl -s -connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -o /dev/null -w "%{http_code}" "http://127.0.0.1:9080/hello")
         BODY=$(curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40  "http://127.0.0.1:9080/hello")
         if [[ "$HTTP_CODE" -ne 200 || "$BODY" != "hello world" ]]; then
           echo "ERROR: Expected 200 and body 'hello world', got code=$HTTP_CODE, body=$BODY"

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -10,24 +10,43 @@ package:
       - bash
       # base64 is required at runtime
       - coreutils
+      - gd
+      - geoip
+      - libgcc
+      - libxslt
       - luajit
-      - openresty
+      - merged-usrsbin
+      - openssl
+      - pcre
+      - perl
+      - wolfi-baselayout
+      - zlib
 
 environment:
   contents:
     packages:
+      - bash
       - build-base
       - busybox
+      - busybox
       - ca-certificates-bundle
+      - coreutils
       - curl
       - etcd
       - gcc
+      - gd-dev
+      - geoip-dev
       - gnupg
+      - libwasmtime
+      - libxml2-dev
+      - libxslt-dev
+      - linux-headers
+      - lua-resty-events
+      - lua-resty-worker-events
       - luajit
       - luajit-dev
       - luarocks
       - openldap-dev
-      - openresty
       - openssl
       - openssl-dev
       - patch
@@ -36,28 +55,187 @@ environment:
       - perl
       - perl-app-cpanminus
       - perl-dev
+      - readline-dev
       - unzip
+      - wasmtime
+      - wasmtime-dev
       - wget
       - xz
       - yaml-dev
       - zlib-dev
 
+vars:
+  BUILD_DIRECTORY: "/home/build"
+  OPENRESTY_VERSION: "1.27.1.2"
+  OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"
+  NGINX_VERSION: "1.27.1"
+  RESTY_EVENTS_VERSION: "0.3.1"
+  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787"
+  NGX_MULTI_UPSTREAM_VERSION: "1.3.2"
+  NGX_MULTI_UPSTREAM_CHECKSUM: "0c9e4cec7cb8ec281a4e66fe2dcf2b927c8ef46d"
+  DUBBO_MODULE_VERSION: "1.0.2"
+  DUBBO_MODULE_CHECKSUM: "4aabf9448fe4a49ca71009af8e03645ee5dadd15"
+  APISIX_NGINX_MODULE_VERSION: "1.19.2"
+  APISIX_NGINX_MODULE_CHECKSUM: "b94ebabffc87d88d540346dc3edb5f7606418305"
+  WASM_NGINX_MODULE_VERSION: "0.7.0"
+  WASM_NGINX_MODULE_CHECKSUM: "0b4b31d6ecfdbc587e8ea455ed6e920a98aadff1"
+  LUA_VAR_NGINX_MODULE_VERSION: "v0.5.3"
+  LUA_VAR_NGINX_MODULE_CHECKSUM: "dc04c71e14e8a0407831f9019043d7e6da61b3c3"
+
+# apisix builds openresty from source with a several added modules:
+# https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L82
 pipeline:
+  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/
+    uses: fetch
+    with:
+      uri: https://openresty.org/download/openresty-${{vars.OPENRESTY_VERSION}}.tar.gz
+      expected-sha256: ${{vars.OPENRESTY_CHECKSUM}}
   - uses: git-checkout
+    with:
+      repository: https://github.com/Kong/lua-resty-events
+      tag: ${{vars.RESTY_EVENTS_VERSION}}
+      expected-commit: ${{vars.RESTY_EVENTS_CHECKSUM}}
+      destination: lua-resty-events
+  - uses: git-checkout
+    with:
+      repository: https://github.com/api7/ngx_multi_upstream_module.git
+      tag: ${{vars.NGX_MULTI_UPSTREAM_VERSION}}
+      expected-commit: ${{vars.NGX_MULTI_UPSTREAM_CHECKSUM}}
+      destination: nginx-multi-upstream
+  - uses: git-checkout
+    with:
+      repository: https://github.com/api7/mod_dubbo.git
+      tag: ${{vars.DUBBO_MODULE_VERSION}}
+      expected-commit: ${{vars.DUBBO_MODULE_CHECKSUM}}
+      destination: dubbo-module
+  - uses: git-checkout
+    with:
+      repository: https://github.com/api7/apisix-nginx-module.git
+      tag: ${{vars.APISIX_NGINX_MODULE_VERSION}}
+      expected-commit: ${{vars.APISIX_NGINX_MODULE_CHECKSUM}}
+      destination: apisix-nginx-module
+  - uses: git-checkout
+    with:
+      repository: https://github.com/api7/wasm-nginx-module.git
+      tag: ${{vars.WASM_NGINX_MODULE_VERSION}}
+      expected-commit: ${{vars.WASM_NGINX_MODULE_CHECKSUM}}
+      destination: wasm-nginx-module
+  - uses: git-checkout
+    with:
+      repository: https://github.com/api7/lua-var-nginx-module
+      tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
+      expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
+      destination: lua-var-nginx-module
+  # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
+  - name: Apply ngx-multi-upstream patches
+    working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
+    runs: |
+      ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+  - name: Apply apisix-nginx-module patches
+    working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
+    runs: |
+      ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+  - name: Configure openresty build
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    runs: |
+      ./configure \
+        --add-module=../lua-resty-events \
+        --add-module=../dubbo-module \
+        --add-module=../nginx-multi-upstream \
+        --add-module=../lua-var-nginx-module \
+        --add-module=../wasm-nginx-module \
+        --add-module=../apisix-nginx-module/src/meta \
+        --add-module=../apisix-nginx-module/src/stream \
+        --build=${{host.triplet.gnu}} \
+        --with-pcre \
+        --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/include' \
+        --with-ld-opt='-L/usr/lib -Wl,-rpath,/usr/lib' \
+        --conf-path=/etc/nginx/nginx.conf \
+        --sbin-path=/usr/bin/nginx \
+        --error-log-path=/var/log/openresty/error.log \
+        --http-log-path=/var/log/openresty/access.log \
+        --pid-path=/var/log/openresty/nginx.pid \
+        --lock-path=/var/log/openresty/nginx.lock \
+        --http-client-body-temp-path=/var/run/openresty/nginx-client-body \
+        --http-proxy-temp-path=/var/run/openresty/nginx-proxy \
+        --http-fastcgi-temp-path=/var/run/openresty/nginx-fastcgi \
+        --http-uwsgi-temp-path=/var/run/openresty/nginx-uwsgi \
+        --http-scgi-temp-path=/var/run/openresty/nginx-scgi \
+        --with-poll_module \
+        --with-pcre-jit \
+        --without-http_rds_json_module \
+        --without-http_rds_csv_module \
+        --without-lua_rds_parser \
+        --with-stream \
+        --with-stream_ssl_module \
+        --with-stream_ssl_preread_module \
+        --with-http_v2_module \
+        --with-http_v3_module \
+        --without-mail_pop3_module \
+        --without-mail_imap_module \
+        --without-mail_smtp_module \
+        --with-http_stub_status_module \
+        --with-http_realip_module \
+        --with-http_addition_module \
+        --with-http_auth_request_module \
+        --with-http_secure_link_module \
+        --with-http_random_index_module \
+        --with-http_gzip_static_module \
+        --with-http_sub_module \
+        --with-http_dav_module \
+        --with-http_flv_module \
+        --with-http_mp4_module \
+        --with-http_gunzip_module \
+        --with-threads \
+        --with-compat \
+        --with-luajit=/usr \
+        --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
+        --with-pcre-jit
+  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    uses: autoconf/make
+  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    uses: autoconf/make-install
+  - name: Move openresty binaries to /usr/bin
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
+  - name: Setup default openresty config files
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    runs: |
+      mkdir -p ${{targets.destdir}}/var/run/openresty/
+      mkdir -p ${{targets.destdir}}/etc/nginx/conf.d
+      install -m644 -D nginx.conf ${{targets.destdir}}/etc/nginx/
+      install -m644 -D default.conf ${{targets.destdir}}/etc/nginx/conf.d
+      mkdir -p ${{targets.destdir}}/var/log/openresty
+      ln -sf /dev/stdout ${{targets.destdir}}/var/log/openresty/access.log
+      ln -sf /dev/stderr ${{targets.destdir}}/var/log/openresty/error.log
+  - name: Install lua-resty-events library into the openresty directory
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+    runs: |
+      install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
+      install -m644 -D /usr/local/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
+      install -m644 -D /usr/local/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
+  - uses: strip
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+  - uses: git-checkout
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
       repository: https://github.com/apache/apisix
       tag: ${{package.version}}
       expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
-
+      destination: apache-apisix
+  # Patch to update the apisix script to use our lua libraries
   - uses: patch
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
       patches: set-deps-path.patch
-
-  - runs: |
+  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+    runs: |
       luarocks install apisix-master-0.rockspec --tree deps --only-deps
-
   # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
-  - name: Setup required directories
+  - name: Setup required apisix directories
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
     runs: |
       install -d "${{targets.contextdir}}"/usr/local/apisix/
       install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
@@ -228,7 +406,8 @@ subpackages:
         - brotli
         - ca-certificates-bundle
     pipeline:
-      - runs: |
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+        runs: |
           install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -7,6 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      # https://github.com/apache/apisix/blob/master/docker/debian-dev/docker-entrypoint.sh
       - bash
       # base64 is required at runtime
       - coreutils
@@ -66,6 +67,9 @@ environment:
       - zlib-dev
 
 vars:
+  # These environment variables need updated for each new release. Retrieve their
+  # correct values from here, replacing <package-version> with the package version.
+  #   - https://github.com/api7/apisix-build-tools/blob/apisix/<package-version>/build-apisix-runtime.sh
   BUILD_DIRECTORY: "/home/build"
   OPENRESTY_VERSION: "1.27.1.2"
   OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -28,13 +28,13 @@ environment:
       - openldab-dev
       - openresty
       - openssl
+      - openssl-dev
       - patch
       - pcre
       - pcre-dev
       - perl
       - perl-app-cpanminus
       - perl-dev
-      - perl-extutils-embed
       - unzip
       - wget
       - xz
@@ -48,11 +48,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 75d94c051fc940a174fbdba4ce0588c13fecf864
 
-  - runs: ./configure --prefix=/usr --with-lua=/usr
+  # - runs: ./configure --prefix=/usr --with-lua=/usr
 
-  - uses: autoconf/make
+  # - uses: autoconf/make
 
-  - uses: autoconf/make-install
+  # - uses: autoconf/make-install
 
 update:
   enabled: true
@@ -61,10 +61,10 @@ update:
     strip-prefix: v
     use-tag: true
 
-test:
-  environment:
-    contents:
-      packages:
+# test:
+#   environment:
+#     contents:
+#       packages:
 
-  pipeline:
-    - runs: |
+#   pipeline:
+#     - runs: |

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -517,17 +517,17 @@ test:
         }
         EOF
         )
-        curl -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" -d "$route_payload" | jq
+        curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" -d "$route_payload" | jq
         # Wait for route to be loaded
         sleep 2
         # Test without key
-        CODE_NO_KEY=$(curl -s -o /dev/null -w "%{http_code}" "${PROXY_URL}/secure")
+        CODE_NO_KEY=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -s -o /dev/null -w "%{http_code}" "${PROXY_URL}/secure")
         if [[ "$CODE_NO_KEY" -ne 401 ]]; then
           echo "ERROR: Expected 401 without key, got $CODE_NO_KEY"
           exit 1
         fi
         # Test with key - should get 200 (proxied to upstream)
-        CODE_KEY=$(curl -s -o /dev/null -w "%{http_code}" -H "apikey: consumer-key" "${PROXY_URL}/secure")
+        CODE_KEY=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -s -o /dev/null -w "%{http_code}" -H "apikey: consumer-key" "${PROXY_URL}/secure")
         if [[ "$CODE_KEY" -ne 200 ]]; then
           echo "ERROR: Expected 200 with key, got $CODE_KEY"
           exit 1

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -11,8 +11,11 @@ package:
       - bash
       # base64 is required at runtime
       - coreutils
+      - dash-binsh
+      - gawk
       - gd
       - geoip
+      - grep
       - libgcc
       - libwasmtime
       - libxslt

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -424,6 +424,8 @@ subpackages:
       - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
         runs: |
           install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
+          install -d "${{targets.contextdir}}"/usr/local/openresty/bin/
+          ln -sf /usr/bin/openresty "${{targets.contextdir}}"/usr/local/openresty/bin/openresty
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
           install docker/debian-dev/docker-entrypoint.sh "${{targets.contextdir}}"/
@@ -441,10 +443,95 @@ test:
     contents:
       packages:
         - etcd
+        - curl
+        - yq
+        - jq
+        - nodejs
+    environment:
+      PROXY_URL: "http://127.0.0.1:9080"
+      ADMIN_URL: "http://127.0.0.1:9180"
   pipeline:
     - runs: |
         apisix version | grep ${{package.version}}
         apisix test | grep "configuration test is successful"
-    - name: "Test setup and run apisix"
+    - name: "Setup and run apisix, run simple http endpoint with python"
       runs: |
         nohup etcd >/tmp/etcd.log 2>&1 &
+        apisix start
+    - name: "Spin up a simple nodejs web app."
+      runs: |
+        nohup node <<'JS' > server.log 2>&1 &
+        const http = require('http');
+        http.createServer((req, res) => {
+          if (req.url === '/get') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ secure: 'yes' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        }).listen(8000, () => console.log('Listening on http://0.0.0.0:8000'));
+        JS
+    - name: "Test routes endpoint"
+      runs: |
+        ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)
+        curl -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 0
+        payload=$(cat <<EOF
+        {
+          "uri": "/hello",
+          "plugins": {
+            "response-rewrite": {
+              "body": "hello world",
+              "status_code": 200
+            }
+          }
+        }
+        EOF
+        )
+        curl -X PUT -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes/100" -d "$payload"
+        # wait for route to be available
+        sleep 2
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:9080/hello")
+        BODY=$(curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40  "http://127.0.0.1:9080/hello")
+        if [[ "$HTTP_CODE" -ne 200 || "$BODY" != "hello world" ]]; then
+          echo "ERROR: Expected 200 and body 'hello world', got code=$HTTP_CODE, body=$BODY"
+          exit 1
+        fi
+        curl -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 1
+    - name: "Test key-auth plugin"
+      runs: |
+        ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)
+        # Create consumer with key-auth plugin
+        consumer_payload=$(cat <<EOF
+        { "username": "test-consumer", "plugins": {"key-auth": {"key": "consumer-key"}}}
+        EOF
+        )
+        curl -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/consumers/test-consumer" -d "$consumer_payload" | jq
+        # Create route with key-auth plugin and mock upstream
+        ROUTE_KA=101
+        route_payload=$(cat <<EOF
+        {
+          "uri": "/secure",
+          "plugins": {"key-auth": {}, "proxy-rewrite": {"uri": "/get"}},
+          "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:8000": 1}, "scheme": "http"}
+        }
+        EOF
+        )
+        curl -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" -d "$route_payload" | jq
+        # Wait for route to be loaded
+        sleep 2
+        # Test without key
+        CODE_NO_KEY=$(curl -s -o /dev/null -w "%{http_code}" "${PROXY_URL}/secure")
+        if [[ "$CODE_NO_KEY" -ne 401 ]]; then
+          echo "ERROR: Expected 401 without key, got $CODE_NO_KEY"
+          exit 1
+        fi
+        # Test with key - should get 200 (proxied to upstream)
+        CODE_KEY=$(curl -s -o /dev/null -w "%{http_code}" -H "apikey: consumer-key" "${PROXY_URL}/secure")
+        if [[ "$CODE_KEY" -ne 200 ]]; then
+          echo "ERROR: Expected 200 with key, got $CODE_KEY"
+          exit 1
+        fi
+        # Cleanup
+        curl -s -H "X-API-KEY: ${ADMIN_KEY}" -X DELETE "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" >/dev/null
+        curl -s -H "X-API-KEY: ${ADMIN_KEY}" -X DELETE "${ADMIN_URL}/apisix/admin/consumers/test-consumer" >/dev/null

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -457,7 +457,7 @@ test:
     - name: "Setup and run apisix, run simple http endpoint with python"
       runs: |
         nohup etcd >/dev/null 2>&1 &
-        curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 1 --retry-max-time 40 http://127.0.01:2379/health
+        curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:2379/health
     - name: "Apisix server start"
       uses: test/daemon-check-output
       with:
@@ -465,24 +465,10 @@ test:
         expected_output: "trying to initialize the data of etcd"
         error_strings: |
           "all etcd nodes are unavailable"
-    - name: "Spin up a simple nodejs web app."
-      runs: |
-        nohup node <<'JS' > server.log 2>&1 &
-        const http = require('http');
-        http.createServer((req, res) => {
-          if (req.url === '/get') {
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ secure: 'yes' }));
-          } else {
-            res.writeHead(404);
-            res.end();
-          }
-        }).listen(8000, () => console.log('Listening on http://0.0.0.0:8000'));
-        JS
     - name: "Test routes endpoint"
       runs: |
         ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)
-        curl -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 0
+        curl --fail -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 0
         payload=$(cat <<EOF
         {
           "uri": "/hello",
@@ -495,25 +481,39 @@ test:
         }
         EOF
         )
-        curl -X PUT -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes/100" -d "$payload"
-        # wait for route to be available
-        sleep 2
-        HTTP_CODE=$(curl -s -connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -o /dev/null -w "%{http_code}" "http://127.0.0.1:9080/hello")
-        BODY=$(curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40  "http://127.0.0.1:9080/hello")
+        curl --fail -X PUT -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes/100" -d "$payload"
+        HTTP_CODE=$(curl --fail -s --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 -o /dev/null -w "%{http_code}" "http://127.0.0.1:9080/hello")
+        BODY=$(curl --fail -s  "http://127.0.0.1:9080/hello")
         if [[ "$HTTP_CODE" -ne 200 || "$BODY" != "hello world" ]]; then
           echo "ERROR: Expected 200 and body 'hello world', got code=$HTTP_CODE, body=$BODY"
           exit 1
         fi
-        curl -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 1
+        curl --fail -s -H "X-API-KEY: ${ADMIN_KEY}" "http://127.0.0.1:9180/apisix/admin/routes" | jq .total | grep 1
     - name: "Test key-auth plugin"
       runs: |
+        # Start a simple nodejs webserver
+        cat <<'EOF' > server.js
+        const http = require('http');
+        http.createServer((req, res) => {
+          if (req.url === '/get') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ secure: 'yes' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        }).listen(8000, () => console.log('Listening on http://0.0.0.0:8000'));
+        EOF
+        nohup node server.js &
+        curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:8000/get
+        # Get the API key
         ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)
         # Create consumer with key-auth plugin
         consumer_payload=$(cat <<EOF
         { "username": "test-consumer", "plugins": {"key-auth": {"key": "consumer-key"}}}
         EOF
         )
-        curl -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/consumers/test-consumer" -d "$consumer_payload" | jq
+        curl --fail -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/consumers/test-consumer" -d "$consumer_payload" | jq
         # Create route with key-auth plugin and mock upstream
         ROUTE_KA=101
         route_payload=$(cat <<EOF
@@ -524,17 +524,15 @@ test:
         }
         EOF
         )
-        curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" -d "$route_payload" | jq
-        # Wait for route to be loaded
-        sleep 2
+        curl --fail -s -H "Content-Type: application/json" -H "X-API-KEY: ${ADMIN_KEY}" -X PUT "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" -d "$route_payload" | jq
         # Test without key
-        CODE_NO_KEY=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -s -o /dev/null -w "%{http_code}" "${PROXY_URL}/secure")
+        CODE_NO_KEY=$(curl -s --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 -o /dev/null -w "%{http_code}" "${PROXY_URL}/secure")
         if [[ "$CODE_NO_KEY" -ne 401 ]]; then
           echo "ERROR: Expected 401 without key, got $CODE_NO_KEY"
           exit 1
         fi
         # Test with key - should get 200 (proxied to upstream)
-        CODE_KEY=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -s -o /dev/null -w "%{http_code}" -H "apikey: consumer-key" "${PROXY_URL}/secure")
+        CODE_KEY=$(curl --fail -s -o /dev/null -w "%{http_code}" -H "apikey: consumer-key" "${PROXY_URL}/secure")
         if [[ "$CODE_KEY" -ne 200 ]]; then
           echo "ERROR: Expected 200 with key, got $CODE_KEY"
           exit 1

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -1,16 +1,17 @@
 package:
   name: apache-apisix
-  version: "3.12.0"
+  version: "3.13.0"
   epoch: 0
   description: "The Cloud-Native API Gateway and AI Gateway"
   copyright:
     - license: Apache-2.0
-  options:
-    no-depends: true
   dependencies:
     runtime:
-      - etcd
+      - bash
+      # base64 is required at runtime
+      - coreutils
       - luajit
+      - openresty
 
 environment:
   contents:
@@ -25,7 +26,7 @@ environment:
       - luajit
       - luajit-dev
       - luarocks
-      - openldab-dev
+      - openldap-dev
       - openresty
       - openssl
       - openssl-dev
@@ -45,14 +46,194 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/apache/apisix
-      tag: v${{package.version}}
-      expected-commit: 75d94c051fc940a174fbdba4ce0588c13fecf864
+      tag: ${{package.version}}
+      expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
 
-  # - runs: ./configure --prefix=/usr --with-lua=/usr
+  - uses: patch
+    with:
+      patches: set-deps-path.patch
 
-  # - uses: autoconf/make
+  - runs: |
+      luarocks install apisix-master-0.rockspec --tree deps --only-deps
 
-  # - uses: autoconf/make-install
+  # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
+  - name: Setup required directories
+    runs: |
+      install -d "${{targets.contextdir}}"/usr/local/apisix/
+      install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
+      install -d "${{targets.contextdir}}"/usr/local/apisix/conf/cert
+      install conf/mime.types "${{targets.contextdir}}"/usr/local/apisix/conf/mime.types
+      install conf/config.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/config.yaml
+      install conf/debug.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/debug.yaml
+      install conf/cert/* "${{targets.contextdir}}"/usr/local/apisix/conf/cert/
+
+      # directories listed in alphabetical order
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix
+      install apisix/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/admin
+      install apisix/admin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/admin/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer
+      install apisix/balancer/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/cli
+      install apisix/cli/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/cli/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/control
+      install apisix/control/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/control/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core
+      install apisix/core/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns
+      install apisix/core/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery
+      install apisix/discovery/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/
+
+      install -d \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes \
+        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
+
+      install apisix/discovery/consul/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul/
+      install apisix/discovery/consul_kv/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv/
+      install apisix/discovery/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns/
+      install apisix/discovery/eureka/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka/
+      install apisix/discovery/kubernetes/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes/
+      install apisix/discovery/nacos/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos/
+      install apisix/discovery/tars/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http
+      install apisix/http/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router
+      install apisix/http/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model
+      install apisix/include/apisix/model/*.proto "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect
+      install apisix/inspect/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins
+      install apisix/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin
+      install apisix/plugins/ext-plugin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode
+      install apisix/plugins/grpc-transcode/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction
+      install apisix/plugins/ip-restriction/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn
+      install apisix/plugins/limit-conn/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req
+      install apisix/plugins/limit-req/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count
+      install apisix/plugins/limit-count/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa
+      install apisix/plugins/opa/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus
+      install apisix/plugins/prometheus/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache
+      install apisix/plugins/proxy-cache/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless
+      install apisix/plugins/serverless/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog
+      install apisix/plugins/syslog/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls
+      install apisix/plugins/tencent-cloud-cls/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub
+      install apisix/pubsub/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/secret
+      install apisix/secret/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/secret/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin
+      install apisix/plugins/zipkin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router
+      install apisix/ssl/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream
+      install apisix/stream/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins
+      install apisix/stream/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router
+      install apisix/stream/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc
+      install apisix/stream/xrpc/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis
+      install apisix/stream/xrpc/protocols/redis/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo
+      install apisix/stream/xrpc/protocols/dubbo/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/utils
+      install apisix/utils/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/utils/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy
+      install apisix/plugins/ai-proxy/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers
+      install apisix/plugins/ai-drivers/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings
+      install apisix/plugins/ai-rag/embeddings/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search
+      install apisix/plugins/ai-rag/vector-search/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search/
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker
+      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport
+      install apisix/plugins/mcp/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/
+      install apisix/plugins/mcp/broker/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker/
+      install apisix/plugins/mcp/transport/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport/
+
+      install -d "${{targets.contextdir}}"/usr/bin/
+      install bin/apisix "${{targets.contextdir}}"/usr/bin/apisix
+
+      install -d "${{targets.contextdir}}"/usr/local/apisix/deps/bin
+      install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
+      mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
+      mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
+
+subpackages:
+  - name: "apache-apisix-compat"
+    description: "Compat package for apache-apisix"
+    dependencies:
+      runtime:
+        # https://github.com/apache/apisix-docker/blob/release/apisix-3.13.0/debian/Dockerfile#L45
+        - brotli
+        - ca-certificates-bundle
+    pipeline:
+      - runs: |
+          install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
+          ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
+          ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
+          install docker/debian-dev/docker-entrypoint.sh "${{targets.contextdir}}"/
+          install docker/utils/check_standalone_config.sh "${{targets.contextdir}}"/
 
 update:
   enabled: true
@@ -61,10 +242,15 @@ update:
     strip-prefix: v
     use-tag: true
 
-# test:
-#   environment:
-#     contents:
-#       packages:
-
-#   pipeline:
-#     - runs: |
+test:
+  environment:
+    contents:
+      packages:
+        - etcd
+  pipeline:
+    - runs: |
+        apisix version | grep ${{package.version}}
+        apisix test | grep "configuration test is successful"
+    - name: "Test setup and run apisix"
+      runs: |
+        nohup etcd >/tmp/etcd.log 2>&1 &

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -13,6 +13,7 @@ package:
       - gd
       - geoip
       - libgcc
+      - libwasmtime
       - libxslt
       - luajit
       - merged-usrsbin
@@ -27,7 +28,6 @@ environment:
     packages:
       - bash
       - build-base
-      - busybox
       - busybox
       - ca-certificates-bundle
       - coreutils
@@ -62,6 +62,7 @@ environment:
       - wget
       - xz
       - yaml-dev
+      - zlib
       - zlib-dev
 
 vars:
@@ -205,8 +206,8 @@ pipeline:
     runs: |
       mkdir -p ${{targets.destdir}}/var/run/openresty/
       mkdir -p ${{targets.destdir}}/etc/nginx/conf.d
-      install -m644 -D nginx.conf ${{targets.destdir}}/etc/nginx/
-      install -m644 -D default.conf ${{targets.destdir}}/etc/nginx/conf.d
+      install -m644 -D ${{vars.BUILD_DIRECTORY}}/nginx.conf ${{targets.destdir}}/etc/nginx/
+      install -m644 -D ${{vars.BUILD_DIRECTORY}}/default.conf ${{targets.destdir}}/etc/nginx/conf.d
       mkdir -p ${{targets.destdir}}/var/log/openresty
       ln -sf /dev/stdout ${{targets.destdir}}/var/log/openresty/access.log
       ln -sf /dev/stderr ${{targets.destdir}}/var/log/openresty/error.log
@@ -229,7 +230,7 @@ pipeline:
   - uses: patch
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
-      patches: set-deps-path.patch
+      patches: ${{vars.BUILD_DIRECTORY}}/set-deps-path.patch
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
     runs: |
       luarocks install apisix-master-0.rockspec --tree deps --only-deps
@@ -396,6 +397,8 @@ pipeline:
       install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
       mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
       mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
+
+      cd asdf
 
 subpackages:
   - name: "apache-apisix-compat"

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -161,17 +161,6 @@ pipeline:
         --with-pcre \
         --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/include' \
         --with-ld-opt='-L/usr/lib -Wl,-rpath,/usr/lib' \
-        --conf-path=/etc/nginx/nginx.conf \
-        --sbin-path=/usr/bin/nginx \
-        --error-log-path=/var/log/openresty/error.log \
-        --http-log-path=/var/log/openresty/access.log \
-        --pid-path=/var/log/openresty/nginx.pid \
-        --lock-path=/var/log/openresty/nginx.lock \
-        --http-client-body-temp-path=/var/run/openresty/nginx-client-body \
-        --http-proxy-temp-path=/var/run/openresty/nginx-proxy \
-        --http-fastcgi-temp-path=/var/run/openresty/nginx-fastcgi \
-        --http-uwsgi-temp-path=/var/run/openresty/nginx-uwsgi \
-        --http-scgi-temp-path=/var/run/openresty/nginx-scgi \
         --with-poll_module \
         --with-pcre-jit \
         --without-http_rds_json_module \
@@ -434,7 +423,7 @@ subpackages:
           install -d "${{targets.contextdir}}"/usr/local/openresty/bin/
           ln -sf /usr/bin/openresty "${{targets.contextdir}}"/usr/local/openresty/bin/openresty
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
-          ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
+          ln -sf /dev/stderr "${{targets.contextdir}}"/usr/local/apisix/logs/error.log
           install docker/debian-dev/docker-entrypoint.sh "${{targets.contextdir}}"/
           install docker/utils/check_standalone_config.sh "${{targets.contextdir}}"/
 
@@ -461,7 +450,7 @@ test:
     - runs: |
         apisix version | grep ${{package.version}}
         apisix test | grep "configuration test is successful"
-    - name: "Setup and run apisix, run simple http endpoint with python"
+    - name: "Setup and run apisix"
       runs: |
         nohup etcd >/dev/null 2>&1 &
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:2379/health

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -1,0 +1,93 @@
+package:
+  name: apache-apisix
+  version: "3.12.0"
+  epoch: 0
+  description: "The Cloud-Native API Gateway and AI Gateway"
+  copyright:
+    - license: Apache-2.0
+  options:
+    no-depends: true
+  dependencies:
+    runtime:
+      - curl
+      - gcc
+      - git
+      - luajit
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - luajit-dev
+      - openssl-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/luarocks/luarocks
+      tag: v${{package.version}}
+      expected-commit: 705bb7408656ae9a60709894920284f83d948ec3
+
+  - runs: ./configure --prefix=/usr --with-lua=/usr
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  github:
+    identifier: luarocks/luarocks
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - luajit-dev
+        - glibc-dev
+        - openresty
+        - curl
+        - wget
+        - bash
+        - zlib-dev
+        - glibc-dev
+        - python3
+  pipeline:
+    - runs: |
+        # install lzlib rock
+        luarocks --version
+        curl -LO https://luarocks.org/manifests/hisham/lzlib-0.4.1.53-4.rockspec
+        luarocks install lzlib-0.4.1.53-4.rockspec ZLIB_INCDIR=/usr/include
+
+        # start openresty
+        cp default.conf /etc/nginx/conf.d/default.conf
+        openresty -g "daemon off;" > /dev/null 2>&1 &
+        OPENRESTY_PID=$!
+        sleep 1
+
+        # Generate zlib-compressed data
+        echo -n "Hello from lzlib!" | \
+        python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.compress(sys.stdin.buffer.read()))' \
+        > /tmp/compressed_data.bin
+
+        # 3) Send the POST request to localhost
+        curl -i -X POST --data-binary @/tmp/compressed_data.bin http://127.0.0.1:80/
+
+        # 5) Check the error log for our success message
+        if grep -q "Successfully decompressed: Hello from lzlib!" /var/log/openresty/all_error.log; then
+          echo "Test PASSED: ✔ Found decompressed message."
+          kill $OPENRESTY_PID
+          exit 0
+        else
+          echo "Test FAILED: ✗ Message not decompressed!"
+          # Show the last few lines of error log to help debug
+          echo "Log tail:"
+          tail -n 20 /var/log/openresty/all_error.log
+          kill $OPENRESTY_PID
+          exit 1
+        fi

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -9,9 +9,7 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - curl
-      - gcc
-      - git
+      - etcd
       - luajit
 
 environment:
@@ -20,16 +18,35 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - curl
+      - etcd
+      - gcc
+      - gnupg
+      - luajit
       - luajit-dev
-      - openssl-dev
+      - luarocks
+      - openldab-dev
+      - openresty
+      - openssl
+      - patch
+      - pcre
+      - pcre-dev
+      - perl
+      - perl-app-cpanminus
+      - perl-dev
+      - perl-extutils-embed
+      - unzip
+      - wget
+      - xz
+      - yaml-dev
       - zlib-dev
 
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/luarocks/luarocks
+      repository: https://github.com/apache/apisix
       tag: v${{package.version}}
-      expected-commit: 705bb7408656ae9a60709894920284f83d948ec3
+      expected-commit: 75d94c051fc940a174fbdba4ce0588c13fecf864
 
   - runs: ./configure --prefix=/usr --with-lua=/usr
 
@@ -40,7 +57,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: luarocks/luarocks
+    identifier: apache/apisix
     strip-prefix: v
     use-tag: true
 
@@ -48,46 +65,6 @@ test:
   environment:
     contents:
       packages:
-        - luajit-dev
-        - glibc-dev
-        - openresty
-        - curl
-        - wget
-        - bash
-        - zlib-dev
-        - glibc-dev
-        - python3
+
   pipeline:
     - runs: |
-        # install lzlib rock
-        luarocks --version
-        curl -LO https://luarocks.org/manifests/hisham/lzlib-0.4.1.53-4.rockspec
-        luarocks install lzlib-0.4.1.53-4.rockspec ZLIB_INCDIR=/usr/include
-
-        # start openresty
-        cp default.conf /etc/nginx/conf.d/default.conf
-        openresty -g "daemon off;" > /dev/null 2>&1 &
-        OPENRESTY_PID=$!
-        sleep 1
-
-        # Generate zlib-compressed data
-        echo -n "Hello from lzlib!" | \
-        python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.compress(sys.stdin.buffer.read()))' \
-        > /tmp/compressed_data.bin
-
-        # 3) Send the POST request to localhost
-        curl -i -X POST --data-binary @/tmp/compressed_data.bin http://127.0.0.1:80/
-
-        # 5) Check the error log for our success message
-        if grep -q "Successfully decompressed: Hello from lzlib!" /var/log/openresty/all_error.log; then
-          echo "Test PASSED: ✔ Found decompressed message."
-          kill $OPENRESTY_PID
-          exit 0
-        else
-          echo "Test FAILED: ✗ Message not decompressed!"
-          # Show the last few lines of error log to help debug
-          echo "Log tail:"
-          tail -n 20 /var/log/openresty/all_error.log
-          kill $OPENRESTY_PID
-          exit 1
-        fi

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -127,6 +127,7 @@ pipeline:
       tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
       destination: lua-var-nginx-module
+  # Apply upstream patches to configure out nginx server
   # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
   - name: Apply ngx-multi-upstream patches
     working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
@@ -136,6 +137,7 @@ pipeline:
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+  # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
   - name: Configure openresty build
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
@@ -145,6 +147,7 @@ pipeline:
         --add-module=../nginx-multi-upstream \
         --add-module=../lua-var-nginx-module \
         --add-module=../wasm-nginx-module \
+        --add-module=../apisix-nginx-module \
         --add-module=../apisix-nginx-module/src/meta \
         --add-module=../apisix-nginx-module/src/stream \
         --build=${{host.triplet.gnu}} \
@@ -208,17 +211,28 @@ pipeline:
       mkdir -p ${{targets.destdir}}/etc/nginx/conf.d
       install -m644 -D ${{vars.BUILD_DIRECTORY}}/nginx.conf ${{targets.destdir}}/etc/nginx/
       install -m644 -D ${{vars.BUILD_DIRECTORY}}/default.conf ${{targets.destdir}}/etc/nginx/conf.d
-      mkdir -p ${{targets.destdir}}/var/log/openresty
-      ln -sf /dev/stdout ${{targets.destdir}}/var/log/openresty/access.log
-      ln -sf /dev/stderr ${{targets.destdir}}/var/log/openresty/error.log
+      install -d ${{targets.contextdir}}/var/log/openresty
+      ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
+      ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
+  # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
+  # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
   - name: Install lua-resty-events library into the openresty directory
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
       install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
       install -m644 -D /usr/local/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
       install -m644 -D /usr/local/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
+  - name: Install apisix-nginx-module
+    working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
+    runs: |
+      OPENRESTY_PREFIX="${{targets.destdir}}/usr/local/openresty" make install
+  - name: Install wasm-nginx-module
+    working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
+    runs: |
+      install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
   - uses: strip
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+  # With openresty built and the modules in place, checkout apisix
   - uses: git-checkout
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
@@ -397,8 +411,6 @@ pipeline:
       install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
       mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
       mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
-
-      cd asdf
 
 subpackages:
   - name: "apache-apisix-compat"

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -220,8 +220,8 @@ pipeline:
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
       install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
-      install -m644 -D /usr/local/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
-      install -m644 -D /usr/local/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
+      install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
+      install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
   - name: Install apisix-nginx-module
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
     runs: |
@@ -532,6 +532,3 @@ test:
           echo "ERROR: Expected 200 with key, got $CODE_KEY"
           exit 1
         fi
-        # Cleanup
-        curl -s -H "X-API-KEY: ${ADMIN_KEY}" -X DELETE "${ADMIN_URL}/apisix/admin/routes/${ROUTE_KA}" >/dev/null
-        curl -s -H "X-API-KEY: ${ADMIN_KEY}" -X DELETE "${ADMIN_URL}/apisix/admin/consumers/test-consumer" >/dev/null

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -456,8 +456,15 @@ test:
         apisix test | grep "configuration test is successful"
     - name: "Setup and run apisix, run simple http endpoint with python"
       runs: |
-        etcd 2>&1 &
-        apisix start
+        nohup etcd >/dev/null 2>&1 &
+        curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 1 --retry-max-time 40 http://127.0.01:2379/health
+    - name: "Apisix server start"
+      uses: test/daemon-check-output
+      with:
+        start: apisix start
+        expected_output: "trying to initialize the data of etcd"
+        error_strings: |
+          "all etcd nodes are unavailable"
     - name: "Spin up a simple nodejs web app."
       runs: |
         nohup node <<'JS' > server.log 2>&1 &

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -456,7 +456,7 @@ test:
         apisix test | grep "configuration test is successful"
     - name: "Setup and run apisix, run simple http endpoint with python"
       runs: |
-        nohup etcd >/tmp/etcd.log 2>&1 &
+        etcd 2>&1 &
         apisix start
     - name: "Spin up a simple nodejs web app."
       runs: |

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -322,6 +322,8 @@ test:
     - name: "Setup and run apisix"
       runs: |
         nohup etcd >/dev/null 2>&1 &
+        CHILD_PID=$!
+        trap "kill $CHILD_PID" EXIT
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:2379/health
       uses: test/daemon-check-output
       with:
@@ -369,6 +371,8 @@ test:
         }).listen(8000, () => console.log('Listening on http://0.0.0.0:8000'));
         EOF
         nohup node server.js &
+        CHILD_PID=$!
+        trap "kill $CHILD_PID" EXIT
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:8000/get
         # Get the API key
         ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -44,7 +44,6 @@ environment:
       - libxml2-dev
       - libxslt-dev
       - linux-headers
-      - lua-resty-events
       - lua-resty-worker-events
       - luajit-dev
       - luarocks
@@ -73,8 +72,9 @@ vars:
   OPENRESTY_VERSION: "1.27.1.2"
   OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"
   NGINX_VERSION: "1.27.1"
-  RESTY_EVENTS_VERSION: "0.3.1"
-  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787"
+  # 0.2.0 is required by apisix
+  RESTY_EVENTS_VERSION: "0.2.0"
+  RESTY_EVENTS_CHECKSUM: "8448a92cec36ac04ea522e78f6496ba03c9b1fd8"
   NGX_MULTI_UPSTREAM_VERSION: "1.3.2"
   NGX_MULTI_UPSTREAM_CHECKSUM: "0c9e4cec7cb8ec281a4e66fe2dcf2b927c8ef46d"
   DUBBO_MODULE_VERSION: "1.0.2"
@@ -201,7 +201,7 @@ pipeline:
         runs: |
           mkdir -p ${{targets.destdir}}/usr/bin
           mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
-      - name: Setup default openresty config files
+      - name: Setup openresty configuration
         working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
         runs: |
           mkdir -p ${{targets.destdir}}/var/run/openresty/
@@ -211,14 +211,6 @@ pipeline:
           install -d ${{targets.contextdir}}/var/log/openresty
           ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
           ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
-      # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
-      # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
-      - name: Install lua-resty-events library into the openresty directory
-        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-        runs: |
-          install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
-          install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
-          install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
       - name: Install apisix-nginx-module
         working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
         runs: |
@@ -227,6 +219,11 @@ pipeline:
         working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
         runs: |
           install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
+      - name: Install lua-resty-events module
+        working-directory: ${{vars.BUILD_DIRECTORY}}/lua-resty-events
+        uses: autoconf/make-install
+        with:
+          opts: "LUA_LIB_DIR=/usr/local/openresty/lualib/"
   - name: "Build Apache APISIX"
     pipeline:
       # With openresty built and the modules in place, checkout apisix
@@ -250,15 +247,16 @@ pipeline:
         uses: autoconf/make-install
         with:
           dir: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
-      - name: Install required dependencies
+      - name: Install required dependencies and move files to correct locations
         working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
         runs: |
           install -d "${{targets.contextdir}}"/usr/local/apisix/deps/lib
           install -d "${{targets.contextdir}}"/usr/local/apisix/deps/share
+          install -m755 -D /usr/bin/apisix "${{targets.contextdir}}"/usr/local/bin/apisix
           mv /usr/local/apisix/* "${{targets.contextdir}}"/usr/local/apisix/
           mv /usr/share/lua/5.1/apisix "${{targets.contextdir}}"/usr/local/apisix/
-          mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
-          mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
+          mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/
+          mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/
   # As of 3.13.0, apisix-dashboard is included in the apisix image:
   # https://github.com/apache/apisix/pull/12276
   - name: "Build and Install APISIX Dashboard"
@@ -274,7 +272,7 @@ pipeline:
         runs: |
           ./apisix-build-tools/build-apisix-dashboard.sh .
           mv ./ui ${{targets.contextdir}}/usr/local/apisix/
-      - uses: strip
+  - uses: strip
 
 subpackages:
   - name: "apache-apisix-compat"
@@ -289,9 +287,11 @@ subpackages:
         runs: |
           install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
           install -d "${{targets.contextdir}}"/usr/local/openresty/bin/
+          install -d "${{targets.contextdir}}"/usr/bin
           ln -sf /usr/bin/openresty "${{targets.contextdir}}"/usr/local/openresty/bin/openresty
           ln -sf /dev/stdout "${{targets.contextdir}}"/usr/local/apisix/logs/access.log
           ln -sf /dev/stderr "${{targets.contextdir}}"/usr/local/apisix/logs/error.log
+          ln -sf /usr/local/bin/apisix "${{targets.contextdir}}"/usr/bin/apisix
           install docker/debian-dev/docker-entrypoint.sh "${{targets.contextdir}}"/
           install docker/utils/check_standalone_config.sh "${{targets.contextdir}}"/
 

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -322,8 +322,6 @@ test:
     - name: "Setup and run apisix"
       runs: |
         nohup etcd >/dev/null 2>&1 &
-        CHILD_PID=$!
-        trap "kill $CHILD_PID" EXIT
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:2379/health
       uses: test/daemon-check-output
       with:
@@ -371,8 +369,6 @@ test:
         }).listen(8000, () => console.log('Listening on http://0.0.0.0:8000'));
         EOF
         nohup node server.js &
-        CHILD_PID=$!
-        trap "kill $CHILD_PID" EXIT
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:8000/get
         # Get the API key
         ADMIN_KEY=$(yq e -r '.deployment.admin.admin_key[] | .key' /usr/local/apisix/conf/config.yaml)
@@ -405,3 +401,5 @@ test:
           echo "ERROR: Expected 200 with key, got $CODE_KEY"
           exit 1
         fi
+        pkill etcd
+        pkill node

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -86,320 +86,324 @@ vars:
 # apisix builds openresty from source with a several added modules:
 # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L82
 pipeline:
-  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/
-    uses: fetch
-    with:
-      uri: https://openresty.org/download/openresty-${{vars.OPENRESTY_VERSION}}.tar.gz
-      expected-sha256: ${{vars.OPENRESTY_CHECKSUM}}
-  - uses: git-checkout
-    with:
-      repository: https://github.com/Kong/lua-resty-events
-      tag: ${{vars.RESTY_EVENTS_VERSION}}
-      expected-commit: ${{vars.RESTY_EVENTS_CHECKSUM}}
-      destination: lua-resty-events
-  - uses: git-checkout
-    with:
-      repository: https://github.com/api7/ngx_multi_upstream_module.git
-      tag: ${{vars.NGX_MULTI_UPSTREAM_VERSION}}
-      expected-commit: ${{vars.NGX_MULTI_UPSTREAM_CHECKSUM}}
-      destination: nginx-multi-upstream
-  - uses: git-checkout
-    with:
-      repository: https://github.com/api7/mod_dubbo.git
-      tag: ${{vars.DUBBO_MODULE_VERSION}}
-      expected-commit: ${{vars.DUBBO_MODULE_CHECKSUM}}
-      destination: dubbo-module
-  - uses: git-checkout
-    with:
-      repository: https://github.com/api7/apisix-nginx-module.git
-      tag: ${{vars.APISIX_NGINX_MODULE_VERSION}}
-      expected-commit: ${{vars.APISIX_NGINX_MODULE_CHECKSUM}}
-      destination: apisix-nginx-module
-  - uses: git-checkout
-    with:
-      repository: https://github.com/api7/wasm-nginx-module.git
-      tag: ${{vars.WASM_NGINX_MODULE_VERSION}}
-      expected-commit: ${{vars.WASM_NGINX_MODULE_CHECKSUM}}
-      destination: wasm-nginx-module
-  - uses: git-checkout
-    with:
-      repository: https://github.com/api7/lua-var-nginx-module
-      tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
-      expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
-      destination: lua-var-nginx-module
-  # Apply upstream patches to configure out nginx server
-  # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
-  - name: Apply ngx-multi-upstream patches
-    working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
-    runs: |
-      ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-  - name: Apply apisix-nginx-module patches
-    working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
-    runs: |
-      ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-  # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
-  - name: Configure openresty build
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    runs: |
-      ./configure \
-        --add-module=../lua-resty-events \
-        --add-module=../dubbo-module \
-        --add-module=../nginx-multi-upstream \
-        --add-module=../lua-var-nginx-module \
-        --add-module=../wasm-nginx-module \
-        --add-module=../apisix-nginx-module \
-        --add-module=../apisix-nginx-module/src/meta \
-        --add-module=../apisix-nginx-module/src/stream \
-        --build=${{host.triplet.gnu}} \
-        --with-pcre \
-        --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/include' \
-        --with-ld-opt='-L/usr/lib -Wl,-rpath,/usr/lib' \
-        --with-poll_module \
-        --with-pcre-jit \
-        --without-http_rds_json_module \
-        --without-http_rds_csv_module \
-        --without-lua_rds_parser \
-        --with-stream \
-        --with-stream_ssl_module \
-        --with-stream_ssl_preread_module \
-        --with-http_v2_module \
-        --with-http_v3_module \
-        --without-mail_pop3_module \
-        --without-mail_imap_module \
-        --without-mail_smtp_module \
-        --with-http_stub_status_module \
-        --with-http_realip_module \
-        --with-http_addition_module \
-        --with-http_auth_request_module \
-        --with-http_secure_link_module \
-        --with-http_random_index_module \
-        --with-http_gzip_static_module \
-        --with-http_sub_module \
-        --with-http_dav_module \
-        --with-http_flv_module \
-        --with-http_mp4_module \
-        --with-http_gunzip_module \
-        --with-threads \
-        --with-compat \
-        --with-luajit=/usr \
-        --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
-        --with-pcre-jit
-  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    uses: autoconf/make
-  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    uses: autoconf/make-install
-  - name: Move openresty binaries to /usr/bin
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
-  - name: Setup default openresty config files
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    runs: |
-      mkdir -p ${{targets.destdir}}/var/run/openresty/
-      mkdir -p ${{targets.destdir}}/etc/nginx/conf.d
-      install -m644 -D ${{vars.BUILD_DIRECTORY}}/nginx.conf ${{targets.destdir}}/etc/nginx/
-      install -m644 -D ${{vars.BUILD_DIRECTORY}}/default.conf ${{targets.destdir}}/etc/nginx/conf.d
-      install -d ${{targets.contextdir}}/var/log/openresty
-      ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
-      ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
-  # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
-  # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
-  - name: Install lua-resty-events library into the openresty directory
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    runs: |
-      install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
-      install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
-      install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
-  - name: Install apisix-nginx-module
-    working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
-    runs: |
-      OPENRESTY_PREFIX="${{targets.destdir}}/usr/local/openresty" make install
-  - name: Install wasm-nginx-module
-    working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
-    runs: |
-      install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
-  # With openresty built and the modules in place, checkout apisix
-  - uses: git-checkout
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    with:
-      repository: https://github.com/apache/apisix
-      tag: ${{package.version}}
-      expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
-      destination: apache-apisix
-  # Patch to update the apisix script to use our lua libraries
-  - uses: patch
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-    with:
-      patches: ${{vars.BUILD_DIRECTORY}}/set-deps-path.patch
-  - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
-    runs: |
-      luarocks install apisix-master-0.rockspec --tree deps --only-deps
-  # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
-  - name: Setup required apisix directories
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
-    runs: |
-      install -d "${{targets.contextdir}}"/usr/local/apisix/
-      install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
-      install -d "${{targets.contextdir}}"/usr/local/apisix/conf/cert
-      install conf/mime.types "${{targets.contextdir}}"/usr/local/apisix/conf/mime.types
-      install conf/config.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/config.yaml
-      install conf/debug.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/debug.yaml
-      install conf/cert/* "${{targets.contextdir}}"/usr/local/apisix/conf/cert/
+  - pipeline:
+      - name: "Build Openresty"
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/
+        uses: fetch
+        with:
+          uri: https://openresty.org/download/openresty-${{vars.OPENRESTY_VERSION}}.tar.gz
+          expected-sha256: ${{vars.OPENRESTY_CHECKSUM}}
+      - uses: git-checkout
+        with:
+          repository: https://github.com/Kong/lua-resty-events
+          tag: ${{vars.RESTY_EVENTS_VERSION}}
+          expected-commit: ${{vars.RESTY_EVENTS_CHECKSUM}}
+          destination: lua-resty-events
+      - uses: git-checkout
+        with:
+          repository: https://github.com/api7/ngx_multi_upstream_module.git
+          tag: ${{vars.NGX_MULTI_UPSTREAM_VERSION}}
+          expected-commit: ${{vars.NGX_MULTI_UPSTREAM_CHECKSUM}}
+          destination: nginx-multi-upstream
+      - uses: git-checkout
+        with:
+          repository: https://github.com/api7/mod_dubbo.git
+          tag: ${{vars.DUBBO_MODULE_VERSION}}
+          expected-commit: ${{vars.DUBBO_MODULE_CHECKSUM}}
+          destination: dubbo-module
+      - uses: git-checkout
+        with:
+          repository: https://github.com/api7/apisix-nginx-module.git
+          tag: ${{vars.APISIX_NGINX_MODULE_VERSION}}
+          expected-commit: ${{vars.APISIX_NGINX_MODULE_CHECKSUM}}
+          destination: apisix-nginx-module
+      - uses: git-checkout
+        with:
+          repository: https://github.com/api7/wasm-nginx-module.git
+          tag: ${{vars.WASM_NGINX_MODULE_VERSION}}
+          expected-commit: ${{vars.WASM_NGINX_MODULE_CHECKSUM}}
+          destination: wasm-nginx-module
+      - uses: git-checkout
+        with:
+          repository: https://github.com/api7/lua-var-nginx-module
+          tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
+          expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
+          destination: lua-var-nginx-module
+      # Apply upstream patches to configure out nginx server
+      # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
+      - name: Apply ngx-multi-upstream patches
+        working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
+        runs: |
+          ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+      - name: Apply apisix-nginx-module patches
+        working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
+        runs: |
+          ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+      # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
+      - name: Configure openresty build
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        runs: |
+          ./configure \
+            --add-module=../lua-resty-events \
+            --add-module=../dubbo-module \
+            --add-module=../nginx-multi-upstream \
+            --add-module=../lua-var-nginx-module \
+            --add-module=../wasm-nginx-module \
+            --add-module=../apisix-nginx-module \
+            --add-module=../apisix-nginx-module/src/meta \
+            --add-module=../apisix-nginx-module/src/stream \
+            --build=${{host.triplet.gnu}} \
+            --with-pcre \
+            --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/include' \
+            --with-ld-opt='-L/usr/lib -Wl,-rpath,/usr/lib' \
+            --with-poll_module \
+            --with-pcre-jit \
+            --without-http_rds_json_module \
+            --without-http_rds_csv_module \
+            --without-lua_rds_parser \
+            --with-stream \
+            --with-stream_ssl_module \
+            --with-stream_ssl_preread_module \
+            --with-http_v2_module \
+            --with-http_v3_module \
+            --without-mail_pop3_module \
+            --without-mail_imap_module \
+            --without-mail_smtp_module \
+            --with-http_stub_status_module \
+            --with-http_realip_module \
+            --with-http_addition_module \
+            --with-http_auth_request_module \
+            --with-http_secure_link_module \
+            --with-http_random_index_module \
+            --with-http_gzip_static_module \
+            --with-http_sub_module \
+            --with-http_dav_module \
+            --with-http_flv_module \
+            --with-http_mp4_module \
+            --with-http_gunzip_module \
+            --with-threads \
+            --with-compat \
+            --with-luajit=/usr \
+            --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
+            --with-pcre-jit
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        uses: autoconf/make
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        uses: autoconf/make-install
+      - name: Move openresty binaries to /usr/bin
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        runs: |
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
+      - name: Setup default openresty config files
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        runs: |
+          mkdir -p ${{targets.destdir}}/var/run/openresty/
+          mkdir -p ${{targets.destdir}}/etc/nginx/conf.d
+          install -m644 -D ${{vars.BUILD_DIRECTORY}}/nginx.conf ${{targets.destdir}}/etc/nginx/
+          install -m644 -D ${{vars.BUILD_DIRECTORY}}/default.conf ${{targets.destdir}}/etc/nginx/conf.d
+          install -d ${{targets.contextdir}}/var/log/openresty
+          ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
+          ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
+      # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
+      # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
+      - name: Install lua-resty-events library into the openresty directory
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        runs: |
+          install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
+          install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
+          install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
+      - name: Install apisix-nginx-module
+        working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
+        runs: |
+          OPENRESTY_PREFIX="${{targets.destdir}}/usr/local/openresty" make install
+      - name: Install wasm-nginx-module
+        working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
+        runs: |
+          install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
+  - pipeline:
+      - name: "Build Apache APISIX"
+      # With openresty built and the modules in place, checkout apisix
+      - uses: git-checkout
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        with:
+          repository: https://github.com/apache/apisix
+          tag: ${{package.version}}
+          expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
+          destination: apache-apisix
+      # Patch to update the apisix script to use our lua libraries
+      - uses: patch
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+        with:
+          patches: ${{vars.BUILD_DIRECTORY}}/set-deps-path.patch
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+        runs: |
+          luarocks install apisix-master-0.rockspec --tree deps --only-deps
+      # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
+      - name: Setup required apisix directories
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+        runs: |
+          install -d "${{targets.contextdir}}"/usr/local/apisix/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/conf/cert
+          install conf/mime.types "${{targets.contextdir}}"/usr/local/apisix/conf/mime.types
+          install conf/config.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/config.yaml
+          install conf/debug.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/debug.yaml
+          install conf/cert/* "${{targets.contextdir}}"/usr/local/apisix/conf/cert/
 
-      # directories listed in alphabetical order
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix
-      install apisix/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/
+          # directories listed in alphabetical order
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix
+          install apisix/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/admin
-      install apisix/admin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/admin/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/admin
+          install apisix/admin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/admin/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer
-      install apisix/balancer/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer
+          install apisix/balancer/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/cli
-      install apisix/cli/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/cli/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/cli
+          install apisix/cli/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/cli/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/control
-      install apisix/control/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/control/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/control
+          install apisix/control/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/control/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core
-      install apisix/core/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core
+          install apisix/core/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns
-      install apisix/core/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns
+          install apisix/core/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery
-      install apisix/discovery/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery
+          install apisix/discovery/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/
 
-      install -d \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes \
-        "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
+          install -d \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes \
+            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
 
-      install apisix/discovery/consul/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul/
-      install apisix/discovery/consul_kv/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv/
-      install apisix/discovery/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns/
-      install apisix/discovery/eureka/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka/
-      install apisix/discovery/kubernetes/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes/
-      install apisix/discovery/nacos/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos/
-      install apisix/discovery/tars/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
+          install apisix/discovery/consul/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul/
+          install apisix/discovery/consul_kv/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv/
+          install apisix/discovery/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns/
+          install apisix/discovery/eureka/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka/
+          install apisix/discovery/kubernetes/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes/
+          install apisix/discovery/nacos/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos/
+          install apisix/discovery/tars/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http
-      install apisix/http/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http
+          install apisix/http/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router
-      install apisix/http/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router
+          install apisix/http/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model
-      install apisix/include/apisix/model/*.proto "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model
+          install apisix/include/apisix/model/*.proto "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect
-      install apisix/inspect/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect
+          install apisix/inspect/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins
-      install apisix/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins
+          install apisix/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin
-      install apisix/plugins/ext-plugin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin
+          install apisix/plugins/ext-plugin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode
-      install apisix/plugins/grpc-transcode/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode
+          install apisix/plugins/grpc-transcode/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction
-      install apisix/plugins/ip-restriction/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction
+          install apisix/plugins/ip-restriction/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn
-      install apisix/plugins/limit-conn/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn
+          install apisix/plugins/limit-conn/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req
-      install apisix/plugins/limit-req/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req
+          install apisix/plugins/limit-req/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count
-      install apisix/plugins/limit-count/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count
+          install apisix/plugins/limit-count/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa
-      install apisix/plugins/opa/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa
+          install apisix/plugins/opa/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus
-      install apisix/plugins/prometheus/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus
+          install apisix/plugins/prometheus/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache
-      install apisix/plugins/proxy-cache/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache
+          install apisix/plugins/proxy-cache/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless
-      install apisix/plugins/serverless/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless
+          install apisix/plugins/serverless/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog
-      install apisix/plugins/syslog/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog
+          install apisix/plugins/syslog/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls
-      install apisix/plugins/tencent-cloud-cls/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls
+          install apisix/plugins/tencent-cloud-cls/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub
-      install apisix/pubsub/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub
+          install apisix/pubsub/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/secret
-      install apisix/secret/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/secret/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/secret
+          install apisix/secret/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/secret/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin
-      install apisix/plugins/zipkin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin
+          install apisix/plugins/zipkin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router
-      install apisix/ssl/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router
+          install apisix/ssl/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream
-      install apisix/stream/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream
+          install apisix/stream/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins
-      install apisix/stream/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins
+          install apisix/stream/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router
-      install apisix/stream/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router
+          install apisix/stream/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc
-      install apisix/stream/xrpc/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc
+          install apisix/stream/xrpc/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis
-      install apisix/stream/xrpc/protocols/redis/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis
+          install apisix/stream/xrpc/protocols/redis/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo
-      install apisix/stream/xrpc/protocols/dubbo/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo
+          install apisix/stream/xrpc/protocols/dubbo/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/utils
-      install apisix/utils/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/utils/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/utils
+          install apisix/utils/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/utils/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy
-      install apisix/plugins/ai-proxy/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy
+          install apisix/plugins/ai-proxy/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers
-      install apisix/plugins/ai-drivers/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers
+          install apisix/plugins/ai-drivers/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings
-      install apisix/plugins/ai-rag/embeddings/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings
+          install apisix/plugins/ai-rag/embeddings/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search
-      install apisix/plugins/ai-rag/vector-search/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search
+          install apisix/plugins/ai-rag/vector-search/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search/
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker
-      install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport
-      install apisix/plugins/mcp/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/
-      install apisix/plugins/mcp/broker/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker/
-      install apisix/plugins/mcp/transport/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport/
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker
+          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport
+          install apisix/plugins/mcp/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/
+          install apisix/plugins/mcp/broker/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker/
+          install apisix/plugins/mcp/transport/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport/
 
-      install -d "${{targets.contextdir}}"/usr/bin/
-      install bin/apisix "${{targets.contextdir}}"/usr/bin/apisix
+          install -d "${{targets.contextdir}}"/usr/bin/
+          install bin/apisix "${{targets.contextdir}}"/usr/bin/apisix
 
-      install -d "${{targets.contextdir}}"/usr/local/apisix/deps/bin
-      install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
-      mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
-      mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
-  - uses: strip
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+          install -d "${{targets.contextdir}}"/usr/local/apisix/deps/bin
+          install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
+          mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
+          mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
+      - uses: strip
+        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
 
 subpackages:
   - name: "apache-apisix-compat"

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -48,6 +48,7 @@ environment:
       - lua-resty-worker-events
       - luajit-dev
       - luarocks
+      - nodejs
       - openldap-dev
       - openresty
       - openssl-dev
@@ -55,6 +56,7 @@ environment:
       - pcre-dev
       - perl-app-cpanminus
       - perl-dev
+      - pnpm
       - readline-dev
       - unzip
       - wasmtime-dev
@@ -83,6 +85,9 @@ vars:
   WASM_NGINX_MODULE_CHECKSUM: "0b4b31d6ecfdbc587e8ea455ed6e920a98aadff1"
   LUA_VAR_NGINX_MODULE_VERSION: "v0.5.3"
   LUA_VAR_NGINX_MODULE_CHECKSUM: "dc04c71e14e8a0407831f9019043d7e6da61b3c3"
+  # This checksum is retrived from the apisix-build-tools repository
+  # https://github.com/api7/apisix-build-tools
+  APISIX_BUILD_TOOLS_CHECKSUM: "cbf9796396f543e9e6757abd465273b3021e544d"
 
 # apisix builds openresty from source with a several added modules:
 # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L82
@@ -250,8 +255,25 @@ pipeline:
         runs: |
           install -d "${{targets.contextdir}}"/usr/local/apisix/deps/lib
           install -d "${{targets.contextdir}}"/usr/local/apisix/deps/share
+          mv /usr/local/apisix/* "${{targets.contextdir}}"/usr/local/apisix/
+          mv /usr/share/lua/5.1/apisix "${{targets.contextdir}}"/usr/local/apisix/
           mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
           mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
+  # As of 3.13.0, apisix-dashboard is included in the apisix image:
+  # https://github.com/apache/apisix/pull/12276
+  - name: "Build and Install APISIX Dashboard"
+    pipeline:
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+        uses: git-checkout
+        with:
+          repository: https://github.com/api7/apisix-build-tools.git
+          tag: "apisix/${{package.version}}"
+          expected-commit: ${{vars.APISIX_BUILD_TOOLS_CHECKSUM}}
+          destination: apisix-build-tools
+      - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+        runs: |
+          ./apisix-build-tools/build-apisix-dashboard.sh .
+          mv ./ui ${{targets.contextdir}}/usr/local/apisix/
       - uses: strip
 
 subpackages:

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -11,7 +11,7 @@ package:
       - bash
       # base64 is required at runtime
       - coreutils
-      - dash-binsh
+      - bash-binsh
       - gawk
       - gd
       - geoip
@@ -20,11 +20,9 @@ package:
       - libwasmtime
       - libxslt
       - luajit
-      - merged-usrsbin
       - openssl
       - pcre
       - perl
-      - wolfi-baselayout
       - zlib
 
 environment:
@@ -47,30 +45,25 @@ environment:
       - linux-headers
       - lua-resty-events
       - lua-resty-worker-events
-      - luajit
       - luajit-dev
       - luarocks
       - openldap-dev
-      - openssl
       - openssl-dev
       - patch
-      - pcre
       - pcre-dev
-      - perl
       - perl-app-cpanminus
       - perl-dev
       - readline-dev
       - unzip
-      - wasmtime
+      - bash-binsh
       - wasmtime-dev
       - wget
       - xz
       - yaml-dev
-      - zlib
       - zlib-dev
 
 vars:
-  # These environment variables need updated for each new release. Retrieve their
+  # These environment variables need to be updated for each new release. Retrieve their
   # correct values from here, replacing <package-version> with the package version.
   #   - https://github.com/api7/apisix-build-tools/blob/apisix/<package-version>/build-apisix-runtime.sh
   BUILD_DIRECTORY: "/home/build"
@@ -78,7 +71,7 @@ vars:
   OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"
   NGINX_VERSION: "1.27.1"
   RESTY_EVENTS_VERSION: "0.3.1"
-  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787"
+  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787" 
   NGX_MULTI_UPSTREAM_VERSION: "1.3.2"
   NGX_MULTI_UPSTREAM_CHECKSUM: "0c9e4cec7cb8ec281a4e66fe2dcf2b927c8ef46d"
   DUBBO_MODULE_VERSION: "1.0.2"
@@ -98,53 +91,62 @@ pipeline:
     with:
       uri: https://openresty.org/download/openresty-${{vars.OPENRESTY_VERSION}}.tar.gz
       expected-sha256: ${{vars.OPENRESTY_CHECKSUM}}
+
   - uses: git-checkout
     with:
       repository: https://github.com/Kong/lua-resty-events
       tag: ${{vars.RESTY_EVENTS_VERSION}}
       expected-commit: ${{vars.RESTY_EVENTS_CHECKSUM}}
       destination: lua-resty-events
+
   - uses: git-checkout
     with:
       repository: https://github.com/api7/ngx_multi_upstream_module.git
       tag: ${{vars.NGX_MULTI_UPSTREAM_VERSION}}
       expected-commit: ${{vars.NGX_MULTI_UPSTREAM_CHECKSUM}}
       destination: nginx-multi-upstream
+
   - uses: git-checkout
     with:
       repository: https://github.com/api7/mod_dubbo.git
       tag: ${{vars.DUBBO_MODULE_VERSION}}
       expected-commit: ${{vars.DUBBO_MODULE_CHECKSUM}}
       destination: dubbo-module
+
   - uses: git-checkout
     with:
       repository: https://github.com/api7/apisix-nginx-module.git
       tag: ${{vars.APISIX_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.APISIX_NGINX_MODULE_CHECKSUM}}
       destination: apisix-nginx-module
+
   - uses: git-checkout
     with:
       repository: https://github.com/api7/wasm-nginx-module.git
       tag: ${{vars.WASM_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.WASM_NGINX_MODULE_CHECKSUM}}
       destination: wasm-nginx-module
+  
   - uses: git-checkout
     with:
       repository: https://github.com/api7/lua-var-nginx-module
       tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
       destination: lua-var-nginx-module
+
   # Apply upstream patches to configure out nginx server
   # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
   - name: Apply ngx-multi-upstream patches
     working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+
   - name: Apply apisix-nginx-module patches
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
   # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
+
   - name: Configure openresty build
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
@@ -191,15 +193,19 @@ pipeline:
         --with-luajit=/usr \
         --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
         --with-pcre-jit
+
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     uses: autoconf/make
+
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     uses: autoconf/make-install
+
   - name: Move openresty binaries to /usr/bin
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
+
   - name: Setup default openresty config files
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
@@ -210,6 +216,7 @@ pipeline:
       install -d ${{targets.contextdir}}/var/log/openresty
       ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
       ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
+
   # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
   # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
   - name: Install lua-resty-events library into the openresty directory
@@ -218,16 +225,18 @@ pipeline:
       install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
       install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
       install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
+
   - name: Install apisix-nginx-module
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
     runs: |
       OPENRESTY_PREFIX="${{targets.destdir}}/usr/local/openresty" make install
+
   - name: Install wasm-nginx-module
     working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
     runs: |
       install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
-  - uses: strip
-    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+
+
   # With openresty built and the modules in place, checkout apisix
   - uses: git-checkout
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
@@ -236,14 +245,17 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
       destination: apache-apisix
+
   # Patch to update the apisix script to use our lua libraries
   - uses: patch
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
       patches: ${{vars.BUILD_DIRECTORY}}/set-deps-path.patch
+
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
     runs: |
       luarocks install apisix-master-0.rockspec --tree deps --only-deps
+
   # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
   - name: Setup required apisix directories
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
@@ -408,6 +420,9 @@ pipeline:
       mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
       mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
 
+  - uses: strip
+    working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
+
 subpackages:
   - name: "apache-apisix-compat"
     description: "Compat package for apache-apisix"
@@ -428,11 +443,8 @@ subpackages:
           install docker/utils/check_standalone_config.sh "${{targets.contextdir}}"/
 
 update:
-  enabled: true
-  github:
-    identifier: apache/apisix
-    strip-prefix: v
-    use-tag: true
+  enabled: false
+  exclude-reason: "This package requires manual updates due to its complexity and dependencies on specific versions of other software."
 
 test:
   environment:
@@ -454,7 +466,6 @@ test:
       runs: |
         nohup etcd >/dev/null 2>&1 &
         curl --fail --retry 5 --retry-delay 2 --retry-connrefused --retry-max-time 15 http://127.0.0.1:2379/health
-    - name: "Apisix server start"
       uses: test/daemon-check-output
       with:
         start: apisix start

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -49,6 +49,7 @@ environment:
       - luajit-dev
       - luarocks
       - openldap-dev
+      - openresty
       - openssl-dev
       - patch
       - pcre-dev
@@ -86,8 +87,8 @@ vars:
 # apisix builds openresty from source with a several added modules:
 # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L82
 pipeline:
-  - pipeline:
-      - name: "Build Openresty"
+  - name: "Build Openresty"
+    pipeline:
       - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/
         uses: fetch
         with:
@@ -221,8 +222,8 @@ pipeline:
         working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
         runs: |
           install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
-  - pipeline:
-      - name: "Build Apache APISIX"
+  - name: "Build Apache APISIX"
+    pipeline:
       # With openresty built and the modules in place, checkout apisix
       - uses: git-checkout
         working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
@@ -241,169 +242,17 @@ pipeline:
           luarocks install apisix-master-0.rockspec --tree deps --only-deps
       # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
       - name: Setup required apisix directories
+        uses: autoconf/make-install
+        with:
+          dir: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
+      - name: Install required dependencies
         working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
         runs: |
-          install -d "${{targets.contextdir}}"/usr/local/apisix/
-          install -d "${{targets.contextdir}}"/usr/local/apisix/logs/
-          install -d "${{targets.contextdir}}"/usr/local/apisix/conf/cert
-          install conf/mime.types "${{targets.contextdir}}"/usr/local/apisix/conf/mime.types
-          install conf/config.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/config.yaml
-          install conf/debug.yaml "${{targets.contextdir}}"/usr/local/apisix/conf/debug.yaml
-          install conf/cert/* "${{targets.contextdir}}"/usr/local/apisix/conf/cert/
-
-          # directories listed in alphabetical order
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix
-          install apisix/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/admin
-          install apisix/admin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/admin/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer
-          install apisix/balancer/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/balancer/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/cli
-          install apisix/cli/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/cli/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/control
-          install apisix/control/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/control/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core
-          install apisix/core/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns
-          install apisix/core/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/core/dns/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery
-          install apisix/discovery/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/
-
-          install -d \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes \
-            "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
-
-          install apisix/discovery/consul/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul/
-          install apisix/discovery/consul_kv/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/consul_kv/
-          install apisix/discovery/dns/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/dns/
-          install apisix/discovery/eureka/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/eureka/
-          install apisix/discovery/kubernetes/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/kubernetes/
-          install apisix/discovery/nacos/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/nacos/
-          install apisix/discovery/tars/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/discovery/tars/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http
-          install apisix/http/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router
-          install apisix/http/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/http/router/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model
-          install apisix/include/apisix/model/*.proto "${{targets.contextdir}}"/usr/local/apisix/apisix/include/apisix/model/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect
-          install apisix/inspect/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/inspect/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins
-          install apisix/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin
-          install apisix/plugins/ext-plugin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ext-plugin/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode
-          install apisix/plugins/grpc-transcode/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/grpc-transcode/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction
-          install apisix/plugins/ip-restriction/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ip-restriction/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn
-          install apisix/plugins/limit-conn/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-conn/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req
-          install apisix/plugins/limit-req/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-req/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count
-          install apisix/plugins/limit-count/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/limit-count/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa
-          install apisix/plugins/opa/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/opa/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus
-          install apisix/plugins/prometheus/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/prometheus/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache
-          install apisix/plugins/proxy-cache/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/proxy-cache/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless
-          install apisix/plugins/serverless/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/serverless/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog
-          install apisix/plugins/syslog/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/syslog/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls
-          install apisix/plugins/tencent-cloud-cls/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/tencent-cloud-cls/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub
-          install apisix/pubsub/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/pubsub/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/secret
-          install apisix/secret/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/secret/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin
-          install apisix/plugins/zipkin/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/zipkin/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router
-          install apisix/ssl/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/ssl/router/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream
-          install apisix/stream/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins
-          install apisix/stream/plugins/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/plugins/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router
-          install apisix/stream/router/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/router/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc
-          install apisix/stream/xrpc/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis
-          install apisix/stream/xrpc/protocols/redis/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/redis/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo
-          install apisix/stream/xrpc/protocols/dubbo/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/stream/xrpc/protocols/dubbo/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/utils
-          install apisix/utils/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/utils/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy
-          install apisix/plugins/ai-proxy/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-proxy/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers
-          install apisix/plugins/ai-drivers/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-drivers/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings
-          install apisix/plugins/ai-rag/embeddings/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/embeddings/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search
-          install apisix/plugins/ai-rag/vector-search/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/ai-rag/vector-search/
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker
-          install -d "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport
-          install apisix/plugins/mcp/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/
-          install apisix/plugins/mcp/broker/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/broker/
-          install apisix/plugins/mcp/transport/*.lua "${{targets.contextdir}}"/usr/local/apisix/apisix/plugins/mcp/transport/
-
-          install -d "${{targets.contextdir}}"/usr/bin/
-          install bin/apisix "${{targets.contextdir}}"/usr/bin/apisix
-
-          install -d "${{targets.contextdir}}"/usr/local/apisix/deps/bin
-          install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
+          install -d "${{targets.contextdir}}"/usr/local/apisix/deps/lib
+          install -d "${{targets.contextdir}}"/usr/local/apisix/deps/share
           mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
           mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
       - uses: strip
-        working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
 
 subpackages:
   - name: "apache-apisix-compat"
@@ -425,8 +274,12 @@ subpackages:
           install docker/utils/check_standalone_config.sh "${{targets.contextdir}}"/
 
 update:
-  enabled: false
+  enabled: true
+  manual: true
   exclude-reason: "This package requires manual updates due to its complexity and dependencies on specific versions of other software."
+  github:
+    identifier: apache/apisix
+    use-tag: true
 
 test:
   environment:

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -9,9 +9,9 @@ package:
     runtime:
       # https://github.com/apache/apisix/blob/master/docker/debian-dev/docker-entrypoint.sh
       - bash
+      - bash-binsh
       # base64 is required at runtime
       - coreutils
-      - bash-binsh
       - gawk
       - gd
       - geoip
@@ -29,6 +29,7 @@ environment:
   contents:
     packages:
       - bash
+      - bash-binsh
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -55,7 +56,6 @@ environment:
       - perl-dev
       - readline-dev
       - unzip
-      - bash-binsh
       - wasmtime-dev
       - wget
       - xz
@@ -71,7 +71,7 @@ vars:
   OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"
   NGINX_VERSION: "1.27.1"
   RESTY_EVENTS_VERSION: "0.3.1"
-  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787" 
+  RESTY_EVENTS_CHECKSUM: "bc85295b7c23eda2dbf2b4acec35c93f77b26787"
   NGX_MULTI_UPSTREAM_VERSION: "1.3.2"
   NGX_MULTI_UPSTREAM_CHECKSUM: "0c9e4cec7cb8ec281a4e66fe2dcf2b927c8ef46d"
   DUBBO_MODULE_VERSION: "1.0.2"
@@ -91,61 +91,52 @@ pipeline:
     with:
       uri: https://openresty.org/download/openresty-${{vars.OPENRESTY_VERSION}}.tar.gz
       expected-sha256: ${{vars.OPENRESTY_CHECKSUM}}
-
   - uses: git-checkout
     with:
       repository: https://github.com/Kong/lua-resty-events
       tag: ${{vars.RESTY_EVENTS_VERSION}}
       expected-commit: ${{vars.RESTY_EVENTS_CHECKSUM}}
       destination: lua-resty-events
-
   - uses: git-checkout
     with:
       repository: https://github.com/api7/ngx_multi_upstream_module.git
       tag: ${{vars.NGX_MULTI_UPSTREAM_VERSION}}
       expected-commit: ${{vars.NGX_MULTI_UPSTREAM_CHECKSUM}}
       destination: nginx-multi-upstream
-
   - uses: git-checkout
     with:
       repository: https://github.com/api7/mod_dubbo.git
       tag: ${{vars.DUBBO_MODULE_VERSION}}
       expected-commit: ${{vars.DUBBO_MODULE_CHECKSUM}}
       destination: dubbo-module
-
   - uses: git-checkout
     with:
       repository: https://github.com/api7/apisix-nginx-module.git
       tag: ${{vars.APISIX_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.APISIX_NGINX_MODULE_CHECKSUM}}
       destination: apisix-nginx-module
-
   - uses: git-checkout
     with:
       repository: https://github.com/api7/wasm-nginx-module.git
       tag: ${{vars.WASM_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.WASM_NGINX_MODULE_CHECKSUM}}
       destination: wasm-nginx-module
-  
   - uses: git-checkout
     with:
       repository: https://github.com/api7/lua-var-nginx-module
       tag: ${{vars.LUA_VAR_NGINX_MODULE_VERSION}}
       expected-commit: ${{vars.LUA_VAR_NGINX_MODULE_CHECKSUM}}
       destination: lua-var-nginx-module
-
   # Apply upstream patches to configure out nginx server
   # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L130
   - name: Apply ngx-multi-upstream patches
     working-directory: ${{vars.BUILD_DIRECTORY}}/nginx-multi-upstream/
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-
   - name: Apply apisix-nginx-module patches
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-
   # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
   - name: Configure openresty build
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
@@ -193,19 +184,15 @@ pipeline:
         --with-luajit=/usr \
         --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
         --with-pcre-jit
-
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     uses: autoconf/make
-
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     uses: autoconf/make-install
-
   - name: Move openresty binaries to /usr/bin
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       mv ${{targets.destdir}}/usr/local/openresty/bin/* ${{targets.destdir}}/usr/bin/
-
   - name: Setup default openresty config files
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |
@@ -216,7 +203,6 @@ pipeline:
       install -d ${{targets.contextdir}}/var/log/openresty
       ln -sf /dev/stdout ${{targets.contextdir}}/var/log/openresty/access.log
       ln -sf /dev/stderr ${{targets.contextdir}}/var/log/openresty/error.log
-
   # Install lua-resty-events, apisix-nginx-module, and wasm-nginx-module
   # https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L208
   - name: Install lua-resty-events library into the openresty directory
@@ -225,18 +211,14 @@ pipeline:
       install -d ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat
       install -m644 -D /usr/lib/lua/resty/events/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/
       install -m644 -D /usr/lib/lua/resty/events/compat/*.lua  ${{targets.destdir}}/usr/local/openresty/site/lualib/resty/events/compat/
-
   - name: Install apisix-nginx-module
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module
     runs: |
       OPENRESTY_PREFIX="${{targets.destdir}}/usr/local/openresty" make install
-
   - name: Install wasm-nginx-module
     working-directory: ${{vars.BUILD_DIRECTORY}}/wasm-nginx-module
     runs: |
       install -m 664 lib/resty/*.lua ${{targets.destdir}}/usr/local/openresty/lualib/resty
-
-
   # With openresty built and the modules in place, checkout apisix
   - uses: git-checkout
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
@@ -245,17 +227,14 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 77dacda31277a31d6014b4970e36bae2a5c30907
       destination: apache-apisix
-
   # Patch to update the apisix script to use our lua libraries
   - uses: patch
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     with:
       patches: ${{vars.BUILD_DIRECTORY}}/set-deps-path.patch
-
   - working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
     runs: |
       luarocks install apisix-master-0.rockspec --tree deps --only-deps
-
   # https://github.com/apache/apisix/blob/master/Makefile#L248-L388
   - name: Setup required apisix directories
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}/apache-apisix
@@ -419,7 +398,6 @@ pipeline:
       install bin/apisix "${{targets.contextdir}}"/usr/local/apisix/deps/bin/apisix
       mv deps/lib "${{targets.contextdir}}"/usr/local/apisix/deps/lib
       mv deps/share "${{targets.contextdir}}"/usr/local/apisix/deps/share
-
   - uses: strip
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
 

--- a/apache-apisix.yaml
+++ b/apache-apisix.yaml
@@ -62,10 +62,10 @@ environment:
       - yaml-dev
       - zlib-dev
 
+# These environment variables need to be updated for each new release. Retrieve their
+# correct values from here, replacing <package-version> with the package version.
+#   - https://github.com/api7/apisix-build-tools/blob/apisix/<package-version>/build-apisix-runtime.sh
 vars:
-  # These environment variables need to be updated for each new release. Retrieve their
-  # correct values from here, replacing <package-version> with the package version.
-  #   - https://github.com/api7/apisix-build-tools/blob/apisix/<package-version>/build-apisix-runtime.sh
   BUILD_DIRECTORY: "/home/build"
   OPENRESTY_VERSION: "1.27.1.2"
   OPENRESTY_CHECKSUM: "74f076f7e364b2a99a6c5f9bb531c27610c78985abe956b442b192a2295f7548"
@@ -145,8 +145,8 @@ pipeline:
     working-directory: ${{vars.BUILD_DIRECTORY}}/apisix-nginx-module/patch
     runs: |
       ./patch.sh ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
-  # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
 
+  # Configure is replicated from here: https://github.com/api7/apisix-build-tools/blob/apisix/3.13.0/build-apisix-runtime.sh#L161
   - name: Configure openresty build
     working-directory: ${{vars.BUILD_DIRECTORY}}/openresty-${{vars.OPENRESTY_VERSION}}
     runs: |

--- a/apache-apisix/default.conf
+++ b/apache-apisix/default.conf
@@ -1,0 +1,58 @@
+# nginx.vh.default.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/etc/nginx/conf.d/default.conf`
+#
+# It tracks the `server` section of the upstream OpenResty's `nginx.conf`.
+#
+# This config (and any other configs in `etc/nginx/conf.d/`) is loaded by
+# default by the `include` directive in `/etc/nginx/nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/local/openresty/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/local/openresty/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           /usr/local/openresty/nginx/html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/apache-apisix/nginx.conf
+++ b/apache-apisix/nginx.conf
@@ -1,0 +1,90 @@
+# nginx.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/etc/nginx/nginx.conf`
+# and is the file loaded by nginx at startup,
+# unless the user specifies otherwise.
+#
+# It tracks the upstream OpenResty's `nginx.conf`, but removes the `server`
+# section and adds this directive:
+#     `include /etc/nginx/conf.d/*.conf;`
+#
+# The `docker-openresty` file `nginx.vh.default.conf` is copied to
+# `/etc/nginx/conf.d/default.conf`.  It contains the `server section
+# of the upstream `nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+#user  nobody;
+#worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    # Enables or disables the use of underscores in client request header fields.
+    # When the use of underscores is disabled, request header fields whose names contain underscores are marked as invalid and become subject to the ignore_invalid_headers directive.
+    # underscores_in_headers off;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+        # Log in JSON Format
+        # log_format nginxlog_json escape=json '{ "timestamp": "$time_iso8601", '
+        # '"remote_addr": "$remote_addr", '
+        #  '"body_bytes_sent": $body_bytes_sent, '
+        #  '"request_time": $request_time, '
+        #  '"response_status": $status, '
+        #  '"request": "$request", '
+        #  '"request_method": "$request_method", '
+        #  '"host": "$host",'
+        #  '"upstream_addr": "$upstream_addr",'
+        #  '"http_x_forwarded_for": "$http_x_forwarded_for",'
+        #  '"http_referrer": "$http_referer", '
+        #  '"http_user_agent": "$http_user_agent", '
+        #  '"http_version": "$server_protocol", '
+        #  '"nginx_access": true }';
+        # access_log /dev/stdout nginxlog_json;
+
+    # See Move default writable paths to a dedicated directory (#119)
+    # https://github.com/openresty/docker-openresty/issues/119
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    # Don't reveal OpenResty version to clients.
+    # server_tokens off;
+}

--- a/apache-apisix/set-deps-path.patch
+++ b/apache-apisix/set-deps-path.patch
@@ -1,0 +1,21 @@
+diff --git a/bin/apisix b/bin/apisix
+index f4c75fbb..11c780d9 100755
+--- a/bin/apisix
++++ b/bin/apisix
+@@ -38,11 +38,12 @@ if [[ -e $OR_EXEC && "$OR_VER" -ge 119 ]]; then
+     # OpenResty version is >= 1.19, use luajit by default
+     ROOT=$(${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')
+     # find the luajit binary of openresty
+-    LUAJIT_BIN="$ROOT"/luajit/bin/luajit
+-
++    LUAJIT_BIN="/usr/bin/luajit"
++    LUA_EXTRA_PATH="package.path = '/usr/local/apisix/deps/share/lua/5.1/?/init.lua;' .. package.path"
++ 
+     # use the luajit of openresty
+-    echo "$LUAJIT_BIN $APISIX_LUA $*"
+-    exec $LUAJIT_BIN $APISIX_LUA $*
++    echo "$LUAJIT_BIN -e "$LUA_EXTRA_PATH" $APISIX_LUA $*"
++    exec $LUAJIT_BIN -e "$LUA_EXTRA_PATH" $APISIX_LUA $*
+ else
+     echo "ERROR: Please check the version of OpenResty and Lua, OpenResty 1.19+ + LuaJIT is required for Apache APISIX."
+ fi

--- a/apache-apisix/set-deps-path.patch
+++ b/apache-apisix/set-deps-path.patch
@@ -1,7 +1,7 @@
 diff --git a/bin/apisix b/bin/apisix
 index f4c75fbb..11c780d9 100755
---- a/bin/apisix
-+++ b/bin/apisix
+--- a/apache-apisix/bin/apisix
++++ b/apache-apisix/bin/apisix
 @@ -38,11 +38,12 @@ if [[ -e $OR_EXEC && "$OR_VER" -ge 119 ]]; then
      # OpenResty version is >= 1.19, use luajit by default
      ROOT=$(${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

There are several dependencies brought in to build into openresty, which greatly add to the complexity to this package. I referenced the [ingress-nginx-controller](https://github.com/wolfi-dev/os/blob/main/ingress-nginx-controller-1.12.yaml) package in styling this one. That package follows a similar practice of building openresty from source.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
