### PR TITLE
new package: go-slim

### DIFF
--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -77,7 +77,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
-  
+
   - name: "${{package.name}}-slim"
     description: "Go without CGO or runtime dependencies"
     dependencies:

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -68,7 +68,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "go-1.20-doc"
+  - name: "${{package.name}}-doc"
     description: "go documentation"
     pipeline:
       - runs: |
@@ -77,6 +77,57 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+  
+  - name: "${{package.name}}-slim"
+    description: "Go without CGO or runtime dependencies"
+    dependencies:
+      provides:
+        - go-slim=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # Create necessary directories
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mkdir -p "${{targets.contextdir}}"/usr/lib/go/bin
+
+          # Install core binaries
+          for bin in go gofmt; do
+            install -Dm755 "${{targets.destdir}}"/usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/lib/go/bin/$bin
+            ln -s /usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/bin/
+          done
+
+          # Copy standard library and essential files
+          cp -a "${{targets.destdir}}"/usr/lib/go/pkg "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/lib "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/src "${{targets.contextdir}}"/usr/lib/go/
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - name: Test Go installation
+          runs: |
+            # Write a simple "Hello World" Go program
+            cat <<EOF > hello.go
+            package main
+            import "fmt"
+            func main() {
+                fmt.Println("Hello World")
+            }
+            EOF
+
+            # Format the Go program
+            go fmt hello.go
+
+            # Run the Go program and check the output
+            go run hello.go | grep "Hello World"
+            go version
+            go help
+            gofmt --help
+        - name: Test Go cross-compilation
+          runs: |
+            # Build the Go program for a different OS/architecture
+            GOOS=freebsd GOARCH=amd64 go build hello.go
 
 update:
   enabled: true
@@ -134,6 +185,11 @@ test:
             C.hello()
         }
         EOF
+
+        # TODO: Remove after upstream issue resolved
+        if [ ${{build.arch}} = "aarch64" ]; then
+          export GCC_SPEC_FILE=/dev/null
+        fi
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -93,6 +93,58 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+  
+  - name: "${{package.name}}-slim"
+    description: "Go without CGO or runtime dependencies"
+    dependencies:
+      provides:
+        - go-slim=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # Create necessary directories
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mkdir -p "${{targets.contextdir}}"/usr/lib/go/bin
+
+          # Install core binaries
+          for bin in go gofmt; do
+            install -Dm755 "${{targets.destdir}}"/usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/lib/go/bin/$bin
+            ln -s /usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/bin/
+          done
+
+          # Copy standard library and essential files
+          cp -a "${{targets.destdir}}"/usr/lib/go/pkg "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/lib "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/src "${{targets.contextdir}}"/usr/lib/go/
+          cp -p "${{targets.destdir}}"/usr/lib/go/go.env "${{targets.contextdir}}"/usr/lib/go/go.env
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - name: Test Go installation
+          runs: |
+            # Write a simple "Hello World" Go program
+            cat <<EOF > hello.go
+            package main
+            import "fmt"
+            func main() {
+                fmt.Println("Hello World")
+            }
+            EOF
+
+            # Format the Go program
+            go fmt hello.go
+
+            # Run the Go program and check the output
+            go run hello.go | grep "Hello World"
+            go version
+            go help
+            gofmt --help
+        - name: Test Go cross-compilation
+          runs: |
+            # Build the Go program for a different OS/architecture
+            GOOS=freebsd GOARCH=amd64 go build hello.go
 
 update:
   enabled: true
@@ -150,6 +202,11 @@ test:
             C.hello()
         }
         EOF
+
+        # TODO: Remove after upstream issue resolved
+        if [ ${{build.arch}} = "aarch64" ]; then
+          export GCC_SPEC_FILE=/dev/null
+        fi
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -93,7 +93,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
-  
+
   - name: "${{package.name}}-slim"
     description: "Go without CGO or runtime dependencies"
     dependencies:

--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -92,6 +92,96 @@ subpackages:
       pipeline:
         - uses: test/docs
 
+  - name: "${{package.name}}-slim"
+    description: "Go without CGO or runtime dependencies"
+    dependencies:
+      provides:
+        - go-slim=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # Create necessary directories
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mkdir -p "${{targets.contextdir}}"/usr/lib/go/bin
+
+          # Install core binaries
+          for bin in go gofmt; do
+            install -Dm755 "${{targets.destdir}}"/usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/lib/go/bin/$bin
+            ln -s /usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/bin/
+          done
+
+          # Copy standard library and essential files
+          cp -a "${{targets.destdir}}"/usr/lib/go/pkg "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/lib "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/src "${{targets.contextdir}}"/usr/lib/go/
+          cp -p "${{targets.destdir}}"/usr/lib/go/go.env "${{targets.contextdir}}"/usr/lib/go/go.env
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - name: Test Go installation
+          runs: |
+            # Write a simple "Hello World" Go program
+            cat <<EOF > hello.go
+            package main
+            import "fmt"
+            func main() {
+                fmt.Println("Hello World")
+            }
+            EOF
+
+            # Format the Go program
+            go fmt hello.go
+
+            # Run the Go program and check the output
+            go run hello.go | grep "Hello World"
+            go version
+            go help
+            gofmt --help
+        - name: Test Go cross-compilation
+          runs: |
+            # Build the Go program for a different OS/architecture
+            GOOS=freebsd GOARCH=amd64 go build hello.go
+        - name: Test telemetry settings
+          runs: |
+            fail() { echo "FAIL:" "$@" 1>&2; exit 1; }
+
+            tmpd=$(mktemp -d)
+            trap "rm -R '$tmpd'" EXIT
+            export HOME="$tmpd/home"
+            mkdir "$HOME"
+
+            out=$(go telemetry) || fail "'go telemetry' exited $?"
+            [ "$out" = "off" ] ||
+              fail "go telemetry output '$out'. expected 'off'"
+
+            cfgdir="$HOME/.config/go/telemetry"
+            if [ -d "$cfgdir" ]; then
+              fail "$cfgdir was created by running 'go telemetry'"
+            fi
+
+            go telemetry on ||
+              fail "'go telemetry on' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after 'on' exited $?"
+            [ "$out" = "on" ] ||
+              fail "go telemetry after 'on' output '$out'. expected 'on'"
+
+            [ -f "$cfgdir/mode" ] ||
+              fail "ERROR: 'go telemetry on' did not write ~/${cfgdir#$HOME/}"
+
+            go telemetry local ||
+              fail "'go telemetry local' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after 'local' exited $?"
+            [ "$out" = "local" ] ||
+              fail "go telemetry after 'local' output '$out'. expected 'on'"
+
+            go telemetry off ||
+              fail "explicit 'go telemetry off' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
+            [ "$out" = "off" ] ||
+              fail "go telemetry after explicit off output '$out'. expected 'off'"
+
 update:
   enabled: true
   shared: true
@@ -148,6 +238,11 @@ test:
             C.hello()
         }
         EOF
+
+        # TODO: Remove after upstream issue resolved
+        if [ ${{build.arch}} = "aarch64" ]; then
+          export GCC_SPEC_FILE=/dev/null
+        fi
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.4"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -112,6 +112,82 @@ subpackages:
       - runs: |
           find "${{targets.destdir}}/usr/lib/go/pkg/tool" -type f -name "${{range.key}}" \
             -exec install -Dm755 \{\} "${{targets.contextdir}}/usr/bin/${{range.key}}" \;
+
+  - name: "go-slim"
+    description: Go without CGO or runtime deps
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/go
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+
+          cp -r "${{targets.destdir}}"/usr/lib/go/* "${{targets.subpkgdir}}"/usr/lib/go/
+
+          for bin in go gofmt; do
+            ln -s /usr/lib/go/bin/$bin "${{targets.subpkgdir}}"/usr/bin/
+          done
+    test:
+      pipeline:
+        - name: Test Go installation
+          runs: |
+            # Write a simple "Hello World" Go program
+            cat <<EOF > hello.go
+            package main
+            import "fmt"
+            func main() {
+                fmt.Println("Hello World")
+            }
+            EOF
+
+            # Format the Go program
+            go fmt hello.go
+
+            # Run the Go program and check the output
+            go run hello.go | grep "Hello World"
+            go version
+            go help
+            gofmt --help
+        - name: Test Go cross-compilation
+          runs: |
+            # Build the Go program for a different OS/architecture
+            GOOS=freebsd GOARCH=amd64 go build hello.go
+        - name: Test telemetry settings
+          runs: |
+            fail() { echo "FAIL:" "$@" 1>&2; exit 1; }
+
+            tmpd=$(mktemp -d)
+            trap "rm -R '$tmpd'" EXIT
+            export HOME="$tmpd/home"
+            mkdir "$HOME"
+
+            out=$(go telemetry) || fail "'go telemetry' exited $?"
+            [ "$out" = "off" ] ||
+              fail "go telemetry output '$out'. expected 'off'"
+
+            cfgdir="$HOME/.config/go/telemetry"
+            if [ -d "$cfgdir" ]; then
+              fail "$cfgdir was created by running 'go telemetry'"
+            fi
+
+            go telemetry on ||
+              fail "'go telemetry on' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after 'on' exited $?"
+            [ "$out" = "on" ] ||
+              fail "go telemetry after 'on' output '$out'. expected 'on'"
+
+            [ -f "$cfgdir/mode" ] ||
+              fail "ERROR: 'go telemetry on' did not write ~/${cfgdir#$HOME/}"
+
+            go telemetry local ||
+              fail "'go telemetry local' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after 'local' exited $?"
+            [ "$out" = "local" ] ||
+              fail "go telemetry after 'local' output '$out'. expected 'on'"
+
+            go telemetry off ||
+              fail "explicit 'go telemetry off' exited $?"
+            out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
+            [ "$out" = "off" ] ||
+              fail "go telemetry after explicit off output '$out'. expected 'off'"
 
 update:
   enabled: true

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -96,8 +96,8 @@ subpackages:
     description: "go documentation"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share
-          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+          mkdir -p "${{targets.contextdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.contextdir}}"/usr/share/
     test:
       pipeline:
         - uses: test/docs
@@ -113,19 +113,33 @@ subpackages:
           find "${{targets.destdir}}/usr/lib/go/pkg/tool" -type f -name "${{range.key}}" \
             -exec install -Dm755 \{\} "${{targets.contextdir}}/usr/bin/${{range.key}}" \;
 
-  - name: "go-slim"
-    description: Go without CGO or runtime deps
+  - name: "${{package.name}}-slim"
+    description: "Go without CGO or runtime dependencies"
+    dependencies:
+      provides:
+        - go-slim=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/go
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          # Create necessary directories
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mkdir -p "${{targets.contextdir}}"/usr/lib/go/bin
 
-          cp -r "${{targets.destdir}}"/usr/lib/go/* "${{targets.subpkgdir}}"/usr/lib/go/
-
+          # Install core binaries
           for bin in go gofmt; do
-            ln -s /usr/lib/go/bin/$bin "${{targets.subpkgdir}}"/usr/bin/
+            install -Dm755 "${{targets.destdir}}"/usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/lib/go/bin/$bin
+            ln -s /usr/lib/go/bin/$bin "${{targets.contextdir}}"/usr/bin/
           done
+
+          # Copy standard library and essential files
+          cp -a "${{targets.destdir}}"/usr/lib/go/pkg "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/lib "${{targets.contextdir}}"/usr/lib/go/
+          cp -a "${{targets.destdir}}"/usr/lib/go/src "${{targets.contextdir}}"/usr/lib/go/
+          cp -p "${{targets.destdir}}"/usr/lib/go/go.env "${{targets.contextdir}}"/usr/lib/go/go.env
     test:
+      environment:
+        contents:
+          packages:
+            - busybox
       pipeline:
         - name: Test Go installation
           runs: |
@@ -245,6 +259,11 @@ test:
             C.hello()
         }
         EOF
+
+        # TODO: Remove after upstream issue resolved
+        if [ ${{build.arch}} = "aarch64" ]; then
+          export GCC_SPEC_FILE=/dev/null
+        fi
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"


### PR DESCRIPTION
Creating a slimmed-down Go subpackage without `cgo` or the runtime deps of the main Go package.