### PR TITLE
feat(gitness): bump dep for GHSA-vrw8-fxc6-2r93

### DIFF
--- a/gitness.yaml
+++ b/gitness.yaml
@@ -10,9 +10,9 @@ environment:
   contents:
     packages:
       - build-base
-      - gcc-14-default
       - busybox
       - ca-certificates-bundle
+      - gcc-14-default
       - go
       - nodejs
       - protobuf

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -10,6 +10,7 @@ environment:
   contents:
     packages:
       - build-base
+      - gcc-14-default
       - busybox
       - ca-certificates-bundle
       - go

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
   version: "3.2.0"
-  epoch: 1
+  epoch: 2
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,7 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
         golang.org/x/net@v0.38.0
         github.com/cloudflare/circl@v1.6.1
+        github.com/go-chi/chi/v5@v5.2.2
 
   - runs: |
       cd web


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump `github.com/go-chi/chi/v5` to `v5.2.2`
