### PR TITLE
kserve: fix CVE-2025-4565 and urllib3 CVEs

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: "0.15.2"
-  epoch: 1
+  epoch: 2
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -103,6 +103,14 @@ subpackages:
           # h11: CVE-2025-43859 GHSA-vqfr-h8mv-ghfj
           poetry add \
             "h11=^0.16.0"
+
+          # protobuf: CVE-2025-4565 GHSA-8qvm-5x2c-j2w7
+          poetry add \
+            "protobuf=^4.25.8"
+
+          # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v
+          poetry add \
+            "urllib3=^2.5.0"
 
           poetry run pip freeze | grep -v kserve > requirements.txt
           poetry build


### PR DESCRIPTION
## Summary

- Fixed protobuf CVE-2025-4565 by bumping to version 4.25.8
- Fixed urllib3 CVEs (CVE-2025-50182, CVE-2025-50181) by bumping to version 2.5.0  
- Incremented package epoch from 1 to 2 to trigger rebuild

## Changes

- Added `poetry add "protobuf=^4.25.8"` to fix denial of service vulnerability
- Added `poetry add "urllib3=^2.5.0"` to fix redirect control issues
- Updated epoch in package metadata

## Testing

- ✅ Package builds successfully 
- ✅ All tests pass
- ✅ CVE scan shows no remaining vulnerabilities in kserve-storage-controller

The fixes follow the existing pattern established in the kserve package for dependency version management via poetry.