### PR TITLE
kubevelta: Bump epoch to resolve CVE-2025-4673 and CVE-2025-22874

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: "1.10.3"
-  epoch: 6
+  epoch: 7
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bumps epoch to pull in latest Go version to resolve above CVEs. There are still two outstanding CVEs, around helm, that we have advisories for and I confirmed that they cannot be gobump'ed still.