### PR TITLE
step: Bump epoch, latest Go build

### DIFF
--- a/step.yaml
+++ b/step.yaml
@@ -1,7 +1,7 @@
 package:
   name: step
   version: "0.28.6"
-  epoch: 5
+  epoch: 6
   description: A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bumps epoch to grab latest Go build, ensure GHSA-vrw8-fxc6-2r93 CVE resolved.

Local build after bump:

```
powersj@framework ~/s/os (step/cve)> wolfictl scan packages/x86_64/step-0.28.6-r6.apk
🔎 Scanning "packages/x86_64/step-0.28.6-r6.apk"
✅ No vulnerabilities found
```