### PR TITLE
kubeflow-pipelines: fix urllib3 CVEs

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -17,6 +17,7 @@ environment:
     packages:
       - argo-cd
       - eslint
+      - gcc-14-default
       - go-licenses
       - jq
       - kubectl

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.5.0"
-  epoch: 3
+  epoch: 4
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -104,6 +104,9 @@ subpackages:
 
             # Patch GHSA-jfmj-5v4g-7637
             sed -i 's|zipp==3.15.0|zipp==3.19.1|g' requirements.txt
+
+            # google-auth: upgrade to support urllib3 2.x (fixes dependency conflict)
+            sed -i 's|google-auth==2.23.0|google-auth==2.40.3|g' requirements.txt
 
             # GHSA-79v4-65xg-pq4g
             echo "cryptography==44.0.1" >> requirements.txt

--- a/kubeflow-pipelines/fix-CVE-urllib3.patch
+++ b/kubeflow-pipelines/fix-CVE-urllib3.patch
@@ -1,7 +1,9 @@
 From 2850fa4031ff3adfa8af50eb6d22d16557a7e09e Mon Sep 17 00:00:00 2001
 From: Debasish Biswas <debasishbsws.dev@gmail.com>
 Date: Fri, 17 Jan 2025 19:11:47 +0530
-Subject: [PATCH 3/5] Remedieate(CVE): GHSA-34jh-p97f-mpxf
+Subject: [PATCH 3/5] fix(CVE): update urllib3 to fix CVE-2025-50181/50182
+
+Updated urllib3 to 2.5.0 to fix urllib3 CVEs GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v.
 
 Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>
 ---
@@ -17,7 +19,7 @@ index ba27bcb21..85f7f8cbe 100644
      #   importlib-metadata
      #   kfp
 -urllib3==1.26.16
-+urllib3==1.26.19
++urllib3==2.5.0
      # via
      #   google-auth
      #   kfp


### PR DESCRIPTION
## Summary

- Fixed urllib3 CVE-2025-50182 and CVE-2025-50181 by upgrading from 1.26.16 to 2.5.0
- Updated google-auth from 2.23.0 to 2.40.3 to resolve dependency conflicts
- Incremented package epoch from 3 to 4 to trigger rebuild

## Changes

- Modified `fix-CVE-urllib3.patch` to update urllib3 to version 2.5.0
- Added `sed` command to replace google-auth with compatible version 2.40.3
- Updated epoch in package metadata

## Testing

- Package builds successfully with resolved dependency conflicts
- urllib3 CVEs are addressed with the 2.5.0 upgrade

## Notes

The protobuf CVE (CVE-2025-4565) affecting version 3.20.3 will be addressed separately via advisory, as it requires a major version upgrade (3.x → 4.x) that upstream kubeflow-pipelines has not implemented yet.