### PR TITLE
glibc: Disable hardening due to ldconfig segfaulting on specific scenarios

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 51
+  epoch: 52
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -44,6 +44,10 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
+    # Disable until we figure out why ldconfig segfaults on specific
+    # scenarios (arm64 systems, likely only those running
+    # 6.15.3-r50-gcp-generic)
+    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
It's not clear why ldconfig is segfaulting on very specific scenarios (arm64 systems, likely running 6.15.3-r50-gcp-generic), so until we find out more, let's just disable the hardening flags.