### PR TITLE
confluent-docker-utils: fix urllib3 CVEs GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v

### DIFF
--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-docker-utils
   version: "0.0.162"
-  epoch: 0
+  epoch: 1
   description: This package provides Docker Utility Belt (dub) and Confluent Platform Utility Belt (cub).
   copyright:
     - license: Apache-2.0
@@ -39,6 +39,9 @@ pipeline:
       # Workaround to fix `AttributeError: cython_sources` issue
       # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638587228
       echo 'PyYAML==6.0.1' >> requirements.txt
+
+      # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v
+      echo 'urllib3>=2.5.0' >> requirements.txt
 
   - runs: |
       python3=python${{vars.py-version}}


### PR DESCRIPTION
## Summary
- Fixed urllib3 CVEs GHSA-48p4-8xcf-vxj5 (CVE-2025-50182) and GHSA-pq67-6m6q-mj2v (CVE-2025-50181)
- Added urllib3>=2.5.0 constraint to requirements.txt
- Incremented epoch from 0 to 1

## Test plan
- [x] Package builds successfully
- [x] All tests pass
- [x] CVE scan shows no vulnerabilities found