### PR TITLE
dask-kubernetes: bump epoch to ensure urllib3 2.5.0 for CVE fixes

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.4.3"
-  epoch: 3
+  epoch: 4
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"


### PR DESCRIPTION
Bump epoch from 3 to 4 to ensure updated package with urllib3 2.5.0 which fixes urllib3 CVEs.

The package automatically gets urllib3 2.5.0 through its distributed>=2022.08.1 dependency which requires urllib3>=1.26.5, and pip installs the latest compatible version (2.5.0).

Fixes:
- GHSA-pq67-6m6q-mj2v (CVE-2025-50181) 
- GHSA-48p4-8xcf-vxj5 (CVE-2025-50182)

Testing:
- Built successfully  
- Tests pass
- CVE scan shows no vulnerabilities