### PR TITLE
haproxy: Add dataplaneapi to compat image

### DIFF
--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.1"
-  epoch: 5
+  epoch: 6
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -118,6 +118,7 @@ subpackages:
         - haproxy-iamguarded-compat=${{package.full-version}}
       runtime:
         - ${{package.name}}
+        - dataplaneapi
     pipeline:
       - uses: iamguarded/build-compat
         with:
@@ -132,6 +133,7 @@ subpackages:
           chmod g+rwX /opt/iamguarded
 
           ln -s /usr/bin/haproxy /opt/iamguarded/haproxy/bin/haproxy
+          ln -s /usr/bin/dataplaneapi /opt/iamguarded/haproxy-dataplaneapi/bin/dataplaneapi
       - uses: iamguarded/finalize-compat
         with:
           package: haproxy


### PR DESCRIPTION
dataplaneapi (a supporting program for haproxy) is required as part of the compat packages.