### PR TITLE
dataplaneapi: migrate to version streams

### DIFF
--- a/dataplaneapi-3.2.yaml
+++ b/dataplaneapi-3.2.yaml
@@ -1,35 +1,31 @@
 package:
-  name: dataplaneapi
+  name: dataplaneapi-3.2
   version: "3.2.1"
-  epoch: 0
+  epoch: 1
   description: HAProxy Data Plane API
+  dependencies:
+    provides:
+      - dataplaneapi=${{package.full-version}}
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/haproxytech/dataplaneapi
       tag: v${{package.version}}
-      destination: dataplaneapi
       expected-commit: 32af2b443ecd40f6772d73d2f4b62cb95a2b90ce
 
-  - runs: |
-      set -x
-      cd dataplaneapi
-      make build
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -m755 build/dataplaneapi ${{targets.destdir}}/usr/bin/dataplaneapi
-
-  - uses: strip
+  - uses: go/build
+    with:
+      packages: ./cmd/dataplaneapi
+      ldflags: |
+        -X main.GitRepo=https://github.com/haproxytech/dataplaneapi
+        -X main.GitTag=v${{package.version}}
+        -X main.GitCommit=$(git rev-parse HEAD)
+        -X main.GitDirty=false
+        -X main.BuildTime=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+      output: dataplaneapi
 
 update:
   enabled: true


### PR DESCRIPTION
this is used together with haproxy and haproxy <major>.<minor> imports dataplaneapi <major.minor> so this commit migrates dataplaneapi to version streams.

