### PR TITLE
nginx-stable: use stable versions correctly

### DIFF
--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -40,7 +40,7 @@ environment:
 
 var-transforms:
   - from: ${{package.version}}
-    match: '^(\d+)\.(\d+)\.'
+    match: '^(\d+)\.(\d+)\.(\d+)'
     replace: '$2'
     to: minor-version
 

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,8 @@
 package:
   name: nginx-stable
-  version: "1.27.5"
-  epoch: 1
+  # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
+  version: "1.28.0"
+  epoch: 2
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -37,6 +38,12 @@ environment:
       - zeromq-dev
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: '^(\d+)\.(\d+)\.'
+    replace: '$2'
+    to: minor-version
+
 data:
   - name: modules
     items:
@@ -51,11 +58,22 @@ data:
 # TODO look at adding extra modules like alpine does https://git.alpinelinux.org/aports/tree/main/nginx/APKBUILD#n149
 # Also note the nginx inc config https://hg.nginx.org/pkg-oss/file/tip/alpine
 pipeline:
+  - name: validate-stable-version
+    runs: |
+      # Ensure stable version is even (e.g., 1.26.x, 1.28.x)
+      # ref: https://nginx.org/
+      MINOR=${{vars.minor-version}}
+      if [ $((MINOR % 2)) -ne 0 ]; then
+        echo "ERROR: nginx-stable must use even minor versions (e.g., 1.26.x, 1.28.x)"
+        echo "Current version: ${{package.version}} has odd minor version: $MINOR"
+        exit 1
+      fi
+      echo "Version validation passed: ${{package.version}} is a valid stable version"
   - uses: git-checkout
     with:
       repository: https://github.com/nginx/nginx.git
       tag: release-${{package.version}}
-      expected-commit: 6ac8b69f06bc10d5503f636da888fa70095b151c
+      expected-commit: 481d28cb4e04c8096b9b6134856891dc52ecc68f
       destination: nginx-stable
       # ref: https://github.com/nginx/nginx/pull/631
       # TODO: remove once this get in stable release
@@ -272,5 +290,6 @@ update:
   github:
     identifier: nginx/nginx
     use-tag: true
-    tag-filter: release-1.27
+    # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
+    tag-filter: release-1.28
     strip-prefix: release-

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -75,10 +75,6 @@ pipeline:
       tag: release-${{package.version}}
       expected-commit: 481d28cb4e04c8096b9b6134856891dc52ecc68f
       destination: nginx-stable
-      # ref: https://github.com/nginx/nginx/pull/631
-      # TODO: remove once this get in stable release
-      cherry-picks: |
-        master/444954abacef1d77f3dc6e9b1878684c7e6fe5b3: Fixed -Wunterminated-string-initialization with gcc15.
   - name: configure
     working-directory: nginx-stable
     runs: |


### PR DESCRIPTION

    nginx-stable: use stable versions correctly

    nginx project stable versions are always evenly tagged, it should never
    be odd unless upstream changes something.

    this commit adds a check at build time to ensure that we always use even
    tags for stable nginx builds.