### PR TITLE
withdraw nginx incorrect versioned packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -7,3 +7,7 @@ openjdk-24-default-jvm-24.0.1-r5.apk
 
 nrjmx-2.8.0-r0.apk
 nrjmx-2.8.1-r0.apk
+
+nginx-stable-1.27.5-r0.apk
+nginx-stable-1.27.5-r1.apk
+nginx-mainline-1.28.0-r0.apk


### PR DESCRIPTION
nginx stable should always use even minor versions and nginx mainline should always use odd minor versions.

ref: https://nginx.org and https://endoflife.date/nginx