### PR TITLE
feat(jupyter-base-notebook): bump lib to remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: "7.4.3"
-  epoch: 1
+  epoch: 2
   description: Jupyter Notebook
   dependencies:
     runtime:

--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -33,7 +33,7 @@ pipeline:
 
       # CVE-2025-47287
       pip install --upgrade tornado==6.5.0
-      
+
       # Remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
       pip install --upgrade urllib3>=2.5.0
 

--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -33,6 +33,9 @@ pipeline:
 
       # CVE-2025-47287
       pip install --upgrade tornado==6.5.0
+      
+        # Remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
+      pip install --upgrade urllib3>=2.5.0
 
       jupyter server --generate-config
       # The default config is written to the user's home directory.

--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -34,7 +34,7 @@ pipeline:
       # CVE-2025-47287
       pip install --upgrade tornado==6.5.0
       
-        # Remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
+      # Remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
       pip install --upgrade urllib3>=2.5.0
 
       jupyter server --generate-config


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump urllib3 to `v2.5.0`.
