### PR TITLE
keycloak: bump epoch

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: "26.2.5"
-  epoch: 2
+  epoch: 3
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
To remediate CVE-2025-49574 GHSA-9623-mj7j-p9v4.

See also: https://github.com/chainguard-dev/CVE-Dashboard/issues/25410
