### PR TITLE
rapidjson: Backport patch to fix build with CMake 4.0

### DIFF
--- a/rapidjson.yaml
+++ b/rapidjson.yaml
@@ -1,7 +1,7 @@
 package:
   name: rapidjson
   version: 1.1.0
-  epoch: 3
+  epoch: 4
   description: Fast JSON parser/generator for C++ with both SAX/DOM style API
   copyright:
     - license: BSD-2-Clause
@@ -38,6 +38,10 @@ pipeline:
   - uses: patch
     with:
       patches: do-not-include-gtest-src-dir.patch
+
+  - uses: patch
+    with:
+      patches: fix-build-with-cmake-4.patch
 
   - runs: |
       CXXFLAGS="$CXXFLAGS -std=c++14" \

--- a/rapidjson/fix-build-with-cmake-4.patch
+++ b/rapidjson/fix-build-with-cmake-4.patch
@@ -1,0 +1,41 @@
+From f50158d3dcb19784fd13318197921d7c05bd7f0b Mon Sep 17 00:00:00 2001
+From: Christian Fersch <git@chron.visiondesigns.de>
+Date: Mon, 15 Jan 2024 07:44:16 +0100
+Subject: [PATCH] Increase CMake minimum version to 3.5 (fixes #2159)
+
+Origin: backport, https://github.com/Tencent/rapidjson/commit/ebd87cb468fb4cb060b37e579718c4a4125416c1
+Bug: https://github.com/Tencent/rapidjson/issues/2159
+
+---
+ CMakeLists.txt | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ceda71b1..c2022d7d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,11 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+-if(POLICY CMP0025)
+-  # detect Apple's Clang
+-  cmake_policy(SET CMP0025 NEW)
+-endif()
+-if(POLICY CMP0054)
+-  cmake_policy(SET CMP0054 NEW)
+-endif()
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+ 
+ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
+ 
+@@ -16,6 +9,8 @@ set(LIB_MINOR_VERSION "1")
+ set(LIB_PATCH_VERSION "0")
+ set(LIB_VERSION_STRING "${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION}.${LIB_PATCH_VERSION}")
+ 
++PROJECT(RapidJSON VERSION "${LIB_VERSION_STRING}" LANGUAGES CXX)
++
+ # compile in release with debug info mode by default
+ if(NOT CMAKE_BUILD_TYPE)
+     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+-- 
+2.47.2
+


### PR DESCRIPTION
I chose to backport a patch because cherry-picking would required pulling in a number of unrelated commits to solve conflicts.