### PR TITLE
Fix broken symlinks in the manpages for libedit

### DIFF
--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 10
+  epoch: 11
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause
@@ -36,8 +36,8 @@ subpackages:
     pipeline:
       - uses: split/manpages
       - runs: |
-          mv "${{targets.subpkgdir}}"/usr/share/man/man3/editline.3 "${{targets.subpkgdir}}"/usr/share/man/man3/libedit.3
-          mv "${{targets.subpkgdir}}"/usr/share/man/man3/history.3 "${{targets.subpkgdir}}"/usr/share/man/man3/libedit-history.3
+          ln -s editline.3 "${{targets.subpkgdir}}"/usr/share/man/man3/libedit.3
+          ln -s history.3 "${{targets.subpkgdir}}"/usr/share/man/man3/libedit-history.3
     test:
       pipeline:
         - uses: test/docs


### PR DESCRIPTION
The libedit-doc package was full of broken symlinks:

```
=== BROKEN SYMLINK ANALYSIS === 
BROKEN SYMLINKS FOUND IN: libedit-doc
  Broken symlink: /usr/share/man/man3/el_deletestr.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_end.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_get.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_getc.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_gets.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_init.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_init_fd.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_insertstr.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_line.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_parse.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_push.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_reset.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_resize.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_set.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_source.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wdeletestr.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wget.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wgetc.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wgets.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_winsertstr.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wline.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wparse.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wpush.3 -> editline.3
  Broken symlink: /usr/share/man/man3/el_wset.3 -> editline.3
...
```