### PR TITLE
keycloak, keycloak-operator: patch quarkus-vertx to 3.24.0 for GHSA-9623-mj7j-p9v4

### DIFF
--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-operator
   version: "26.2.5"
-  epoch: 1
+  epoch: 2
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0

--- a/keycloak-operator/pombump-deps.yaml
+++ b/keycloak-operator/pombump-deps.yaml
@@ -19,3 +19,8 @@ patches:
   - groupId: io.netty
     artifactId: netty-handler
     version: 4.1.118.Final
+  - groupId: io.quarkus
+    artifactId: quarkus-vertx
+    version: 3.24.0
+    scope: import
+    type: pom

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: "26.2.5"
-  epoch: 2
+  epoch: 3
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak/pombump-deps.yaml
+++ b/keycloak/pombump-deps.yaml
@@ -19,6 +19,11 @@ patches:
     version: 3.18.4
     scope: import
     type: pom
+  - groupId: io.quarkus
+    artifactId: quarkus-vertx
+    version: 3.24.0
+    scope: import
+    type: pom
   - groupId: org.postgresql
     artifactId: postgresql
     version: 42.7.7


### PR DESCRIPTION
## Summary

This PR patches quarkus-vertx to 3.24.0 to fix GHSA-9623-mj7j-p9v4 in keycloak and keycloak-operator packages.

**Vulnerability**: GHSA-9623-mj7j-p9v4 - Quarkus potentially leaks data when duplicating a duplicated context
- Severity: MODERATE  
- Affected versions: >= 3.16.0.CR1, <= 3.20.1
- Fixed in: 3.24.0

## Changes

### keycloak
- Added quarkus-vertx 3.24.0 to pombump-deps.yaml
- Bumped epoch from 2 to 3

### keycloak-operator
- Added quarkus-vertx 3.24.0 to pombump-deps.yaml  
- Bumped epoch from 1 to 2

## Technical Details

Both packages use Keycloak 26.2.5 which pins Quarkus to 3.20.1, placing them in the vulnerable range. This is a minor version bump (3.20.1 → 3.24.0) within the Quarkus 3.x series, so compatibility should be maintained.

The keycloak-operator is itself a Quarkus application, making it directly vulnerable to the context duplication issue.

## Testing

Please build and test both packages to ensure:
1. Packages build successfully with the patched dependency
2. CVE scan confirms GHSA-9623-mj7j-p9v4 is resolved
3. Functionality remains intact