### PR TITLE
nginx-(mainline|stable): use git backend for update

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -338,9 +338,9 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: nginx/nginx
-    use-tag: true
-    # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
-    tag-filter: release-1.29
+  # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
+  ignore-regex-patterns:
+    - ^(\d+)\.(\d+)[02468]\.(\d+)$
+  git:
+    tag-filter-prefix: release-
     strip-prefix: release-

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -283,9 +283,9 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: nginx/nginx
-    use-tag: true
-    # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
-    tag-filter: release-1.28
+  # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
+  ignore-regex-patterns:
+    - ^(\d+)\.(\d+)[13579]\.(\d+)$
+  git:
+    tag-filter-prefix: release-
     strip-prefix: release-


### PR DESCRIPTION
    nginx-(mainline|stable): use git backend for update

    this will ensure that our nginx are upto date.

    as of now tags are stale and because of filter when series of nginx
    comes out they don't get updated unless we udpate them manully.

    this commit changes the update backend to use git.
    and then we're ignoring odd versions during update for nginx-stable and
    vice-versa for mainline.