### PR TITLE
Aws-fsx-csi-driver package addition

### DIFF
--- a/aws-fsx-csi-driver.yaml
+++ b/aws-fsx-csi-driver.yaml
@@ -1,0 +1,58 @@
+package:
+  name: aws-fsx-csi-driver
+  version: "1.4.0"
+  epoch: 0
+  description: The Amazon FSx for Lustre Container Storage Interface (CSI) Driver implements CSI specification for container orchestrators (CO) to manage lifecycle of Amazon FSx for Lustre filesystems.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
+      tag: v${{package.version}}
+      expected-commit: a88da05d2911e8d25efed68b969413057f4d0668
+
+  - uses: go/build
+    with:
+      packages: ./cmd
+      output: aws-fsx-csi-driver
+      ldflags: |
+        -s -w
+        -X sigs.k8s.io/aws-fsx-csi-driver/pkg/driver.driverVersion=${{package.version}}
+        -X sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud.driverVersion=${{package.version}}
+        -X sigs.k8s.io/aws-fsx-csi-driver/pkg/driver.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/aws-fsx-csi-driver/pkg/driver.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compat package for ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"//bin
+          ln -sf /usr/bin/aws-fsx-csi-driver "${{targets.contextdir}}"/bin/aws-fsx-csi-driver
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/aws-fsx-csi-driver
+    tag-filter: ^v\d+\.\d+\.\d+$
+    use-tag: true
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: "Version test"
+      runs: |
+        aws-fsx-csi-driver --version 2>&1 | grep ${{package.version}}
+    - name: "Basic functionality test"
+      runs: |
+        export AWS_REGION=us-west-2
+        export AWS_AVAILABILITY_ZONES=us-west-2a
+        # Default function will give non-zero exit code since it needs AWS credentials
+        aws-fsx-csi-driver > driver.log 2>&1 || true
+        # Validations over logs
+        grep -q "fsx.csi.aws.com" driver.log
+        grep -q "Retrieving EC2 instance identity Metadata" driver.log
+        grep -q "us-west-2" driver.log
+        grep -q "unable to load in-cluster configuration" driver.log

--- a/aws-fsx-csi-driver.yaml
+++ b/aws-fsx-csi-driver.yaml
@@ -29,7 +29,7 @@ subpackages:
     description: Compat package for ${{package.name}}
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"//bin
+          mkdir -p "${{targets.contextdir}}"/bin
           ln -sf /usr/bin/aws-fsx-csi-driver "${{targets.contextdir}}"/bin/aws-fsx-csi-driver
 
 update:


### PR DESCRIPTION
**aws-fsx-csi-driver  package** `Current version: v1.4.0`
- The Amazon FSx for Lustre Container Storage Interface (CSI) Driver implements CSI specification for container orchestrators (CO) to manage lifecycle of Amazon FSx for Lustre filesystems.

**Type**: Go binary
**REF**: https://github.com/kubernetes-sigs/aws-fsx-csi-driver

**Tests:**
- Basic version and functionality tests