### PR TITLE
initial build for aws-node-termination-handler

### DIFF
--- a/aws-node-termination-handler.yaml
+++ b/aws-node-termination-handler.yaml
@@ -1,0 +1,54 @@
+package:
+  name: aws-node-termination-handler
+  version: "1.25.1"
+  epoch: 0
+  description: Gracefully handle EC2 instance shutdown within Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5641359c91288d0589c3c188309ce2771eb93838
+      repository: https://github.com/aws/aws-node-termination-handler
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.38.0
+
+  - uses: go/build
+    with:
+      ldflags: -X github.com/google/ko/pkg/commands.Version=${{package.version}}
+      output: node-termination-handler
+      packages: ./cmd/node-termination-handler.go
+      tags: nthlinux
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package for the ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/node-termination-handler ${{targets.contextdir}}/node-termination-handler
+    test:
+      pipeline:
+        - runs: test "$(readlink /node-termination-handler)" = "/usr/bin/node-termination-handler"
+
+update:
+  enabled: true
+  github:
+    identifier: aws/aws-node-termination-handler
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        # The project queries the metadata service: https://github.com/aws/aws-node-termination-handler/blob/main/pkg/ec2metadata/ec2metadata.go#L356
+        # so the tests will fail if the metadata service is not available like:
+        # so testing is not an option here since the project constantly queries AWS Metadata Service and it keeps failing like this:
+        # Get "http://169.254.169.254/latest/meta-data/spot/instance-action": dial tcp 169.254.169.254:80: connect: network is unreachable
+        node-termination-handler -h


### PR DESCRIPTION
testing is not an option here since the project constantly queries AWS Metadata Service and it keeps failing like this:

```bash
2025/06/30 12:02:52 WARN panic: There was a problem checking for spot ITNs: Unable to parse metadata response: Unable to get a response from IMDS: Get "http://169.254.169.254/latest/meta-data/spot/instance-action": dial tcp 169.254.169.254:80: connect: network is unreachable
```