### PR TITLE
superset: remediate cve

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: "4.1.2"
-  epoch: 5
+  epoch: 6
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -79,7 +79,7 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.0.6 requests==2.32.4 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2
+      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.0.6 requests==2.32.4 urllib3==2.5.0 certifi==2024.07.04 zipp==3.19.2
 
       # Dependencies required during runtime
       pip install pillow pyarrow


### PR DESCRIPTION
Bump urllib3 to 2.5.0 to remediate the cve:
- GHSA-48p4-8xcf-vxj5
- GHSA-pq67-6m6q-mj2v