### PR TITLE
keycloack: bump quarkus-vertx dependency

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: "26.2.5"
-  epoch: 2
+  epoch: 3
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak/pombump-properties.yaml
+++ b/keycloak/pombump-properties.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: "quarkus.version"
+    value: "3.24.1"
+  - property: "quarkus.build.version"
+    value: "3.24.1"
+  - property: "hibernate-orm.plugin.version"
+    value: "6.7.0.Final"
+  - property: "hibernate.c3p0.version"
+    value: "6.7.0.Final"


### PR DESCRIPTION
Bump quarkus-vertx dependency to remediate CVE-2025-49574 GHSA-9623-mj7j-p9v4.

See also: https://github.com/chainguard-dev/CVE-Dashboard/issues/25410