### PR TITLE
Moving to mainline to match njs

### DIFF
--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -2,14 +2,14 @@
 package:
   name: nginx-s3-gateway
   version: 0_git20250605
-  epoch: 2
+  epoch: 3
   description: NGINX S3 Gateway
   copyright:
     - license: Apache-2.0
   # BYO nginx
   dependencies:
     replaces:
-      - nginx-stable-config
+      - nginx-mainline-config
     runtime:
       - njs
       - gzip
@@ -20,7 +20,7 @@ package:
       - zlib
       - lerc
       - libdeflate
-      - nginx-stable
+      - nginx-mainline
       - nginx-mod-http_xslt_filter
       - nginx-mod-http_image_filter
       - nginx-mod-http_geoip
@@ -102,10 +102,10 @@ subpackages:
     description: Unprivileged configuration for NGINX S3 Gateway
     dependencies:
       replaces:
-        - nginx-stable-config
+        - nginx-mainline-config
       runtime:
         - njs
-        - nginx-stable
+        - nginx-mainline
         - nginx-mod-http_xslt_filter
         - nginx-mod-http_image_filter
         - nginx-mod-http_geoip
@@ -133,7 +133,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - nginx-stable
+            - nginx-mainline
         accounts:
           groups:
             - groupname: nginx
@@ -185,7 +185,7 @@ test:
   environment:
     contents:
       packages:
-        - nginx-stable
+        - nginx-mainline
     accounts:
       groups:
         - groupname: nginx


### PR DESCRIPTION
ngx_http_js_module is built by njs
have to use mainline here:
https://github.com/wolfi-dev/os/blob/main/njs.yaml#L21