### PR TITLE
cmake-3: Version stream cmake

### DIFF
--- a/cmake-3.yaml
+++ b/cmake-3.yaml
@@ -1,0 +1,95 @@
+package:
+  name: cmake-3
+  version: 3.31.7
+  epoch: 0
+  description: "CMake 3.x is an open-source, cross-platform family of tools designed to build, test and package software"
+  dependencies:
+    provides:
+      - cmake=${{package.full-version}}
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - curl-dev
+      - expat-dev
+      - jsoncpp-dev
+      - libarchive-dev
+      - libuv-dev
+      - ncurses-dev
+      - nghttp2-dev
+      - openssl-dev
+      - rhash-dev
+      - samurai
+      - wolfi-base
+      - xz-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.cmake.org/files/v3.31/cmake-${{package.version}}.tar.gz
+      expected-sha256: a6d2eb1ebeb99130dfe63ef5a340c3fdb11431cce3d7ca148524c125924cea68
+
+  # Depending on system libraries for everything we have, as if any of
+  # them use cmake they are built with cmake-bootstrap instead. Apart
+  # from cppdap, as we don't package it standalone.
+  - runs: |
+      ./bootstrap \
+        --prefix=/usr \
+        --mandir=/share/man \
+        --datadir=/share/cmake \
+        --docdir=/share/doc/cmake \
+        --system-libs \
+        --no-system-cppdap \
+        --generator=Ninja \
+        --parallel=$(nproc)
+
+  - runs: |
+      ninja
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" ninja install
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: true # be careful upgrading cmake as it is a core package
+  release-monitor:
+    identifier: 306
+    version-filter-prefix: "3."
+
+test:
+  environment:
+    contents:
+      packages:
+        - make
+        - gcc
+        - autoconf
+        - automake
+        - build-base
+  pipeline:
+    - uses: test/tw/ldd-check
+    - working-directory: wolfi-tests
+      runs: |
+        cmake --version
+        ccmake --version
+        ccmake --help
+        cmake --help
+        cpack --version
+        cpack --help
+        ctest --version
+        ctest --help
+    - working-directory: wolfi-tests
+      runs: |
+        mkdir -p build
+        cd build
+        cmake ..
+        make
+        ./hello_wolfi

--- a/cmake-3/wolfi-tests/CMakeLists.txt
+++ b/cmake-3/wolfi-tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(HelloWorld)
+cmake_minimum_required(VERSION 3.31.7...3.999)
+
+add_executable(hello_wolfi main.cpp)

--- a/cmake-3/wolfi-tests/main.cpp
+++ b/cmake-3/wolfi-tests/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(int argc, char** argv){
+	std::cout << "Hello Wolfi" << std::endl;
+	return 0;
+}


### PR DESCRIPTION
With CMake 4.0 almost ready to be uploaded to Wolfi, there are a few packages that still FTBFS with it.  We need to version stream CMake 3.x to make sure these packages keep building fine.