### PR TITLE
glibc: Cherry-pick AArch64 fix & re-enable hardening

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 52
+  epoch: 53
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -44,10 +44,6 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
-    # Disable until we figure out why ldconfig segfaults on specific
-    # scenarios (arm64 systems, likely only those running
-    # 6.15.3-r50-gcp-generic)
-    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout
@@ -114,6 +110,7 @@ pipeline:
         release/2.41/master/899dd3ab2fc2bff6b8d37345ee34b7b1ef23fa0c: x86_64: Fix typo in ifunc-impl-list.c.
         release/2.41/master/515d4166f4dbcf43b1568e3f63a19d9a92b2d50e: elf: Fix subprocess status handling for tst-dlopen-sgid (bug 32987)
         master/81467d4b6168c7ce40d951d6b32e387109c0e5ae: elf: Add optimization barrier for __ehdr_start and _end
+        master/681a24ae4d0cb8ed92de98b4da660308840b09ba: AArch64: Avoid memset ifunc in cpu-features.c [BZ #33112]
 
   - uses: patch
     with:

--- a/glibc/vendor/ld.so.conf.d/libc.conf
+++ b/glibc/vendor/ld.so.conf.d/libc.conf
@@ -1,6 +1,2 @@
 /usr/local/lib
-/usr/local/lib64
-/lib
-/lib64
 /usr/lib
-/usr/lib64


### PR DESCRIPTION
Upstream fixed the issue we were having with hardening on Axion platforms.  We can now reenable it.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/14236