### PR TITLE
feat: add aznfs-mount package

### DIFF
--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -1,0 +1,38 @@
+package:
+  name: aznfs-mount
+  version: "2.0.12"
+  epoch: 0
+  description: AZNFS Mount Helper
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - util-linux
+      - procps
+      - iptables
+      - conntrack-tools
+      - coreutils
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - gcc
+      - cmake
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Azure/AZNFS-mount.git
+      tag: ${{package.version}}
+      expected-commit: 9511dd9b91eed27ea68ae83d8ba14fd3d3c67dd1
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mkdir -p "${{targets.contextdir}}"/opt/microsoft/aznfs/
+      gcc src/mount.aznfs.c -o "${{targets.contextdir}}"/usr/bin/mount.aznfs
+      install -Dm755 src/aznfswatchdog "${{targets.contextdir}}"/usr/bin/aznfswatchdog
+      install -Dm755 src/mountscript.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/mountscript.sh
+      install -Dm755 scripts/aznfs_install.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/aznfs_install.sh
+      install -Dm755 lib/common.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/common.sh

--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -7,19 +7,19 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - util-linux
-      - procps
-      - iptables
       - conntrack-tools
       - coreutils
+      - iptables
+      - procps
+      - util-linux
 
 environment:
   contents:
     packages:
       - build-base
       - busybox
-      - gcc
       - cmake
+      - gcc
 
 pipeline:
   - uses: git-checkout
@@ -36,3 +36,9 @@ pipeline:
       install -Dm755 src/mountscript.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/mountscript.sh
       install -Dm755 scripts/aznfs_install.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/aznfs_install.sh
       install -Dm755 lib/common.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/common.sh
+
+update:
+  enabled: true
+  github:
+    identifier: Azure/AZNFS-mount
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
