### PR TITLE
fix(tofu-controller): add missing runtime deps for tf-runner subpackage

### DIFF
--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: tofu-controller
   version: "0.16.0_rc5"
-  epoch: 0
+  epoch: 1
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0
@@ -51,6 +51,15 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-runner
     description: tf-runner binary for tofu-controller
+    dependencies:
+      runtime:
+        - git
+        - gnupg
+        - libcrypto3
+        - libretls
+        - libssl3
+        - openssh-client
+        - tini
     pipeline:
       - uses: go/build
         with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
- adds missing runtime dependencies for `tofu-controller-runner` subpackage

Ref: https://github.com/flux-iac/tofu-controller/blob/main/runner-base.Dockerfile#L47-L57

