### PR TITLE
Pin cmake-3 build dependency on packages FTBFSing with CMake 4.0

### DIFF
--- a/apache-orc.yaml
+++ b/apache-orc.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-orc
   version: "2.1.2"
-  epoch: 0
+  epoch: 1
   description: "the smallest, fastest columnar storage for Hadoop workloads"
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ environment:
   contents:
     packages:
       - build-base
-      - cmake
+      - cmake-3
       - lz4-dev
       - protobuf-dev
       - samurai

--- a/brunsli.yaml
+++ b/brunsli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brunsli
   version: 0.1
-  epoch: 1
+  epoch: 2
   description: Practical JPEG Repacker
   copyright:
     - license: MIT
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
 
 pipeline:
   - uses: git-checkout

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdrkit
   version: 1.1.11
-  epoch: 0
+  epoch: 1
   description: Suite of programs for CD/DVD recording, ISO image creation, and audio CD extraction
   copyright:
     - license: GPL-2.0-only
@@ -18,7 +18,7 @@ environment:
       - bzip2
       - bzip2-dev
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - file
       - gcc
       - libcap-dev

--- a/cjson.yaml
+++ b/cjson.yaml
@@ -1,7 +1,7 @@
 package:
   name: cjson
   version: 1.7.18
-  epoch: 1
+  epoch: 2
   description: Lighweight JSON parser in C
   copyright:
     - license: MIT
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - samurai
 
 pipeline:

--- a/clucene.yaml
+++ b/clucene.yaml
@@ -2,7 +2,7 @@
 package:
   name: clucene
   version: 2.3.3.4
-  epoch: 2
+  epoch: 3
   description: A C++ port of Lucene
   copyright:
     - license: LGPL-2.0-or-later OR Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - samurai
       - zlib-dev
 

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 5
+  epoch: 6
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - cups-dev
       - gsm-dev
       - gst-plugins-base-dev

--- a/glew.yaml
+++ b/glew.yaml
@@ -1,7 +1,7 @@
 package:
   name: glew
   version: 2.2.0
-  epoch: 4
+  epoch: 5
   description: "A cross-platform C/C++ extension loading library"
   copyright:
     - license: GPL-2.0-or-later
@@ -10,7 +10,7 @@ environment:
   contents:
     packages:
       - build-base
-      - cmake
+      - cmake-3
       - glu
       - libLLVM-16
       - libx11-dev

--- a/graphite2.yaml
+++ b/graphite2.yaml
@@ -1,7 +1,7 @@
 package:
   name: graphite2
   version: 1.3.14
-  epoch: 4
+  epoch: 5
   description: reimplementation of the SIL Graphite text processing engine
   copyright:
     - license: LGPL-2.1-or-later OR MPL-1.1
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - freetype-dev
       - gcc-14-default
       - samurai

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpsl-native
   version: 7.4.0
-  epoch: 4
+  epoch: 5
   description: this library provides functionality missing from .NET Core via system calls
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ environment:
   contents:
     packages:
       - build-base
-      - cmake
+      - cmake-3
       - gtest-dev
       - wolfi-base
 

--- a/lzo.yaml
+++ b/lzo.yaml
@@ -1,7 +1,7 @@
 package:
   name: lzo
   version: "2.10"
-  epoch: 1
+  epoch: 2
   description: LZO -- a real-time data compression library
   copyright:
     - license: GPL-2.0-or-later
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - samurai
 
 pipeline:

--- a/mysql-connector-cpp.yaml
+++ b/mysql-connector-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-connector-cpp
   version: "9.3.0"
-  epoch: 1
+  epoch: 2
   description: MySQL Connector/C++ is a MySQL database connector for C++
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - gcc-14-default
       - lz4-dev
       - openssl-dev

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: "3.0.1"
-  epoch: 1
+  epoch: 2
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - bzip2
-      - cmake
+      - cmake-3
       - gawk
       - gcc-14-default
       - git

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: "1.17.0"
-  epoch: 0
+  epoch: 1
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ environment:
     packages:
       - bash
       - bazel-6
-      - cmake
+      - cmake-3
       - gcc~13
       - openjdk-11
       - openssl-dev

--- a/qhull.yaml
+++ b/qhull.yaml
@@ -2,7 +2,7 @@
 package:
   name: qhull
   version: "2020.2"
-  epoch: 1
+  epoch: 2
   description: Calculate convex hulls and related structures
   copyright:
     - license: Qhull
@@ -15,7 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
 
 pipeline:
   - uses: git-checkout

--- a/rtrlib.yaml
+++ b/rtrlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: rtrlib
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: An open-source C implementation of the RPKI/Router Protocol client
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ environment:
   contents:
     packages:
       - build-base
-      - cmake
+      - cmake-3
       - cmocka-dev
       - doxygen
       - graphviz

--- a/snappy-java.yaml
+++ b/snappy-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: snappy-java
   version: 1.1.10.7
-  epoch: 0
+  epoch: 1
   description: Snappy compressor/decompressor for Java
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - curl
       - openjdk-8-default-jdk
       - samurai

--- a/woff2.yaml
+++ b/woff2.yaml
@@ -1,7 +1,7 @@
 package:
   name: woff2
   version: 1.0.2
-  epoch: 4
+  epoch: 5
   description: Web Open Font Format 2 reference implementation
   copyright:
     - license: MIT
@@ -15,7 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - gcc-14-default
       - samurai
 

--- a/yajl.yaml
+++ b/yajl.yaml
@@ -1,7 +1,7 @@
 package:
   name: yajl
   version: 2.1.0
-  epoch: 6
+  epoch: 7
   description: Yet Another JSON Library (YAJL)
   copyright:
     - license: ISC
@@ -14,7 +14,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake
+      - cmake-3
       - samurai
 
 pipeline:


### PR DESCRIPTION
A few of our packages are failing to build with CMake 4.0, which will be uploaded soon to the archive.  In order to keep everything building, let's pin these packages to the `cmake-3` build dependency.

I will work on creating bugs for each of these packages afterwards so that we can keep track of them (and eventually move them over to CMake 4.0 when they're fixed).