### PR TITLE
haproxy: Drop dataplaneapi dependency from compat package

### DIFF
--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.1"
-  epoch: 6
+  epoch: 7
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -118,7 +118,6 @@ subpackages:
         - haproxy-iamguarded-compat=${{package.full-version}}
       runtime:
         - ${{package.name}}
-        - dataplaneapi
     pipeline:
       - uses: iamguarded/build-compat
         with:
@@ -139,6 +138,10 @@ subpackages:
           package: haproxy
           version: ${{vars.major-version}}
     test:
+      environment:
+        contents:
+          packages:
+            - dataplaneapi
       pipeline:
         - uses: iamguarded/test-compat
           with:


### PR DESCRIPTION
This drops the explicit dependency on the dataplaneapi package from the compat package as it's causing conflicts down the line with switching between "normal" and fips-enabled packages.