### PR TITLE
feat(cassandra-reaper): bump dep to remediate GHSA-h46c-h94j-95f3

### DIFF
--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: "3.8.0"
-  epoch: 5
+  epoch: 6
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/cassandra-reaper/src/server/pombump-deps.yaml
+++ b/cassandra-reaper/src/server/pombump-deps.yaml
@@ -11,3 +11,6 @@ patches:
   - groupId: commons-beanutils
     artifactId: commons-beanutils
     version: 1.11.0
+  - groupId: com.fasterxml.jackson.core
+    artifactId: jackson-core
+    version: 2.15.0


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump `com.fasterxml.jackson.core:jackson-core` to `v2.15.0`
