### PR TITLE
Builds pypiserver

### DIFF
--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Minimal PyPI server for uploading & downloading packages with pip/easy_install
   copyright:
-    - license: MIT AND ZLIB/LIBPNG
+    - license: MIT AND Zlib
   dependencies:
     provider-priority: 0
 

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -67,8 +67,8 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/data"
-          install -Dpm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/entrypoint.sh
-          install -Dpm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/gunicorn.conf.py
+          install -Dm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/entrypoint.sh
+          install -Dm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/gunicorn.conf.py
           ln -sf /usr/bin/entrypoint.sh "${{targets.subpkgdir}}/entrypoint.sh"
           ln -sf /usr/bin/gunicorn.conf.py "${{targets.subpkgdir}}/data/gunicorn.conf.py"
     test:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -54,10 +54,12 @@ subpackages:
               import ${{vars.import}}
         - name: functional test
           runs: |
-            apk add py3.11-pip
-            pip3.11 download coloredlogs -d my-packages
-            pypi-server run --disable-fallback -p 8080 my-packages &
-            pip install   --no-index   --find-links http://localhost:8080/packages/   coloredlogs
+            apk add py${{range.key}}-pip wait-for-it
+            pip${{range.key}} download coloredlogs -d my-packages
+            touch /tmp/dummy-welcome.html
+            pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
+            wait-for-it localhost:8080
+            pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -68,6 +68,20 @@ subpackages:
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
 
+  - name: py3-pypiserver-compat
+    description: Compatibility files for running py3-pypiserver as per Docker image
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/data"
+          install -Dpm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/entrypoint.sh
+          install -Dpm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/gunicorn.conf.py
+          ln -sf /usr/bin/entrypoint.sh "${{targets.subpkgdir}}/entrypoint.sh"
+          ln -sf /usr/bin/gunicorn.conf.py "${{targets.subpkgdir}}/data/gunicorn.conf.py"
+    test:
+      pipeline:
+        - runs: test "$(readlink /entrypoint.sh)" = "docker/entrypoint.sh"
+        - runs: test "$(readlink /data/gunicorn.conf.py)" = "docker/gunicorn.conf.py"
+
 test:
   pipeline:
     - uses: python/import

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -38,8 +38,6 @@ subpackages:
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
       provider-priority: ${{range.value}}
-      provides:
-        - py3-${{vars.pypi-package}}
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -40,7 +40,7 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
-      #runtime:
+        #runtime:
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -62,7 +62,6 @@ subpackages:
             pid=$!
             wait-for-it localhost:8080
             pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs
-            echo $pid
             kill $pid
 
   - name: py3-pypiserver-compat

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -53,8 +53,18 @@ subpackages:
             imports: |
               import ${{vars.import}}
         - name: functional test
-          runs: "echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\npid=$!\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs\necho \"\U0001F9CC\"\necho $pid\nkill $pid\n"
-
+          runs: |
+            echo "\U0001F916\"
+            apk add py${{range.key}}-pip wait-for-it
+            pip${{range.key}} download coloredlogs -d my-packages
+            touch /tmp/dummy-welcome.html
+            pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
+            pid=$!
+            wait-for-it localhost:8080
+            pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs
+            echo "\U0001F9CC"
+            echo $pid
+            kill $pid
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -52,6 +52,12 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+        - name: functional test
+          runs: |
+            apk add py3.11-pip
+            pip3.11 download coloredlogs -d my-packages
+            pypi-server run --disable-fallback -p 8080 my-packages &
+            pip install   --no-index   --find-links http://localhost:8080/packages/   coloredlogs
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -68,6 +74,12 @@ test:
       with:
         imports: |
           import ${{vars.import}}
+    - name: functional test
+      runs: |
+        apk add py3.11-pip
+        pip3.11 download coloredlogs -d my-packages
+        pypi-server run --disable-fallback -p 8080 my-packages &
+        pip install   --no-index   --find-links http://localhost:8080/packages/   coloredlogs
 
 update:
   enabled: true

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -54,12 +54,14 @@ subpackages:
               import ${{vars.import}}
         - name: functional test
           runs: |
+            echo "🤖"
             apk add py${{range.key}}-pip wait-for-it
             pip${{range.key}} download coloredlogs -d my-packages
             touch /tmp/dummy-welcome.html
             pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
             wait-for-it localhost:8080
             pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs
+            echo "🧌"
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:
@@ -73,19 +75,6 @@ subpackages:
       pipeline:
         - runs: test "$(readlink /entrypoint.sh)" = "docker/entrypoint.sh"
         - runs: test "$(readlink /data/gunicorn.conf.py)" = "docker/gunicorn.conf.py"
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import ${{vars.import}}
-    - name: functional test
-      runs: |
-        apk add py3.11-pip
-        pip3.11 download coloredlogs -d my-packages
-        pypi-server run --disable-fallback -p 8080 my-packages &
-        pip install   --no-index   --find-links http://localhost:8080/packages/   coloredlogs
 
 update:
   enabled: true

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -62,7 +62,6 @@ subpackages:
             pid=$!
             wait-for-it localhost:8080
             pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs
-            echo "\U0001F9CC"
             echo $pid
             kill $pid
 

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -54,7 +54,6 @@ subpackages:
               import ${{vars.import}}
         - name: functional test
           runs: |
-            echo "\U0001F916\"
             apk add py${{range.key}}-pip wait-for-it
             pip${{range.key}} download coloredlogs -d my-packages
             touch /tmp/dummy-welcome.html

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -65,6 +65,7 @@ subpackages:
             echo "\U0001F9CC"
             echo $pid
             kill $pid
+
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -53,7 +53,19 @@ subpackages:
             imports: |
               import ${{vars.import}}
         - name: functional test
-          runs: "echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs\necho \"\U0001F9CC\"\n"
+          runs: |
+            echo "🤖"
+            apk add py${{range.key}}-pip wait-for-it
+            pip${{range.key}} download coloredlogs -d my-packages
+            touch /tmp/dummy-welcome.html
+            pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
+            pid=$!
+            wait-for-it localhost:8080
+            pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs
+            echo "🧌"
+            echo $pid
+            kill $pid
+          #"echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs\necho \"\U0001F9CC\"\n"
 
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -53,19 +53,7 @@ subpackages:
             imports: |
               import ${{vars.import}}
         - name: functional test
-          runs: |
-            echo "🤖"
-            apk add py${{range.key}}-pip wait-for-it
-            pip${{range.key}} download coloredlogs -d my-packages
-            touch /tmp/dummy-welcome.html
-            pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
-            pid=$!
-            wait-for-it localhost:8080
-            pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs
-            echo "🧌"
-            echo $pid
-            kill $pid
-          #"echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs\necho \"\U0001F9CC\"\n"
+          runs: "echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\npid=$!\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/ coloredlogs\necho \"\U0001F9CC\"\necho $pid\nkill $pid\n"
 
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -40,7 +40,7 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
-        #runtime:
+
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -76,3 +76,4 @@ update:
   github:
     identifier: pypiserver/pypiserver
     use-tag: true
+    strip-prefix: v

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -58,15 +58,35 @@ subpackages:
             pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
             wait-for-it localhost:8080
             pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs
-
-  - name: py3-supported-${{vars.pypi-package}}
-    description: meta package providing ${{vars.pypi-package}} for supported python versions.
-    dependencies:
-      runtime:
-        - py3.10-${{vars.pypi-package}}
-        - py3.11-${{vars.pypi-package}}
-        - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
+  #- range: py-versions
+  #  name: py${{range.key}}-${{vars.pypi-package}}-bin
+  #  description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+  #  dependencies:
+  #    runtime:
+  #      - py${{range.key}}-${{vars.pypi-package}}
+  #    provides:
+  #      - ${{package.name}}
+  #      - py3-${{vars.pypi-package}}-bin
+  #      - py3-${{vars.pypi-package}}
+  #    provider-priority: ${{range.value}}
+  #  pipeline:
+  #    - runs: |
+  #        mkdir -p ${{targets.contextdir}}/usr/
+  #        tree
+  #        mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+  #        echo "🧌"
+  #  test:
+  #    pipeline:
+  #      - runs: |
+  #          pypi-server --version
+  #- name: py3-supported-${{vars.pypi-package}}
+  #  description: meta package providing ${{vars.pypi-package}} for supported python versions.
+  #  dependencies:
+  #    runtime:
+  #      - py3.10-${{vars.pypi-package}}
+  #      - py3.11-${{vars.pypi-package}}
+  #      - py3.12-${{vars.pypi-package}}
+  #      - py3.13-${{vars.pypi-package}}
 
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -40,7 +40,6 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
-
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -73,8 +73,8 @@ subpackages:
           ln -sf /usr/bin/gunicorn.conf.py "${{targets.subpkgdir}}/data/gunicorn.conf.py"
     test:
       pipeline:
-        - runs: test "$(readlink /entrypoint.sh)" = "docker/entrypoint.sh"
-        - runs: test "$(readlink /data/gunicorn.conf.py)" = "docker/gunicorn.conf.py"
+        - runs: test "$(readlink /entrypoint.sh)" = "/usr/bin/entrypoint.sh"
+        - runs: test "$(readlink /data/gunicorn.conf.py)" = "/usr/bin/gunicorn.conf.py"
 
 update:
   enabled: true

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -53,15 +53,8 @@ subpackages:
             imports: |
               import ${{vars.import}}
         - name: functional test
-          runs: |
-            echo "🤖"
-            apk add py${{range.key}}-pip wait-for-it
-            pip${{range.key}} download coloredlogs -d my-packages
-            touch /tmp/dummy-welcome.html
-            pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
-            wait-for-it localhost:8080
-            pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs
-            echo "🧌"
+          runs: "echo \"\U0001F916\"\napk add py${{range.key}}-pip wait-for-it\npip${{range.key}} download coloredlogs -d my-packages\ntouch /tmp/dummy-welcome.html\npypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &\nwait-for-it localhost:8080\npip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs\necho \"\U0001F9CC\"\n"
+
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -66,7 +66,7 @@ subpackages:
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}/data"
+          mkdir -p "${{targets.subpkgdir}}/data/packages"
           install -Dm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/entrypoint.sh
           install -Dm0755 -t "${{targets.subpkgdir}}/usr/bin/" ./docker/gunicorn.conf.py
           ln -sf /usr/bin/entrypoint.sh "${{targets.subpkgdir}}/entrypoint.sh"

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -38,6 +38,8 @@ subpackages:
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
       provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -58,36 +60,6 @@ subpackages:
             pypi-server run --disable-fallback --welcome /tmp/dummy-welcome.html -p 8080 my-packages &
             wait-for-it localhost:8080
             pip${{range.key}} install --no-index --find-links http://localhost:8080/packages/   coloredlogs
-  #- range: py-versions
-  #  name: py${{range.key}}-${{vars.pypi-package}}-bin
-  #  description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
-  #  dependencies:
-  #    runtime:
-  #      - py${{range.key}}-${{vars.pypi-package}}
-  #    provides:
-  #      - ${{package.name}}
-  #      - py3-${{vars.pypi-package}}-bin
-  #      - py3-${{vars.pypi-package}}
-  #    provider-priority: ${{range.value}}
-  #  pipeline:
-  #    - runs: |
-  #        mkdir -p ${{targets.contextdir}}/usr/
-  #        tree
-  #        mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
-  #        echo "🧌"
-  #  test:
-  #    pipeline:
-  #      - runs: |
-  #          pypi-server --version
-  #- name: py3-supported-${{vars.pypi-package}}
-  #  description: meta package providing ${{vars.pypi-package}} for supported python versions.
-  #  dependencies:
-  #    runtime:
-  #      - py3.10-${{vars.pypi-package}}
-  #      - py3.11-${{vars.pypi-package}}
-  #      - py3.12-${{vars.pypi-package}}
-  #      - py3.13-${{vars.pypi-package}}
-
   - name: py3-pypiserver-compat
     description: Compatibility files for running py3-pypiserver as per Docker image
     pipeline:

--- a/py3-pypiserver.yaml
+++ b/py3-pypiserver.yaml
@@ -1,0 +1,78 @@
+package:
+  name: py3-pypiserver
+  version: 2.3.2
+  epoch: 0
+  description: Minimal PyPI server for uploading & downloading packages with pip/easy_install
+  copyright:
+    - license: MIT AND ZLIB/LIBPNG
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: pypiserver
+  import: pypiserver
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 01915d1a689327da763efb3a3358f4e91207da24
+      repository: https://github.com/pypiserver/pypiserver
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      #runtime:
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pypiserver/pypiserver
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
