### PR TITLE
use the correct subpackage names for the provides

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.1.1"
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -89,8 +89,6 @@ subpackages:
       no-depends: true
       no-provides: true
     dependencies:
-      provides:
-        - ${{package.name}}=${{package.full-version}}
       runtime:
         - bash
         - busybox
@@ -152,8 +150,6 @@ subpackages:
       no-depends: true
       no-provides: true
     dependencies:
-      provides:
-        - mlflow=${{package.full-version}}
       runtime:
         - bash
         - busybox


### PR DESCRIPTION
the existing provides have been overwriting (and racing!) the `${{package.name}}` provides (`mlflow`)