### PR TITLE
Add lua-resty packages

### DIFF
--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -28,7 +28,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: openresty/lua-resty-events
+    identifier: Kong/lua-resty-events
     use-tag: true
 
 test:

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -30,5 +30,46 @@ update:
     use-tag: true
 
 test:
+  environment:
+    contents:
+      packages:
+        - bash
+        - openresty
   pipeline:
     - uses: test/tw/ldd-check
+    - name: "Check lua-resty-events Installation"
+      runs: |
+        echo "Verifying lua-resty-events installation..."
+        if [ -f "/usr/local/lib/lua/resty/events/init.lua" ]; then
+          echo "lua-resty-events module found."
+        else
+          echo "lua-resty-events module not found!" && exit 1
+        fi
+    - name: "Test lua-resty-events with ngx Mock"
+      runs: |
+        echo "Running a simple Lua script with resty.events..."
+
+        # Set the correct LUA_PATH and LUA_CPATH
+        export LUA_PATH="/usr/local/lib/lua/resty/events/?.lua;;"
+        export LUA_CPATH="/usr/local/lib/lua/resty/events/?.so;;"
+
+        # Create a simple ngx mock for tests to avoid errors
+        cat <<EOF > test_events.lua
+        -- at the top of test_events.lua, before requiring the module:
+        package.path = "/usr/local/lib/lua/?.lua;/usr/local/lib/lua/?/init.lua;;" .. package.path
+
+        local events = require "resty.events"
+        -- this special flag disables the UNIX socket listener
+        local ev = assert(events.new{ testing = true })        -- testing=true skips the socket :contentReference[oaicite:1]{index=1}
+
+        -- subscribe/publish exactly as before
+        local cb = ev:subscribe("*","*", function(data, event, source, wid)
+          print("↪ received:", data, "event:", event)
+        end)
+
+        assert(ev:publish("all","demo","greeting","hello world"))
+        print("published greeting")
+        EOF
+
+        # Run the Lua script
+        resty test_events.lua

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -20,8 +20,16 @@ pipeline:
       expected-commit: bc85295b7c23eda2dbf2b4acec35c93f77b26787
 
   - uses: autoconf/make
+    with:
+      opts: |
+        LUA_LIB_DIR=/usr/lib/lua
+        PREFIX=/usr
 
   - uses: autoconf/make-install
+    with:
+      opts: |
+        LUA_LIB_DIR=/usr/lib/lua
+        PREFIX=/usr
 
 update:
   enabled: true
@@ -40,7 +48,7 @@ test:
     - name: "Check lua-resty-events Installation"
       runs: |
         echo "Verifying lua-resty-events installation..."
-        if [ -f "/usr/local/lib/lua/resty/events/init.lua" ]; then
+        if [ -f "/usr/lib/lua/resty/events/init.lua" ]; then
           echo "lua-resty-events module found."
         else
           echo "lua-resty-events module not found!" && exit 1
@@ -52,7 +60,7 @@ test:
         # Create a simple ngx mock for tests to avoid errors
         cat <<EOF > test_events.lua
         -- make sure your lualib tree is on package.path
-        package.path = "/usr/local/lib/lua/?.lua;/usr/local/lib/lua/?/init.lua;;" .. package.path
+        package.path = "/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua;;" .. package.path
 
         local events = require "resty.events"
         -- testing=true skips all socket setup

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -11,8 +11,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - ca-certificates-bundle
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -1,0 +1,36 @@
+package:
+  name: lua-resty-events
+  version: 0.3.1
+  epoch: 0
+  description: "Inter process Pub/Sub pattern for Nginx worker processes"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Kong/lua-resty-events
+      tag: ${{package.version}}
+      expected-commit: bc85295b7c23eda2dbf2b4acec35c93f77b26787
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  github:
+    identifier: openresty/lua-resty-events
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -49,25 +49,24 @@ test:
       runs: |
         echo "Running a simple Lua script with resty.events..."
 
-        # Set the correct LUA_PATH and LUA_CPATH
-        export LUA_PATH="/usr/local/lib/lua/resty/events/?.lua;;"
-        export LUA_CPATH="/usr/local/lib/lua/resty/events/?.so;;"
-
         # Create a simple ngx mock for tests to avoid errors
         cat <<EOF > test_events.lua
-        -- at the top of test_events.lua, before requiring the module:
+        -- make sure your lualib tree is on package.path
         package.path = "/usr/local/lib/lua/?.lua;/usr/local/lib/lua/?/init.lua;;" .. package.path
 
         local events = require "resty.events"
-        -- this special flag disables the UNIX socket listener
-        local ev = assert(events.new{ testing = true })        -- testing=true skips the socket :contentReference[oaicite:1]{index=1}
-
-        -- subscribe/publish exactly as before
-        local cb = ev:subscribe("*","*", function(data, event, source, wid)
-          print("↪ received:", data, "event:", event)
+        -- testing=true skips all socket setup
+        local ev = assert(events.new {
+        listening              = "unix:/tmp/events.sock",
+        testing                = true,                     -- optional, bypass the UDS broker entirely (default false)
+        })
+        -- subscribe to everything
+        ev:subscribe("*","*", function(data, event)
+          print("↪ received:", event, "->", data)
         end)
 
-        assert(ev:publish("all","demo","greeting","hello world"))
+        -- publish a demo event
+        assert(ev:publish("all","cli-demo","greeting","hello world"))
         print("published greeting")
         EOF
 

--- a/lua-resty-events.yaml
+++ b/lua-resty-events.yaml
@@ -79,4 +79,4 @@ test:
         EOF
 
         # Run the Lua script
-        resty test_events.lua
+        resty test_events.lua | grep "published greeting"

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -126,4 +126,4 @@ test:
         EOF
 
         # Run the Lua script
-        resty test_events.lua
+        resty test_events.lua | grep "smoke test passed"

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -31,5 +31,91 @@ update:
     use-tag: true
 
 test:
+  environment:
+    contents:
+      packages:
+        - bash
+        - openresty
   pipeline:
     - uses: test/tw/ldd-check
+    - name: "Check lua-resty-worker-events Installation"
+      runs: |
+        echo "Verifying lua-resty-worker-events installation..."
+        if [ -f "/usr/local/lib/lua/resty/worker/events.lua" ]; then
+          echo "lua-resty-worker-events module found."
+        else
+          echo "lua-resty-worker-events module not found!" && exit 1
+        fi
+    - name: "Test lua-resty-worker-events with ngx Mock"
+      runs: |
+        echo "Running a simple Lua script with resty.events..."
+
+        # Create a simple ngx mock for tests to avoid errors
+        cat <<EOF > test_events.lua
+        #!/usr/bin/env resty
+
+        -- 1) Make sure your lualib tree is on package.path
+        package.path = "/usr/local/lib/lua/?.lua;/usr/local/lib/lua/?/init.lua;;" .. package.path
+
+        -- 2) Stub out enough of ngx for a standalone CLI test
+        _G.ngx = {
+          worker = {
+            pid     = function() return 12345 end,
+            exiting = function() return false end,
+          },
+          shared = {
+            process_events = {
+              get  = function(_)      return 0 end,
+              add  = function(_,_,_)  return true end,
+              incr = (function()
+                local n = 0
+                return function(_,_) n = n + 1; return n end
+              end)(),
+            },
+          },
+          log          = function(...) end,
+          ERR          = 3,
+          WARN         = 2,
+          DEBUG        = 4,
+          timer        = {
+            -- ngx.timer.at(delay, fn, ...) ⇒ true on success, err on failure
+            at = function(_, fn, ...)
+              -- (you could invoke fn here if you wanted to simulate callbacks)
+              return true
+            end,
+          },
+          sleep        = function(_) end,
+          now          = function() return 0 end,
+          update_time  = function() end,
+        }
+
+        -- 3) Load the module
+        local ev = require "resty.worker.events"                  -- :contentReference[oaicite:0]{index=0}
+
+        -- 4) Use the event_list helper to avoid magic strings
+        local events = ev.event_list("cli-test", "hello", "world") -- :contentReference[oaicite:1]{index=1}
+        assert(events._source == "cli-test" and events.hello == "hello" and events.world == "world")
+
+        -- 5) Configure the shared‐dict (must match ngx.shared key above)
+        local ok, err = ev.configure {
+          shm           = "process_events",  -- from lua_shared_dict process_events 1m
+          timeout       = 2,
+          interval      = 0,      -- disable background polling
+          wait_interval = 0.01,
+          wait_max      = 0.1,
+          shm_retries   = 1,
+        }
+        assert(ok, err)                                           -- :contentReference[oaicite:2]{index=2}
+
+        -- 6) Test posting a “global” event
+        local posted, perr = ev.post("cli-test", events.hello, { msg = "world" })
+        assert(posted, perr)                                      -- :contentReference[oaicite:3]{index=3}
+
+        -- 7) Test posting a “local” event
+        assert(ev.post_local("cli-test", events.world, { msg = "local-only" }))
+
+        print("lua-resty-worker-events basic API smoke test passed")
+        EOF
+
+        # Run the Lua script
+        resty test_events.lua

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -1,3 +1,4 @@
+# Note that while lua-resty-worker-events hasn't received updates since 2022, it does look to be feature complete.
 package:
   name: lua-resty-worker-events
   version: 2.0.1
@@ -11,8 +12,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - ca-certificates-bundle
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -21,8 +21,16 @@ pipeline:
       expected-commit: 6676dc7369a7792386fa754dc81b894070491282
 
   - uses: autoconf/make
+    with:
+      opts: |
+        LUA_LIB_DIR=/usr/lib/lua
+        PREFIX=/usr
 
   - uses: autoconf/make-install
+    with:
+      opts: |
+        LUA_LIB_DIR=/usr/lib/lua
+        PREFIX=/usr
 
 update:
   enabled: true
@@ -41,7 +49,7 @@ test:
     - name: "Check lua-resty-worker-events Installation"
       runs: |
         echo "Verifying lua-resty-worker-events installation..."
-        if [ -f "/usr/local/lib/lua/resty/worker/events.lua" ]; then
+        if [ -f "/usr/lib/lua/resty/worker/events.lua" ]; then
           echo "lua-resty-worker-events module found."
         else
           echo "lua-resty-worker-events module not found!" && exit 1
@@ -55,7 +63,7 @@ test:
         #!/usr/bin/env resty
 
         -- 1) Make sure your lualib tree is on package.path
-        package.path = "/usr/local/lib/lua/?.lua;/usr/local/lib/lua/?/init.lua;;" .. package.path
+        package.path = "/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua;;" .. package.path
 
         -- 2) Stub out enough of ngx for a standalone CLI test
         _G.ngx = {

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -1,0 +1,36 @@
+package:
+  name: lua-resty-worker-events
+  version: 2.0.1
+  epoch: 0
+  description: "Inter process Pub/Sub pattern for Nginx worker processes"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Kong/lua-resty-worker-events
+      tag: ${{package.version}}
+      expected-commit: 6676dc7369a7792386fa754dc81b894070491282
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  github:
+    identifier: openresty/lua-resty-worker-events
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/lua-resty-worker-events.yaml
+++ b/lua-resty-worker-events.yaml
@@ -28,7 +28,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: openresty/lua-resty-worker-events
+    identifier: Kong/lua-resty-worker-events
     use-tag: true
 
 test:


### PR DESCRIPTION
Adds lua-resty-events and lua-resty-worker-events. Note that the [lua-resty-worker-events repo](https://github.com/Kong/lua-resty-worker-events) hasn't received updates in a few years, but it does look to be in a feature complete state. It's a relatively simple single file project with just a few hundred lines. 

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:
https://github.com/wolfi-dev/os/pull/57662

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
