### PR TITLE
pg-failover-slots: Rename package

### DIFF
--- a/pg-failover-slots.yaml
+++ b/pg-failover-slots.yaml
@@ -1,10 +1,14 @@
 package:
-  name: pg-failover-slots-16
+  name: pg-failover-slots
   version: 1.1.0
-  epoch: 3
-  description: PG Failover Slots extension for PostgreSQL 16
+  epoch: 0
+  description: PG Failover Slots extension for PostgreSQL
   copyright:
     - license: BSD-3-Clause
+
+vars:
+  # The upstream currently supports postgresql 11-17 inclusive.
+  postgresql-version: 17
 
 environment:
   contents:
@@ -12,10 +16,10 @@ environment:
       - automake
       - build-base
       - busybox
-      # NOTE: align with clang version in postgresql-*-dev
+      # NOTE: align with clang version in postgresql-N-dev
       - clang-19
       - krb5-dev
-      - postgresql-16-dev
+      - postgresql-${{vars.postgresql-version}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -33,7 +37,7 @@ pipeline:
 test:
   pipeline:
     - runs: |
-        if [[ -f /usr/lib/postgresql16/pg_failover_slots.so ]]; then
+        if [[ -f /usr/lib/postgresql${{vars.postgresql-version}}/pg_failover_slots.so ]]; then
           echo "pg_failover_slots library found!"
         else
           echo "pg_failover_slots library not found!"


### PR DESCRIPTION
Here I rename the pg-failover-slots-16 package to pg-failover-slots.
I do this because the pg-failover-slots package is compatible with
postgresql versions 11 to 17 inclusive, hence we don't need a postgresql
specific version of the package.

This PR supersedes #58023.

Note that there are no advisories to move/copy for this package.

closes: #58023
