### PR TITLE
Implement no-hardening.spec

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 21
+  epoch: 22
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
@@ -3,3 +3,6 @@
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now
+
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/no-hardening.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/no-hardening.spec
@@ -1,0 +1,2 @@
+%include_noerr </usr/lib/oldglibc/gcc.spec>
+%include_noerr </home/build/.melange.gcc.spec>

--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -41,13 +41,17 @@ pipeline:
               disablearg=--config-system-dir=/var/empty
               ;;
       esac
-      GCC_SPEC_FILE=/dev/null ${{inputs.cc}} $disablearg -v -o hello-disabled hello.c
-      out=$(./hello-disabled 1 || true)
+      GCC_SPEC_FILE=/dev/null ${{inputs.cc}} $disablearg -v -o hello-disabled.null hello.c
+      out=$(./hello-disabled.null 1 || true)
+      [ "$out" = "hello-c" ]
+
+      GCC_SPEC_FILE=no-hardening.spec ${{inputs.cc}} $disablearg -v -o hello-disabled.spec hello.c
+      out=$(./hello-disabled.spec 1 || true)
       [ "$out" = "hello-c" ]
 
       # Compile without bind now. Test for -fhardened support (introduced in
       # gcc 14), and no-op the test if unsupported.
-      GCC_SPEC_FILE=/dev/null ${{inputs.cc}} -fhardened -Wl,-z,lazy -v -o hello-lazy hello.c || cp hello-disabled hello-lazy
+      GCC_SPEC_FILE=/dev/null ${{inputs.cc}} -fhardened -Wl,-z,lazy -v -o hello-lazy hello.c || cp hello-disabled.spec hello-lazy
       out=$(./hello-lazy 1 || true)
       [ "$out" = "hello-c" ]
 
@@ -67,7 +71,8 @@ pipeline:
       ### </DELETE>
 
       # Test disabling hardening flags
-      hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled && exit 1
+      hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled.null && exit 1
+      hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled.spec && exit 1
 
       # Test disabling bindnow
       hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-lazy && exit 1


### PR DESCRIPTION
- **gcc: add optional spec file integration to versions 11, 12 and 13**
  

- **gcc: add a no-hardening.spec file**
  Unlike common pattern to use /dev/null instead add an explicit
  no-hardening.spec file, which still has melange and toolchain
  integrations.
  

- **openssf-compiler-options epoch bump**
  

- **gcc: add test cases for no-hardening.spec**
  