### PR TITLE
boring-registry: fix GHSA-fv92-fjc5-jj9h

### DIFF
--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: "0.16.4"
-  epoch: 1
+  epoch: 2
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT
@@ -22,6 +22,11 @@ pipeline:
       expected-commit: 43b9e409a3758f3180ba6dab57667bd859f56897
       repository: https://github.com/TierMobility/boring-registry
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/go-viper/mapstructure/v2@v2.3.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
- Fix GHSA-fv92-fjc5-jj9h vulnerability in boring-registry
- Update github.com/go-viper/mapstructure/v2 from v2.2.1 to v2.3.0
- Increment epoch to 2

## Changes
- Added go/bump step to update vulnerable dependency
- Incremented epoch to force package rebuild

## Test plan
- [x] Package builds successfully
- [x] Tests pass (version and help commands work)
- [x] CVE scan confirms no vulnerabilities found