### PR TITLE
python builds fixes for 2.28

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -69,7 +69,7 @@ pipeline:
          --prefix=/usr \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
-         --enable-optimizations \
+         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
          --enable-shared \
          --with-lto \
          --with-computed-gotos \

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: "3.10.18"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -71,14 +71,13 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
-         --without-lto \
+         --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \
          --with-system-expat \
          --with-system-libmpdec \
          --without-ensurepip \
          --with-builtin-hashlib-hashes=blake2 \
-         --with-lto \
          --with-wheel-pkg-dir=/usr/share/python-wheels
 
   - uses: autoconf/make

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: "3.11.13"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -70,14 +70,13 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
-         --without-lto \
+         --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \
          --with-system-expat \
          --with-system-libmpdec \
          --without-ensurepip \
          --with-builtin-hashlib-hashes=blake2 \
-         --with-lto \
          --with-wheel-pkg-dir=/usr/share/python-wheels
 
   - uses: autoconf/make

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -68,7 +68,7 @@ pipeline:
          --prefix=/usr \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
-         --enable-optimizations \
+         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
          --enable-shared \
          --with-lto \
          --with-computed-gotos \

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -78,14 +78,13 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
-         --without-lto \
+         --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \
          --with-system-expat \
          --with-system-libmpdec \
          --without-ensurepip \
          --with-builtin-hashlib-hashes=blake2 \
-         --with-lto \
          --with-wheel-pkg-dir=/usr/share/python-wheels
 
   - uses: autoconf/make

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -76,7 +76,7 @@ pipeline:
          --prefix=/usr \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
-         --enable-optimizations \
+         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
          --enable-shared \
          --with-lto \
          --with-computed-gotos \

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.11"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -79,14 +79,13 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
-         --without-lto \
+         --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \
          --with-system-expat \
          --with-system-libmpdec \
          --without-ensurepip \
          --with-builtin-hashlib-hashes=blake2 \
-         --with-lto \
          --with-wheel-pkg-dir=/usr/share/python-wheels
 
   - uses: autoconf/make

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.5"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -77,7 +77,7 @@ pipeline:
          --prefix=/usr \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
-         --enable-optimizations \
+         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
          --enable-shared \
          --with-lto \
          --with-computed-gotos \


### PR DESCRIPTION
- **With or without you, it is building with lto**
  

- **Disable optimizations for oldglibc builds due to gcc missmatch**
  

- **Epoch bump**

Due to missmatch of gcc 14.2 and 14.3 between wolfi and 2.28 builds profiling build fails, disable profile guided optimisations in 2.28 builds for now.
  