### PR TITLE
Do not create /usr/lib32 or empty symlinks for i686 .so files

### DIFF
--- a/rust-1.69.yaml
+++ b/rust-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.69
   version: 1.69.0
-  epoch: 2
+  epoch: 3
   description: "Empowering everyone to build reliable and efficient software. (version 1.69.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -113,12 +113,6 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
-    runs: |
-      cd ${{targets.destdir}}
-      mkdir -p ${{targets.destdir}}/usr/lib32
-      ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
-
   - runs: |
       cd ${{targets.destdir}}
       ln -srft usr/lib usr/lib/rustlib/${{build.arch}}-unknown-linux-gnu/lib/*.so


### PR DESCRIPTION
An analysis of broken symlinks in packages found the following:

=== BROKEN SYMLINK ANALYSIS === 
BROKEN SYMLINKS FOUND IN: rust-1.69
  Broken symlink: /usr/lib32/*.so -> ../lib/rustlib/i686-unknown-linux-gnu/lib/*.so

There is nothing in lib/rustlib/i686-unknown-linux-gnu/lib so let's not try to create symlinks to .so files in that folder.