### PR TITLE
kyverno-notation-aws: remediate cve

### DIFF
--- a/kyverno-notation-aws.yaml
+++ b/kyverno-notation-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-notation-aws
   version: 1.1
-  epoch: 17
+  epoch: 18
   description: Kyverno extension service for Notation and the AWS signer
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
         github.com/kyverno/kyverno@v1.14.0
         github.com/open-policy-agent/opa@v1.4.0
         github.com/cloudflare/circl@v1.6.1
+        github.com/go-viper/mapstructure/v2@v2.3.0
       replaces: github.com/docker/docker=github.com/docker/docker@v26.1.5+incompatible
 
   - uses: go/build


### PR DESCRIPTION
Remediate cve GHSA-fv92-fjc5-jj9h by bumping mapstructure/v2 to v2.3.0