### PR TITLE
logstash-9: remediate cves

### DIFF
--- a/logstash-9.yaml
+++ b/logstash-9.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9
   version: "9.0.3"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -102,7 +102,13 @@ pipeline:
       echo "gem 'rack-session', '2.1.1'" >> Gemfile.template
       echo "gem 'net-imap', '0.5.8'" >> Gemfile.template
       # Fix GHSA-xc9x-jj77-9p9j
-      sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"
+      sed -i 's/"date", "= 3.3.3"/"date", ">= 3.4.1"/' "Gemfile.template"
+      # Fix GHSA-22h5-pq3x-2gf2
+      sed -i 's/"uri", "~> 0.12.3"/"uri", "~> 0.12.4"/' "Gemfile.template"
+      # Fix GHSA-72qj-48g4-5xgx
+      echo 'gem "jruby-openssl", "~> 0.15.4"' >> Gemfile.template
+      # Fix GHSA-gh9q-2xrm-x6qv and GHSA-mhwm-jh88-3gjf
+      sed -i 's/"cgi", "~> 0.3.7"/"cgi", "~> 0.4.2"/' "Gemfile.template"
 
       for plugin in ${{vars.separately-packaged-plugins}}
       do


### PR DESCRIPTION
We remediated the following CVEs by upgrading gems in the package definition:
- CVE GHSA-22h5-pq3x-2gf2: upgraded uri gem from ~> 0.12.3 to ~> 0.12.4
- CVE GHSA-72qj-48g4-5xgx: added jruby-openssl gem 0.15.4
- CVE GHSA-gh9q-2xrm-x6qv and GHSA-mhwm-jh88-3gjf: upgraded cgi gem from ~> 0.3.7 to ~> 0.4.2