### PR TITLE
glibc: update ld.so.conf for completed usrmerge

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 52
+  epoch: 53
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc/vendor/ld.so.conf.d/libc.conf
+++ b/glibc/vendor/ld.so.conf.d/libc.conf
@@ -1,6 +1,2 @@
 /usr/local/lib
-/usr/local/lib64
-/lib
-/lib64
 /usr/lib
-/usr/lib64


### PR DESCRIPTION
Now that usrmerge has been fully completed, the output from ldd often
looks odd. As if all libraries moved to /lib, when in fact they are
all actually in /usr/lib. Update the libc.conf to only use
non-symlinked real library locations. This will make ldd output to be
clean and reference /usr/lib for all libraries.
