### PR TITLE
Builds compat package to run redis w/harbor

### DIFF
--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.13
   version: "2.13.1"
-  epoch: 2
+  epoch: 3
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0

--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -179,7 +179,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/etc
-          
+
           cp ./make/photon/redis/docker-healthcheck ${{targets.subpkgdir}}/usr/bin/
           cp ./make/photon/redis/redis.conf ${{targets.subpkgdir}}/etc/
     test:

--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -186,8 +186,8 @@ subpackages:
       pipeline:
         - runs: |
             set -e
-            test -x /usr/bin/docker-healthcheck
-            test -s /etc/redis.conf
+            stat /usr/bin/docker-healthcheck
+            stat /etc/redis.conf
 
 test:
   pipeline:

--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -170,6 +170,25 @@ subpackages:
         - runs: |
             harbor-registryctl --help
 
+  - name: ${{package.name}}-redis-compat
+    description: Compat package for running redis with harbor
+    dependencies:
+      provides:
+        - harbor-redis-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mkdir -p ${{targets.subpkgdir}}/etc
+          
+          cp ./make/photon/redis/docker-healthcheck ${{targets.subpkgdir}}/usr/bin/
+          cp ./make/photon/redis/redis.conf ${{targets.subpkgdir}}/etc/
+    test:
+      pipeline:
+        - runs: |
+            set -e
+            test -x /usr/bin/docker-healthcheck
+            test -s /etc/redis.conf
+
 test:
   pipeline:
     - runs: |


### PR DESCRIPTION
This sub-package is being added based on this customer request: https://github.com/chainguard-dev/image-requests/issues/6260

When users try to use 'redis' with harbor, but it appears as if harbor require some customisations to redis in order to run the image alongside harbor. To that end, harbor publishes their own 'redis' image:

```
goharbor/redis-photon
```
The source code for building this image, appears to reside here:
https://github.com/goharbor/harbor/tree/main/make/photon/redis

We don't currently build that image variant today, and given this request it'd be useful to do so. i.e we are adding this package to provide the expected endpoint and conf files.