### PR TITLE
opentelemetry-collector: remdiate cve

### DIFF
--- a/opentelemetry-collector.yaml
+++ b/opentelemetry-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector
   version: "0.128.0"
-  epoch: 1
+  epoch: 2
   description: OpenTelemetry Collector
   copyright:
     - license: Apache-2.0
@@ -115,6 +115,8 @@ pipeline:
       yq eval '.replaces += ["golang.org/x/net => golang.org/x/net v0.38.0"]' builder-config.yaml -i
       yq eval '.replaces += ["golang.org/x/oauth2 => golang.org/x/oauth2 v0.27.0"]' builder-config.yaml -i
       yq eval '.replaces += ["github.com/golang-jwt/jwt/v5 => github.com/golang-jwt/jwt/v5 v5.2.2"]' builder-config.yaml -i
+      # remediate GHSA-fv92-fjc5-jj9h
+      yq eval '.replaces += ["github.com/go-viper/mapstructure/v2 => github.com/go-viper/mapstructure/v2 v2.3.0"]' builder-config.yaml -i
       ${{targets.destdir}}/usr/bin/ocb --config=builder-config.yaml
 
       install -Dm755 ./_build/otelcol "${{targets.destdir}}"/usr/bin/otelcol


### PR DESCRIPTION
Remediate GHSA-fv92-fjc5-jj9h by bumping go-viper/mapstructure/v2 to v2.3.0
