### PR TITLE
malcontent/1.14.0 package update; yara-x/1.3.0 test update

### DIFF
--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -13,6 +13,7 @@ package:
 environment:
   contents:
     packages:
+      - gcc-14-default
       - openssl-dev
       - yara-x
 

--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,6 +1,6 @@
 package:
   name: malcontent
-  version: "1.13.1"
+  version: "1.14.0"
   epoch: 0
   description: enumerate file capabilities, including malicious behaviors
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/malcontent
       tag: v${{package.version}}
-      expected-commit: f25bfd683d39cafe68012ad03193ffab033d674a
+      expected-commit: 7a07a304612ebf3334ddae7d925d96fcda0a29fd
 
   - uses: go/build
     with:

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -14,6 +14,7 @@ environment:
       - build-base
       - ca-certificates-bundle
       - cargo-c
+      - gcc-14-default
       - openssl-dev
       - perl
       - rust
@@ -53,7 +54,7 @@ test:
   environment:
     contents:
       packages:
-        - gcc
+        - gcc-14-default
         - git
         - glibc-dev
         - go

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -59,11 +59,6 @@ test:
         - go
         - pkgconf-dev
   pipeline:
-    # TODO: re-enable once malcontent is released to support the breaking changes in v1.3.0
-    # - runs: |
-    #     git clone https://github.com/chainguard-dev/malcontent.git
-    #     cd malcontent
-    #     time -v go run cmd/mal/mal.go --min-risk critical --min-file-risk critical scan yr /usr:
     - uses: test/tw/ldd-check
     - uses: test/pkgconf
     - runs: |
@@ -80,3 +75,7 @@ test:
     - runs: |
         yr --help
         yr --version | grep ${{package.version}}
+    - runs: |
+        git clone https://github.com/chainguard-dev/malcontent.git
+        cd malcontent
+        time -v go run cmd/mal/mal.go --min-risk critical --min-file-risk critical scan yr /usr


### PR DESCRIPTION
This PR bumps malcontent to `1.14.0` to pull in the yara-x `1.3.0` update and re-enables the yara-x malcontent tests since it now uses the correct version of yara-x.

Edit: I also added `gcc-14-default` to work around the ARM64 issues with `gcc-15`.