### PR TITLE
kwok: create sa token and ca.cert

### DIFF
--- a/amazon-cloudwatch-agent-operator.yaml
+++ b/amazon-cloudwatch-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-cloudwatch-agent-operator
   version: "3.1.0"
-  epoch: 1
+  epoch: 2
   description: Software developed to manage the CloudWatch Agent on kubernetes.
   copyright:
     - license: Apache-2.0
@@ -71,13 +71,9 @@ test:
     - name: Install CRDs
       working-directory: amazon-cloudwatch-agent-operator/config/crd/
       runs: |
-        kubectl wait --for=condition=Ready nodes --all
         kustomize build | kubectl apply --server-side=true -f -
         # wait for all CRDs to be created
         sleep 3
-
-        mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
-        kubectl create token default > /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: "Test manager run"
       uses: test/daemon-check-output
       with:

--- a/amazon-cloudwatch-agent-operator.yaml
+++ b/amazon-cloudwatch-agent-operator.yaml
@@ -66,6 +66,8 @@ test:
       KUBERNETES_SERVICE_PORT: 32764
   pipeline:
     - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
     - name: Fetch the testdata from the source repo
       runs: git clone --depth=1 https://github.com/aws/amazon-cloudwatch-agent-operator
     - name: Install CRDs

--- a/cert-manager-webhook-pdns.yaml
+++ b/cert-manager-webhook-pdns.yaml
@@ -36,7 +36,7 @@ update:
     identifier: zachomedia/cert-manager-webhook-pdns
     strip-prefix: v
   ignore-regex-patterns:
-    - 'cert-manager-webhook-pdns-'
+    - "cert-manager-webhook-pdns-"
 
 test:
   environment:
@@ -49,6 +49,8 @@ test:
         - mkcert
   pipeline:
     - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
     - runs: |
         kubectl create rolebinding default-get-configmap \
         --clusterrole=view \

--- a/cert-manager-webhook-pdns.yaml
+++ b/cert-manager-webhook-pdns.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-webhook-pdns
   version: "2.5.2"
-  epoch: 8
+  epoch: 9
   description: A PowerDNS webhook for cert-manager
   copyright:
     - license: MIT
@@ -50,16 +50,6 @@ test:
   pipeline:
     - uses: test/kwok/cluster
     - runs: |
-        # wait until you have a serviceaccount default
-        while ! kubectl get serviceaccount default -n kube-system; do
-          echo "Waiting for serviceaccount default in kube-system namespace..."
-          sleep 1
-        done
-        mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
-        kubectl create token default > /var/run/secrets/kubernetes.io/serviceaccount/token
-        CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
-        cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
         kubectl create rolebinding default-get-configmap \
         --clusterrole=view \
         --serviceaccount=default:default \

--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -58,7 +58,6 @@ pipeline:
 
   - name: Create ServiceAccount and Token
     runs: |
-      #!/usr/bin/env bash
       set -euo pipefail
       # https://kubernetes.io/docs/concepts/security/service-accounts/#default-service-accounts
       if [ "${{inputs.serviceaccount}}" != "true" ]; then

--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -8,6 +8,16 @@ needs:
     - kubernetes # has a runtime dependency on kubectl
     - etcd
 
+inputs:
+  namespace:
+    description: namespace in which we want to run the operator/controller/manager
+    required: true
+    default: default
+  serviceaccount:
+    description: some of operator/controller/manager apps require a SA to run
+    required: true
+    default: false # For security reason, token are not created by default since 1.24 (LegacyServiceAccountTokenNoAutoGeneration feature-gate enabled by default)
+
 pipeline:
   - runs: |
       # ensure we can create a cluster using our own components instead of
@@ -50,14 +60,19 @@ pipeline:
     runs: |
       #!/usr/bin/env bash
       set -euo pipefail
+      # https://kubernetes.io/docs/concepts/security/service-accounts/#default-service-accounts
+      if [ "${{inputs.serviceaccount}}" != "true" ]; then
+        echo "Skipping ServiceAccount and Token creation as per input"
+        exit 0
+      fi
       # Create a ServiceAccount and Token for the kwokctl cluster, fix for:
       # "Fail to create in-cluster Kubernetes config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"
       export KUBERNETES_SERVICE_HOST=127.0.0.1
       export KUBERNETES_SERVICE_PORT=32764
       DIR=/var/run/secrets/kubernetes.io/serviceaccount
       mkdir -p "$DIR"
-      kubectl create serviceaccount default --dry-run=client -o yaml | kubectl apply -f -
-      kubectl create token default > "$DIR"/token
+      kubectl create serviceaccount default -n ${{inputs.namespace}} --dry-run=client -o yaml | kubectl apply -f -
+      kubectl create token default -n ${{inputs.namespace}} > "$DIR"/token
       CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
       cp $CA "$DIR"/ca.crt
-      echo default > "$DIR/namespace"
+      echo ${{inputs.namespace}} > "$DIR/namespace"

--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -45,3 +45,19 @@ pipeline:
 
       kubectl wait --for=condition=Ready nodes --all
       kubectl cluster-info
+
+  - name: Create ServiceAccount and Token
+    runs: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # Create a ServiceAccount and Token for the kwokctl cluster, fix for:
+      # "Fail to create in-cluster Kubernetes config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"
+      export KUBERNETES_SERVICE_HOST=127.0.0.1
+      export KUBERNETES_SERVICE_PORT=32764
+      DIR=/var/run/secrets/kubernetes.io/serviceaccount
+      mkdir -p "$DIR"
+      kubectl create serviceaccount default --dry-run=client -o yaml | kubectl apply -f -
+      kubectl create token default > "$DIR"/token
+      CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+      cp $CA "$DIR"/ca.crt
+      echo default > "$DIR/namespace"

--- a/sealed-secrets.yaml
+++ b/sealed-secrets.yaml
@@ -89,6 +89,8 @@ test:
       runs: |
         controller --version | grep ${{package.version}}
     - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
     - uses: test/daemon-check-output
       with:
         start: /usr/bin/controller

--- a/sealed-secrets.yaml
+++ b/sealed-secrets.yaml
@@ -1,7 +1,7 @@
 package:
   name: sealed-secrets
   version: "0.30.0"
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller and tool for one-way encrypted Secrets
   copyright:
     - license: Apache-2.0
@@ -93,11 +93,6 @@ test:
       with:
         start: /usr/bin/controller
         setup: |
-          mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
-          CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
-          cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          kubectl create serviceaccount default
-          kubectl create token default > /var/run/secrets/kubernetes.io/serviceaccount/token
           kubectl create role secrets-admin --verb='*' --resource=secrets
           kubectl create rolebinding default-secrets-admin-binding --role=secrets-admin --serviceaccount=default:default
         timeout: 30


### PR DESCRIPTION
`kwok` pipeline now creates `token`, `ca.crt`, and `namepspace` files for default SA located in `/var/run/secrets/kubernetes.io/serviceaccount`.

Previous work: https://github.com/wolfi-dev/os/pull/50425