### PR TITLE
Update Versions and enable update for future # total packages

### DIFF
--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-alembic
-  version: 1.11.3
-  epoch: 7
+  version: 1.16.2
+  epoch: 0
   description: A database migration tool for SQLAlchemy.
   copyright:
     - license: MIT
@@ -35,7 +35,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sqlalchemy/alembic
-      expected-commit: 47850ab7dbc88905db8abf7abab6a48699d4a50a
+      expected-commit: b63852d7c7a3be9c0ef7087aab2f86451f6b5e89
       tag: rel_${{vars.mangled-package-version}}
 
 subpackages:
@@ -49,6 +49,7 @@ subpackages:
         - py${{range.key}}-mako
         - py${{range.key}}-python-editor
         - py${{range.key}}-sqlalchemy
+        - py${{range.key}}-tomli
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -109,8 +110,11 @@ test:
           import ${{vars.import}}
 
 update:
-  enabled: false
-  manual: true
-  exclude-reason: This requires manual updates because of the strange tagging scheme.
-  github:
-    identifier: sqlalchemy/alembic
+  enabled: true
+  ignore-regex-patterns:
+    - 'post'
+  version-transform:
+    - match: \_
+      replace: .
+  git:
+    strip-prefix: rel_

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyfarmhash
-  version: 0.3.2
-  epoch: 6
+  version: 0.4.0
+  epoch: 0
   description: Google FarmHash Bindings for Python
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 4146308a0ed0b37d69003199c90fa59b155666c9deb0249b40e594cee10551ea
+      expected-sha256: f350327057de3c8912b227dc22794e0dd11c767fc9db6070ae84c49a96934865
       uri: https://files.pythonhosted.org/packages/source/p/pyfarmhash/pyfarmhash-${{package.version}}.tar.gz
 
 subpackages:

--- a/py3-pykube-ng.yaml
+++ b/py3-pykube-ng.yaml
@@ -78,6 +78,5 @@ test:
           import ${{vars.import}}
 
 update:
-  enabled: false
-  manual: true
-  exclude-reason: we need to manually update because it does not use github
+  enabled: true
+  git: {}

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/pytz/
 package:
   name: py3-pytz
-  version: 2024.1
-  epoch: 4
+  version: 2025.2
+  epoch: 0
   description: World timezone definitions, modern and historical
   copyright:
     - license: MIT
@@ -31,7 +31,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812
+      expected-sha256: 360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3
       uri: https://files.pythonhosted.org/packages/source/p/pytz/pytz-${{package.version}}.tar.gz
 
 subpackages:
@@ -64,7 +64,6 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
 
 update:
-  enabled: false
-  exclude-reason: releases have an odd structure
+  enabled: true
   release-monitor:
     identifier: 6537


### PR DESCRIPTION
- For py3-pyfarmhash I could not find a way to enable update but found a newer version we can update to
