### PR TITLE
withdraw pg-failover-slots-16

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -7,3 +7,9 @@ langfuse-web-compat-3.75.1-r1.apk
 langfuse-web-3-3.75.1-r1.apk
 langfuse-3-3.75.1-r1.apk
 langfuse-worker-3-3.75.1-r1.apk
+
+pg-failover-slots-16-1.0.1-r0.apk
+pg-failover-slots-16-1.1.0-r0.apk
+pg-failover-slots-16-1.1.0-r1.apk
+pg-failover-slots-16-1.1.0-r2.apk
+pg-failover-slots-16-1.1.0-r3.apk


### PR DESCRIPTION
I am withdrawing pg-failover-slots-16 because it has been renamed to
pg-failover-slots, since it is not specific to any one version of
postgres.  This is to avoid anyone accidentally depending on an
unmaintained package.

See #58129
