### PR TITLE
openssf-compiler-options: Disable GCS on ARM64 builds

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 22
+  epoch: 23
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -2,7 +2,7 @@
 + %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now -z gcs=never
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
GCS[1] support was implemented in GCC 15 and it's interacting badly with our builds so far.  Let's temporarily disable it.

[1]: https://docs.kernel.org/arch/arm64/gcs.html

Fixes: #58294