### PR TITLE
open-webui: fix GHSA-xg8h-j46f-w952 by updating pillow to >=11.3.0

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.15"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -60,6 +60,9 @@ pipeline:
 
   - name: Create virtual env / Install open-webui / Install model data
     runs: |
+      # CVE fix: Update pillow to 11.3.0+ to fix GHSA-xg8h-j46f-w952
+      sed -i 's/"pillow==11.2.1"/"pillow>=11.3.0"/' pyproject.toml
+
       # Create virtual env
       uv venv --seed
       source .venv/bin/activate


### PR DESCRIPTION
## Summary

- Fixes Pillow heap buffer overflow vulnerability GHSA-xg8h-j46f-w952 in open-webui package  
- Updates pillow dependency from 11.2.1 to >=11.3.0
- Increments epoch to 1 to force package rebuild

## CVE Details

- **CVE**: GHSA-xg8h-j46f-w952 
- **Component**: Pillow 11.2.1
- **Severity**: High
- **Issue**: Heap buffer overflow when writing large (>64k) DDS format images
- **Affects**: Pillow >= 11.2.0, < 11.3.0
- **Fixed in**: Pillow 11.3.0

## Changes

1. **Modified pyproject.toml constraint**: Uses `sed` to update `"pillow==11.2.1"` to `"pillow>=11.3.0"` before installation
2. **Incremented epoch**: From 0 to 1 to ensure package rebuilds with new dependency

## Remediation Approach

The fix uses the same pattern as kubeflow-pipelines-visualization-server, which already uses `pillow>=11.3.0` for this CVE. The dependency update is applied before the `uv pip install .` command that reads pyproject.toml.

## Testing Instructions

**Manual build required** (large package with ML dependencies):

```bash
make package/open-webui
make test/open-webui  
wolfictl scan packages/*/*/open-webui-*.apk
```

Expected: CVE scan should show GHSA-xg8h-j46f-w952 is resolved.