### PR TITLE
kubeflow-pipelines-visualization-server: fix pillow CVE GHSA-xg8h-j46f-w952

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.5.0"
-  epoch: 3
+  epoch: 4
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0

--- a/kubeflow-pipelines-visualization-server/modified-requirements.in
+++ b/kubeflow-pipelines-visualization-server/modified-requirements.in
@@ -20,4 +20,5 @@ tornado==6.*
 
 # CVE Fixes / Other Fixes
 numpy==1.23.5
+pillow>=11.3.0
 pyarrow-hotfix==0.*


### PR DESCRIPTION
## Summary
- Updates pillow dependency to >=11.3.0 to fix CVE-2025-48379 (GHSA-xg8h-j46f-w952)
- Bumps epoch from 3 to 4 to force package rebuild
- Ensures the visualization server uses the secure pillow version