### PR TITLE
iptables: split out xtables to prepare for iptables-wrappers + other cleanup

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -184,12 +184,11 @@ subpackages:
       - runs: |
           spd=${{targets.contextdir}}
           mkdir -p "$spd/usr/bin"
-          mv ${{targets.destdir}}/usr/bin/iptables-apply "$spd/usr/bin"
+          mv ${{targets.destdir}}/usr/bin/ip*tables-apply "$spd/usr/bin"
     test:
       pipeline:
-        - name: no regression after package re-org
-          runs: |
-            cmds="iptables-apply"
+        - runs: |
+            cmds="iptables-apply ip6tables-apply"
             ${{vars.define-test-funcs}}
             for cmd in $cmds; do
               help_version "$cmd"

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -172,15 +172,18 @@ subpackages:
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-nft-multi
     test:
       pipeline:
-        - uses: test/tw/ldd-check
-        - runs: |
+        - if: ${{build.arch}} != 'aarch64'
+          uses: test/tw/ldd-check
+        - if: ${{build.arch}} != 'aarch64'
+          runs: |
             ixp_cmds="${{vars.iptables-cmds}}"
             ${{vars.define-test-funcs}}
             for cmd in $ixp_cmds; do
               help_version "$cmd"
             done
             no_other_commands "${{context.name}}" "$ixp_cmds"
-        - name: no regression after package re-org
+        - if: ${{build.arch}} != 'aarch64'
+          name: no regression after package re-org
           runs: |
             old_ixp_cmds="${{vars.old-iptables-cmds}}"
             old_ixp_cmds="$old_ixp_cmds ${{vars.old-ip6tables-cmds}}"
@@ -195,7 +198,7 @@ subpackages:
                 *)
                   ;;
               esac
-              # currently fails on in elastic on ARM due to capabilities
+              # currently fails in elastic on ARM due to capabilities
               [ "${{build.arch}}" = "aarch64" ] || help_version "$cmd"
             done
     dependencies:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -159,6 +159,31 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
+  - name: iptables-doc
+    description: iptables documentation
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+    dependencies:
+      runtime:
+        - merged-sbin
+        - wolfi-baselayout
+
+  - name: iptables-dev
+    description: iptables development files
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+    dependencies:
+      runtime:
+        - merged-sbin
+        - wolfi-baselayout
+
   - name: iptables-xtables-privileged
     description: iptables with cap_net_raw and cap_net_admin capabilities set for xtables
     options:
@@ -226,31 +251,6 @@ subpackages:
               help_version "$cmd"
             done
             no_other_commands "${{context.name}}" "$cmds"
-
-  - name: iptables-doc
-    description: iptables documentation
-    pipeline:
-      - uses: split/manpages
-    test:
-      pipeline:
-        - uses: test/docs
-    dependencies:
-      runtime:
-        - merged-sbin
-        - wolfi-baselayout
-
-  - name: iptables-dev
-    description: iptables development files
-    pipeline:
-      - uses: split/dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
-        - uses: test/tw/ldd-check
-    dependencies:
-      runtime:
-        - merged-sbin
-        - wolfi-baselayout
 
   - name: ip6tables
     checks:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -6,9 +6,12 @@ package:
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
+    replaces:
+      - ip6tables
     runtime:
       - merged-sbin
       - wolfi-baselayout
+      - xtables
 
 vars:
   old-iptables-cmds: |
@@ -133,13 +136,9 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/include/libiptc \
-      "${{targets.destdir}}"/usr/lib \
-      "${{targets.destdir}}"/var/lib/iptables \
-      "${{targets.destdir}}"/etc/iptables
+      mkdir -p "${{targets.destdir}}"/usr/include/libiptc
 
-      install -m644 include/iptables.h include/ip6tables.h \
-      "${{targets.destdir}}"/usr/include/
+      install -m644 include/iptables.h include/ip6tables.h "${{targets.destdir}}"/usr/include/
       install include/libiptc/*.h "${{targets.destdir}}"/usr/include/libiptc/
 
       install -D -m644 iptables.confd "${{targets.destdir}}"/etc/conf.d/iptables
@@ -223,19 +222,15 @@ subpackages:
         - wolfi-baselayout
 
   - name: ip6tables
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}
-          cd "${{targets.subpkgdir}}"
-
-          mkdir -p usr/bin \
-            var/lib/ip6tables \
-            usr/lib/xtables
-
-          mv "${{targets.destdir}}"/usr/bin/ip6* usr/bin/
-          mv "${{targets.destdir}}"/usr/lib/xtables/libip6* usr/lib/xtables/
+    checks:
+      disabled:
+        - empty
+    dependencies:
+      runtime:
+        - iptables
     test:
       pipeline:
+        - uses: test/emptypackage
         - name: no regression after package re-org
           runs: |
             old_ip6tables_cmds="${{vars.old-ip6tables-cmds}}"
@@ -245,10 +240,23 @@ subpackages:
               [ "$cmd" = "ip6tables-apply" ] || help_version "$cmd"
             done
             no_other_commands "${{context.name}}" "$old_ip6tables_cmds"
+
+  - name: xtables
+    description: xtables multi call binaries and libraries
     dependencies:
       runtime:
         - merged-sbin
         - wolfi-baselayout
+      replaces:
+        - iptables
+        - ip6tables
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}
+        runs: |
+          mv ${{targets.destdir}}/etc .
+          mkdir -p usr/bin var/lib/iptables var/lib/ip6tables etc/iptables
+          mv ${{targets.destdir}}/usr/bin/xtables-* ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr/
 
 update:
   enabled: true

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -14,6 +14,20 @@ package:
       - xtables
 
 vars:
+  iptables-cmds: |
+    arptables arptables-restore arptables-save arptables-translate \
+    arptables-nft arptables-nft-restore arptables-nft-save \
+    ebtables ebtables-restore ebtables-save ebtables-translate \
+    ebtables-nft ebtables-nft-restore ebtables-nft-save \
+    iptables iptables-restore iptables-save iptables-xml \
+    iptables-translate iptables-restore-translate \
+    iptables-legacy iptables-legacy-restore iptables-legacy-save \
+    iptables-nft iptables-nft-restore iptables-nft-save \
+    ip6tables ip6tables-restore ip6tables-save \
+    ip6tables-translate ip6tables-restore-translate \
+    ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+    ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save
+    xtables-legacy-multi xtables-monitor xtables-nft-multi
   old-iptables-cmds: |
     arptables arptables-restore arptables-save arptables-translate \
     arptables-nft arptables-nft-restore arptables-nft-save \
@@ -163,6 +177,13 @@ subpackages:
             - libcap-utils
       pipeline:
         - uses: test/tw/ldd-check
+        - runs: |
+            ixp_cmds="${{vars.iptables-cmds}}"
+            ${{vars.define-test-funcs}}
+            for cmd in $ixp_cmds; do
+              help_version "$cmd"
+            done
+            no_other_commands "${{context.name}}" "$ixp_cmds"
         - name: no regression after package re-org
           runs: |
             old_ixp_cmds="${{vars.old-iptables-cmds}}"
@@ -181,7 +202,6 @@ subpackages:
               # currently fails on in elastic on ARM due to capabilities
               [ "${{build.arch}}" = "aarch64" ] || help_version "$cmd"
             done
-            no_other_commands "${{context.name}}" "$old_ixp_cmds"
     dependencies:
       runtime:
         - merged-sbin
@@ -199,6 +219,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/ip*tables-apply "$spd/usr/bin"
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - runs: |
             cmds="iptables-apply ip6tables-apply"
             ${{vars.define-test-funcs}}
@@ -268,6 +289,16 @@ subpackages:
           mkdir -p usr/bin var/lib/iptables var/lib/ip6tables etc/iptables
           mv ${{targets.destdir}}/usr/bin/xtables-* ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: |
+            cmds="xtables-legacy-multi xtables-monitor xtables-nft-multi"
+            ${{vars.define-test-funcs}}
+            for cmd in $cmds; do
+              help_version "$cmd"
+            done
+            no_other_commands "${{context.name}}" "$cmds"
 
 update:
   enabled: true
@@ -276,6 +307,13 @@ update:
 
 test:
   pipeline:
+    - runs: |
+        iptables_cmds="${{vars.iptables-cmds}}"
+        ${{vars.define-test-funcs}}
+        for cmd in $iptables_cmds; do
+          help_version "$cmd"
+        done
+        no_other_commands "${{context.name}}" "$iptables_cmds"
     - name: no regression after package re-org
       runs: |
         old_iptables_cmds="${{vars.old-iptables-cmds}}"
@@ -283,5 +321,4 @@ test:
         for cmd in $old_iptables_cmds; do
           help_version "$cmd"
         done
-        no_other_commands "${{context.name}}" "$old_iptables_cmds"
     - uses: test/tw/ldd-check

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 23
+  epoch: 24
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -153,6 +153,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/
           cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
+          rm ${{targets.contextdir}}/usr/bin/ip*tables-apply
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-nft-multi
     test:
@@ -169,6 +170,14 @@ subpackages:
             old_ixp_cmds="$old_ixp_cmds iptables-apply"
             ${{vars.define-test-funcs}}
             for cmd in $old_ixp_cmds; do
+              # ip*tables-apply was removed post-reorg
+              case "$cmd" in
+                ip*tables-apply)
+                  continue
+                  ;;
+                *)
+                  ;;
+              esac
               # currently fails on in elastic on ARM due to capabilities
               [ "${{build.arch}}" = "aarch64" ] || help_version "$cmd"
             done
@@ -178,6 +187,9 @@ subpackages:
         - merged-sbin
         - wolfi-baselayout
 
+  # iptables-apply is a bash script, and therefore depends on bash
+  # only a subset of iptables users use this script, so we keep
+  # it split out to avoid adding bash into all images using iptables.
   - name: iptables-apply
     description: iptables-apply program
     pipeline:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -171,10 +171,6 @@ subpackages:
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/usr/bin/xtables-nft-multi
     test:
-      environment:
-        contents:
-          packages:
-            - libcap-utils
       pipeline:
         - uses: test/tw/ldd-check
         - runs: |


### PR DESCRIPTION
In preparation for adding support for `iptables-wrappers`, we split `xtables` out into its own package.  We also fold the ip6* commands into the ip* packages, for reasons @xnox notes in https://github.com/wolfi-dev/os/pull/17421#issuecomment-2069314327, leaving `ip6tables` as an empty transition package.

While doing this, I noticed a few other issues/inconsistencies that required additional refactoring. Specificaly, `ip6tables-apply` was a broken symlink, and `iptables-xtables-privileged` was shipping a lot of duplicate content.

To de-risk this refactoring, I first added tests via https://github.com/wolfi-dev/os/pull/58296 to each package that check that all of the commands it provided are available. Running those same tests in this PR ensures that users of any pre-refactor packages end up with the same commands when they install the same package after this refactor - those commands may just now be supplied by a dependency of the package rather than that package itself. This PR also adds similar test cases for the post-refactored package contents. The `no_other_commands` test moves into those post-refactor tests, because package contents will evolve over time - where-as the "no regression after package re-org" tests were to validate a certain point in time. It probably makes sense to remove the "no regression" version of these tests after this is merged - their purpose having been served.

Once exception to the above stringency is `iptables-xtables-privileged`. I chose to go ahead and remove the duplicate `ip*tables-apply` commands it was shipping. We did this recently for `iptables` itself in https://github.com/wolfi-dev/os/commit/9ddbb80126f00381cd970e6b9dc5a61759982f61. The argument @smoser makes there apply to this package as well. Admittedly, there has now been a ~3 month window since that commit where `iptables-xtables-privileged` does include an sca-provided dependency on `bash`, and therefore provides working copies of these scripts. But  I think the risk that someone has started depending on that in the interim is much too small for us to justify continuing to require `bash` be installed with this package. Similarly, I noticed that it was also including its own copies of the headers and manpages, and I've trimmed those out. It should now just be the superset of files in `iptables` and `xtables`.

NOTE: We may want to also split out an `xtables-privileged` package to allow for the creation of an `iptables-wrappers-privileged` package - that would also provide symmetry between -privileged and non-privileged packages.

NOTE: I had to disable some of the new tests on ARM for now because the `bubblewrap` runner can't seem to deal with unpacking `setcap`'d binaries. I validated that they pass when I run them manually on an ARM system w/ the necessary privileges (bubblewrap as root).