### PR TITLE
add font-lohit family

### DIFF
--- a/font-lklug-sinhala.yaml
+++ b/font-lklug-sinhala.yaml
@@ -1,0 +1,35 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: font-lklug-sinhala
+  version: 0.6_git20250704
+  epoch: 0
+  description: Unicode Sinhala font by Lanka Linux User Group
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - fontforge
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://salsa.debian.org/fonts-team/fonts-lklug-sinhala
+      expected-commit: e059baf13cf556c98d83aeadd209083492fc5e8e
+      branch: master
+
+  - runs: |
+      make ttf
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/lklug-sinhala
+      install -D -m644 *.ttf -t "${{targets.destdir}}"/usr/share/fonts/lklug-sinhala
+
+update:
+  enabled: false
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-lohit-extras.yaml
+++ b/font-lohit-extras.yaml
@@ -1,0 +1,60 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: font-lohit-extras
+  version: 2.4.3
+  epoch: 0
+  description: Lohit fonts family project to supporting Indian scripts.
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - fontforge
+      - ttfautohint
+
+pipeline:
+  - runs: true # Dummy step to make this a valid pipeline, so Melange can process subpackages.
+
+data:
+  - name: fonts-extra
+    items:
+      kashmiri: 833496d5810caff036943ccd32b6b7ceb116b6631da1ff5e6e3293bcce50fd105608770f82eaca25b822eb1001edd24bbb1a9f9480be501f579d7563ec81618f
+      maithili: 9b69e29feed8d0b06ecaea35c944f0c3cd4502e47896966c8d6a3599b87f9cec1173f48104084df7f573319f00a73ff4d78a7f3019806740625712fc2b2a1df6
+      konkani: f3a1bbbf78d3e7841151bfe52be652833672b99602f9c93e109b2cbac9ad6f2cc983813b12e01c8d21bf780a07268a6a6e0e4c714eb12f86f83503bab3150ebc
+      sindhi: 5145e5e36e5349e6d6099b5af73034f8cb4a2dbffa490e4297991f7d8181dbc1d425ab0f5759a1b47b0479bf684cef602760371d2807049dc0f9fa4344d0efcd
+
+subpackages:
+  - range: fonts-extra
+    name: font-lohit-${{range.key}} # font-lohit-extras in the package name is just a placeholder, we need to use `font-lohit-${{range.key}}` to match the original font-lohit package naming convention.
+    description: "${{range.key}} font"
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://releases.pagure.org/lohit/lohit-${{range.key}}-ttf-${{package.version}}.tar.gz
+          expected-sha512: ${{range.value}}
+          extract: true
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/fonts/lohit-${{range.key}}" \
+                  "${{targets.subpkgdir}}/etc/fonts/conf.avail" \
+                  "${{targets.subpkgdir}}/etc/fonts/conf.d"
+
+          install -Dm644 *.ttf "${{targets.subpkgdir}}/usr/share/fonts/lohit-${{range.key}}/"
+
+          for conf in *.conf; do
+              install -Dm644 "$conf" "${{targets.subpkgdir}}/etc/fonts/conf.avail/$conf"
+              ln -sf ../conf.avail/"$conf" "${{targets.subpkgdir}}/etc/fonts/conf.d/$conf"
+          done
+    test:
+      pipeline:
+        - uses: test/fonts
+
+update:
+  enabled: false
+  exclude-reason: No releases or tags since 2017, see https://pagure.io/lohit
+
+test:
+  pipeline:
+    - uses: test/emptypackage

--- a/font-lohit.yaml
+++ b/font-lohit.yaml
@@ -21,6 +21,10 @@ package:
       - font-lohit-tamil-classical
       - font-lohit-tamil
       - font-lohit-telugu
+      - font-lohit-kashmiri
+      - font-lohit-maithili
+      - font-lohit-konkani
+      - font-lohit-sindhi
 
 environment:
   contents:
@@ -36,6 +40,9 @@ pipeline:
       expected-commit: 7a8b554983e6c41d4104bd9f8f7e423e8bfe31fa
       repository: https://github.com/pravins/lohit
       branch: master
+
+vars:
+  fonts_extra_version: 2.4.3 # No new releaases since 2020, so using the last known version.
 
 data:
   - name: fonts
@@ -53,11 +60,6 @@ data:
       tamil-classical:
       tamil:
       telugu:
-      #lklug-sinhala:
-      #kashmiri:
-      #maithili:
-      #konkani:
-      #sindhi:
 
 subpackages:
   - range: fonts

--- a/font-lohit.yaml
+++ b/font-lohit.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Lohit fonts family project to supporting Indian scripts.
   copyright:
-    - license: GPL-2.0-or-later
+    - license: OFL-1.1
   dependencies:
     runtime:
       - font-lohit-assamese

--- a/font-lohit.yaml
+++ b/font-lohit.yaml
@@ -1,0 +1,89 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: font-lohit
+  version: 0_git20250703
+  epoch: 0
+  description: Lohit fonts family project to supporting Indian scripts.
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - font-lohit-assamese
+      - font-lohit-bengali
+      - font-lohit-devanagari
+      - font-lohit-gujarati
+      - font-lohit-gurmukhi
+      - font-lohit-kannada
+      - font-lohit-malayalam
+      - font-lohit-marathi
+      - font-lohit-nepali
+      - font-lohit-odia
+      - font-lohit-tamil-classical
+      - font-lohit-tamil
+      - font-lohit-telugu
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - fontforge
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7a8b554983e6c41d4104bd9f8f7e423e8bfe31fa
+      repository: https://github.com/pravins/lohit
+      branch: master
+
+data:
+  - name: fonts
+    items:
+      assamese:
+      bengali:
+      devanagari:
+      gujarati:
+      gurmukhi:
+      kannada:
+      malayalam:
+      marathi:
+      nepali:
+      odia:
+      tamil-classical:
+      tamil:
+      telugu:
+      #lklug-sinhala:
+      #kashmiri:
+      #maithili:
+      #konkani:
+      #sindhi:
+
+subpackages:
+  - range: fonts
+    name: ${{package.name}}-${{range.key}}
+    description: "${{range.key}} font"
+    pipeline:
+      - runs: |
+          cd ${{range.key}}
+          cp ../AUTHORS ../scripts/apply_featurefile.py ../scripts/auto_test.py  ../generate*.pe ../COPYRIGHT ../OFL.txt ../README .
+          make ttf
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/fonts/lohit
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/fontconfig/conf.avail/
+          mkdir -p "${{targets.subpkgdir}}"/etc/fonts/conf.d
+          install -D -m644 *.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/lohit
+          for i in $(find . -name '*.conf'); do
+            install -D -m644 "$i" -t ${{targets.subpkgdir}}/etc/fonts/conf.avail/
+            ln -sf /etc/fonts/conf.avail/$i ${{targets.subpkgdir}}/etc/fonts/conf.d/$i
+          done
+    test:
+      pipeline:
+        - uses: test/fonts
+
+update:
+  enabled: false
+  exclude-reason: No releases or tags
+
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
