### PR TITLE
Fix multiple CVE for kubeflow

### DIFF
--- a/kubeflow.yaml
+++ b/kubeflow.yaml
@@ -5,7 +5,7 @@
 package:
   name: kubeflow
   version: "1.10.0"
-  epoch: 3
+  epoch: 4
   description: Kubeflow Go Components
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,7 @@ pipeline:
         golang.org/x/text@v0.3.8
         github.com/gogo/protobuf@v1.3.2
         google.golang.org/protobuf@v1.33.0
+        golang.org/x/net@v0.38.0
       modroot: components/notebook-controller
 
   - uses: go/bump
@@ -51,6 +52,7 @@ pipeline:
         google.golang.org/protobuf@v1.33.0
         github.com/emicklei/go-restful@v2.16.0
         gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+        golang.org/x/net@v0.38.0
         google.golang.org/grpc@v1.56.3
       modroot: components/profile-controller
 


### PR DESCRIPTION
Critical
CVE-2024-45337 / GHSA-v778-237x-gjrc
High
CVE-2022-27191 / GHSA-8c26-wmh5-6g9v
CVE-2021-43565 / GHSA-gwc9-m7rh-j2ww
CVE-2022-41723 / GHSA-vvpx-j8f3-3w6h
CVE-2023-39325 / GHSA-4374-p667-p6c8
CVE-2023-44487 / GHSA-qppj-fm5r-hxr3
CVE-2023-45288 / GHSA-4v7x-pqxf-cx7m
CVE-2022-27664 / GHSA-69cg-p879-7622
Medium
CVE-2023-48795 / GHSA-45x7-px36-x8w8
CVE-2022-41717 / GHSA-xrjj-mj9h-534m
CVE-2023-3978 / GHSA-2wrh-6pvc-2jm9
CVE-2024-45338
CVE-2025-22870 / GHSA-qxp5-gwg8-xv66
CVE-2025-22872 / GHSA-vvgc-356p-c3xw

remaining CVE releated to k8s client-go and apimachinery is not fixable as there is missing packages in the new version fo the module
```
k8s.io/apimachinery/pkg/util/clock: module k8s.io/apimachinery@latest found (v0.33.2, replaced by k8s.io/apimachinery@v0.33.2), but does not contain package k8s.io/apimachinery/pkg/util/clock
``` 