### PR TITLE
airflow-3: fix cve remediation

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.0.2"
-  epoch: 3
+  epoch: 4
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -112,9 +112,6 @@ pipeline:
       # CVE-2025-50181 CVE-2025-50182
       uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow urllib3==2.5.0
 
-      # CVE-2025-50213
-      uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow apache-airflow-providers-snowflake>=6.4.0
-
   - name: "Build and install the additional provider packages"
     runs: |
       # By default, the airflow celery provider is not built, but running the upstream helm chart requires it
@@ -144,6 +141,9 @@ pipeline:
         uv pip install --verbose --upgrade --resolution highest --prefix=${{targets.contextdir}}/opt/airflow dist/*.whl
         cd -
       done
+
+  - name: "bump snowflake provider to remediate CVE-2025-50213"
+    runs: uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow apache-airflow-providers-snowflake>=6.4.0
 
   - runs: find . -name '__pycache__' -exec rm -rf {} +
 


### PR DESCRIPTION
Fix the remediation for CVE-2025-50213 by upgrading `apache-airflow-providers-snowflake` after the initial installation.
