### PR TITLE
7zip: update release-monitor ID

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -51,7 +51,7 @@ subpackages:
 update:
   enabled: true
   release-monitor:
-    identifier: 265148
+    identifier: 372314
 
 test:
   environment:


### PR DESCRIPTION
The existing ID, https://release-monitoring.org/project/265148/, seems to be unmaintained and un-updated. It doesn't include today's 7zip release.

https://release-monitoring.org/project/372314/ seems to be the latest one, and does have today's release.

This should fail the update config check, but then after this merges automation should update it to the latest version based on the new release-monitoring info.