### PR TITLE
7zip: update to 2500

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -1,6 +1,6 @@
 package:
   name: 7zip
-  version: 2301
+  version: 25.00
   epoch: 3
   description: "File archiver with a high compression ratio"
   copyright:
@@ -14,11 +14,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://7-zip.org/a/7z${{package.version}}-src.tar.xz
-      expected-sha512: e39f660c023aa65e55388be225b5591fe2a5c9138693f3c9107e2eb4ce97fafde118d3375e01ada99d29de9633f56221b5b3d640c982178884670cd84c8aa986
-      strip-components: 0
+      repository: https://github.com/ip7z/7zip
+      tag: ${{package.version}}
+      expected-commit: 395149956d696e6e3099d8b76d797437f94a6942
 
   - name: Configure and build
     runs: |

--- a/7zip.yaml
+++ b/7zip.yaml
@@ -50,8 +50,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 372314
+  github:
+    identifier: ip7z/7zip
 
 test:
   environment:

--- a/7zip.yaml
+++ b/7zip.yaml
@@ -1,7 +1,7 @@
 package:
   name: 7zip
-  version: 25.00
-  epoch: 3
+  version: 2500
+  epoch: 0
   description: "File archiver with a high compression ratio"
   copyright:
     - license: LGPL-2.0-only
@@ -14,11 +14,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/ip7z/7zip
-      tag: ${{package.version}}
-      expected-commit: 395149956d696e6e3099d8b76d797437f94a6942
+      uri: https://7-zip.org/a/7z${{package.version}}-src.tar.xz
+      expected-sha512: 586723f6fe149645db1eb8d1d27a26977e591e222663073a59e320e432881adaf4bc4067682be2b7ad5443ab0fea9e16b99b12d4ae40ae0f40ae7b23a31b0396
+      strip-components: 0
 
   - name: Configure and build
     runs: |
@@ -50,8 +50,8 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: ip7z/7zip
+  release-monitor:
+    identifier: 372314
 
 test:
   environment:

--- a/7zip.yaml
+++ b/7zip.yaml
@@ -52,6 +52,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 372314
+  version-transform:
+    - match: \.
+      replace: ''
 
 test:
   environment:


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/58418 updated its release-monitoring ID, which we expected to fail the update config check, but it failed for another reason -- because the 7zip source download was not found with the string `25.00`.

Instead, we want to use the new updated RM ID, but transform it so the version can be `2500` (to be > `2300`), and transform the RM metadata so that its `25.00` becomes `2500`, and potentially follows `2501` etc going forward.