### PR TITLE
add xorg-fonts family

### DIFF
--- a/font-wqy-microhei.yaml
+++ b/font-wqy-microhei.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: font-wqy-microhei
   version: 0.2.0

--- a/font-wqy-microhei.yaml
+++ b/font-wqy-microhei.yaml
@@ -1,11 +1,12 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: font-wqy-microhei
-  version: 0.2.0
+  version: 0_git20250706
   epoch: 0
-  description: "WenQuanYi Micro Hei font (CJK sans-serif)"
+  description: Sans-serif style CJK font derived from Droid
   copyright:
     - license: GPL-3.0-or-later
+    - license: Apache-2.0
   dependencies:
     provides:
       - fonts-wqy-microhei=${{package.full-version}}
@@ -13,27 +14,29 @@ package:
 environment:
   contents:
     packages:
-      - binutils # for `ar`
-      - build-base
       - busybox
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 58d0a29af79ce1fc5c63b4276065f0fce27decf6839835f3f9c2e68d9f84ca20
-      uri: https://archive.ubuntu.com/ubuntu/pool/universe/f/fonts-wqy-microhei/fonts-wqy-microhei_0.2.0-beta-3.1_all.deb
-      extract: false
+      repository: https://salsa.debian.org/fonts-team/fonts-wqy-microhei
+      expected-commit: afc811db836c1a0efcb97d82bfaf8916f66b9f2a
+      branch: master
 
   - runs: |
-      ar x fonts-wqy-microhei_0.2.0-beta-3.1_all.deb
-      tar -xf data.tar.*  # Handles .xz or .gz automatically
-      mkdir -p "${{targets.contextdir}}/usr/share/fonts/truetype/wqy"
-      mkdir -p "${{targets.contextdir}}/etc/fonts/conf.avail"
-      mv ./etc/fonts/conf.avail "${{targets.contextdir}}/etc/fonts/conf.avail"
-      mv ./usr/share/fonts/truetype/wqy/*.ttc "${{targets.contextdir}}/usr/share/fonts/truetype/wqy/"
+      mkdir -p ${{targets.destdir}}/usr/share/fonts/wqy-microhei \
+        ${{targets.destdir}}/etc/fonts/conf.avail \
+        ${{targets.destdir}}/etc/fonts/conf.d
+
+      install -Dm644 ./*.ttc -t ${{targets.destdir}}/usr/share/fonts/wqy-microhei
+      install -Dm644 debian/65-wqy-microhei.conf -t ${{targets.destdir}}/etc/fonts/conf.avail/
+      ln -sf /etc/fonts/conf.avail/65-wqy-microhei.conf ${{targets.destdir}}/etc/fonts/conf.d/65-wqy-microhei.conf
+
+  - uses: strip
 
 update:
   enabled: false
+  exclude-reason: No releases or tags
 
 test:
   pipeline:

--- a/font-xorg-adobe100dpi.yaml
+++ b/font-xorg-adobe100dpi.yaml
@@ -1,0 +1,50 @@
+package:
+  name: font-xorg-adobe100dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Adobe 100 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontadobe100dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/adobe-100dpi.git
+      tag: font-adobe-100dpi-${{package.version}}
+      expected-commit: 13f867e9f5be0fcc4776f323f5d5f8f354d2a2c0
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-adobe75dpi.yaml
+++ b/font-xorg-adobe75dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-adobe75dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Adobe 75 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontadobe75dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/adobe-75dpi
+      tag: font-adobe-75dpi-${{package.version}}
+      expected-commit: 6189f2a653b7daa9566f9331bfed41813cbd8cb1
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-adobeutopia100dpi.yaml
+++ b/font-xorg-adobeutopia100dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-adobeutopia100dpi
+  version: 1.0.5
+  epoch: 0
+  description: X.Org Adobe Utopia 100 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontadobeutopia100dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/adobe-utopia-100dpi
+      tag: font-adobe-utopia-100dpi-${{package.version}}
+      expected-commit: b0deb2b3a29bb36ed5a9a4e82095d39c8e8aa67e
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-adobeutopia75dpi.yaml
+++ b/font-xorg-adobeutopia75dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-adobeutopia75dpi
+  version: 1.0.5
+  epoch: 0
+  description: X.Org Adobe Utopia 75 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontadobeutopia75dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/adobe-utopia-75dpi
+      tag: font-adobe-utopia-75dpi-${{package.version}}
+      expected-commit: 448174d449ab42df971cdef89ec0cc018c7f4784
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-adobeutopiatype1.yaml
+++ b/font-xorg-adobeutopiatype1.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-adobeutopiatype1
+  version: 1.0.5
+  epoch: 0
+  description: X.Org Adobe Utopia scalable Type 1 fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontadobeutopiatype1=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/adobe-utopia-type1
+      tag: font-adobe-utopia-type1-${{package.version}}
+      expected-commit: 65cbf23308402be64b8b52ca5511bf97dfebd5fc
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-arabicmisc.yaml
+++ b/font-xorg-arabicmisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-arabicmisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Arabic miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontarabicmisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/arabic-misc
+      tag: font-arabic-misc-${{package.version}}
+      expected-commit: 4b6a6e6221bac21535f28a73109de95f5a1a144a
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bh100dpi.yaml
+++ b/font-xorg-bh100dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bh100dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org B&H 100 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbh100dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bh-100dpi
+      tag: font-bh-100dpi-${{package.version}}
+      expected-commit: 3f767dc9b09fb5fd645bcd3d3f33943c3b5bf142
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bh75dpi.yaml
+++ b/font-xorg-bh75dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bh75dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org B&H 75 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbh75dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bh-75dpi
+      tag: font-bh-75dpi-${{package.version}}
+      expected-commit: c8f122dc110478a091c6dc64768111f9be5a06f5
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bhlucidatypewriter100dpi.yaml
+++ b/font-xorg-bhlucidatypewriter100dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bhlucidatypewriter100dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org B&H Lucida Typewriter 100 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbhlucidatypewriter100dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bh-lucidatypewriter-100dpi
+      tag: font-bh-lucidatypewriter-100dpi-${{package.version}}
+      expected-commit: 371bf370a2b37da4a1d69d761e56ab63ca47e81b
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bhlucidatypewriter75dpi.yaml
+++ b/font-xorg-bhlucidatypewriter75dpi.yaml
@@ -22,7 +22,7 @@ environment:
       - fontconfig
       - fontforge
       - mkfontscale
-      - pkgconf
+      - pkgconf-dev
       - ttfautohint
 
 pipeline:

--- a/font-xorg-bhlucidatypewriter75dpi.yaml
+++ b/font-xorg-bhlucidatypewriter75dpi.yaml
@@ -1,0 +1,50 @@
+package:
+  name: font-xorg-bhlucidatypewriter75dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org B&H Lucida Typewriter 75 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbhlucidatypewriter75dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bh-lucidatypewriter-75dpi
+      tag: font-bh-lucidatypewriter-75dpi-${{package.version}}
+      expected-commit: 85f8b76be95b16659943ca77829b37ab3a22d0de
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bhtype1.yaml
+++ b/font-xorg-bhtype1.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bhtype1
+  version: 1.0.4
+  epoch: 0
+  description: X.Org B&H scalable Type 1 fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbhtype1=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bh-type1
+      tag: font-bh-type1-${{package.version}}
+      expected-commit: 4868bb5e731b8a85afd97b8704d707a871610273
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bitstream100dpi.yaml
+++ b/font-xorg-bitstream100dpi.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bitstream100dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Bitstream 100 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbitstream100dpi=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bitstream-100dpi
+      tag: font-bitstream-100dpi-${{package.version}}
+      expected-commit: 596a6af9d142b23625386f7ed5b038d60f598311
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-bitstreamtype1.yaml
+++ b/font-xorg-bitstreamtype1.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-bitstreamtype1
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Bitstream scalable Type 1 fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbitstreamtype1=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/bitstream-type1
+      tag: font-bitstream-type1-${{package.version}}
+      expected-commit: ef8ad9ed09f10ad8d14eaad4350fcd14e0376871
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-cursormisc.yaml
+++ b/font-xorg-cursormisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-cursormisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org cursor miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontcursormisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/cursor-misc
+      tag: font-cursor-misc-${{package.version}}
+      expected-commit: 73b2095391d5bcf326c903946de48d0710daa169
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-daewoomisc.yaml
+++ b/font-xorg-daewoomisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-daewoomisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Daewoo miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontdaewoomisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/daewoo-misc
+      tag: font-daewoo-misc-${{package.version}}
+      expected-commit: e5f30fb9b698d329aa9fc9fde36e4bf7931516ff
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-decmisc.yaml
+++ b/font-xorg-decmisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-decmisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org DEC miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontdecmisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/dec-misc
+      tag: font-dec-misc-${{package.version}}
+      expected-commit: 65d7dbd604ee50d853625d226a1c7a9baf560013
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-ibmtype1.yaml
+++ b/font-xorg-ibmtype1.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-ibmtype1
+  version: 1.0.4
+  epoch: 0
+  description: X.Org IBM scalable Type 1 fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontibmtype1=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/ibm-type1
+      tag: font-ibm-type1-${{package.version}}
+      expected-commit: 88a51daabc8a5bf2dbb2ace89c638058b01b3cf3
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-isasmisc.yaml
+++ b/font-xorg-isasmisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-isasmisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org ISAS miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontisasmisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/isas-misc
+      tag: font-isas-misc-${{package.version}}
+      expected-commit: 8091c381b8fe691f1d1a8708c43e2b4e97d0e4bc
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-schumachermisc.yaml
+++ b/font-xorg-schumachermisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-schumachermisc
+  version: 1.1.3
+  epoch: 0
+  description: X.Org Schumacher miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontschumachermisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/schumacher-misc
+      tag: font-schumacher-misc-${{package.version}}
+      expected-commit: 226c513c5d3fbcc460bbcaded6eefc482f2e5265
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-screencyrillic.yaml
+++ b/font-xorg-screencyrillic.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-screencyrillic
+  version: 1.0.5
+  epoch: 0
+  description: X.Org screen Cyrillic bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontscreencyrillic=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/screen-cyrillic
+      tag: font-screen-cyrillic-${{package.version}}
+      expected-commit: d08e518280bc42c0ec6763cf07d98106afcb346f
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-sonymisc.yaml
+++ b/font-xorg-sonymisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-sonymisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Sony miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontsonymisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/sony-misc
+      tag: font-sony-misc-${{package.version}}
+      expected-commit: dea9a181f64ca0c6740de4ce23be26bc28b8df81
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-sunmisc.yaml
+++ b/font-xorg-sunmisc.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-sunmisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Sun miscellaneous bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontsunmisc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/sun-misc
+      tag: font-sun-misc-${{package.version}}
+      expected-commit: 73d056e8f92a17608566331293040a2c655b91cc
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-winitzkicyrillic.yaml
+++ b/font-xorg-winitzkicyrillic.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-winitzkicyrillic
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Winitzki Cyrillic bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontwinitzkicyrillic=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/winitzki-cyrillic
+      tag: font-winitzki-cyrillic-${{package.version}}
+      expected-commit: 152be3c032eb8f1a5157ae3bbfe1f36876467855
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-xfree86type1.yaml
+++ b/font-xorg-xfree86type1.yaml
@@ -1,0 +1,52 @@
+package:
+  name: font-xorg-xfree86type1
+  version: 1.0.5
+  epoch: 0
+  description: X.Org XFree86 scalable Type 1 fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontxfree86type1=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/font/xfree86-type1
+      tag: font-xfree86-type1-${{package.version}}
+      expected-commit: e2a0089fc5b6404a6ab417ec6b1b75645283358f
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg.yaml
+++ b/font-xorg.yaml
@@ -1,0 +1,44 @@
+package:
+  name: font-xorg
+  version: 1
+  epoch: 0
+  description: "Meta package for X.Org fonts"
+  dependencies:
+    runtime:
+      - font-xorg-adobe75dpi
+      - font-xorg-adobe100dpi
+      - font-xorg-adobeutopia75dpi
+      - font-xorg-adobeutopia100dpi
+      - font-xorg-adobeutopiatype1
+      - font-xorg-arabicmisc
+      - font-xorg-bh75dpi
+      - font-xorg-bh100dpi
+      - font-xorg-bhlucidatypewriter75dpi
+      - font-xorg-bhlucidatypewriter100dpi
+      - font-xorg-bhtype1
+      - font-xorg-bitstream100dpi
+      - font-xorg-bitstreamtype1
+      - font-xorg-cursormisc
+      - font-xorg-daewoomisc
+      - font-xorg-decmisc
+      - font-xorg-ibmtype1
+      - font-xorg-isasmisc
+      - font-xorg-schumachermisc
+      - font-xorg-screencyrillic
+      - font-xorg-sonymisc
+      - font-xorg-sunmisc
+      - font-xorg-winitzkicyrillic
+      - font-xorg-xfree86type1
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - runs: mkdir -p ${{targets.contextdir}}
+
+update:
+  enabled: false
+  exclude-reason: |
+    This is a meta package for packages that comprise X.Org fonts.

--- a/font-xorg.yaml
+++ b/font-xorg.yaml
@@ -5,16 +5,16 @@ package:
   description: "Meta package for X.Org fonts"
   dependencies:
     runtime:
-      - font-xorg-adobe75dpi
       - font-xorg-adobe100dpi
-      - font-xorg-adobeutopia75dpi
+      - font-xorg-adobe75dpi
       - font-xorg-adobeutopia100dpi
+      - font-xorg-adobeutopia75dpi
       - font-xorg-adobeutopiatype1
       - font-xorg-arabicmisc
-      - font-xorg-bh75dpi
       - font-xorg-bh100dpi
-      - font-xorg-bhlucidatypewriter75dpi
+      - font-xorg-bh75dpi
       - font-xorg-bhlucidatypewriter100dpi
+      - font-xorg-bhlucidatypewriter75dpi
       - font-xorg-bhtype1
       - font-xorg-bitstream100dpi
       - font-xorg-bitstreamtype1

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -22,14 +22,19 @@ pipeline:
       for font_file in $(apk info -qL "$font_pkg" | grep "^${{inputs.path-prefix}}/fonts/"); do
         if [ -f /"$font_file" ]; then
           case /"$font_file" in
-            *.alias|*.dir)
+            *.alias|*.dir|*.scale)
               # Check file type
-              file /"$font_file" | grep -i ": ASCII text"
+              file /"$font_file" | grep -Ei ": (ASCII text|.*font)"
               font_files=true
             ;;
             *.gz)
               # Check file type
               zcat /"$font_file" | file - | grep -i ": .*font"
+              font_files=true
+            ;;
+            *.afm|*.pfa|*.pfb)
+              # Type 1 outline or metrics; make sure 'file' sees a font but skip ttx
+              file /"$font_file" | grep -Ei ": (ASCII font metrics|PostScript .*font|.*font)"
               font_files=true
             ;;
             *)
@@ -53,3 +58,4 @@ pipeline:
         echo "  (c) remove the package entirely"
         exit 1
       fi
+      echo "All font files in package [$font_pkg] are valid fonts."

--- a/pipelines/test/fonts.yaml
+++ b/pipelines/test/fonts.yaml
@@ -33,7 +33,9 @@ pipeline:
               font_files=true
             ;;
             *.afm|*.pfa|*.pfb)
-              # Type 1 outline or metrics; make sure 'file' sees a font but skip ttx
+              # PostScript Type 1 outlines (*.pfa, *.pfb) or metrics (*.afm).
+              # "file" must recognise them as font-related, but "fonttools ttx"
+              # cannot open Type 1 formats, so we **skip** the ttx inspection here.
               file /"$font_file" | grep -Ei ": (ASCII font metrics|PostScript .*font|.*font)"
               font_files=true
             ;;


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
