### PR TITLE
update chromium to 138.0.7204.96

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: "138.0.7204.92"
+  version: "138.0.7204.96"
   epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
@@ -157,7 +157,7 @@ pipeline:
       # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       # which has been automated in https://github.com/chromium-linux-tarballs/chromium-tarballs
       uri: https://github.com/chromium-linux-tarballs/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
-      expected-sha512: 132e53b0d332e23a495cbcb91885f245c9e9698ad3337bff54e99aab451bb7307aca5b9bf073dfdf3db2033aa82b84e0d1b8d5859edd31df62d961c26d2d6dd3
+      expected-sha512: 838483dc3203eb8cfdf0495dc07e8b5362d6715d8ca4348213d0bb6f1e5b059e277ac4d91d678e040d3dd6aa5ded9cdcea66431ae6c9c4224ff2dd491b8d1ae0
 
   - name: Remove binaries from source tree
     runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
