### PR TITLE
feat(strimzi-kafka-operator): update to v0.46.1 and remediate GHSA-p7c9-8xx8-h74f

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
-  version: "0.46.0"
-  epoch: 6
+  version: "0.46.1"
+  epoch: 0
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,7 @@ pipeline:
     with:
       repository: https://github.com/strimzi/strimzi-kafka-operator
       tag: ${{package.version}}
-      expected-commit: 58f559c753fb68f58a04b4ad8c7612d472de5059
+      expected-commit: 7767f1f3c1ff26de55c59c6b39fa9cd0cb3e6ce4
 
   - uses: patch
     with:

--- a/strimzi-kafka-operator/pombump-deps.yaml
+++ b/strimzi-kafka-operator/pombump-deps.yaml
@@ -8,3 +8,6 @@ patches:
   - groupId: org.apache.kafka
     artifactId: kafka-clients
     version: 3.9.1
+  - groupId: org.apache.kafka
+    artifactId: kafka_2.13
+    version: 3.8.1


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update package version and remediate https://github.com/advisories/GHSA-p7c9-8xx8-h74f
