### PR TITLE
openssf-compiler-options: Revert addition of "-z gcs=never" to ARM64 builds

### DIFF
--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -2,7 +2,7 @@
 + %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now -z gcs=never
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
Despite being deprecated upstream, GNU gold is still being used by a number of Go projects.  It doesn't support "-z gcs=never", and therefore our previous change to the compiler flags will break builds.

Let's temporarily revert the change until we can figure out a way to switch Go builds to GNU ld.