### PR TITLE
cilium-1.17: use new iptables-wrappers package

### DIFF
--- a/cilium-1.17.yaml
+++ b/cilium-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.17
   version: "1.17.5"
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -14,13 +14,9 @@ package:
       # cilium does compilations at runtime on the node.
       - clang-17
       - cni-plugins-loopback
-      # iptables packages are needed at build time because cilium-iptables
-      # has a script that changes based on the presences of these packages
-      # at build time.
-      - ip6tables
       - iproute2
       - ipset
-      - iptables
+      - iptables-wrappers
       - kmod
       - llvm17
       - merged-sbin
@@ -44,8 +40,6 @@ environment:
       - git
       - go
       - grep
-      - ip6tables
-      - iptables # for cilium-iptables
       - isl-dev
       - libtool
       - llvm-libcxx-17
@@ -137,23 +131,14 @@ subpackages:
     description: iptables compatibility package for cilium
     dependencies:
       runtime:
-        - iptables
+        - iptables-wrappers
         - merged-sbin
         - wolfi-baselayout
       provides:
         - cilium-iptables=${{package.full-version}}
-    pipeline:
-      - runs: |
-          # This script generates a wrapper based on the version
-          # of iptables provided by the build environment.
-          ./images/runtime/iptables-wrapper-installer.sh
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv /sbin/iptables-wrapper ${{targets.subpkgdir}}/usr/bin/iptables-wrapper
-      - uses: strip
     test:
       pipeline:
-        - runs: |
-            test -x /usr/bin/iptables-wrapper
+        - uses: test/emptypackage
 
   - name: ${{package.name}}-operator-generic
     description: Generic operator for cilium


### PR DESCRIPTION
Switch cilium-iptables over to a metapackage that brings in the new
iptables-wrappers package. This allows containers to adapt to whatever
iptables variant is in-use by the host at runtime.

Since there should no longer be build-time detection, we should no
longer need iptables packages in the build environment.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
