### PR TITLE
go-1.2*: Don't force use of `gold` when linking on ARM64

### DIFF
--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 4
+  epoch: 5
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -28,6 +28,10 @@ pipeline:
       uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
       expected-sha256: 1aef321a0e3e38b7e91d2d7eb64040666cabdcc77d383de3c9522d0d69b67f4e
       strip-components: 0
+
+  - uses: patch
+    with:
+      patches: use-gnu-ld-arm64.patch
 
   - runs: |
       cd go/src

--- a/go-1.20/use-gnu-ld-arm64.patch
+++ b/go-1.20/use-gnu-ld-arm64.patch
@@ -1,0 +1,76 @@
+From 6d265b008e3d106b2706645e5a88cd8e2fb98953 Mon Sep 17 00:00:00 2001
+From: Dirk Müller <dirk@dmllr.de>
+Date: Wed, 09 Mar 2022 17:47:23 +0100
+Subject: [PATCH] cmd/link: stop forcing binutils-gold dependency on aarch64
+
+The bfd linker appears to be working just fine at least in version
+2.41 or above. Reject the known broken one instead, which
+avoids an architecture specific linker dependency that
+is cumbersome for distributions.
+
+Fixes #22040.
+
+Change-Id: I9f377e47c22ef20497479c0978c053ed5de46a38
+
+Origin: https://go-review.googlesource.com/c/go/+/391115
+Bug: https://github.com/golang/go/issues/22040
+Bug-Wolfi: https://github.com/wolfi-dev/os/issues/58493
+
+---
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 6eae9002b5..73c30f1aa8 100644
+--- a/go/src/cmd/link/internal/ld/lib.go
++++ b/go/src/cmd/link/internal/ld/lib.go
+@@ -1550,30 +1550,6 @@ func (ctxt *Link) hostlink() {
+ 			// Use lld to avoid errors from default linker (issue #38838)
+ 			altLinker = "lld"
+ 		}
+-
+-		if ctxt.Arch.InFamily(sys.ARM, sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM, the GNU linker will generate COPY relocations
+-			// even with -znocopyreloc set.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			//
+-			// On ARM64, the GNU linker will fail instead of
+-			// generating COPY relocations.
+-			//
+-			// In both cases, switch to gold.
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
+-			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
+-			cmd := exec.Command(name, args...)
+-			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM external linker must be gold (issue #15696), but is not: %s", out)
+-				}
+-			}
+-		}
+ 	}
+ 	if ctxt.Arch.Family == sys.ARM64 && buildcfg.GOOS == "freebsd" {
+ 		// Switch to ld.bfd on freebsd/arm64.
+diff --git a/src/make.bash b/src/make.bash
+index b67ae15..7df4910 100755
+--- a/go/src/make.bash
++++ b/go/src/make.bash
+@@ -94,6 +94,16 @@
+ 	;;
+ esac
+ 
++# Test for bad bfd.ld
++if test "$(uname -m)" = "aarch64" && ld -v | grep -E "GNU ld.* 2\.([0-3]|40)"; then
++	echo 'ERROR: Your system uses bfd.LD 2.40 or older which has issues with dynamic linking on aarch64'
++	echo 'Consider upgrading or switching to binutils-gold.'
++	echo
++	echo 'See https://sourceware.org/bugzilla/show_bug.cgi?id=30437'
++
++	exit 1
++fi
++
+ # Test for bad ld.
+ if ld --version 2>&1 | grep 'gold.* 2\.20' >/dev/null; then
+ 	echo 'ERROR: Your system has gold 2.20 installed.'

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: "1.22.12"
-  epoch: 3
+  epoch: 4
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -10,7 +10,6 @@ package:
       - go=${{package.full-version}}
     runtime:
       - bash
-      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - build-base
 
 environment:
@@ -38,11 +37,10 @@ pipeline:
 
   - uses: patch
     with:
-      patches: cmd-go-always-emit-ldflags-version-information.patch
-
-  - uses: patch
-    with:
-      patches: CVE-2025-22871-net-http-reject-newlines-in-ch.patch
+      patches: |
+        cmd-go-always-emit-ldflags-version-information.patch
+        CVE-2025-22871-net-http-reject-newlines-in-ch.patch
+        use-gnu-ld-arm64.patch
 
   - runs: |
       cd src

--- a/go-1.22/use-gnu-ld-arm64.patch
+++ b/go-1.22/use-gnu-ld-arm64.patch
@@ -1,0 +1,73 @@
+From 6d265b008e3d106b2706645e5a88cd8e2fb98953 Mon Sep 17 00:00:00 2001
+From: Dirk Müller <dirk@dmllr.de>
+Date: Wed, 09 Mar 2022 17:47:23 +0100
+Subject: [PATCH] cmd/link: stop forcing binutils-gold dependency on aarch64
+
+The bfd linker appears to be working just fine at least in version
+2.41 or above. Reject the known broken one instead, which
+avoids an architecture specific linker dependency that
+is cumbersome for distributions.
+
+Fixes #22040.
+
+Change-Id: I9f377e47c22ef20497479c0978c053ed5de46a38
+
+Origin: https://go-review.googlesource.com/c/go/+/391115
+Bug: https://github.com/golang/go/issues/22040
+Bug-Wolfi: https://github.com/wolfi-dev/os/issues/58493
+
+---
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 2d8f964..fcf0bc7 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1670,27 +1670,6 @@
+ 			// Use lld to avoid errors from default linker (issue #38838)
+ 			altLinker = "lld"
+ 		}
+-
+-		if ctxt.Arch.InFamily(sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM64, the GNU linker will fail with
+-			// -znocopyreloc if it thinks a COPY relocation is
+-			// required. Switch to gold.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			// https://go.dev/issue/22040
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
+-			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
+-			cmd := exec.Command(name, args...)
+-			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM64 external linker must be gold (issue #15696, 22040), but is not: %s", out)
+-				}
+-			}
+-		}
+ 	}
+ 	if ctxt.Arch.Family == sys.ARM64 && buildcfg.GOOS == "freebsd" {
+ 		// Switch to ld.bfd on freebsd/arm64.
+diff --git a/src/make.bash b/src/make.bash
+index b67ae15..7df4910 100755
+--- a/src/make.bash
++++ b/src/make.bash
+@@ -94,6 +94,16 @@
+ 	;;
+ esac
+ 
++# Test for bad bfd.ld
++if test "$(uname -m)" = "aarch64" && ld -v | grep -E "GNU ld.* 2\.([0-3]|40)"; then
++	echo 'ERROR: Your system uses bfd.LD 2.40 or older which has issues with dynamic linking on aarch64'
++	echo 'Consider upgrading or switching to binutils-gold.'
++	echo
++	echo 'See https://sourceware.org/bugzilla/show_bug.cgi?id=30437'
++
++	exit 1
++fi
++
+ # Test for bad ld.
+ if ld --version 2>&1 | grep 'gold.* 2\.20' >/dev/null; then
+ 	echo 'ERROR: Your system has gold 2.20 installed.'

--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.23
   version: "1.23.10"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -10,7 +10,6 @@ package:
       - go=${{package.full-version}}
     runtime:
       - bash
-      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - build-base
 
 environment:
@@ -41,6 +40,7 @@ pipeline:
       patches: |
         cmd-go-always-emit-ldflags-version-information.patch
         change-default-telemetry-from-local-to-off.patch
+        use-gnu-ld-arm64.patch
 
   - runs: |
       cd src

--- a/go-1.23/use-gnu-ld-arm64.patch
+++ b/go-1.23/use-gnu-ld-arm64.patch
@@ -1,0 +1,73 @@
+From 6d265b008e3d106b2706645e5a88cd8e2fb98953 Mon Sep 17 00:00:00 2001
+From: Dirk Müller <dirk@dmllr.de>
+Date: Wed, 09 Mar 2022 17:47:23 +0100
+Subject: [PATCH] cmd/link: stop forcing binutils-gold dependency on aarch64
+
+The bfd linker appears to be working just fine at least in version
+2.41 or above. Reject the known broken one instead, which
+avoids an architecture specific linker dependency that
+is cumbersome for distributions.
+
+Fixes #22040.
+
+Change-Id: I9f377e47c22ef20497479c0978c053ed5de46a38
+
+Origin: https://go-review.googlesource.com/c/go/+/391115
+Bug: https://github.com/golang/go/issues/22040
+Bug-Wolfi: https://github.com/wolfi-dev/os/issues/58493
+
+---
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 2d8f964..fcf0bc7 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1670,27 +1670,6 @@
+ 			// Use lld to avoid errors from default linker (issue #38838)
+ 			altLinker = "lld"
+ 		}
+-
+-		if ctxt.Arch.InFamily(sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM64, the GNU linker will fail with
+-			// -znocopyreloc if it thinks a COPY relocation is
+-			// required. Switch to gold.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			// https://go.dev/issue/22040
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
+-			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
+-			cmd := exec.Command(name, args...)
+-			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM64 external linker must be gold (issue #15696, 22040), but is not: %s", out)
+-				}
+-			}
+-		}
+ 	}
+ 	if ctxt.Arch.Family == sys.ARM64 && buildcfg.GOOS == "freebsd" {
+ 		// Switch to ld.bfd on freebsd/arm64.
+diff --git a/src/make.bash b/src/make.bash
+index b67ae15..7df4910 100755
+--- a/src/make.bash
++++ b/src/make.bash
+@@ -94,6 +94,16 @@
+ 	;;
+ esac
+ 
++# Test for bad bfd.ld
++if test "$(uname -m)" = "aarch64" && ld -v | grep -E "GNU ld.* 2\.([0-3]|40)"; then
++	echo 'ERROR: Your system uses bfd.LD 2.40 or older which has issues with dynamic linking on aarch64'
++	echo 'Consider upgrading or switching to binutils-gold.'
++	echo
++	echo 'See https://sourceware.org/bugzilla/show_bug.cgi?id=30437'
++
++	exit 1
++fi
++
+ # Test for bad ld.
+ if ld --version 2>&1 | grep 'gold.* 2\.20' >/dev/null; then
+ 	echo 'ERROR: Your system has gold 2.20 installed.'

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.4"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -10,7 +10,6 @@ package:
       - go=${{package.full-version}}
     runtime:
       - bash
-      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - build-base
 
 environment:
@@ -41,6 +40,7 @@ pipeline:
       patches: |
         cmd-go-always-emit-ldflags-version-information.patch
         change-default-telemetry-from-local-to-off.patch
+        use-gnu-ld-arm64.patch
 
   - runs: |
       cd src

--- a/go-1.24/use-gnu-ld-arm64.patch
+++ b/go-1.24/use-gnu-ld-arm64.patch
@@ -1,0 +1,73 @@
+From 6d265b008e3d106b2706645e5a88cd8e2fb98953 Mon Sep 17 00:00:00 2001
+From: Dirk Müller <dirk@dmllr.de>
+Date: Wed, 09 Mar 2022 17:47:23 +0100
+Subject: [PATCH] cmd/link: stop forcing binutils-gold dependency on aarch64
+
+The bfd linker appears to be working just fine at least in version
+2.41 or above. Reject the known broken one instead, which
+avoids an architecture specific linker dependency that
+is cumbersome for distributions.
+
+Fixes #22040.
+
+Change-Id: I9f377e47c22ef20497479c0978c053ed5de46a38
+
+Origin: https://go-review.googlesource.com/c/go/+/391115
+Bug: https://github.com/golang/go/issues/22040
+Bug-Wolfi: https://github.com/wolfi-dev/os/issues/58493
+
+---
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 2d8f964..fcf0bc7 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1670,27 +1670,6 @@
+ 			// Use lld to avoid errors from default linker (issue #38838)
+ 			altLinker = "lld"
+ 		}
+-
+-		if ctxt.Arch.InFamily(sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM64, the GNU linker will fail with
+-			// -znocopyreloc if it thinks a COPY relocation is
+-			// required. Switch to gold.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			// https://go.dev/issue/22040
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
+-			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
+-			cmd := exec.Command(name, args...)
+-			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM64 external linker must be gold (issue #15696, 22040), but is not: %s", out)
+-				}
+-			}
+-		}
+ 	}
+ 	if ctxt.Arch.Family == sys.ARM64 && buildcfg.GOOS == "freebsd" {
+ 		// Switch to ld.bfd on freebsd/arm64.
+diff --git a/src/make.bash b/src/make.bash
+index b67ae15..7df4910 100755
+--- a/src/make.bash
++++ b/src/make.bash
+@@ -94,6 +94,16 @@
+ 	;;
+ esac
+ 
++# Test for bad bfd.ld
++if test "$(uname -m)" = "aarch64" && ld -v | grep -E "GNU ld.* 2\.([0-3]|40)"; then
++	echo 'ERROR: Your system uses bfd.LD 2.40 or older which has issues with dynamic linking on aarch64'
++	echo 'Consider upgrading or switching to binutils-gold.'
++	echo
++	echo 'See https://sourceware.org/bugzilla/show_bug.cgi?id=30437'
++
++	exit 1
++fi
++
+ # Test for bad ld.
+ if ld --version 2>&1 | grep 'gold.* 2\.20' >/dev/null; then
+ 	echo 'ERROR: Your system has gold 2.20 installed.'

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 24
+  epoch: 25
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -2,7 +2,7 @@
 + %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed -O1 --sort-common -z noexecstack -z relro -z now -z gcs=never
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
Golang still forces the use of `gold` when linking programs on ARM64, even though https://sourceware.org/bugzilla/show_bug.cgi?id=19962 has been fixed for quite a while now.  See https://github.com/golang/go/issues/22040 .

There's an upstream patch (https://go-review.googlesource.com/c/go/+/391115) being discussed for a few years, but unfortunately it hasn't been accepted yet.  Meanwhile, binutils upstream announced that `gold` is deprecated and will likely be removed in a future version.

On our side, ever since GCC 15 became our default GCC some of our ARM64 builds started failing because of [GCS](https://docs.kernel.org/arch/arm64/gcs.html) (see https://github.com/wolfi-dev/os/issues/58294).  However, after enabling `-z gcs=never` our Go ARM64 builds started failing because `gold` doesn't support (and probably will never support) the `-z gcs` option.

Let's fix this problem the right way and backport Go's upstream patch to make it *not* force the use of `gold` for linking.  GNU `ld` should work without problems for that.

Fixes: #58493