### PR TITLE
openssh: Update default PATH to prefer /usr/bin over /usr/sbin

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "10.0_p1"
-  epoch: 1
+  epoch: 2
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -56,7 +56,7 @@ pipeline:
          --disable-strip \
          --with-privsep-path=/var/empty \
          --with-xauth=/usr/bin/xauth \
-         --with-default-path='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
+         --with-default-path='/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' \
          --with-privsep-user=sshd \
          --with-ssl-engine \
          --with-pam \


### PR DESCRIPTION
Now that wolfi is usr-merged, /usr/bin is the canonical bin directory.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
