### PR TITLE
wolfi-baselayout: prefer /usr/bin to /usr/sbin in PATH

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -13,6 +13,10 @@ package:
       - merged-bin
       - merged-usrsbin
       - merged-lib
+  checks:
+    disabled:
+      # fails "usrlocal" linter because it creates /usr/local/lib64
+      - usrmerge
 
 environment:
   contents:

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 21
+  epoch: 22
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT

--- a/wolfi-baselayout/vendor/etc/profile
+++ b/wolfi-baselayout/vendor/etc/profile
@@ -12,8 +12,8 @@ append_path () {
 
 append_path "/usr/local/sbin"
 append_path "/usr/local/bin"
-append_path "/usr/sbin"
 append_path "/usr/bin"
+append_path "/usr/sbin"
 append_path "/sbin"
 append_path "/bin"
 unset -f append_path


### PR DESCRIPTION
/usr/bin is the canonical path now that we're usrmerged.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
