### PR TITLE
Fix melange microvm dependencies

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.29.0"
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange.yaml
+++ b/melange.yaml
@@ -37,7 +37,7 @@ subpackages:
         - mount
         - iproute2
         - openssh-server
-        - util-linux-misc
+        - script
         - e2fsprogs
     pipeline:
       - runs: |

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 11
+  epoch: 12
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -14,6 +14,7 @@ package:
       - kmod
       - mount
       - openssh-server
+      - script
       - util-linux-misc
       - xfsprogs
 


### PR DESCRIPTION
This is used in test runs, and was split in https://github.com/wolfi-dev/os/commit/ad809da75e3257eaaf502f3e10a0e26213021c4d to its own subpackage.
I looked through qemu_runner.go and didn't see any usage of other binaries in util-linux-misc.

You can reproduce failures by doing `make test/package` and seeing ` ash: script: not found` failures, but not in this repo. The failure happens while mounting the melange cache inside of the VM, which doesn't happen in wolfi because the makefile doesn't use --cache= during tests. You can see it with `make test/linux-qemu-generic` in enterprise-packages.