### PR TITLE
jitsucom-jitsu: update next.js to ^15.3.3 to fix CVE-2025-30218 and CVE-2025-49005

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.10.0"
-  epoch: 1
+  epoch: 2
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -49,8 +49,8 @@ pipeline:
       patches: consolidated-cve-remedation.patch
 
   - runs: |
-      # CVE-2025-30218
-      (cd webapps/console && npm pkg set dependencies.next=^15.2.4)
+      # CVE-2025-30218, CVE-2025-49005
+      (cd webapps/console && npm pkg set dependencies.next=^15.3.3)
       pnpm install -r --unsafe-perm
       export NEXTJS_STANDALONE_BUILD=1
 


### PR DESCRIPTION
## Summary

Updated Next.js dependency constraint from ^15.2.4 to ^15.3.3 to address cache poisoning vulnerabilities.

## CVEs Fixed

- **CVE-2025-30218** - Next.js cache poisoning vulnerability
- **CVE-2025-49005** - Related Next.js cache poisoning issue

## Changes Made

- Updated Next.js version constraint in package.json manipulation
- Incremented package epoch from 1 to 2 to force rebuild
- Updated inline comment to reference both CVEs

## Technical Details

The fix updates the npm pkg set command that modifies the Next.js dependency during the build process:

```bash
# Before
(cd webapps/console && npm pkg set dependencies.next=^15.2.4)

# After  
(cd webapps/console && npm pkg set dependencies.next=^15.3.3)
```

This ensures the jitsu console webapp uses a patched version of Next.js that resolves the cache poisoning vulnerabilities.

## Testing Done:

- Package build: `make package/jitsucom-jitsu`
- Package test: `make test/jitsucom-jitsu`
- CVE scan: `wolfictl scan packages/*/jitsucom-jitsu-*.apk`
```
jamie.albert@Mac os % wolfictl scan packages/x86_64/jitsucom-jitsu-2.10.0-r2.apk 
🔎 Scanning "packages/x86_64/jitsucom-jitsu-2.10.0-r2.apk"
✅ No vulnerabilities found
jamie.albert@Mac os % 
```