### PR TITLE
add apache-exporter package

### DIFF
--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -18,6 +18,7 @@ pipeline:
       deps: |-
         golang.org/x/crypto@v0.35.0
         golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
 
   - uses: go/build
     with:

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -25,11 +25,32 @@ pipeline:
       packages: .
       output: apache_exporter
       ldflags: |
-        -X github.com/prometheus/common/version.Version=$(cat ./VERSION) \
+        -X github.com/prometheus/common/version.Version=${{package.version}} \
         -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD) \
         -X github.com/prometheus/common/version.Branch=$(git rev-parse --abbrev-ref HEAD) \
         -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) \
         -X github.com/prometheus/common/version.BuildDate=$(date +"%Y%m%d-%H:%M:%S")
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package for apache-exporter container environments
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/bin
+          ln -sf /usr/bin/apache_exporter ${{targets.contextdir}}/bin/apache_exporter
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - runs: |
+            stat /bin/apache_exporter
+            test "$(readlink /bin/apache_exporter)" = "/usr/bin/apache_exporter"
+            test -x /usr/bin/apache_exporter
 
 update:
   enabled: true
@@ -44,6 +65,7 @@ test:
       packages:
         - curl
         - apache2
+        - wait-for-it
   pipeline:
     - name: "Basic functionality tests"
       runs: |
@@ -60,9 +82,9 @@ test:
         post: |
           #!/bin/sh -e
           # Test that metrics endpoint is accessible even when Apache is down
-          curl -s http://localhost:9117/metrics | grep -q "apache_up"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up"
           # Should show apache_up as 0 since Apache is not accessible
-          curl -s http://localhost:9117/metrics | grep -q "apache_up 0"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up 0"
     - name: "Test with mock Apache server"
       uses: test/daemon-check-output
       with:
@@ -82,13 +104,7 @@ test:
           APACHE_PID=$!
           sleep 3
 
-          # Wait for Apache to be ready
-          for i in $(seq 1 10); do
-            if curl -s http://localhost/server-status?auto > /dev/null 2>&1; then
-              break
-            fi
-            sleep 1
-          done
+          wait-for-it localhost:80 -t 30 --strict
         start: apache_exporter --scrape_uri="http://localhost/server-status?auto"
         timeout: 30
         expected_output: |
@@ -97,7 +113,7 @@ test:
         post: |
           #!/bin/sh -e
           # Test that metrics endpoint is accessible and shows Apache is up
-          curl -s http://localhost:9117/metrics | grep -q "apache_up 1"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up 1"
 
           # Cleanup Apache process
           kill $APACHE_PID 2>/dev/null || true

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -49,9 +49,10 @@ test:
     - name: "Basic functionality tests"
       runs: |
         apache_exporter --version 2>&1 | grep -q "${{package.version}}"
-        apache_exporter --help 2>&1
+        apache_exporter --help
     - name: "Test entrypoint /bin/apache_exporter"
       runs: |
+        stat /bin/apache_exporter
         test -x /bin/apache_exporter
     - name: "Test exporter startup without Apache"
       uses: test/daemon-check-output
@@ -84,7 +85,6 @@ test:
           # Start Apache server
           httpd -D FOREGROUND > /dev/null 2>&1 &
           APACHE_PID=$!
-          sleep 3
 
           wait-for-it localhost:80 -t 30 --strict
         start: apache_exporter --scrape_uri="http://localhost/server-status?auto"
@@ -96,6 +96,3 @@ test:
           #!/bin/sh -e
           # Test that metrics endpoint is accessible and shows Apache is up
           curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up 1"
-
-          # Cleanup Apache process
-          kill $APACHE_PID 2>/dev/null || true

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -50,6 +50,9 @@ test:
       runs: |
         apache_exporter --version 2>&1 | grep -q "${{package.version}}"
         apache_exporter --help 2>&1
+    - name: "Test entrypoint /bin/apache_exporter"
+      runs: |
+        test -x /bin/apache_exporter
     - name: "Test exporter startup without Apache"
       uses: test/daemon-check-output
       with:

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -84,9 +84,8 @@ test:
 
           # Start Apache server
           httpd -D FOREGROUND > /dev/null 2>&1 &
-          APACHE_PID=$!
 
-          wait-for-it localhost:80 -t 30 --strict
+          wait-for-it localhost:80 -t 10 --strict
         start: apache_exporter --scrape_uri="http://localhost/server-status?auto"
         timeout: 30
         expected_output: |

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -1,0 +1,102 @@
+package:
+  name: apache-exporter
+  version: "1.0.10"
+  epoch: 0
+  description: apache-exporter exposes Apache server metrics for Prometheus monitoring
+  copyright:
+    - license: MIT
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Lusitaniae/apache_exporter
+      tag: v${{package.version}}
+      expected-commit: c4206b529038d79f20f2eeba98a9780c8cb4a2c2
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.38.0
+
+  - uses: go/build
+    with:
+      packages: .
+      output: apache-exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=$(cat ./VERSION) \
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD) \
+        -X github.com/prometheus/common/version.Branch=$(git rev-parse --abbrev-ref HEAD) \
+        -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) \
+        -X github.com/prometheus/common/version.BuildDate=$(date +"%Y%m%d-%H:%M:%S")
+
+update:
+  enabled: true
+  github:
+    identifier: Lusitaniae/apache_exporter
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - apache2
+  pipeline:
+    - name: "Basic functionality tests"
+      runs: |
+        apache-exporter --version 2>&1 | grep -q "${{package.version}}"
+        apache-exporter --help 2>&1
+    - name: "Test exporter startup without Apache"
+      uses: test/daemon-check-output
+      with:
+        start: apache-exporter --scrape_uri="http://localhost:9999/server-status?auto"
+        timeout: 15
+        expected_output: |
+          Starting apache_exporter
+          Listening on
+        post: |
+          #!/bin/sh -e
+          # Test that metrics endpoint is accessible even when Apache is down
+          curl -s http://localhost:9117/metrics | grep -q "apache_up"
+          # Should show apache_up as 0 since Apache is not accessible
+          curl -s http://localhost:9117/metrics | grep -q "apache_up 0"
+    - name: "Test with mock Apache server"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          # Create Apache configuration for mod_status
+          mkdir -p /etc/apache2/conf.d
+          cat > /etc/apache2/conf.d/status.conf <<EOF
+          <Location "/server-status">
+              SetHandler server-status
+              Require all granted
+          </Location>
+          ExtendedStatus On
+          EOF
+
+          # Start Apache server
+          httpd -D FOREGROUND > /dev/null 2>&1 &
+          APACHE_PID=$!
+          sleep 3
+
+          # Wait for Apache to be ready
+          for i in $(seq 1 10); do
+            if curl -s http://localhost/server-status?auto > /dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+        start: apache-exporter --scrape_uri="http://localhost/server-status?auto"
+        timeout: 30
+        expected_output: |
+          Starting apache_exporter
+          Listening on
+        post: |
+          #!/bin/sh -e
+          # Test that metrics endpoint is accessible and shows Apache is up
+          curl -s http://localhost:9117/metrics | grep -q "apache_up 1"
+
+          # Cleanup Apache process
+          kill $APACHE_PID 2>/dev/null || true

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -49,10 +49,10 @@ test:
       runs: |
         apache_exporter --version 2>&1 | grep -q "${{package.version}}"
         apache_exporter --help 2>&1
-          - name: "Test exporter startup without Apache"
-        uses: test/daemon-check-output
-        with:
-          start: apache_exporter --scrape_uri="http://localhost:9999/server-status?auto"
+    - name: "Test exporter startup without Apache"
+      uses: test/daemon-check-output
+      with:
+        start: apache_exporter --scrape_uri="http://localhost:9999/server-status?auto"
         timeout: 15
         expected_output: |
           Starting apache_exporter

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -31,27 +31,6 @@ pipeline:
         -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) \
         -X github.com/prometheus/common/version.BuildDate=$(date +"%Y%m%d-%H:%M:%S")
 
-subpackages:
-  - name: ${{package.name}}-compat
-    description: Compatibility package for apache-exporter container environments
-    dependencies:
-      runtime:
-        - ${{package.name}}
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/bin
-          ln -sf /usr/bin/apache_exporter ${{targets.contextdir}}/bin/apache_exporter
-    test:
-      environment:
-        contents:
-          packages:
-            - ${{package.name}}
-      pipeline:
-        - runs: |
-            stat /bin/apache_exporter
-            test "$(readlink /bin/apache_exporter)" = "/usr/bin/apache_exporter"
-            test -x /usr/bin/apache_exporter
-
 update:
   enabled: true
   github:

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -23,7 +23,7 @@ pipeline:
   - uses: go/build
     with:
       packages: .
-      output: apache-exporter
+      output: apache_exporter
       ldflags: |
         -X github.com/prometheus/common/version.Version=$(cat ./VERSION) \
         -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD) \
@@ -47,12 +47,12 @@ test:
   pipeline:
     - name: "Basic functionality tests"
       runs: |
-        apache-exporter --version 2>&1 | grep -q "${{package.version}}"
-        apache-exporter --help 2>&1
-    - name: "Test exporter startup without Apache"
-      uses: test/daemon-check-output
-      with:
-        start: apache-exporter --scrape_uri="http://localhost:9999/server-status?auto"
+        apache_exporter --version 2>&1 | grep -q "${{package.version}}"
+        apache_exporter --help 2>&1
+          - name: "Test exporter startup without Apache"
+        uses: test/daemon-check-output
+        with:
+          start: apache_exporter --scrape_uri="http://localhost:9999/server-status?auto"
         timeout: 15
         expected_output: |
           Starting apache_exporter
@@ -89,7 +89,7 @@ test:
             fi
             sleep 1
           done
-        start: apache-exporter --scrape_uri="http://localhost/server-status?auto"
+        start: apache_exporter --scrape_uri="http://localhost/server-status?auto"
         timeout: 30
         expected_output: |
           Starting apache_exporter

--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -28,8 +28,8 @@ pipeline:
         -X github.com/prometheus/common/version.Version=${{package.version}} \
         -X github.com/prometheus/common/version.Revision=$(git rev-parse --short HEAD) \
         -X github.com/prometheus/common/version.Branch=$(git rev-parse --abbrev-ref HEAD) \
-        -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) \
-        -X github.com/prometheus/common/version.BuildDate=$(date +"%Y%m%d-%H:%M:%S")
+        -X github.com/prometheus/common/version.BuildUser=linky@chainguard.dev \
+        -X github.com/prometheus/common/version.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true
@@ -48,8 +48,9 @@ test:
   pipeline:
     - name: "Basic functionality tests"
       runs: |
-        apache_exporter --version 2>&1 | grep -q "${{package.version}}"
-        apache_exporter --help
+        set -o pipefail
+        apache_exporter --version 2>&1 | grep -F -e "${{package.version}}"
+        apache_exporter --help 2>&1 | grep -F -e "usage: apache_exporter"
     - name: "Test entrypoint /bin/apache_exporter"
       runs: |
         stat /bin/apache_exporter
@@ -63,11 +64,11 @@ test:
           Starting apache_exporter
           Listening on
         post: |
-          #!/bin/sh -e
+          set -o pipefail
           # Test that metrics endpoint is accessible even when Apache is down
-          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -F -e "apache_up"
           # Should show apache_up as 0 since Apache is not accessible
-          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up 0"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -F -e "apache_up 0"
     - name: "Test with mock Apache server"
       uses: test/daemon-check-output
       with:
@@ -94,4 +95,4 @@ test:
         post: |
           #!/bin/sh -e
           # Test that metrics endpoint is accessible and shows Apache is up
-          curl -s --retry 3 http://localhost:9117/metrics | grep -q "apache_up 1"
+          curl -s --retry 3 http://localhost:9117/metrics | grep -F -e "apache_up 1"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
