### PR TITLE
ceph: fix FTBFS with cmake 4

### DIFF
--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.2"
   description: Distributed object, block, and file storage
-  epoch: 7
+  epoch: 8
   copyright:
     - license: LGPL-2.1
   resources:
@@ -67,7 +67,7 @@ environment:
       - bison
       - boost-dev
       - build-base
-      - cmake
+      - cmake-3
       - cryptsetup-dev
       - curl-dev
       - doxygen


### PR DESCRIPTION
Build ceph with cmake-3 as it doesn't fully support cmake 4.

See also:
 https://github.com/wolfi-dev/os/issues/58496