### PR TITLE
go-1.20: Don't depend on binutils-gold

### DIFF
--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 5
+  epoch: 6
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -10,7 +10,6 @@ package:
       - go=1.20.999 # This should be go=${{package.version}}-${{package.epoch}}
     runtime:
       - bash
-      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - build-base
 
 environment:


### PR DESCRIPTION
We don't need to depend on `binutils-gold` anymore.