### PR TITLE
airflow-3: downgrade flask to supported 2.2.5

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.0.2"
-  epoch: 4
+  epoch: 5
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -143,7 +143,19 @@ pipeline:
       done
 
   - name: "bump snowflake provider to remediate CVE-2025-50213"
-    runs: uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow apache-airflow-providers-snowflake>=6.4.0
+    runs: |
+      uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow apache-airflow-providers-snowflake>=6.4.0
+
+  # Flask >2.2.5 is not supported. Using Flask > 2.2.5 causes the same issue
+  # as the one documented here:
+  # - https://github.com/spec-first/connexion/issues/1699#issuecomment-1524042812
+  # Upstream is working on supporting Flask 2.2.5+, as documented in the issue
+  # and PR below:
+  # - https://github.com/apache/airflow/issues/52509
+  # - https://github.com/apache/airflow/pull/50960
+  - name: "Downgrade Flask 2.2.5"
+    runs: |
+      uv pip install --verbose --upgrade --prefix=${{targets.contextdir}}/opt/airflow Flask==2.2.5
 
   - runs: find . -name '__pycache__' -exec rm -rf {} +
 
@@ -329,6 +341,11 @@ test:
         export PYTHONPATH=/opt/airflow/lib/python${{vars.py-version}}/site-packages
         HOME=/home/build airflow version | grep ${{package.version}}
         python${{vars.py-version}} -c "import airflow"
+    - name: "Test Flask is at the supported version"
+      runs: |
+        set -e
+        export PYTHONPATH=/opt/airflow/lib/python${{vars.py-version}}/site-packages
+        python -c "from flask.json import JSONEncoder"
     - name: "List providers"
       runs: |
         export PATH=/opt/airflow/bin:$PATH


### PR DESCRIPTION
Upstream does not support Flake 2.2.5+ [1], and this makes connexion dependency to fail [2].

Failure log is shared below:

```
File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
  return _bootstrap._gcd_import(name[level:], package, level)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
File "<frozen importlib._bootstrap_external>", line 999, in exec_module
File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  from connexion import FlaskApi
File "/opt/airflow/lib/python3.12/site-packages/airflow/providers/fab/auth_manager/fab_auth_manager.py", line 27, in <module>
File "/opt/airflow/lib/python3.12/site-packages/connexion/__init__.py", line 32, in <module>
  from .apps.flask_app import FlaskApp
File "/opt/airflow/lib/python3.12/site-packages/connexion/apps/flask_app.py", line 153, in <module>
  class FlaskJSONEncoder(json.JSONEncoder):
AttributeError: module 'flask.json' has no attribute 'JSONEncoder'
```

Upstream is working to upgrade FAB to v5 [3], so we may have in the near future support for Flask v3.
With the occasion, this commit adds a test specific to the Flask JSON encoder.
Last but not least, no CVEs are added with this dependency downgrade.

References:
1. https://github.com/apache/airflow/issues/52509
2. https://github.com/spec-first/connexion/issues/1699#issuecomment-1524042812
3. https://github.com/apache/airflow/pull/50960
