### PR TITLE
azure-ipam: make package reproducible

### DIFF
--- a/azure-ipam.yaml
+++ b/azure-ipam.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-ipam
   version: "0.4.0"
-  epoch: 0
+  epoch: 1
   description: Azure VNET IPAM plugins manage IP address assignments to containers.
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ subpackages:
 
           cd $embed_dir
 
-          gzip --verbose --best --recursive .
+          gzip --verbose --best --recursive --no-name .
 
           for f in *.gz
           do


### PR DESCRIPTION
Disclaimer: I have no earthly clue whether this makes the package non-functional. Dropping timestamps from the gzip output makes it reproducible, but I don't know if those are load-bearing for the actual app to work.

If this isn't okay, we can drop this change and note that we expect this package not to be reproducible.