### PR TITLE
feat: add -dev package to wasmtime

### DIFF
--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -47,7 +47,7 @@ pipeline:
       mv target/release/wasmtime ${{targets.destdir}}/usr/bin/
 
       # Install dev headers
-      cmake -DWASMTIME_HEADER_DST=${{targets.destdir}}/usr -P ./crates/c-api/cmake/install-headers.cmake
+      cmake -DWASMTIME_HEADER_DST=${{targets.destdir}}/usr/include -P ./crates/c-api/cmake/install-headers.cmake
 
   - uses: strip
 

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -46,6 +46,9 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wasmtime ${{targets.destdir}}/usr/bin/
 
+      # Install dev headers
+      cmake -DWASMTIME_HEADER_DST=${{targets.destdir}}/usr -P ./crates/c-api/cmake/install-headers.cmake
+
   - uses: strip
 
 subpackages:
@@ -60,6 +63,22 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+
+  - name: "${{package.name}}-dev"
+    description: "dev headers for wasmtime"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - merged-usrsbin
+        - wolfi-baselayout
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+          with:
+            # Auto detection uses '--packages=wasmtime', which is incorrect
+            packages: "${{package.name}}-dev"
 
 update:
   enabled: true

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -68,10 +68,6 @@ subpackages:
     description: "dev headers for wasmtime"
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
     test:
       pipeline:
         - uses: test/pkgconf

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmtime
   version: "34.0.1"
-  epoch: 0
+  epoch: 1
   description: "A fast and secure runtime for WebAssembly"
   copyright:
     - license: Apache-2.0
@@ -76,9 +76,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            # Auto detection uses '--packages=wasmtime', which is incorrect
-            packages: "${{package.name}}-dev"
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adds a -dev package to wasmtime, as required by apisix build process.



Related:
https://github.com/wolfi-dev/os/pull/57662


<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
