### PR TITLE
postfix: Add `ld.so.conf.d` snippet

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.2"
-  epoch: 3
+  epoch: 4
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -178,6 +178,9 @@ pipeline:
       chown root:postfix "${{targets.contextdir}}"/var/spool/postfix/pid
       chgrp postdrop "${{targets.contextdir}}"/var/spool/postfix/maildrop \
       	"${{targets.contextdir}}"/var/spool/postfix/public
+
+      mkdir -p "${{targets.contextdir}}"/etc/ld.so.conf.d
+      echo "/usr/lib/postfix/" > "${{targets.contextdir}}"/etc/ld.so.conf.d/postfix.conf
 
       cd "${{targets.contextdir}}"/etc/postfix/
       for map in ldap mysql pcre pgsql sqlite lmdb; do


### PR DESCRIPTION
While doing some melange work I noticed that `postfix-stone`'s binaries depend on libraries that are installed under `/usr/lib/postfix`, but because we don't ship a `ld.so.conf.d` for that, it's not possible to run the binaries.

Let's rectify that.  I don't feel comfortable enabling `ldd-check` just yet because melange isn't generating proper dependencies for the libraries (see https://github.com/chainguard-dev/melange/pull/2072 for a current WIP).