### PR TITLE
java-cacerts-default: Ensure java-certs script is copied to contextdir so it is present in the package.

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -55,6 +55,24 @@ subpackages:
             --purpose server-auth /etc/ssl/certs/java/cacerts
           EOF
           chmod +x "${{targets.contextdir}}"/etc/ca-certificates/update.d/java-cacerts
+    test:
+      environment:
+        contents:
+          packages:
+            - openssl
+            - openjdk-23
+      pipeline:
+        - runs: |
+            test -x /etc/ca-certificates/update.d/java-cacerts
+        - runs: |
+            /etc/ca-certificates/update.d/java-cacerts
+            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout
+            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----BEGIN PUBLIC KEY-----$"
+            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----END PUBLIC KEY-----$"
+        - runs: |
+            openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -out /usr/local/share/ca-certificates/server.crt -subj "/CN=someteststring/"
+            update-ca-certificates
+            /usr/lib/jvm/java-23-openjdk/bin/keytool  -v -list -cacerts -storepass changeit | grep someteststring
 
 update:
   enabled: true

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -49,12 +49,12 @@ subpackages:
           # make update-ca-certificates still work.
           mkdir -p "${{targets.contextdir}}"/etc/ssl/certs/java
           ln -s /usr/lib/jvm/default-jvm/lib/security/cacerts "${{targets.contextdir}}"/etc/ssl/certs/java/cacerts
-          mkdir -p "${{targets.destdir}}"/etc/ca-certificates/update.d
-          cat > "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts <<EOF
+          mkdir -p "${{targets.contextdir}}"/etc/ca-certificates/update.d
+          cat > "${{targets.contextdir}}"/etc/ca-certificates/update.d/java-cacerts <<EOF
           exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors \
             --purpose server-auth /etc/ssl/certs/java/cacerts
           EOF
-          chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
+          chmod +x "${{targets.contextdir}}"/etc/ca-certificates/update.d/java-cacerts
 
 update:
   enabled: true

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: "20241121"
-  epoch: 41
+  epoch: 42
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT


### PR DESCRIPTION
Replace destdir with contextdir in the subpackage

Signed-off-by: Max Allan <max.allan@chainguard.dev>
