### PR TITLE
openjdk-7: use alternative apache archive CDN

### DIFF
--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 7
+  epoch: 8
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later
@@ -113,7 +113,7 @@ pipeline:
   - working-directory: /home/build/third-party/apache-ant
     uses: fetch
     with:
-      uri: https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.16-bin.tar.gz
+      uri: https://dlcdn.apache.org/ant/binaries/apache-ant-1.9.16-bin.tar.gz
       expected-sha512: 8d542a7a636a491e76170148881b6f413f4564aad1ab034f426bd946be93382001862bd6c60865aa2b57b39b9633e0181fe8997dd6323123aaf76b410ec4a366
 
   - working-directory: /home/build/third-party/rhino


### PR DESCRIPTION
Use an alternative apache CDN as the primary one gets rate-limited.