### PR TITLE
maven-stage0/openjdk-7/serf: change mirror url

### DIFF
--- a/maven-stage0.yaml
+++ b/maven-stage0.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven-stage0
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 0869a4f71238e3eeec21051d062cfd915d34abe905c9bfebf94cd34578db0be7
-      uri: https://archive.apache.org/dist/maven/maven-3/${{package.version}}/binaries/apache-maven-${{package.version}}-bin.tar.gz
+      uri: https://dlcdn.apache.org/maven/maven-3/${{package.version}}/binaries/apache-maven-${{package.version}}-bin.tar.gz
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/java/maven

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 7
+  epoch: 8
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later
@@ -113,7 +113,7 @@ pipeline:
   - working-directory: /home/build/third-party/apache-ant
     uses: fetch
     with:
-      uri: https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.16-bin.tar.gz
+      uri: https://dlcdn.apache.org/ant/binaries/apache-ant-1.9.16-bin.tar.gz
       expected-sha512: 8d542a7a636a491e76170148881b6f413f4564aad1ab034f426bd946be93382001862bd6c60865aa2b57b39b9633e0181fe8997dd6323123aaf76b410ec4a366
 
   - working-directory: /home/build/third-party/rhino

--- a/serf.yaml
+++ b/serf.yaml
@@ -1,7 +1,7 @@
 package:
   name: serf
   version: 1.3.10
-  epoch: 1
+  epoch: 2
   description: High-Performance Asynchronous HTTP Client Library
   copyright:
     - license: Apache-2.0 AND Zlib
@@ -24,7 +24,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6
-      uri: https://archive.apache.org/dist/serf/serf-${{package.version}}.tar.bz2
+      uri: https://dlcdn.apache.org/serf/serf-${{package.version}}.tar.bz2
 
   - runs: scons PREFIX=/usr
 


### PR DESCRIPTION
archive.apache.org is known for rate-limiting and blocking connections, apache now recommends using dlcdn.apache.org instead.

https://www.apache.org/dyn/closer.cgi
https://apache.org/history/mirror-history.html
