### PR TITLE
rke2-cloud-provider

### DIFF
--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -49,7 +49,8 @@ update:
   github:
     identifier: rancher/image-build-rke2-cloud-provider
     strip-prefix: v
-    strip-suffix: -.*-.*-build.*
+    use-tag: true
+    strip-suffix: -.
 
 test:
   pipeline:

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -49,7 +49,7 @@ update:
   github:
     identifier: rancher/image-build-rke2-cloud-provider
     strip-prefix: v
-    strip-suffix: -.*
+    strip-suffix: -.*-.*-build.*
 
 test:
   pipeline:

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -6,18 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  contents:
-    packages:
-      - clang
-      - file
-      - gawk
-      - gcc
-      - git
-      - jq
-      - lld
-      - make
-
 pipeline:
   - uses: git-checkout
     with:

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -30,7 +30,7 @@ pipeline:
     with:
       packages: .
       output: cloud-controller-manager
-      ldflags: -X github.com/k3s-io/k3s/pkg/version.Program=rke2 -X github.com/k3s-io/k3s/pkg/version.Version="${K3S_VERSION}""
+      ldflags: -X github.com/k3s-io/k3s/pkg/version.Program=rke2 -X github.com/k3s-io/k3s/pkg/version.Version="${K3S_VERSION}"
 
 subpackages:
   - name: "${{package.name}}-compat"

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -30,7 +30,7 @@ pipeline:
     with:
       packages: .
       output: cloud-controller-manager
-      ldflags: -X github.com/k3s-io/k3s/pkg/version.Program=rke2 -X github.com/k3s-io/k3s/pkg/version.Version=$K3S_VERSION
+      ldflags: -X github.com/k3s-io/k3s/pkg/version.Program=rke2 -X github.com/k3s-io/k3s/pkg/version.Version="${K3S_VERSION}""
 
 subpackages:
   - name: "${{package.name}}-compat"

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -2,25 +2,21 @@ package:
   name: rke2-cloud-provider
   version: "1.33.1"
   epoch: 0
-  description: cloud controller manager for RKE2
+  description: cloud controller manager for rke2
   copyright:
     - license: Apache-2.0
-
 
 environment:
   contents:
     packages:
-      - gawk
-      - jq
+      - clang
       - file
+      - gawk
       - gcc
       - git
-      - make
-      - clang
+      - jq
       - lld
-
-vars:
-  tag-suffix: ""
+      - make
 
 pipeline:
   - uses: git-checkout
@@ -32,7 +28,7 @@ pipeline:
 
   - name: Get k3s version
     runs: |
-        K3S_VERSION=$(go list -f '{{.Version}}' -m github.com/k3s-io/k3s)
+      K3S_VERSION=$(go list -f '{{.Version}}' -m github.com/k3s-io/k3s)
 
   - uses: go/build
     with:
@@ -54,7 +50,6 @@ update:
     identifier: rancher/image-build-rke2-cloud-provider
     strip-prefix: v
     strip-suffix: -.*
-    tag-filter: v
 
 test:
   pipeline:

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -26,6 +26,14 @@ pipeline:
       # Needs to be updated manually from https://github.com/rancher/image-build-rke2-cloud-provider/releases
       tag: v${{package.version}}-0.20250516163953-99d91538b132-build20250612
 
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/golang-jwt/jwt/v4@v4.5.2
+        golang.org/x/crypto@v0.35.0
+        golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
+
   - name: Get k3s version
     runs: |
       K3S_VERSION=$(go list -f '{{.Version}}' -m github.com/k3s-io/k3s)
@@ -56,4 +64,4 @@ update:
 test:
   pipeline:
     - runs: |
-        rke2-cloud-provider --help
+        cloud-controller-manager --help

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -1,0 +1,62 @@
+package:
+  name: rke2-cloud-provider
+  version: "1.33.1"
+  epoch: 0
+  description: cloud controller manager for RKE2
+  copyright:
+    - license: Apache-2.0
+
+
+environment:
+  contents:
+    packages:
+      - gawk
+      - jq
+      - file
+      - gcc
+      - git
+      - make
+      - clang
+      - lld
+
+vars:
+  tag-suffix: ""
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/image-build-rke2-cloud-provider
+      expected-commit: b24b25084b1c172f0b46a482c5dfca7987b9e2ed
+      # Needs to be updated manually from https://github.com/rancher/image-build-rke2-cloud-provider/releases
+      tag: v${{package.version}}-0.20250516163953-99d91538b132-build20250612
+
+  - name: Get k3s version
+    runs: |
+        K3S_VERSION=$(go list -f '{{.Version}}' -m github.com/k3s-io/k3s)
+
+  - uses: go/build
+    with:
+      packages: .
+      output: cloud-controller-manager
+      ldflags: -X github.com/k3s-io/k3s/pkg/version.Program=rke2 -X github.com/k3s-io/k3s/pkg/version.Version=$K3S_VERSION
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -sf /usr/bin/cloud-controller-manager ${{targets.subpkgdir}}/usr/local/bin/cloud-controller-manager
+
+update:
+  enabled: true
+  github:
+    identifier: rancher/image-build-rke2-cloud-provider
+    strip-prefix: v
+    strip-suffix: -.*
+    tag-filter: v
+
+test:
+  pipeline:
+    - runs: |
+        rke2-cloud-provider --help

--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -46,11 +46,12 @@ subpackages:
 
 update:
   enabled: true
+  manual: true
   github:
     identifier: rancher/image-build-rke2-cloud-provider
     strip-prefix: v
     use-tag: true
-    strip-suffix: -.
+    strip-suffix: -.*
 
 test:
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
