### PR TITLE
postgresql: add ecpg and libecpg-dev packages

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -111,7 +111,7 @@ pipeline:
   # We package it now with a dedicated package.
   - name: Remove ECPG duplicate
     runs: |
-      rm -f /home/build/melange-out/postgresql-17/usr/libexec/postgresql17/ecpg
+      rm ${{targets.contextdir}}/usr/libexec/postgresql17/ecpg
 
   - uses: strip
 

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -11,6 +11,7 @@ package:
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
       - tzdata
+      - ecpg=${{package.full-version}}
 
 environment:
   environment:
@@ -107,6 +108,11 @@ pipeline:
       sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
       grep -F "listen_addresses = '*'" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
 
+  # We package it now with a dedicated package.
+  - name: Remove ECPG duplicate
+    runs: |
+      rm -f /home/build/melange-out/postgresql-17/usr/libexec/postgresql17/ecpg
+
   - uses: strip
 
 vars:
@@ -124,6 +130,7 @@ subpackages:
         - openssl-dev
         - ${{package.name}}-client
         - libpq-16
+        - libpq-16-dev
     description: postgresql dev
     test:
       pipeline:
@@ -210,6 +217,31 @@ subpackages:
       provides:
         - libecpg=${{package.full-version}}
 
+  - name: libecpg-16-dev
+    description: Embedded PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+    dependencies:
+      provider-priority: 16
+      provides:
+        - libecpg-dev=${{package.full-version}}
+
   - name: ecpg-16
     description: Embedded PostgreSQL SQL preprocessor for C programs
     pipeline:
@@ -217,6 +249,10 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/libexec/postgresql16/ecpg ${{targets.subpkgdir}}/usr/bin/
     test:
+      environment:
+        contents:
+          packages:
+            - libecpg-dev=${{package.full-version}}
       pipeline:
         - uses: test/tw/ldd-check
         - runs: ecpg --help
@@ -264,7 +300,7 @@ subpackages:
                 return 0;
             }
             EOF
-            ecpg test.pgc
+            ecpg -I /usr/include/postgresql test.pgc
     dependencies:
       provider-priority: 16
       provides:

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -10,8 +10,8 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
-      - tzdata
       - ecpg=${{package.full-version}}
+      - tzdata
 
 environment:
   environment:
@@ -108,11 +108,6 @@ pipeline:
       sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
       grep -F "listen_addresses = '*'" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
 
-  # We package it now with a dedicated package.
-  - name: Remove ECPG duplicate
-    runs: |
-      rm ${{targets.contextdir}}/usr/libexec/postgresql16/ecpg
-
   - uses: strip
 
 vars:
@@ -130,7 +125,7 @@ subpackages:
         - openssl-dev
         - ${{package.name}}-client
         - libpq-16
-        - libpq-16-dev
+        - libecpg-16-dev
     description: postgresql dev
     test:
       pipeline:
@@ -219,6 +214,12 @@ subpackages:
 
   - name: libecpg-16-dev
     description: Embedded PostgreSQL libraries (development files)
+    dependencies:
+      provider-priority: 16
+      runtime:
+        - libecpg-16=${{package.full-version}}
+      provides:
+        - libecpg-dev=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
@@ -229,26 +230,41 @@ subpackages:
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
 
-          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
-          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
-          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg_compat.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
     test:
+      environment:
+        contents:
+          packages:
+            - pkgconf
       pipeline:
         - uses: test/tw/ldd-check
-        - uses: test/tw/pkgconf
-    dependencies:
-      provider-priority: 16
-      provides:
-        - libecpg-dev=${{package.full-version}}
+        - runs: |
+            # Test that key header files are present
+            test -f /usr/include/postgresql/ecpg_config.h
+            test -f /usr/include/postgresql/ecpglib.h
+            test -f /usr/include/postgresql/pgtypes.h
+            test -f /usr/include/postgresql/sqlca.h
+
+            # Test that pkgconfig files are present and working
+            pkg-config --exists libecpg
+            pkg-config --exists libecpg_compat
+            pkg-config --exists libpgtypes
+
+            # Test that static libraries are present
+            test -f /usr/lib/libecpg.a
+            test -f /usr/lib/libpgtypes.a
 
   - name: ecpg-16
     description: Embedded PostgreSQL SQL preprocessor for C programs
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
-          mv ${{targets.destdir}}/usr/libexec/postgresql16/ecpg ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/libexec/${{vars.mangled-package-name}}/ecpg ${{targets.subpkgdir}}/usr/bin/
     test:
       environment:
         contents:

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -111,7 +111,7 @@ pipeline:
   # We package it now with a dedicated package.
   - name: Remove ECPG duplicate
     runs: |
-      rm ${{targets.contextdir}}/usr/libexec/postgresql17/ecpg
+      rm ${{targets.contextdir}}/usr/libexec/postgresql16/ecpg
 
   - uses: strip
 
@@ -218,25 +218,26 @@ subpackages:
         - libecpg=${{package.full-version}}
 
   - name: libecpg-16-dev
-    description: Embedded PostgreSQL libraries
+    description: Embedded PostgreSQL libraries (development files)
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
 
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
         - uses: test/tw/ldd-check
+        - uses: test/tw/pkgconf
     dependencies:
       provider-priority: 16
       provides:

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.9"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -209,6 +209,66 @@ subpackages:
       provider-priority: 16
       provides:
         - libecpg=${{package.full-version}}
+
+  - name: ecpg-16
+    description: Embedded PostgreSQL SQL preprocessor for C programs
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/libexec/postgresql16/ecpg ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: ecpg --help
+        - runs: |
+            cat <<"EOF" >test.pgc
+            /* test.pgc */
+            #include <stdio.h>
+            #include <stdlib.h>
+            #include <string.h>
+
+            EXEC SQL INCLUDE sqlca;
+
+            int main() {
+                EXEC SQL BEGIN DECLARE SECTION;
+                const char *db = "testdb";
+                const char *user = "postgres";
+                int id;
+                char name[100];
+                EXEC SQL END DECLARE SECTION;
+
+                EXEC SQL CONNECT TO :db USER :user;
+
+                if (sqlca.sqlcode < 0) {
+                    fprintf(stderr, "Connection failed: %s\n", sqlca.sqlerrm.sqlerrmc);
+                    exit(1);
+                }
+
+                EXEC SQL CREATE TABLE IF NOT EXISTS demo (id INT, name TEXT);
+                EXEC SQL INSERT INTO demo (id, name) VALUES (1, 'chainguard');
+                EXEC SQL COMMIT;
+
+                EXEC SQL DECLARE cur CURSOR FOR SELECT id, name FROM demo;
+                EXEC SQL OPEN cur;
+
+                while (1) {
+                    EXEC SQL FETCH cur INTO :id, :name;
+                    if (sqlca.sqlcode != 0) break;
+                    printf("Row: id = %d, name = %s\n", id, name);
+                }
+
+                EXEC SQL CLOSE cur;
+                EXEC SQL COMMIT;
+                EXEC SQL DISCONNECT;
+
+                return 0;
+            }
+            EOF
+            ecpg test.pgc
+    dependencies:
+      provider-priority: 16
+      provides:
+        - ecpg=${{package.full-version}}
 
   - name: ${{package.name}}-oci-entrypoint-base
     description: Base for PostgreSQL entrypoint in OCI containers

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -111,7 +111,7 @@ pipeline:
   # We package it now with a dedicated package.
   - name: Remove ECPG duplicate
     runs: |
-      rm -f /home/build/melange-out/postgresql-17/usr/libexec/postgresql17/ecpg
+      rm ${{targets.contextdir}}/usr/libexec/postgresql17/ecpg
 
   - uses: strip
 
@@ -218,25 +218,26 @@ subpackages:
         - libecpg=${{package.full-version}}
 
   - name: libecpg-17-dev
-    description: Embedded PostgreSQL libraries
+    description: Embedded PostgreSQL libraries (development files)
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
 
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
-          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
         - uses: test/tw/ldd-check
+        - uses: test/tw/pkgconf
     dependencies:
       provider-priority: 17
       provides:

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -10,8 +10,8 @@ package:
       - postgresql=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
-      - tzdata
       - ecpg=${{package.full-version}}
+      - tzdata
 
 environment:
   environment:
@@ -108,11 +108,6 @@ pipeline:
       sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
       grep -F "listen_addresses = '*'" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
 
-  # We package it now with a dedicated package.
-  - name: Remove ECPG duplicate
-    runs: |
-      rm ${{targets.contextdir}}/usr/libexec/postgresql17/ecpg
-
   - uses: strip
 
 vars:
@@ -130,7 +125,7 @@ subpackages:
         - openssl-dev
         - ${{package.name}}-client
         - libpq-17
-        - libpq-17-dev
+        - libecpg-17-dev
     description: postgresql dev
     test:
       pipeline:
@@ -219,6 +214,12 @@ subpackages:
 
   - name: libecpg-17-dev
     description: Embedded PostgreSQL libraries (development files)
+    dependencies:
+      provider-priority: 17
+      runtime:
+        - libecpg-17=${{package.full-version}}
+      provides:
+        - libecpg-dev=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
@@ -229,19 +230,34 @@ subpackages:
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
 
-          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
           mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
-          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
-          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libecpg_compat.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+          mv ${{targets.outdir}}/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
     test:
+      environment:
+        contents:
+          packages:
+            - pkgconf
       pipeline:
         - uses: test/tw/ldd-check
-        - uses: test/tw/pkgconf
-    dependencies:
-      provider-priority: 17
-      provides:
-        - libecpg-dev=${{package.full-version}}
+        - runs: |
+            # Test that key header files are present
+            test -f /usr/include/postgresql/ecpg_config.h
+            test -f /usr/include/postgresql/ecpglib.h
+            test -f /usr/include/postgresql/pgtypes.h
+            test -f /usr/include/postgresql/sqlca.h
+
+            # Test that pkgconfig files are present and working
+            pkg-config --exists libecpg
+            pkg-config --exists libecpg_compat
+            pkg-config --exists libpgtypes
+
+            # Test that static libraries are present
+            test -f /usr/lib/libecpg.a
+            test -f /usr/lib/libpgtypes.a
 
   - name: ecpg-17
     description: Embedded PostgreSQL SQL preprocessor for C programs
@@ -252,7 +268,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
-          mv ${{targets.destdir}}/usr/libexec/postgresql17/ecpg ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/libexec/${{vars.mangled-package-name}}/ecpg ${{targets.subpkgdir}}/usr/bin/
     test:
       environment:
         contents:

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -11,6 +11,7 @@ package:
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
       - tzdata
+      - ecpg=${{package.full-version}}
 
 environment:
   environment:
@@ -107,6 +108,11 @@ pipeline:
       sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
       grep -F "listen_addresses = '*'" ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample
 
+  # We package it now with a dedicated package.
+  - name: Remove ECPG duplicate
+    runs: |
+      rm -f /home/build/melange-out/postgresql-17/usr/libexec/postgresql17/ecpg
+
   - uses: strip
 
 vars:
@@ -124,6 +130,7 @@ subpackages:
         - openssl-dev
         - ${{package.name}}-client
         - libpq-17
+        - libpq-17-dev
     description: postgresql dev
     test:
       pipeline:
@@ -210,13 +217,46 @@ subpackages:
       provides:
         - libecpg=${{package.full-version}}
 
+  - name: libecpg-17-dev
+    description: Embedded PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/postgresql/informix ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/postgresql/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/postgresql/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/
+          mv /home/build/melange-out/${{package.name}}-dev/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+    dependencies:
+      provider-priority: 17
+      provides:
+        - libecpg-dev=${{package.full-version}}
+
   - name: ecpg-17
     description: Embedded PostgreSQL SQL preprocessor for C programs
+    dependencies:
+      provider-priority: 17
+      provides:
+        - ecpg=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/libexec/postgresql17/ecpg ${{targets.subpkgdir}}/usr/bin/
     test:
+      environment:
+        contents:
+          packages:
+            - libecpg-dev=${{package.full-version}}
       pipeline:
         - uses: test/tw/ldd-check
         - runs: ecpg --help
@@ -264,11 +304,7 @@ subpackages:
                 return 0;
             }
             EOF
-            ecpg test.pgc
-    dependencies:
-      provider-priority: 17
-      provides:
-        - ecpg=${{package.full-version}}
+            ecpg -I /usr/include/postgresql test.pgc
 
   - name: ${{package.name}}-oci-entrypoint-base
     description: Base for PostgreSQL entrypoint in OCI containers

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.5"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -209,6 +209,66 @@ subpackages:
       provider-priority: 17
       provides:
         - libecpg=${{package.full-version}}
+
+  - name: ecpg-17
+    description: Embedded PostgreSQL SQL preprocessor for C programs
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/libexec/postgresql17/ecpg ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: ecpg --help
+        - runs: |
+            cat <<"EOF" >test.pgc
+            /* test.pgc */
+            #include <stdio.h>
+            #include <stdlib.h>
+            #include <string.h>
+
+            EXEC SQL INCLUDE sqlca;
+
+            int main() {
+                EXEC SQL BEGIN DECLARE SECTION;
+                const char *db = "testdb";
+                const char *user = "postgres";
+                int id;
+                char name[100];
+                EXEC SQL END DECLARE SECTION;
+
+                EXEC SQL CONNECT TO :db USER :user;
+
+                if (sqlca.sqlcode < 0) {
+                    fprintf(stderr, "Connection failed: %s\n", sqlca.sqlerrm.sqlerrmc);
+                    exit(1);
+                }
+
+                EXEC SQL CREATE TABLE IF NOT EXISTS demo (id INT, name TEXT);
+                EXEC SQL INSERT INTO demo (id, name) VALUES (1, 'chainguard');
+                EXEC SQL COMMIT;
+
+                EXEC SQL DECLARE cur CURSOR FOR SELECT id, name FROM demo;
+                EXEC SQL OPEN cur;
+
+                while (1) {
+                    EXEC SQL FETCH cur INTO :id, :name;
+                    if (sqlca.sqlcode != 0) break;
+                    printf("Row: id = %d, name = %s\n", id, name);
+                }
+
+                EXEC SQL CLOSE cur;
+                EXEC SQL COMMIT;
+                EXEC SQL DISCONNECT;
+
+                return 0;
+            }
+            EOF
+            ecpg test.pgc
+    dependencies:
+      provider-priority: 17
+      provides:
+        - ecpg=${{package.full-version}}
 
   - name: ${{package.name}}-oci-entrypoint-base
     description: Base for PostgreSQL entrypoint in OCI containers


### PR DESCRIPTION
ecpg is part of postgresql package, while other distros ship it as part of the libecpg-dev package which we don't build. We may not want a full postgres package just for this preprocessor, so it is convenient to have a dedicated package.
In order to avoid breaking changes, we update postgresql package runtime dependencies to include ecpg.

Ecpg also depends on its headers, for which we introduce a libecpg-dev package for this reason. Since the latter takes headers used to be packaged in postgresql-dev package, we update postresql-dev runtime dependencies to avoid breaking changes.

In summary, we introduce new packages:
- ecpg
- libecpg-dev

We update dependencies:
- postgresql: +ecpg
- posgresql-dev: +libecpg-dev

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
- [ ] Functional tests are present.
- [ ] We cannot write functional tests, but smoke tests are present (e.g. `--help/--version` checks) - explain why in notes below.
- [ ] Tests fail **and** pass when it's expected.