### PR TITLE
consul-k8s-1.7: bump helm to v3.18.4 to fix GHSA-557j-xg8c-q2mm

### DIFF
--- a/consul-k8s-1.7.yaml
+++ b/consul-k8s-1.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: consul-k8s-1.7
   version: "1.7.2"
-  epoch: 0
+  epoch: 1
   description: The consul-k8s includes first-class integrations between Consul and Kubernetes.
   copyright:
     - license: MPL-2.0
@@ -17,6 +17,15 @@ pipeline:
       repository: https://github.com/hashicorp/consul-k8s
       expected-commit: f35dc640bc37d0755b5ca004f71480a46492cc77
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        helm.sh/helm/v3@v3.18.4
+      replaces: |-
+        github.com/envoyproxy/go-control-plane=github.com/envoyproxy/go-control-plane@v0.12.0
+        github.com/envoyproxy/go-control-plane/contrib=github.com/envoyproxy/go-control-plane/contrib@v0.12.0
+      modroot: cli
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
- Updated consul-k8s-1.7 to use helm v3.18.4
- Added envoyproxy/go-control-plane replace directives to maintain compatibility
- Fixes CVE GHSA-557j-xg8c-q2mm (Helm vulnerable to Code Injection through malicious chart.yaml content)

## Test Plan
- [ ] Package builds successfully
- [ ] CVE scan confirms GHSA-557j-xg8c-q2mm is resolved

## Related
- Enterprise packages PR: https://github.com/chainguard-dev/enterprise-packages/pull/27040