### PR TITLE
go-1.2*: Improve tests

### DIFF
--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 6
+  epoch: 7
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -140,3 +140,19 @@ test:
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"
+    - name: Test using external linker
+    - runs: |
+        # We need to trick Golang into thinking that we're building a binary
+        # that will be used for linking later.  This way, it will force the use
+        # of an external linker.  The way to do this is to use the "-buildmode=plugin"
+        # option
+        cat > external_linker.go << _EOF_
+        package main
+        func main() {
+            return
+        }
+        _EOF_
+        go build -buildmode=plugin external_linker.go
+    - name: Test building a regular project
+    - runs: |
+        go install github.com/junegunn/fzf@v0.64.0

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: "1.22.12"
-  epoch: 4
+  epoch: 5
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -151,3 +151,19 @@ test:
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"
+    - name: Test using external linker
+    - runs: |
+        # We need to trick Golang into thinking that we're building a binary
+        # that will be used for linking later.  This way, it will force the use
+        # of an external linker.  The way to do this is to use the "-buildmode=plugin"
+        # option
+        cat > external_linker.go << _EOF_
+        package main
+        func main() {
+            return
+        }
+        _EOF_
+        go build -buildmode=plugin external_linker.go
+    - name: Test building a regular project
+    - runs: |
+        go install github.com/junegunn/fzf@v0.64.0

--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.23
   version: "1.23.11"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -188,3 +188,19 @@ test:
         out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
         [ "$out" = "off" ] ||
           fail "go telemetry after explicit off output '$out'. expected 'off'"
+    - name: Test using external linker
+    - runs: |
+        # We need to trick Golang into thinking that we're building a binary
+        # that will be used for linking later.  This way, it will force the use
+        # of an external linker.  The way to do this is to use the "-buildmode=plugin"
+        # option
+        cat > external_linker.go << _EOF_
+        package main
+        func main() {
+            return
+        }
+        _EOF_
+        go build -buildmode=plugin external_linker.go
+    - name: Test building a regular project
+    - runs: |
+        go install github.com/junegunn/fzf@v0.64.0

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.5"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -126,6 +126,7 @@ test:
     contents:
       packages:
         - build-base
+        - git
   pipeline:
     - name: Test Go installation
       runs: |
@@ -209,3 +210,19 @@ test:
         out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
         [ "$out" = "off" ] ||
           fail "go telemetry after explicit off output '$out'. expected 'off'"
+    - name: Test using external linker
+    - runs: |
+        # We need to trick Golang into thinking that we're building a binary
+        # that will be used for linking later.  This way, it will force the use
+        # of an external linker.  The way to do this is to use the "-buildmode=plugin"
+        # option
+        cat > external_linker.go << _EOF_
+        package main
+        func main() {
+            return
+        }
+        _EOF_
+        go build -buildmode=plugin external_linker.go
+    - name: Test building a regular project
+    - runs: |
+        go install github.com/junegunn/fzf@v0.64.0


### PR DESCRIPTION
We need to expand the testsuite used for the Golang toolchain in order to:

- Make sure the compiler can build a real project (let's use "fzf" because it's relatively simple and fast to compile).

- Test the usage of an external linker, particularly because of our OpenSSF compiler flags.

Relates: https://github.com/chainguard-dev/internal-dev/issues/14796
Relates: #58493