### PR TITLE
add upstream-compatible layout for apisix-ingress-controller subpackage

### DIFF
--- a/apisix-ingress-controller.yaml
+++ b/apisix-ingress-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: apisix-ingress-controller
   version: "1.8.4"
-  epoch: 0
+  epoch: 1
   description: APISIX Ingress Controller for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,8 @@ pipeline:
       output: apisix-ingress-controller
 
 subpackages:
+  # NOTE: Upstream v1.8.x uses the "/ingress-apisix" layout with a custom entrypoint.
+  # This package mirrors that structure for compatibility. When bumping to v2.x (currently in RC stage it use "/app/..." layout) and need to update entrypoint and file paths accordingly
   - name: ${{package.name}}-compat
     description: Compatibility package for apisix-ingress-controller to match upstream paths
     pipeline:

--- a/apisix-ingress-controller.yaml
+++ b/apisix-ingress-controller.yaml
@@ -35,12 +35,13 @@ subpackages:
     description: Compatibility package for apisix-ingress-controller to match upstream paths
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/app
-          ln -sf /usr/bin/apisix-ingress-controller ${{targets.subpkgdir}}/app/apisix-ingress-controller
+          mkdir -p ${{targets.subpkgdir}}/ingress-apisix/conf
+          ln -sf /usr/bin/apisix-ingress-controller ${{targets.subpkgdir}}/ingress-apisix/apisix-ingress-controller
+          cp ./conf/apisix-schema.json ${{targets.subpkgdir}}/ingress-apisix/conf/apisix-schema.json
     test:
       pipeline:
         - runs: |
-            stat /app/apisix-ingress-controller
+            stat /ingress-apisix/apisix-ingress-controller
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

This PR updates the `apisix-ingress-controller-compat` subpackage to mirror the upstream v1.8.x image layout and entrypoint (/ingress-apisix/...)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
