### PR TITLE
add compat subpkgs for opa

### DIFF
--- a/opa.yaml
+++ b/opa.yaml
@@ -1,7 +1,7 @@
 package:
   name: opa
   version: "1.6.0"
-  epoch: 0
+  epoch: 1
   description: Open Policy Agent (OPA) is an open source, general-purpose policy engine.
   copyright:
     - license: Apache-2.0

--- a/opa.yaml
+++ b/opa.yaml
@@ -36,6 +36,18 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binary in the location expected by opa"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}
+          ln -sf /usr/bin/opa ${{targets.contextdir}}/opa
+    test:
+      pipeline:
+        - runs: |
+            test "$(readlink /opa)" = "/usr/bin/opa"
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
This PR adds a compat subpkg for `opa` to match entrypoint with the upstream