### PR TITLE
crossplane-provider-aws: allocate larger disk for melange build

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,13 +1,14 @@
 package:
   name: crossplane-provider-aws
   version: "1.23.0"
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
   resources:
     cpu: 16
     memory: 16Gi
+    disk: 100Gi
   dependencies:
     runtime:
       - terraform-provider-aws


### PR DESCRIPTION
Allocate larger disk for the melange package build, otherwise the package may FTBFS.

See also:
  https://github.com/wolfi-dev/os/issues/58016