### PR TITLE
Include SCAP content for all supported RHEL products in SSG package

### DIFF
--- a/scap-security-guide.yaml
+++ b/scap-security-guide.yaml
@@ -1,7 +1,7 @@
 package:
   name: scap-security-guide
   version: "0.1.77"
-  epoch: 0
+  epoch: 1
   description: Security automation content in SCAP, Bash, Ansible, and other formats
   copyright:
     - license: BSD-3-Clause
@@ -35,15 +35,11 @@ pipeline:
   - uses: cmake/configure
     with:
       output-dir: build
-      # TODO: RHEL# product suite is not compiling
       opts: |
         -DSSG_ANSIBLE_PLAYBOOKS_ENABLED=False \
         -DSSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED=False \
         -DSSG_BASH_SCRIPTS_ENABLED=False \
-        -DSSG_BATS_TESTS_ENABLED=False \
-        -DSSG_PRODUCT_RHEL7=False \
-        -DSSG_PRODUCT_RHEL8=False \
-        -DSSG_PRODUCT_RHEL9=False
+        -DSSG_BATS_TESTS_ENABLED=False
 
   - uses: cmake/build
     with:


### PR DESCRIPTION
The RHEL products were originally excluded from our SSG package due to compilation errors but this is no longer the case (and `RHEl7` is no longer supported).

RHEL8-10 will now be included as opposed to just RHEL10.