### PR TITLE
postfix: Use `rpath` instead of `ld.so.conf.d` for internal libraries

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.3"
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -145,6 +145,7 @@ pipeline:
       	meta_directory=/etc/postfix \
       	daemon_directory=/usr/libexec/postfix \
       	shlib_directory=/usr/lib/postfix \
+      	SHLIB_RPATH="-Wl,-rpath,/usr/lib/postfix" \
       	sendmail_path=/usr/bin/sendmail \
       	dynamicmaps=yes \
       	shared=yes \
@@ -178,9 +179,6 @@ pipeline:
       chown root:postfix "${{targets.contextdir}}"/var/spool/postfix/pid
       chgrp postdrop "${{targets.contextdir}}"/var/spool/postfix/maildrop \
       	"${{targets.contextdir}}"/var/spool/postfix/public
-
-      mkdir -p "${{targets.contextdir}}"/etc/ld.so.conf.d
-      echo "/usr/lib/postfix/" > "${{targets.contextdir}}"/etc/ld.so.conf.d/postfix.conf
 
       cd "${{targets.contextdir}}"/etc/postfix/
       for map in ldap mysql pcre pgsql sqlite lmdb; do
@@ -225,6 +223,7 @@ subpackages:
     dependencies:
       runtime:
         - merged-usrsbin
+        - postfix=${{package.full-version}}
         - wolfi-baselayout
 
   - range: _subpackages


### PR DESCRIPTION
@xnox pointed out that postfix libraries might be internal rather than public, and after checking the Debian package I noticed that he's right.

Postfix even provides a configuration option to specify what the `rpath` should be when linking binaries, so let's use that instead of shipping an `ld.so.conf.d` snippet.

I've also added a runtime dependency on `postfix` to `postfix-stone`, otherwise its binaries won't run.

Relates: https://github.com/chainguard-dev/melange/pull/2072
Relates: #58604