### PR TITLE
pypy-3.11: add ldd-check test and missing runtime dependencies

### DIFF
--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -21,7 +21,7 @@ package:
       - openssl
       - py3-pip-wheel
       - py3-setuptools-wheel
-      - sqlite
+      - sqlite-libs
       - xz
       - zlib
 

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -15,14 +15,14 @@ package:
     runtime:
       - bzip2-dev
       - gcc
-      - gdbm-dev
+      - gdbm
       - glibc-dev
       - ncurses
       - openssl
       - py3-pip-wheel
       - py3-setuptools-wheel
-      - sqlite-dev
-      - xz-dev
+      - sqlite
+      - xz
       - zlib
 
 environment:

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.11
   description: PyPy is a very fast and compliant implementation of the Python language v 3.11
-  epoch: 0
+  epoch: 1
   version: "7.3.20"
   copyright:
     - license: Apache-2.0
@@ -15,11 +15,14 @@ package:
     runtime:
       - bzip2-dev
       - gcc
+      - gdbm-dev
       - glibc-dev
       - ncurses
       - openssl
       - py3-pip-wheel
       - py3-setuptools-wheel
+      - sqlite-dev
+      - xz-dev
       - zlib
 
 environment:
@@ -171,6 +174,7 @@ test:
       packages:
         - ${{package.name}}-compat
   pipeline:
+    - uses: test/tw/ldd-check
     - name: "check version"
       uses: test/daemon-check-output
       with:


### PR DESCRIPTION
The pypy-3.11 package provides shared library files but was missing ldd-check validation to ensure all library dependencies are satisfied. This adds the test/tw/ldd-check pipeline to verify shared libraries can be properly loaded.

Additionally, adds missing runtime dependencies (gdbm-dev, sqlite-dev, xz-dev) that were identified by the ldd-check test as required for PyPy's CFFI modules to function correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)