### PR TITLE
R: add ldd-check test to R-mathlib subpackage

### DIFF
--- a/R.yaml
+++ b/R.yaml
@@ -2,7 +2,7 @@
 package:
   name: R
   version: "4.5.1"
-  epoch: 0
+  epoch: 1
   description: Language and environment for statistical computing
   copyright:
     - license: ( GPL-2.0-only OR GPL-3.0-only ) AND LGPL-2.1-or-later
@@ -147,6 +147,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libRmath.so* "${{targets.subpkgdir}}"/usr/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: R-dev
     pipeline:


### PR DESCRIPTION
The R-mathlib subpackage provides libRmath.so* shared library files but was missing ldd-check validation to ensure all library dependencies are satisfied. This adds the test/tw/ldd-check pipeline to verify the shared library can be properly loaded.

🤖 Generated with [Claude Code](https://claude.ai/code)