### PR TITLE
Update ldd check to tw format

### DIFF
--- a/db.yaml
+++ b/db.yaml
@@ -1,7 +1,7 @@
 package:
   name: db
   version: 5.3.28
-  epoch: 3
+  epoch: 4
   description: The Berkeley DB embedded database system
   copyright:
     - license: LicenseRef-berkeley-db
@@ -67,9 +67,7 @@ subpackages:
     description: db dev
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
 
   - name: db-doc
     pipeline:
@@ -93,9 +91,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libdb_cxx*.so ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: C++ binding for libdb
 
 update:
@@ -108,6 +104,4 @@ update:
 
 test:
   pipeline:
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/libcld2.yaml
+++ b/libcld2.yaml
@@ -4,7 +4,7 @@ package:
   description: Compact Language Detector 2
   url: https://github.com/CLD2Owners/cld2
   version: 0_git20240911
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -109,6 +109,4 @@ test:
         echo 'int main() { const char* text = "Hello, this is a language detection test."; bool is_plain_text = true; bool is_reliable = false; CLD2::Language lang = CLD2::DetectLanguage(text, strlen(text), is_plain_text, &is_reliable); std::cout << "Detected language: " << CLD2::LanguageCode(lang) << std::endl; return 0; }' >> detect_test.cpp
         g++ -I$INCLUDE_DIR detect_test.cpp -o detect_binary -lcld2
         ./detect_binary | grep -q "en"
-    - uses: test/ldd-check
-      with:
-        packages: ${{package.name}}
+    - uses: test/tw/ldd-check

--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -1,7 +1,7 @@
 package:
   name: mosquitto
   version: "2.0.21"
-  epoch: 41
+  epoch: 42
   description: open source MQTT broker
   copyright:
     - license: EPL-1.0
@@ -80,8 +80,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-          with:
-            packages: mosquitto-dev
 
   - name: mosquitto-doc
     pipeline:
@@ -102,9 +100,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libmosquittopp.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: C++ wrapper for libmosquitto
     dependencies:
       runtime:
@@ -118,9 +114,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libmosquitto.so.* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: mosquitto libs
     dependencies:
       runtime:

--- a/openexr.yaml
+++ b/openexr.yaml
@@ -2,7 +2,7 @@
 package:
   name: openexr
   version: "3.3.4"
-  epoch: 0
+  epoch: 1
   description: High dynamic-range image file format library
   copyright:
     - license: BSD-3-Clause
@@ -72,9 +72,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/ldd-check
-          with:
-            packages: openexr-dev
+        - uses: test/tw/ldd-check
 
   - name: openexr-libiex
     pipeline:
@@ -83,9 +81,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libIex-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libiex
 
   - name: openexr-libilmthread
@@ -95,9 +91,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libIlmThread-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libilmthread
 
   - name: openexr-libopenexr
@@ -107,9 +101,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXR-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexr
 
   - name: openexr-libopenexrcore
@@ -119,9 +111,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXRCore-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexrcore
 
   - name: openexr-libopenexrutil
@@ -131,9 +121,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libOpenEXRUtil-*.so.* "${{targets.subpkgdir}}"/usr/lib
     test:
       pipeline:
-        - uses: test/ldd-check
-          with:
-            packages: $(basename ${{targets.contextdir}})
+        - uses: test/tw/ldd-check
     description: openexr libopenexrutil
 
 test:

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.3"
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -236,11 +236,6 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
     pipeline:
-      # test:
-      #   pipeline:
-      #     - uses: test/ldd-check
-      #       with:
-      #         packages: ${{subpkg.name}}
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/postfix \
                  "${{targets.contextdir}}"/etc/postfix/dynamicmaps.cf.d
@@ -251,6 +246,9 @@ subpackages:
           	"${{targets.subpkgdir}}"/usr/lib/postfix/
           mv "${{targets.destdir}}"/etc/postfix/dynamicmaps.cf.d/$m \
           	"${{targets.subpkgdir}}"/etc/postfix/dynamicmaps.cf.d/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
 update:
   enabled: true

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -232,7 +232,7 @@ subpackages:
     description: "${{range.key}} map support for postfix"
     dependencies:
       runtime:
-        - mariadb-dev
+        - mariadb-11.8-dev
         - merged-usrsbin
         - wolfi-baselayout
     pipeline:


### PR DESCRIPTION
Switch packages from using the test/ldd-check pipeline to the test/tw/ldd-check one.

postfix required some special treatment due to package resolution issues when installing the package e.g.:

```
2025/07/10 15:53:08 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/07/10 15:53:08 ERRO failed to test package: unable to build guest: unable to generate image: installing apk packages: error getting package dependencies: solving "postfix-mysql" constraint: resolving "postfix-mysql-3.10.3-r1.apk" deps:
solving "mariadb-dev" constraint: resolving "mariadb-11.8-dev-11.8.2-r1.apk" deps:
solving "so:libmariadbd.so.19" constraint: resolving "mariadb-11.8-11.8.2-r1.apk" deps:
selecting package mariadb-11.8-11.8.2-r1.apk conflicts with mariadb-10.6.11-r0.apk on "mariadb"
make: *** [Makefile:180: test/postfix] Error 1
```