### PR TITLE
gcc-14: Restore libsanitizer support

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -87,7 +87,6 @@ pipeline:
             --enable-initfini-array \
             --disable-nls \
             --disable-multilib \
-            --disable-libsanitizer \
             --enable-host-shared \
             --enable-shared \
             --enable-threads \
@@ -350,6 +349,9 @@ test:
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler-hardening-check
+      with:
+        cc: gcc-14
+    - uses: test/compiler/asan
       with:
         cc: gcc-14
     - uses: test/tw/ldd-check

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 15.1.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -391,6 +391,9 @@ test:
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler-hardening-check
+      with:
+        cc: gcc
+    - uses: test/compiler/asan
       with:
         cc: gcc
     - uses: test/tw/ldd-check

--- a/pipelines/test/compiler/asan.yaml
+++ b/pipelines/test/compiler/asan.yaml
@@ -1,0 +1,74 @@
+name: Address Sanitizer Test
+
+inputs:
+  cc:
+    description: |
+      CC compiler to use
+    required: true
+
+pipeline:
+  # from https://www.osc.edu/resources/getting_started/howto/howto_use_address_sanitizer
+  - name: no leaks
+    runs: |
+      tmpdir="$(mktemp -d)"
+      trap "rm -rf $tmpdir" EXIT
+      cd "$tmpdir"
+
+      cat > noleak.c <<"EOF"
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+
+      int main(int argc, const char *argv[]) {
+        char *s = malloc(100);
+        strcpy(s, "Hello world!");
+        printf("string is: %s\n", s);
+        free(s);
+        return 0;
+      }
+      EOF
+      ${{inputs.cc}} noleak.c -o noleak -fsanitize=address -lasan
+      [ "$(./noleak 2>&1 | grep -v 'Hello world!')" = "" ]
+
+  - name: missing free
+    runs: |
+      tmpdir="$(mktemp -d)"
+      trap "rm -rf $tmpdir" EXIT
+      cd "$tmpdir"
+
+      cat > leak.c <<"EOF"
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+
+      int main(int argc, const char *argv[]) {
+        char *s = malloc(100);
+        strcpy(s, "Hello world!");
+        printf("string is: %s\n", s);
+        return 0;
+      }
+      EOF
+      ${{inputs.cc}} leak.c -o leak -fsanitize=address -lasan
+      ./leak 2>&1 | grep "detected memory leaks"
+
+  - name: use after free
+    runs: |
+      tmpdir="$(mktemp -d)"
+      trap "rm -rf $tmpdir" EXIT
+      cd "$tmpdir"
+
+      cat > uaf.c <<"EOF"
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+
+      int main(int argc, const char *argv[]) {
+        char *s = malloc(100);
+        free(s);
+        strcpy(s, "Hello world!");
+        printf("string is: %s\n", s);
+        return 0;
+      }
+      EOF
+      ${{inputs.cc}} uaf.c -o uaf -fsanitize=address -lasan
+      ./uaf 2>&1 | grep "heap-use-after-free"


### PR DESCRIPTION
Some programs include the libsanitizer headers. Those headers are only available for GCC versions that were built with libsanitizer support. Today we only enable libsanitizer for the latest gcc version, so we disable it when a gcc version becomes version streamed. However, we also build version-streamed gcc's with --enable-version-specific-runtime-libs, which means these libraries are private and do not conflict with the system libraries installed by the mainline gcc package.

Let's re-enable libsanitizer support in gcc-14 to allow building programs that need it, but do not yet build with GCC 15.

This adds a new asan test pipeline and adds it to gcc-14 and gcc (15) - the latter is mainly to make sure it moves forward with future gcc releases.

Note that the package I need this for statically links libasan, so the fact that the private lib may not be available at runtime is immaterial.

To help verify the absence of unattended consequences, I wrote this script to compare the contents of all the apks before and after:

```bash
#!/bin/sh
for arch in aarch64 x86_64; do
    find old/$arch -name '*.apk' | while read oldapk; do
	newapk="$(echo $oldapk | sed 's/-r2/-r3/' | sed 's/-r1/-r2/' | sed 's/^old/new/')"
	old_contents="$(echo $oldapk | sed 's/apk$/lst/')"
	tar tfz "$oldapk" > "$old_contents" 2> /dev/null
	new_contents="$(echo $newapk | sed 's/apk$/lst/')"
	tar tfz "$newapk" > "$new_contents" 2> /dev/null
	# Ignore version change in spdx file
	sed -i '/^var\/lib\/db\/sbom/d' "$old_contents" "$new_contents"
	diff -u "$old_contents" "$new_contents"
    done
done
```
Results:
```diff
--- old/aarch64/gcc-14-14.3.0-r2.lst	2025-07-16 10:26:09.681296944 -0600
+++ new/aarch64/gcc-14-14.3.0-r3.lst	2025-07-16 10:26:09.681542184 -0600
@@ -46,6 +46,12 @@
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/limits.h
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/omp.h
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/openacc.h
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer/asan_interface.h
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer/common_interface_defs.h
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer/hwasan_interface.h
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer/lsan_interface.h
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/sanitizer/tsan_interface.h
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/ssp
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/ssp/ssp.h
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/include/ssp/stdio.h
@@ -74,6 +80,11 @@
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/install-tools/include/limits.h
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/install-tools/macro_list
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/install-tools/mkheaders.conf
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libasan.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libasan.so
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libasan.so.8
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libasan.so.8.0.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libasan_preinit.o
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libatomic.a
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libatomic.so
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libcaf_single.a
@@ -87,11 +98,22 @@
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libgomp.so.1
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libgomp.so.1.0.0
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libgomp.spec
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libhwasan.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libhwasan.so
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libhwasan.so.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libhwasan.so.0.0.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libhwasan_preinit.o
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libitm.a
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libitm.so
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libitm.so.1
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libitm.so.1.0.0
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libitm.spec
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/liblsan.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/liblsan.so
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/liblsan.so.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/liblsan.so.0.0.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/liblsan_preinit.o
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libsanitizer.spec
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libssp.a
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libssp.so
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libssp.so.0
@@ -99,6 +121,15 @@
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libssp_nonshared.a
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libstdc++exp.a
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/libstdc++fs.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libtsan.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libtsan.so
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libtsan.so.2
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libtsan.so.2.0.0
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libtsan_preinit.o
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libubsan.a
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libubsan.so
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libubsan.so.1
+usr/lib/gcc/aarch64-unknown-linux-gnu/14/libubsan.so.1.0.0
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/plugin
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/plugin/gtype.state
 usr/lib/gcc/aarch64-unknown-linux-gnu/14/plugin/include
--- old/x86_64/gcc-14-14.3.0-r2.lst	2025-07-16 10:26:19.168748736 -0600
+++ new/x86_64/gcc-14-14.3.0-r3.lst	2025-07-16 10:26:19.169032138 -0600
@@ -128,6 +128,12 @@
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/raointintrin.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/rdseedintrin.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/rtmintrin.h
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer/asan_interface.h
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer/common_interface_defs.h
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer/hwasan_interface.h
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer/lsan_interface.h
+usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sanitizer/tsan_interface.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/serializeintrin.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sgxintrin.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/include/sha512intrin.h
@@ -182,6 +188,11 @@
 usr/lib/gcc/x86_64-pc-linux-gnu/14/install-tools/include/limits.h
 usr/lib/gcc/x86_64-pc-linux-gnu/14/install-tools/macro_list
 usr/lib/gcc/x86_64-pc-linux-gnu/14/install-tools/mkheaders.conf
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan.so
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan.so.8
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan.so.8.0.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan_preinit.o
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libatomic.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libatomic.so
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libcaf_single.a
@@ -195,15 +206,26 @@
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libgomp.so.1
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libgomp.so.1.0.0
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libgomp.spec
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libhwasan.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libhwasan.so
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libhwasan.so.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libhwasan.so.0.0.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libhwasan_preinit.o
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libitm.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libitm.so
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libitm.so.1
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libitm.so.1.0.0
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libitm.spec
+usr/lib/gcc/x86_64-pc-linux-gnu/14/liblsan.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/liblsan.so
+usr/lib/gcc/x86_64-pc-linux-gnu/14/liblsan.so.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/liblsan.so.0.0.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/liblsan_preinit.o
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libquadmath.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libquadmath.so
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libquadmath.so.0
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libquadmath.so.0.0.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libsanitizer.spec
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libssp.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libssp.so
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libssp.so.0
@@ -211,6 +233,15 @@
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libssp_nonshared.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libstdc++exp.a
 usr/lib/gcc/x86_64-pc-linux-gnu/14/libstdc++fs.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libtsan.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libtsan.so
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libtsan.so.2
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libtsan.so.2.0.0
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libtsan_preinit.o
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libubsan.a
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libubsan.so
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libubsan.so.1
+usr/lib/gcc/x86_64-pc-linux-gnu/14/libubsan.so.1.0.0
 usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin
 usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/gtype.state
 usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/include
```