### PR TITLE
glibc: compare previous testresults, fail on regression

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -243,43 +243,43 @@ subpackages:
             cat > /tmp/compare-glibc-tests.sh << 'EOF'
             #!/bin/sh
             set -e
-            
+
             # Script to compare glibc test results and detect regressions
             # Usage: ./compare-glibc-tests.sh <current_results_dir> <previous_results_dir>
-            
+
             if [ $# -ne 2 ]; then
                 echo "Usage: $0 <current_results_dir> <previous_results_dir>"
                 exit 1
             fi
-            
+
             CURRENT_DIR="$1"
             PREVIOUS_DIR="$2"
-            
+
             echo "Comparing glibc test results..."
             echo "Current: $CURRENT_DIR"
             echo "Previous: $PREVIOUS_DIR"
             echo
-            
+
             # Use temporary files to track counts (to avoid subshell issues)
             REGRESSION_FILE=$(mktemp)
             NEW_FAILURE_FILE=$(mktemp)
             echo 0 > "$REGRESSION_FILE"
             echo 0 > "$NEW_FAILURE_FILE"
-            
+
             # Find all test result files in current results
             find "$CURRENT_DIR" -name "*.test-result" -type f | while read current_file; do
                 # Get relative path from base directory
                 relative_path="${current_file#$CURRENT_DIR/}"
                 previous_file="$PREVIOUS_DIR/$relative_path"
-                
+
                 # Extract test name and result
                 test_name="${relative_path%.test-result}"
                 current_result=$(grep -E "^(PASS|FAIL|XPASS|XFAIL|SKIP|UNSUPPORTED):" "$current_file" | head -1 | cut -d: -f1)
-                
+
                 if [ -f "$previous_file" ]; then
                     # Test existed before, check for regression
                     previous_result=$(grep -E "^(PASS|FAIL|XPASS|XFAIL|SKIP|UNSUPPORTED):" "$previous_file" | head -1 | cut -d: -f1)
-                    
+
                     # Check for regression: PASS -> FAIL
                     if [ "$previous_result" = "PASS" ] && [ "$current_result" = "FAIL" ]; then
                         echo "REGRESSION: $test_name was PASS, now FAIL"
@@ -295,20 +295,20 @@ subpackages:
                     fi
                 fi
             done
-            
+
             # Read final counts
             REGRESSION_COUNT=$(cat "$REGRESSION_FILE")
             NEW_FAILURE_COUNT=$(cat "$NEW_FAILURE_FILE")
-            
+
             # Clean up temp files
             rm -f "$REGRESSION_FILE" "$NEW_FAILURE_FILE"
-            
+
             # Summary
             echo
             echo "=== SUMMARY ==="
             echo "Regressions (PASS -> FAIL): $REGRESSION_COUNT"
             echo "New test failures: $NEW_FAILURE_COUNT"
-            
+
             # Exit with error if any regressions or new failures found
             if [ $REGRESSION_COUNT -gt 0 ] || [ $NEW_FAILURE_COUNT -gt 0 ]; then
                 echo
@@ -321,18 +321,18 @@ subpackages:
             fi
             EOF
             chmod +x /tmp/compare-glibc-tests.sh
-            
+
             # Copy current results to /current
             mkdir -p /current
             cp -r /usr/share/glibc-testresults/* /current
-            
+
             # Try to install previous version of glibc-testresults
-            apk add --no-cache "glibc-testresults<${{package.version}}"
+            apk add --no-cache "glibc-testresults<${{package.full-version}}"
 
             # Copy previous results to /previous
             mkdir -p /previous
             cp -r /usr/share/glibc-testresults/* /previous
-            
+
             # Run comparison
             /tmp/compare-glibc-tests.sh /current /previous
 

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 53
+  epoch: 54
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -231,6 +231,110 @@ subpackages:
       runtime:
         - merged-lib
         - wolfi-baselayout
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools # So we can install previous glibc-testresults
+      pipeline:
+        - name: Check test results
+          runs: |
+            # Create comparison script
+            cat > /tmp/compare-glibc-tests.sh << 'EOF'
+            #!/bin/sh
+            set -e
+            
+            # Script to compare glibc test results and detect regressions
+            # Usage: ./compare-glibc-tests.sh <current_results_dir> <previous_results_dir>
+            
+            if [ $# -ne 2 ]; then
+                echo "Usage: $0 <current_results_dir> <previous_results_dir>"
+                exit 1
+            fi
+            
+            CURRENT_DIR="$1"
+            PREVIOUS_DIR="$2"
+            
+            echo "Comparing glibc test results..."
+            echo "Current: $CURRENT_DIR"
+            echo "Previous: $PREVIOUS_DIR"
+            echo
+            
+            # Use temporary files to track counts (to avoid subshell issues)
+            REGRESSION_FILE=$(mktemp)
+            NEW_FAILURE_FILE=$(mktemp)
+            echo 0 > "$REGRESSION_FILE"
+            echo 0 > "$NEW_FAILURE_FILE"
+            
+            # Find all test result files in current results
+            find "$CURRENT_DIR" -name "*.test-result" -type f | while read current_file; do
+                # Get relative path from base directory
+                relative_path="${current_file#$CURRENT_DIR/}"
+                previous_file="$PREVIOUS_DIR/$relative_path"
+                
+                # Extract test name and result
+                test_name="${relative_path%.test-result}"
+                current_result=$(grep -E "^(PASS|FAIL|XPASS|XFAIL|SKIP|UNSUPPORTED):" "$current_file" | head -1 | cut -d: -f1)
+                
+                if [ -f "$previous_file" ]; then
+                    # Test existed before, check for regression
+                    previous_result=$(grep -E "^(PASS|FAIL|XPASS|XFAIL|SKIP|UNSUPPORTED):" "$previous_file" | head -1 | cut -d: -f1)
+                    
+                    # Check for regression: PASS -> FAIL
+                    if [ "$previous_result" = "PASS" ] && [ "$current_result" = "FAIL" ]; then
+                        echo "REGRESSION: $test_name was PASS, now FAIL"
+                        count=$(cat "$REGRESSION_FILE")
+                        echo $((count + 1)) > "$REGRESSION_FILE"
+                    fi
+                else
+                    # New test, check if it's failing
+                    if [ "$current_result" = "FAIL" ]; then
+                        echo "NEW FAILURE: $test_name is a new test that is FAIL"
+                        count=$(cat "$NEW_FAILURE_FILE")
+                        echo $((count + 1)) > "$NEW_FAILURE_FILE"
+                    fi
+                fi
+            done
+            
+            # Read final counts
+            REGRESSION_COUNT=$(cat "$REGRESSION_FILE")
+            NEW_FAILURE_COUNT=$(cat "$NEW_FAILURE_FILE")
+            
+            # Clean up temp files
+            rm -f "$REGRESSION_FILE" "$NEW_FAILURE_FILE"
+            
+            # Summary
+            echo
+            echo "=== SUMMARY ==="
+            echo "Regressions (PASS -> FAIL): $REGRESSION_COUNT"
+            echo "New test failures: $NEW_FAILURE_COUNT"
+            
+            # Exit with error if any regressions or new failures found
+            if [ $REGRESSION_COUNT -gt 0 ] || [ $NEW_FAILURE_COUNT -gt 0 ]; then
+                echo
+                echo "Test comparison FAILED: Found regressions or new failures"
+                exit 1
+            else
+                echo
+                echo "Test comparison PASSED: No regressions or new failures found"
+                exit 0
+            fi
+            EOF
+            chmod +x /tmp/compare-glibc-tests.sh
+            
+            # Copy current results to /current
+            mkdir -p /current
+            cp -r /usr/share/glibc-testresults/* /current
+            
+            # Try to install previous version of glibc-testresults
+            apk add --no-cache "glibc-testresults<${{package.version}}"
+
+            # Copy previous results to /previous
+            mkdir -p /previous
+            cp -r /usr/share/glibc-testresults/* /previous
+            
+            # Run comparison
+            /tmp/compare-glibc-tests.sh /current /previous
 
   - name: "ld-linux"
     description: "the GLIBC ELF interpreter"


### PR DESCRIPTION
The intention behind having the `glibc-testresults` package was to eventually use it to drive toward it passing, then make it a required check.

Toward that end, it was proposed we could diff the current results vs the last ones, and fail if we regressed. This is an attempt at doing that.

This fails for me locally (2.41-r53 regresses from 2.41-r52), but at least it should demonstrate the idea. I'm not sure what would have regressed or how.

I'm bumping the epoch to r54 in this PR, so that elastic-build runs the test, but then we should expect that it doesn't regress (if it does, that's a problem!).

Opening in draft to get feedback, even if that feedback is "we're not ready to do this yet" or anything like that.