### PR TITLE
Updated crossplane-provider-keycloak to 1.9.2

### DIFF
--- a/crossplane-provider-keycloak.yaml
+++ b/crossplane-provider-keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-keycloak
-  version: 1.7.0
-  epoch: 12
+  version: 1.9.2
+  epoch: 0
   description: Official Keycloak Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 12dcc112937e0b4451cd1080dd5217ebfacc2b4b
+      expected-commit: 5cd3042a585b7effa0ff708532e620d17c1c4892
       repository: https://github.com/crossplane-contrib/provider-keycloak
       tag: v${{package.version}}
       recurse-submodules: true


### PR DESCRIPTION
Update check issue is known and will be fixed after the intermediary versions are merged as per the escalation.
