### PR TITLE
Updated crossplane-provider-keycloak to 1.11.0

### DIFF
--- a/crossplane-provider-keycloak.yaml
+++ b/crossplane-provider-keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-keycloak
-  version: 1.7.0
-  epoch: 12
+  version: 1.11.0
+  epoch: 0
   description: Official Keycloak Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 12dcc112937e0b4451cd1080dd5217ebfacc2b4b
+      expected-commit: 87db37b2283e50d299553ee975529ccaaf19f007
       repository: https://github.com/crossplane-contrib/provider-keycloak
       tag: v${{package.version}}
       recurse-submodules: true


### PR DESCRIPTION


Update check issue is known and will be fixed after the intermediary versions are merged as per the escalation.
