### PR TITLE
Updated crossplane-provider-keycloak to 2.1.0

### DIFF
--- a/crossplane-provider-keycloak.yaml
+++ b/crossplane-provider-keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-keycloak
-  version: 1.7.0
-  epoch: 12
+  version: 2.1.0
+  epoch: 0
   description: Official Keycloak Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 12dcc112937e0b4451cd1080dd5217ebfacc2b4b
+      expected-commit: 7abd3d3670b7ecf405d5e0b13d7d3dde9f09dfb1
       repository: https://github.com/crossplane-contrib/provider-keycloak
       tag: v${{package.version}}
       recurse-submodules: true
@@ -35,9 +35,7 @@ pipeline:
     with:
       deps: |-
         github.com/hashicorp/go-retryablehttp@v0.7.7
-        golang.org/x/crypto@v0.35.0
         golang.org/x/oauth2@v0.27.0
-        golang.org/x/net@v0.38.0
         github.com/cloudflare/circl@v1.6.1
 
   - name: Code Generation


### PR DESCRIPTION


Update check issue is known and will be fixed after the intermediary versions are merged as per the escalation.
