### PR TITLE
feat: add pushprox package

### DIFF
--- a/pushprox.yaml
+++ b/pushprox.yaml
@@ -51,8 +51,49 @@ test:
     contents:
       packages:
         - ${{package.name}}-client
+        - curl
+        - jq
   pipeline:
     - name: "Basic Smoke Test"
     - runs: |
         pushprox-client --help
         pushprox-proxy --help
+    - name: "Functional Test"
+    - runs: |
+        # Start proxy
+        pushprox-proxy --log.level=debug &
+        proxy_pid=$!
+        sleep 2
+
+        # Wait for proxy to be ready
+        until curl -sf http://localhost:8080/clients; do
+          echo "Waiting for proxy..."
+          sleep 2
+        done
+
+        # Start client and connect to proxy
+        pushprox-client --log.level=debug --proxy-url=http://localhost:8080 &
+        client_pid=$!
+        sleep 2
+
+        # Wait for client to register
+        attempt=0
+        while [ "$attempt" -lt 10 ]; do
+          connected=$(curl -sf http://localhost:8080/clients | jq 'length')
+          if [ "$connected" = "1" ]; then
+            echo "Client successfully registered with proxy."
+            break
+          fi
+          echo "Waiting for client to appear in proxy..."
+          attempt=$((attempt + 1))
+          sleep 2
+        done
+
+        if [ "$connected" != "1" ]; then
+          echo "Client did not register in time"
+          exit 1
+        fi
+
+        # Cleanup processes
+        kill $proxy_pid
+        kill $client_pid

--- a/pushprox.yaml
+++ b/pushprox.yaml
@@ -1,0 +1,58 @@
+package:
+  name: pushprox
+  version: "0.2.0"
+  epoch: 0
+  description: Proxy to allow Prometheus to scrape through NAT etc.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus-community/PushProx.git
+      tag: v${{package.version}}
+      expected-commit: 83cae523a829b055f26f20baa2201dec67ab6f37
+
+  - uses: go/build
+    with:
+      packages: ./cmd/proxy
+      output: ${{package.name}}-proxy
+      ldflags: |
+        -X main.Version=${{package.version}}
+        -extldflags '-static'
+
+subpackages:
+  - name: ${{package.name}}-client
+    description: pushprox-client binary
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/client/main.go
+          output: ${{package.name}}-client
+          ldflags: |
+            -X main.Version=${{package.version}}
+            -extldflags '-static'
+
+  - name: ${{package.name}}-compat
+    description: Compat package for ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/app
+          ln -sf /usr/bin/${{package.name}}-client "${{targets.contextdir}}"/app/${{package.name}}-client
+          ln -sf /usr/bin/${{package.name}}-proxy "${{targets.contextdir}}"/app/${{package.name}}-proxy
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-client
+  pipeline:
+    - name: "Basic Smoke Test"
+    - runs: |
+        pushprox-client --help
+        pushprox-proxy --help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
WIP
Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
