### PR TITLE
apache-arrow: Drop Python 3.10 support

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "20.0.0"
-  epoch: 3
+  epoch: 4
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,6 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -157,7 +156,6 @@ subpackages:
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
       runtime:
-        - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}


### PR DESCRIPTION
Arrow depends on Numpy which no longer supports Python 3.10; aligned
supported Pythons.
