### PR TITLE
add flux-operator-mcp

### DIFF
--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -19,24 +19,36 @@ pipeline:
       output: flux-operator
       ldflags: -X main.VERSION=${{package.version}}
 
-  - uses: go/build
-    with:
-      packages: ./cmd/mcp/
-      output: flux-operator-mcp
-      ldflags: -X main.VERSION=${{package.version}}
-
 subpackages:
+  - name: ${{package.name}}-mcp
+    description: mcp server for ${{package.name}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/mcp/
+          output: flux-operator-mcp
+          ldflags: -X main.VERSION=${{package.version}}
+
   - name: ${{package.name}}-compat
     description: compat package for ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"
           ln -sf /usr/bin/flux-operator ${{targets.contextdir}}/flux-operator
-          ln -sf /usr/bin/flux-operator-mcp ${{targets.contextdir}}/flux-operator-mcp
     test:
       pipeline:
         - runs: |
             stat /flux-operator
+
+  - name: ${{package.name}}-mcp-compat
+    description: compat package for flux-operator-mcp
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"
+          ln -sf /usr/bin/flux-operator-mcp ${{targets.contextdir}}/flux-operator-mcp
+    test:
+      pipeline:
+        - runs: |
             stat /flux-operator-mcp
 
 update:
@@ -54,24 +66,6 @@ test:
         - helm
         - curl
   pipeline:
-    - runs: |
-        /usr/bin/flux-operator --help 2>&1 | grep metrics-addr
-        /usr/bin/flux-operator-mcp -v | grep "${{package.version}}"
-    - uses: test/kwok/cluster
-    - name: "Functional test for opertor"
-      uses: test/daemon-check-output
-      with:
-        setup: |
-          helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --namespace flux-system --create-namespace
-        start: |
-          flux-operator --enable-leader-election=false
-        timeout: 30
-        expected_output: |
-          Starting EventSource
-          Starting workers
-          Starting Controller
-        post: |-
-          curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"
     # - name: "Functional test for operator-mcp"
     #   uses: test/daemon-check-output
     #   with:
@@ -86,3 +80,21 @@ test:
     #       Starting Controller
     #     post: |-
     #       curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"
+    - runs: |
+        /usr/bin/flux-operator --help 2>&1 | grep metrics-addr
+        /usr/bin/flux-operator-mcp -v | grep "${{package.version}}"
+    - uses: test/kwok/cluster
+    - name: "Functional test for operator"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --namespace flux-system --create-namespace
+        start: |
+          flux-operator --enable-leader-election=false
+        timeout: 30
+        expected_output: |
+          Starting EventSource
+          Starting workers
+          Starting Controller
+        post: |-
+          curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"

--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -28,6 +28,52 @@ subpackages:
           packages: ./cmd/mcp/
           output: flux-operator-mcp
           ldflags: -X main.VERSION=${{package.version}}
+    test:
+      environment:
+        environment:
+          KUBECONFIG: "~/.kube/config"
+        contents:
+          packages:
+            - coreutils
+            - curl
+      pipeline:
+        - runs: |
+            /usr/bin/flux-operator-mcp -v | grep "${{package.version}}"
+        - name: "MCP Server API test"
+          runs: |
+            flux-operator-mcp serve --transport sse --port 9090 --read-only &
+            MCP_PID=$!
+            sleep 3
+
+            stdbuf -oL curl -s http://localhost:9090/sse >/tmp/sse_output 2>&1 &
+            PID1=$!
+            sleep 2
+
+            # Extract and sanitize session ID
+            SESSION_ID=$(grep "sessionId=" /tmp/sse_output | cut -d'=' -f2 | head -n1 | tr -d '\r\n ')
+            echo "Session ID: $SESSION_ID"
+
+            # Allow brief delay to ensure session is active
+            sleep 1
+
+            # Send RPC requests
+            curl -s -X POST "http://localhost:9090/message?sessionId=$SESSION_ID" \
+              -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}},"id":1}'
+
+            curl -s -X POST "http://localhost:9090/message?sessionId=$SESSION_ID" \
+              -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}'
+
+            # Give the SSE stream time to receive the response
+            sleep 1
+
+            # Validate the SSE output includes expected tool
+            grep -q "get_flux_instance" /tmp/sse_output
+
+            # Now it's safe to kill the background SSE listener
+            kill $PID1
+            kill $MCP_PID
 
   - name: ${{package.name}}-compat
     description: compat package for ${{package.name}}
@@ -66,23 +112,8 @@ test:
         - helm
         - curl
   pipeline:
-    # - name: "Functional test for operator-mcp"
-    #   uses: test/daemon-check-output
-    #   with:
-    #     setup: |
-    #       helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator-mcp --namespace flux-system --create-namespace
-    #     start: |
-    #       flux-operator-mcp --enable-leader-election=false
-    #     timeout: 30
-    #     expected_output: |
-    #       Starting EventSource
-    #       Starting workers
-    #       Starting Controller
-    #     post: |-
-    #       curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"
     - runs: |
         /usr/bin/flux-operator --help 2>&1 | grep metrics-addr
-        /usr/bin/flux-operator-mcp -v | grep "${{package.version}}"
     - uses: test/kwok/cluster
     - name: "Functional test for operator"
       uses: test/daemon-check-output

--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-operator
   version: "0.24.1"
-  epoch: 0
+  epoch: 1
   description: Flux Operator creates and manages Flux instances running in Kubernetes
   copyright:
     - license: AGPL-3.0-or-later
@@ -19,6 +19,12 @@ pipeline:
       output: flux-operator
       ldflags: -X main.VERSION=${{package.version}}
 
+  - uses: go/build
+    with:
+      packages: ./cmd/mcp/
+      output: flux-operator-mcp
+      ldflags: -X main.VERSION=${{package.version}}
+
 subpackages:
   - name: ${{package.name}}-compat
     description: compat package for ${{package.name}}
@@ -26,9 +32,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"
           ln -sf /usr/bin/flux-operator ${{targets.contextdir}}/flux-operator
+          ln -sf /usr/bin/flux-operator-mcp ${{targets.contextdir}}/flux-operator-mcp
     test:
       pipeline:
-        - runs: stat /flux-operator
+        - runs: |
+            stat /flux-operator
+            stat /flux-operator-mcp
 
 update:
   enabled: true
@@ -47,8 +56,9 @@ test:
   pipeline:
     - runs: |
         /usr/bin/flux-operator --help 2>&1 | grep metrics-addr
+        /usr/bin/flux-operator-mcp -v | grep "${{package.version}}"
     - uses: test/kwok/cluster
-    - name: "Functional test"
+    - name: "Functional test for opertor"
       uses: test/daemon-check-output
       with:
         setup: |
@@ -62,3 +72,17 @@ test:
           Starting Controller
         post: |-
           curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"
+    # - name: "Functional test for operator-mcp"
+    #   uses: test/daemon-check-output
+    #   with:
+    #     setup: |
+    #       helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator-mcp --namespace flux-system --create-namespace
+    #     start: |
+    #       flux-operator-mcp --enable-leader-election=false
+    #     timeout: 30
+    #     expected_output: |
+    #       Starting EventSource
+    #       Starting workers
+    #       Starting Controller
+    #     post: |-
+    #       curl -fsSL localhost:8080/metrics | grep -i "workqueue_work_duration_seconds_bucket"

--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -95,7 +95,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            stat /flux-operator-mcp
+            test "$(readlink /flux-operator-mcp)" = "/usr/bin/flux-operator-mcp"
 
 update:
   enabled: true


### PR DESCRIPTION
The Flux MCP Server connects AI assistants directly to your Kubernetes clusters running Flux Operator, enabling GitOps analysis and troubleshooting through natural language.
https://github.com/controlplaneio-fluxcd/flux-operator/tree/main/cmd/mcp


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
