### PR TITLE
add doppler package

### DIFF
--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,32 @@
+package:
+  name: doppler
+  version: "3.75.1"
+  epoch: 0
+  description: The official CLI for interacting with your Doppler secrets and configuration
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DopplerHQ/cli
+      tag: ${{package.version}}
+      expected-commit: 1f6b5f49ec5ed479d2dd22eaf374141cce7bf7e4
+
+  - uses: go/build
+    with:
+      packages: .
+      output: doppler
+      ldflags: |
+        -X github.com/DopplerHQ/cli/pkg/version.ProgramVersion=${{package.version}}
+
+update:
+  enabled: true
+  git: {}
+
+test:
+  pipeline:
+    - name: "Test doppler version"
+      runs: |
+        doppler --version | grep ${{package.version}}
+        doppler --help


### PR DESCRIPTION
adds doppler package and tests are very minimal because a token is required here. 

```bash
# doppler setup
Doppler Error: you must provide a token
# doppler setup -t asdfqwerty
Unable to fetch projects
Doppler Error: Invalid Auth token
```