### PR TITLE
superset: depend on ecpg and libecpg-dev

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: "5.0.0"
-  epoch: 1
+  epoch: 2
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ package:
     no-provides: true
   dependencies:
     runtime:
+      - ecpg
       - libgomp
       - libtbb-dev
       - openssl
@@ -238,6 +239,8 @@ test:
       packages:
         - ${{package.name}}-entrypoint
   pipeline:
+    - runs: |
+        ecpg --help
     - uses: test/tw/ldd-check
     - uses: test/daemon-check-output
       with:


### PR DESCRIPTION
Superset needs `ecpg` which now has been introduced and depends on `libecpg-dev`. The preprocessor for C is needed by Superset during SQL query validation.