### PR TITLE
erl{25-28}-rebar3: set provides rebar3 + provider priority based on erlang version

### DIFF
--- a/electric.yaml
+++ b/electric.yaml
@@ -1,7 +1,7 @@
 package:
   name: electric
   version: "1.0.24"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -1,13 +1,15 @@
 package:
   name: erl25-rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 0
+  epoch: 1
   version: 3.25.0
   copyright:
     - license: Apache-2.0
   options:
     # escript is not provided by any erlang version
     no-depends: true
+  dependencies:
+    provider-priority: ${{vars.erlMM}}
 
 environment:
   contents:

--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -65,3 +65,6 @@ test:
         stat _build/default/lib/myscript/ebin/myscript.beam
         rebar3 clean
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
+    - uses: test/virtualpackage
+      with:
+        virtual-pkg-name: rebar3

--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -67,4 +67,5 @@ test:
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
     - uses: test/virtualpackage
       with:
+        real-pkg-name: "${{package.name}}"
         virtual-pkg-name: rebar3

--- a/erl25-rebar3.yaml
+++ b/erl25-rebar3.yaml
@@ -10,6 +10,8 @@ package:
     no-depends: true
   dependencies:
     provider-priority: ${{vars.erlMM}}
+    provides:
+      - rebar3
 
 environment:
   contents:

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -65,3 +65,6 @@ test:
         stat _build/default/lib/myscript/ebin/myscript.beam
         rebar3 clean
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
+    - uses: test/virtualpackage
+      with:
+        virtual-pkg-name: rebar3

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -1,13 +1,15 @@
 package:
   name: erl26-rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 0
+  epoch: 1
   version: 3.25.0
   copyright:
     - license: Apache-2.0
   options:
     # escript is not provided by any erlang version
     no-depends: true
+  dependencies:
+    provider-priority: ${{vars.erlMM}}
 
 environment:
   contents:

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -67,4 +67,5 @@ test:
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
     - uses: test/virtualpackage
       with:
+        real-pkg-name: "${{package.name}}"
         virtual-pkg-name: rebar3

--- a/erl26-rebar3.yaml
+++ b/erl26-rebar3.yaml
@@ -10,6 +10,8 @@ package:
     no-depends: true
   dependencies:
     provider-priority: ${{vars.erlMM}}
+    provides:
+      - rebar3
 
 environment:
   contents:

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -65,3 +65,6 @@ test:
         stat _build/default/lib/myscript/ebin/myscript.beam
         rebar3 clean
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
+    - uses: test/virtualpackage
+      with:
+        virtual-pkg-name: rebar3

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -1,13 +1,15 @@
 package:
   name: erl27-rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 0
+  epoch: 1
   version: 3.25.0
   copyright:
     - license: Apache-2.0
   options:
     # escript is not provided by any erlang version
     no-depends: true
+  dependencies:
+    provider-priority: ${{vars.erlMM}}
 
 environment:
   contents:

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -67,4 +67,5 @@ test:
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
     - uses: test/virtualpackage
       with:
+        real-pkg-name: "${{package.name}}"
         virtual-pkg-name: rebar3

--- a/erl27-rebar3.yaml
+++ b/erl27-rebar3.yaml
@@ -10,6 +10,8 @@ package:
     no-depends: true
   dependencies:
     provider-priority: ${{vars.erlMM}}
+    provides:
+      - rebar3
 
 environment:
   contents:

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -67,5 +67,5 @@ test:
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
     - uses: test/virtualpackage
       with:
-        real-pkg-name: "${{package.name}}"        
+        real-pkg-name: "${{package.name}}"
         virtual-pkg-name: rebar3

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -65,3 +65,6 @@ test:
         stat _build/default/lib/myscript/ebin/myscript.beam
         rebar3 clean
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
+    - uses: test/virtualpackage
+      with:
+        virtual-pkg-name: rebar3

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -1,13 +1,15 @@
 package:
   name: erl28-rebar3
   description: Erlang build tool that makes it easy to compile and test Erlang applications and releases.
-  epoch: 0
+  epoch: 1
   version: 3.25.0
   copyright:
     - license: Apache-2.0
   options:
     # escript is not provided by any erlang version
     no-depends: true
+  dependencies:
+    provider-priority: ${{vars.erlMM}}
 
 environment:
   contents:

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -10,6 +10,8 @@ package:
     no-depends: true
   dependencies:
     provider-priority: ${{vars.erlMM}}
+    provides:
+      - rebar3
 
 environment:
   contents:

--- a/erl28-rebar3.yaml
+++ b/erl28-rebar3.yaml
@@ -67,4 +67,5 @@ test:
         { stat _build/default/lib/myscript/ebin/myscript.beam || true ; } 2>&1 | grep "can't stat"
     - uses: test/virtualpackage
       with:
+        real-pkg-name: "${{package.name}}"        
         virtual-pkg-name: rebar3


### PR DESCRIPTION
Ensure that the most recent Erlang rebar3 package is used when a package just declares a dependency on rebar3.