### PR TITLE
pipelines: add new metapackage test

### DIFF
--- a/pipelines/test/metapackage.yaml
+++ b/pipelines/test/metapackage.yaml
@@ -1,0 +1,39 @@
+name: metapackage
+
+# A metapackage is an empty package that only declares dependencies on other packages.
+# This package test ensures a metapackage remains correct and does not regress.
+#
+# Please note the difference with virtual packages. They both act as kind of "shortcuts"
+# to get other packages installed, but with important nuances:
+# Virtual packages don't get installed. Real packages relate to virtual packages via 'provides' directive.
+# Metapackages do get installed, but they are empty. They relate to the actual packages via normal runtime dependency
+pipeline:
+  - uses: test/emptypackage
+  - name: metapackage keyword validation
+    description: Checks that a metapackage description contains the 'meta' keyword
+    runs: |
+      pkg="${{context.name}}"
+
+      # the tail trick here skips the title line and leaves only the description
+      description=$(apk info --installed --description $pkg | tail -n +2)
+
+      if ! echo "$description" | grep -qi "meta"; then
+        echo "FAIL: metapackage [$pkg] description does not contain 'meta' keyword"
+        echo "Description: $description"
+        exit 1
+      fi
+      echo "PASS: metapackage [$pkg] description contains 'meta' keyword"
+  - name: metapackage dependency validation
+    description: Checks that a metapackage contains at least one runtime dependency
+    runs: |
+      pkg="${{context.name}}"
+
+      # the tail trick here skips the title line and leaves only the lines for dependencies
+      # then we remove empty lines, and count remaining lines
+      depends_count=$(apk info --installed --depends $pkg | tail -n +2 | grep -v ^$ | wc -l)
+
+      if [ "${depends_count}" == "0" ]; then
+        echo "FAIL: metapackage [$pkg] has no runtime dependencies"
+        exit 1
+      fi
+      echo "PASS: metapackage [$pkg] has $depends_count runtime dependencies"

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fsspec
   version: "2025.5.1"
-  epoch: 1
+  epoch: 2
   description: File-system specification
   copyright:
     - license: BSD-3-Clause
@@ -73,6 +73,9 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: test/metapackage
 
 update:
   enabled: true


### PR DESCRIPTION
Add new metapackage test pipeline, to verify that a meta package complies with three things:
 * it is empty
 * it has at least 1 runtime dependency
 * it contains the 'meta' keyword in the description

While at it, add the new test to the py3-fsspec package to demonstrate usage.