### PR TITLE
Update ruby3.2-aws-sdk-core to 3.226.2

### DIFF
--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: ruby3.2-aws-sdk-core
-  version: 3.211.0
-  epoch: 1
+  version: "3.226.2"
+  epoch: 0
   description: Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 86cccb96ed7a0ee71cd33847151b4219d30b1571
+      expected-commit: 9a28c56e599f67d6e679011cce59d0dbd8cd6e36
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
       depth: -1
@@ -47,6 +47,42 @@ pipeline:
 
 vars:
   gem: aws-sdk-core
+  latest-version-script: |
+    #!/bin/bash
+    set -e
+
+    PROJECT=aws-sdk-core
+    echo "hello"
+
+    if ! command -v git &> /dev/null; then
+        exit 1
+    fi
+    REPO_URL="https://github.com/aws/aws-sdk-ruby.git"
+    BRANCH="version-3"
+    REPO_DIR="aws-sdk-ruby"
+    OUTPUT=""
+
+    # Ensure the repository directory is set
+    if [ -d "$REPO_DIR" ]; then
+        cd "$REPO_DIR"
+        git pull origin "$BRANCH" 2>&1 || true
+    else
+        git clone --branch "$BRANCH" "$REPO_URL" "$REPO_DIR" 2>&1
+        cd "$REPO_DIR"
+    fi
+      VERSION_FILE="./gems/$PROJECT/VERSION"
+      if [ -f "$VERSION_FILE" ]; then
+          version=$(cat "$VERSION_FILE")
+          OUTPUT="latest-version:$version"
+      else
+          exit 1
+    fi
+    # get the latest commit hash
+    latest_commit=$(git rev-parse HEAD)
+    OUTPUT="$OUTPUT\nexpected-commit:$latest_commit"
+    cd ..
+    echo "----OUTPUT----"
+    echo -e "$OUTPUT"
 
 test:
   environment:


### PR DESCRIPTION
This PR updates ruby3.2-aws-sdk-core to the latest version 3.226.2.

Changes made:
- Updated package version to 3.226.2
- Updated expected commit SHA if applicable

Generated automatically by package update script.