### PR TITLE
Update ruby3.2-aws-sigv4 to 1.12.1

### DIFF
--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: ruby3.2-aws-sigv4
-  version: 1.10.1
+  version: "1.12.1"
   epoch: 0
   description: Amazon Web Services Signature Version 4 signing library. Generates sigv4 signature for HTTP requests.
   copyright:
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 86cccb96ed7a0ee71cd33847151b4219d30b1571
+      expected-commit: 9a28c56e599f67d6e679011cce59d0dbd8cd6e36
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
       depth: -1
@@ -44,6 +44,42 @@ pipeline:
 
 vars:
   gem: aws-sigv4
+  latest-version-script: |
+    #!/bin/bash
+    set -e
+
+    PROJECT=aws-sigv4
+    echo "hello"
+
+    if ! command -v git &> /dev/null; then
+        exit 1
+    fi
+    REPO_URL="https://github.com/aws/aws-sdk-ruby.git"
+    BRANCH="version-3"
+    REPO_DIR="aws-sdk-ruby"
+    OUTPUT=""
+
+    # Ensure the repository directory is set
+    if [ -d "$REPO_DIR" ]; then
+        cd "$REPO_DIR"
+        git pull origin "$BRANCH" 2>&1 || true
+    else
+        git clone --branch "$BRANCH" "$REPO_URL" "$REPO_DIR" 2>&1
+        cd "$REPO_DIR"
+    fi
+      VERSION_FILE="./gems/$PROJECT/VERSION"
+      if [ -f "$VERSION_FILE" ]; then
+          version=$(cat "$VERSION_FILE")
+          OUTPUT="latest-version:$version"
+      else
+          exit 1
+    fi
+    # get the latest commit hash
+    latest_commit=$(git rev-parse HEAD)
+    OUTPUT="$OUTPUT\nexpected-commit:$latest_commit"
+    cd ..
+    echo "----OUTPUT----"
+    echo -e "$OUTPUT"
 
 test:
   environment:


### PR DESCRIPTION
This PR updates ruby3.2-aws-sigv4 to the latest version 1.12.1.

Changes made:
- Updated package version to 1.12.1
- Updated expected commit SHA if applicable

Generated automatically by package update script.