### PR TITLE
feat(druid): bump deps to remediate GHSA-j288-q9x7-2f5v and GHSA-xwmg-2g98-w7v9

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: "33.0.0"
-  epoch: 4
+  epoch: 5
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,11 @@ pipeline:
       expected-commit: 84b59b984b69ebc34e0c971ad207b69384941c0b
 
   - uses: maven/pombump
+
+  - uses: maven/pombump
+    with:
+      patch-file: extensions/druid-pac4j/pombump-deps.yaml
+      pom: extensions-core/druid-pac4j/pom.xml
 
   - runs: |
       mvn -B -ff -q \

--- a/druid/extensions/druid-pac4j/pombump-deps.yaml
+++ b/druid/extensions/druid-pac4j/pombump-deps.yaml
@@ -1,0 +1,4 @@
+patches:
+  - groupId: com.nimbusds
+    artifactId: nimbus-jose-jwt
+    version: 10.0.2

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -26,3 +26,9 @@ patches:
   - groupId: commons-beanutils
     artifactId: commons-beanutils
     version: 1.11.0
+  - groupId: org.apache.commons
+    artifactId: commons-lang3
+    version: 3.18.0
+  - groupId: com.nimbusds
+    artifactId: nimbus-jose-jwt
+    version: 10.0.2


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump deps to remediate https://github.com/advisories/GHSA-j288-q9x7-2f5v and https://github.com/advisories/GHSA-xwmg-2g98-w7v9
