### PR TITLE
Create symlink for metrics-server binary at root of filesystem

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -47,7 +47,7 @@ subpackages:
             set -o pipefail
             readlink -f /coredns | grep /usr/bin/coredns
             /coredns --version
-            coredns --help
+            /coredns --help
 
   - name: kuma-coredns
     description: CoreDNS with plugins used by Kuma

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: "1.12.2"
-  epoch: 0
+  epoch: 1
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,23 @@ pipeline:
   - runs: setcap cap_net_bind_service=+ep "${{targets.contextdir}}/usr/bin/coredns"
 
 subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -s /usr/bin/coredns ${{targets.subpkgdir}}/coredns
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - runs: |
+            set -o pipefail
+            readlink -f /coredns | grep /usr/bin/coredns
+            /coredns --version
+            coredns --help
+
   - name: kuma-coredns
     description: CoreDNS with plugins used by Kuma
     pipeline:

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -39,8 +39,7 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     pipeline:
-      - working-directory: ${{targets.subpkgdir}}
-        runs: |
+      - runs: |
           mkdir -p "${{targets.subpkgdir}}"
           ln -s /usr/bin/metrics-server ${{targets.subpkgdir}}/metrics-server
     test:
@@ -50,8 +49,10 @@ subpackages:
             - ${{package.name}}
       pipeline:
         - runs: |
+            set -o pipefail
             readlink -f /metrics-server | grep /usr/bin/metrics-server
             /metrics-server --help
+            /metrics-server --version
 
   # Note, we don't need to fetch any upstream files, as there aren't any custom
   # entrypoints or scripts required for compatibility with the metrics-server

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: "0.8.0"
-  epoch: 0
+  epoch: 1
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   copyright:
     - license: Apache-2.0
@@ -36,10 +36,26 @@ pipeline:
 
   - uses: strip
 
-# Note, we don't need to fetch any upstream files, as there aren't any custom
-# entrypoints or scripts required for compatibility with the metrics-server
-# Bitnami helm chart.
 subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}
+        runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -s /usr/bin/metrics-server ${{targets.subpkgdir}}/metrics-server
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - runs: |
+            readlink -f /metrics-server | grep /usr/bin/metrics-server
+            /metrics-server --help
+
+  # Note, we don't need to fetch any upstream files, as there aren't any custom
+  # entrypoints or scripts required for compatibility with the metrics-server
+  # Bitnami helm chart.
   - name: ${{package.name}}-bitnami-compat
     description: "Compatibility package for usage with the Bitnami helm chart."
     pipeline:
@@ -58,6 +74,7 @@ subpackages:
         - runs: |
             /opt/bitnami/metrics-server/bin/metrics-server --version
             /opt/bitnami/metrics-server/bin/metrics-server --help
+
   - name: ${{package.name}}-iamguarded-compat
     description: "compat package for iamguarded"
     pipeline:


### PR DESCRIPTION
Creates root level symlinks to the binaries, for closer alignment with other deployment mechanisms, which may expect to find the binaries here