### PR TITLE
No change rebuilds for the latest version of ImageMagick

### DIFF
--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-imagick
   version: "3.8.0"
-  epoch: 0
+  epoch: 1
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: "3.8.0"
-  epoch: 0
+  epoch: 1
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01

--- a/php-8.4-imagick.yaml
+++ b/php-8.4-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-imagick
   version: "3.8.0"
-  epoch: 1
+  epoch: 2
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/issues/59169

A few php-8.x-imagick packages were not rebuilt when we bumped imagemagick-7 to a later version.

php-8.1-imagick was handled due to an update of that upstream.