### PR TITLE
font-xorg: make co-installable

### DIFF
--- a/font-xorg-adobe100dpi.yaml
+++ b/font-xorg-adobe100dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-adobe100dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Adobe 100 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontadobe100dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -37,6 +39,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-adobe75dpi.yaml
+++ b/font-xorg-adobe75dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-adobe75dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Adobe 75 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontadobe75dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-adobeutopia100dpi.yaml
+++ b/font-xorg-adobeutopia100dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-adobeutopia100dpi
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: X.Org Adobe Utopia 100 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontadobeutopia100dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-adobeutopia75dpi.yaml
+++ b/font-xorg-adobeutopia75dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-adobeutopia75dpi
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: X.Org Adobe Utopia 75 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontadobeutopia75dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-adobeutopiatype1.yaml
+++ b/font-xorg-adobeutopiatype1.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-adobeutopiatype1
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: X.Org Adobe Utopia scalable Type 1 fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontadobeutopiatype1=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-arabicmisc.yaml
+++ b/font-xorg-arabicmisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-arabicmisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Arabic miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontarabicmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bh100dpi.yaml
+++ b/font-xorg-bh100dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bh100dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org B&H 100 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbh100dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bh75dpi.yaml
+++ b/font-xorg-bh75dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bh75dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org B&H 75 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbh75dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bhlucidatypewriter100dpi.yaml
+++ b/font-xorg-bhlucidatypewriter100dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bhlucidatypewriter100dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org B&H Lucida Typewriter 100 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbhlucidatypewriter100dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bhlucidatypewriter75dpi.yaml
+++ b/font-xorg-bhlucidatypewriter75dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bhlucidatypewriter75dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org B&H Lucida Typewriter 75 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbhlucidatypewriter75dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -37,6 +39,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bhtype1.yaml
+++ b/font-xorg-bhtype1.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bhtype1
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org B&H scalable Type 1 fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbhtype1=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bitstream100dpi.yaml
+++ b/font-xorg-bitstream100dpi.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bitstream100dpi
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Bitstream 100 dpi bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbitstream100dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-bitstreamtype1.yaml
+++ b/font-xorg-bitstreamtype1.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-bitstreamtype1
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Bitstream scalable Type 1 fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontbitstreamtype1=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-cursormisc.yaml
+++ b/font-xorg-cursormisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-cursormisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org cursor miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontcursormisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-daewoomisc.yaml
+++ b/font-xorg-daewoomisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-daewoomisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Daewoo miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontdaewoomisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-decmisc.yaml
+++ b/font-xorg-decmisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-decmisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org DEC miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontdecmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-dirs.yaml
+++ b/font-xorg-dirs.yaml
@@ -1,0 +1,35 @@
+package:
+  name: font-xorg-dirs
+  version: 1
+  epoch: 0
+  description: Rebuilds fonts.dir / fonts.scale after font changes
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - mkfontscale
+  scriptlets:
+    trigger:
+      paths:
+        - /usr/share/fonts/X11/*
+      script: |
+        #!/bin/sh
+        for d in /usr/share/fonts/X11/{75dpi,100dpi,Type1,misc,cyrillic}; do
+          [ -d "$d" ] || continue
+          mkfontscale "$d" 2>/dev/null || true
+          mkfontdir   "$d" 2>/dev/null || true
+        done
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/X11
+
+update:
+  enabled: false
+  exclude-reason: "This package contains a static configuration file, no updates are needed."

--- a/font-xorg-ibmtype1.yaml
+++ b/font-xorg-ibmtype1.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-ibmtype1
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org IBM scalable Type 1 fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontibmtype1=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-isasmisc.yaml
+++ b/font-xorg-isasmisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-isasmisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org ISAS miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontisasmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-schumachermisc.yaml
+++ b/font-xorg-schumachermisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-schumachermisc
   version: 1.1.3
-  epoch: 0
+  epoch: 1
   description: X.Org Schumacher miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontschumachermisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-screencyrillic.yaml
+++ b/font-xorg-screencyrillic.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-screencyrillic
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: X.Org screen Cyrillic bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontscreencyrillic=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-sonymisc.yaml
+++ b/font-xorg-sonymisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-sonymisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Sony miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontsonymisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-sunmisc.yaml
+++ b/font-xorg-sunmisc.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-sunmisc
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Sun miscellaneous bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontsunmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-winitzkicyrillic.yaml
+++ b/font-xorg-winitzkicyrillic.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-winitzkicyrillic
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: X.Org Winitzki Cyrillic bitmap fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontwinitzkicyrillic=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg-xfree86type1.yaml
+++ b/font-xorg-xfree86type1.yaml
@@ -1,13 +1,15 @@
 package:
   name: font-xorg-xfree86type1
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: X.Org XFree86 scalable Type 1 fonts
   copyright:
     - license: MIT
   dependencies:
     provides:
       - fonts-xorg-fontxfree86type1=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
 
 environment:
   contents:
@@ -39,6 +41,13 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
 
 update:
   enabled: true

--- a/font-xorg.yaml
+++ b/font-xorg.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-xorg
   version: 1
-  epoch: 0
+  epoch: 1
   description: "Meta package for X.Org fonts"
   dependencies:
     runtime:


### PR DESCRIPTION
`font-xorg-dirs` is for to provide fonts.dir and fonts.scale common dirs (using mkfontscale) across all of the font-xorg- packages, instead of duplicate, everywhere, this is a common package

Fix for:

```
fc4079cb3b9d:/work/packages# apk add font-xorg
(1/25) Installing font-xorg-adobe100dpi (1.0.4-r0)
(2/25) Installing font-xorg-adobe75dpi (1.0.4-r0)
(3/25) Installing font-xorg-adobeutopia100dpi (1.0.5-r0)
ERROR: font-xorg-adobeutopia100dpi-1.0.5-r0: trying to overwrite usr/share/fonts/X11/100dpi/fonts.dir owned by font-xorg-adobe100dpi-1.0.4-r0.
(4/25) Installing font-xorg-adobeutopia75dpi (1.0.5-r0)
ERROR: font-xorg-adobeutopia75dpi-1.0.5-r0: trying to overwrite usr/share/fonts/X11/75dpi/fonts.dir owned by font-xorg-adobe75dpi-1.0.4-r0.
(5/25) Installing font-xorg-adobeutopiatype1 (1.0.5-r0)
(6/25) Installing font-xorg-arabicmisc (1.0.4-r0)
(7/25) Installing font-xorg-bh100dpi (1.0.4-r0)
ERROR: font-xorg-bh100dpi-1.0.4-r0: trying to overwrite usr/share/fonts/X11/100dpi/fonts.dir owned by font-xorg-adobe100dpi-1.0.4-r0.
(8/25) Installing font-xorg-bh75dpi (1.0.4-r0)
ERROR: font-xorg-bh75dpi-1.0.4-r0: trying to overwrite usr/share/fonts/X11/75dpi/fonts.dir owned by font-xorg-adobe75dpi-1.0.4-r0.
(9/25) Installing font-xorg-bhlucidatypewriter100dpi (1.0.4-r0)
ERROR: font-xorg-bhlucidatypewriter100dpi-1.0.4-r0: trying to overwrite usr/share/fonts/X11/100dpi/fonts.dir owned by font-xorg-adobe100dpi-1.0.4-r0.
(10/25) Installing font-xorg-bhlucidatypewriter75dpi (1.0.4-r0)
ERROR: font-xorg-bhlucidatypewriter75dpi-1.0.4-r0: trying to overwrite usr/share/fonts/X11/75dpi/fonts.dir owned by font-xorg-adobe75dpi-1.0.4-r0.
(11/25) Installing font-xorg-bhtype1 (1.0.4-r0)
ERROR: font-xorg-bhtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.dir owned by font-xorg-adobeutopiatype1-1.0.5-r0.
ERROR: font-xorg-bhtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.scale owned by font-xorg-adobeutopiatype1-1.0.5-r0.
(12/25) Installing font-xorg-bitstream100dpi (1.0.4-r0)
ERROR: font-xorg-bitstream100dpi-1.0.4-r0: trying to overwrite usr/share/fonts/X11/100dpi/fonts.dir owned by font-xorg-adobe100dpi-1.0.4-r0.
(13/25) Installing font-xorg-bitstreamtype1 (1.0.4-r0)
ERROR: font-xorg-bitstreamtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.dir owned by font-xorg-adobeutopiatype1-1.0.5-r0.
ERROR: font-xorg-bitstreamtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.scale owned by font-xorg-adobeutopiatype1-1.0.5-r0.
(14/25) Installing font-xorg-cursormisc (1.0.4-r0)
ERROR: font-xorg-cursormisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(15/25) Installing font-xorg-daewoomisc (1.0.4-r0)
ERROR: font-xorg-daewoomisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(16/25) Installing font-xorg-decmisc (1.0.4-r0)
ERROR: font-xorg-decmisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(17/25) Installing font-xorg-ibmtype1 (1.0.4-r0)
ERROR: font-xorg-ibmtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.dir owned by font-xorg-adobeutopiatype1-1.0.5-r0.
ERROR: font-xorg-ibmtype1-1.0.4-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.scale owned by font-xorg-adobeutopiatype1-1.0.5-r0.
(18/25) Installing font-xorg-isasmisc (1.0.4-r0)
ERROR: font-xorg-isasmisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(19/25) Installing font-xorg-schumachermisc (1.1.3-r0)
ERROR: font-xorg-schumachermisc-1.1.3-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(20/25) Installing font-xorg-screencyrillic (1.0.5-r0)
(21/25) Installing font-xorg-sonymisc (1.0.4-r0)
ERROR: font-xorg-sonymisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(22/25) Installing font-xorg-sunmisc (1.0.4-r0)
ERROR: font-xorg-sunmisc-1.0.4-r0: trying to overwrite usr/share/fonts/X11/misc/fonts.dir owned by font-xorg-arabicmisc-1.0.4-r0.
(23/25) Installing font-xorg-winitzkicyrillic (1.0.4-r0)
ERROR: font-xorg-winitzkicyrillic-1.0.4-r0: trying to overwrite usr/share/fonts/X11/cyrillic/fonts.dir owned by font-xorg-screencyrillic-1.0.5-r0.
(24/25) Installing font-xorg-xfree86type1 (1.0.5-r0)
ERROR: font-xorg-xfree86type1-1.0.5-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.dir owned by font-xorg-adobeutopiatype1-1.0.5-r0.
ERROR: font-xorg-xfree86type1-1.0.5-r0: trying to overwrite usr/share/fonts/X11/Type1/fonts.scale owned by font-xorg-adobeutopiatype1-1.0.5-r0.
(25/25) Installing font-xorg (1-r0)
19 errors; 42 MiB in 40 packages
```

Example test:

```
82ce4bfb029e:/work/packages# apk add aarch64/font-xorg-adobeutopia100dpi-1.0.5-r1.apk 
(1/9) Installing libfontenc (1.1.8-r1)
(2/9) Installing libbrotlicommon1 (1.1.0-r5)
(3/9) Installing libbrotlidec1 (1.1.0-r5)
(4/9) Installing libbz2-1 (1.0.8-r18)
(5/9) Installing libpng (1.6.49-r0)
(6/9) Installing freetype (2.13.3-r1)
(7/9) Installing mkfontscale (1.2.3-r1)
(8/9) Installing font-xorg-dirs (1-r0)
(9/9) Installing font-xorg-adobeutopia100dpi (1.0.5-r1)
Executing busybox-1.37.0-r46.trigger
Executing mkfontscale-1.2.3-r1.trigger
Executing font-xorg-dirs-1-r0.trigger
OK: 17 MiB in 24 packages
82ce4bfb029e:/work/packages# apk add aarch64/font-xorg-adobeutopia75dpi-1.0.5-r1.apk 
(1/1) Installing font-xorg-adobeutopia75dpi (1.0.5-r1)
Executing mkfontscale-1.2.3-r1.trigger
Executing font-xorg-dirs-1-r0.trigger
OK: 18 MiB in 25 packages
```