### PR TITLE
feat(confluent-kafka): bump deps to remediate GHSA-j288-q9x7-2f5v and upgrade package

### DIFF
--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -8,8 +8,8 @@ package:
   # with the `version:` field.
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
-  version: "8.2.0.10"
-  epoch: 1
+  version: "8.2.0.22"
+  epoch: 0
   description: Community edition of Confluent Kafka.
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: edd6def80be8a8f82c5c949c638a8d634016ae0d
+      expected-commit: c990d2aa922f946be075519df570caf5b99538fb
       repository: https://github.com/confluentinc/kafka
       tag: v${{vars.mangled-package-version}}
 

--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -9,7 +9,7 @@ package:
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
   version: "8.2.0.10"
-  epoch: 0
+  epoch: 1
   description: Community edition of Confluent Kafka.
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,11 @@ pipeline:
       expected-commit: edd6def80be8a8f82c5c949c638a8d634016ae0d
       repository: https://github.com/confluentinc/kafka
       tag: v${{vars.mangled-package-version}}
+
+  - uses: patch
+    with:
+      patches: |
+        GHSA-j288-q9x7-2f5v.patch
 
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8

--- a/confluent-kafka/GHSA-j288-q9x7-2f5v.patch
+++ b/confluent-kafka/GHSA-j288-q9x7-2f5v.patch
@@ -11,10 +11,10 @@ index 266db12355..85aa4946ea 100644
            // be explicit about the javassist dependency version instead of relying on the transitive version
            libs.javassist,
 diff --git a/gradle.properties b/gradle.properties
-index fc40ef793b..64611e9e12 100644
+index b8d806cc03..cc9d208322 100644
 --- a/gradle.properties
 +++ b/gradle.properties
-@@ -26,6 +26,7 @@ version=8.2.0-10-ccs
+@@ -26,6 +26,7 @@ version=8.2.0-22-ccs
  scalaVersion=2.13.16
  # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
  swaggerVersion=2.2.25

--- a/confluent-kafka/GHSA-j288-q9x7-2f5v.patch
+++ b/confluent-kafka/GHSA-j288-q9x7-2f5v.patch
@@ -1,0 +1,24 @@
+diff --git a/build.gradle b/build.gradle
+index 266db12355..85aa4946ea 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -208,6 +208,7 @@ allprojects {
+     // that are unrelated to the project dependencies, we should not change them
+     if (name != "zinc") {
+       resolutionStrategy {
++        force("org.apache.commons:commons-lang3:" + lang3Version)
+         force(
+           // be explicit about the javassist dependency version instead of relying on the transitive version
+           libs.javassist,
+diff --git a/gradle.properties b/gradle.properties
+index fc40ef793b..64611e9e12 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -26,6 +26,7 @@ version=8.2.0-10-ccs
+ scalaVersion=2.13.16
+ # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
+ swaggerVersion=2.2.25
++lang3Version=3.18.0
+ task=build
+ org.gradle.jvmargs=-Xmx2g -Xss100m -XX\:+UseParallelGC
+ org.gradle.parallel=true


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate https://github.com/advisories/GHSA-j288-q9x7-2f5v
