### PR TITLE
feat: added new package: net-kourier

### DIFF
--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -90,6 +90,7 @@ test:
           Profiling enabled
           Running with Standard leader election
         post: |
+          wait-for-it localhost:9090 -t 15
           curl -fsSL http://localhost:9090/metrics | grep -q "net_kourier_controller_client_latency"
           curl -fsSL http://localhost:9090/metrics | grep -q "net_kourier_controller_workqueue_"
           curl -fsSL http://localhost:9090/metrics | grep -q "ingress.Reconciler"

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -78,8 +78,8 @@ test:
       uses: test/daemon-check-output
       with:
         setup: |
-          kubectl create namespace knative-serving || true
-          kubectl create namespace kourier-system || true
+          kubectl create namespace knative-serving
+          kubectl create namespace kourier-system 
           kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${{package.version}}/serving-crds.yaml
         start: "kourier"
         timeout: 30

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -11,7 +11,7 @@ pipeline:
     with:
       expected-commit: 60437bd9c884196ce80cc98ac2885351f6c44255
       repository: https://github.com/knative-extensions/net-kourier
-      tag: v0.45.0
+      tag: knative-v${{package.version}}
 
   - uses: go/build
     with:
@@ -30,12 +30,13 @@ subpackages:
       pipeline:
         - runs: test "$(readlink /ko-app/kourier)" = "/usr/bin/kourier"
 
+# Uses knative-v tags for consistency with other Knative packages and to follow the official Knative release process.
 update:
   enabled: true
   github:
     identifier: knative-extensions/net-kourier
-    strip-prefix: v
-    tag-filter: v
+    strip-prefix: knative-v
+    tag-filter: knative-v
 
 test:
   environment:

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -79,7 +79,7 @@ test:
       with:
         setup: |
           kubectl create namespace knative-serving
-          kubectl create namespace kourier-system 
+          kubectl create namespace kourier-system
           kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${{package.version}}/serving-crds.yaml
         start: "kourier"
         timeout: 30

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -13,11 +13,15 @@ pipeline:
       repository: https://github.com/knative-extensions/net-kourier
       tag: knative-v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/oauth2@v0.27.0
+
   - uses: go/build
     with:
       output: kourier
       packages: ./cmd/kourier
-      vendor: true
 
 subpackages:
   - name: ${{package.name}}-compat

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -63,7 +63,7 @@ test:
     - uses: test/kwok/cluster
     - name: Running daemon logs check tests
       runs: |
-        # Workaround fix for: "Fail to create in-cluster Kubernetes config"
+        # Workaround fix for: "To create in-cluster Kubernetes config"
         DIR=/var/run/secrets/kubernetes.io/serviceaccount
         mkdir -p "$DIR"
         kwokctl --name kwok kubectl create serviceaccount kourier
@@ -80,7 +80,7 @@ test:
         setup: |
           kubectl create namespace knative-serving || true
           kubectl create namespace kourier-system || true
-          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-crds.yaml
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${{package.version}}/serving-crds.yaml
         start: "kourier"
         timeout: 30
         expected_output: |

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -61,10 +61,8 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - name: Fix SA token
+    - name: Running daemon logs check tests
       runs: |
-        #!/usr/bin/env bash
-        set -euo pipefail
         # Workaround fix for: "Fail to create in-cluster Kubernetes config"
         DIR=/var/run/secrets/kubernetes.io/serviceaccount
         mkdir -p "$DIR"

--- a/net-kourier.yaml
+++ b/net-kourier.yaml
@@ -1,0 +1,90 @@
+package:
+  name: net-kourier
+  version: "1.18.0"
+  epoch: 0
+  description: Purpose-built Knative Ingress implementation using just Envoy with no additional CRDs
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 60437bd9c884196ce80cc98ac2885351f6c44255
+      repository: https://github.com/knative-extensions/net-kourier
+      tag: v0.45.0
+
+  - uses: go/build
+    with:
+      output: kourier
+      packages: ./cmd/kourier
+      vendor: true
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "To match with the upstream image entrypoint"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/ko-app
+          ln -sf /usr/bin/kourier ${{targets.contextdir}}/ko-app/kourier
+    test:
+      pipeline:
+        - runs: test "$(readlink /ko-app/kourier)" = "/usr/bin/kourier"
+
+update:
+  enabled: true
+  github:
+    identifier: knative-extensions/net-kourier
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  environment:
+    environment:
+      NAMESPACE: knative-serving
+      POD_NAME: test-kourier
+      CONTAINER_NAME: kourier
+      KOURIER_HTTPOPTION_DISABLED: "true"
+      ENVOY_ADMIN_PORT: "9901"
+      SYSTEM_NAMESPACE: knative-serving
+      METRICS_DOMAIN: knative.dev/samples
+      KOURIER_GATEWAY_NAMESPACE: kourier-system
+      ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID: "false"
+      KUBE_API_BURST: "200"
+      KUBE_API_QPS: "200"
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: Fix SA token
+      runs: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Workaround fix for: "Fail to create in-cluster Kubernetes config"
+        DIR=/var/run/secrets/kubernetes.io/serviceaccount
+        mkdir -p "$DIR"
+        kwokctl --name kwok kubectl create serviceaccount kourier
+        kwokctl --name kwok kubectl -n default create token kourier --duration=8760h > "$DIR/token"
+        CA=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+        cp $CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        echo knative-serving > "$DIR/namespace"
+    - name: Test kourier binary
+      runs: |
+        kourier --help 2>&1  | grep -q "Usage of kourier"
+    - name: Start kourier daemon
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl create namespace knative-serving || true
+          kubectl create namespace kourier-system || true
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.18.0/serving-crds.yaml
+        start: "kourier"
+        timeout: 30
+        expected_output: |
+          Registering
+          Profiling enabled
+          Running with Standard leader election
+        post: |
+          curl -fsSL http://localhost:9090/metrics | grep -q "net_kourier_controller_client_latency"
+          curl -fsSL http://localhost:9090/metrics | grep -q "net_kourier_controller_workqueue_"
+          curl -fsSL http://localhost:9090/metrics | grep -q "ingress.Reconciler"


### PR DESCRIPTION
new package: `net-kourier:0.45.0`
notes: Uses `knative-v` prefixed tags to align with the official Knative [release](https://github.com/knative-extensions/net-kourier/releases) process and maintain consistency with other Knative packagesin the repository (`knative-serving`, `knative-eventing`, etc.). The `knative-v` tags are the primary release format for `net-kourier` with comprehensive release notes and follow Knative's standardized versioning scheme.