### PR TITLE
fix(perl-*): rebuild all perl packages with perl 5.42.0

### DIFF
--- a/perl-algorithm-diff.yaml
+++ b/perl-algorithm-diff.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-algorithm-diff
   version: "1.201"
-  epoch: 2
+  epoch: 3
   description: Compute 'intelligent' differences between two files / lists
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-app-cpanminus.yaml
+++ b/perl-app-cpanminus.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-app-cpanminus
   version: "1.7048"
-  epoch: 0
+  epoch: 1
   description: Get, unpack, build and install modules from CPAN
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-app-cpm.yaml
+++ b/perl-app-cpm.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-app-cpm
   version: "0.997023"
-  epoch: 0
+  epoch: 1
   description: get, unpack, build and install modules from CPAN
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later

--- a/perl-appconfig.yaml
+++ b/perl-appconfig.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-appconfig
   version: "1.71"
-  epoch: 2
+  epoch: 3
   description: AppConfig is a bundle of Perl5 modules for reading configuration files and parsing command line arguments.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-b-hooks-endofscope.yaml
+++ b/perl-b-hooks-endofscope.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-b-hooks-endofscope
   version: "0.28"
-  epoch: 2
+  epoch: 3
   description: Execute code after a scope finished compilation
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-canary-stability.yaml
+++ b/perl-canary-stability.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-canary-stability
   version: "2013"
-  epoch: 4
+  epoch: 5
   description: CPAN/Canary-Stability - canary to check perl compatibility for schmorp's modules
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-capture-tiny.yaml
+++ b/perl-capture-tiny.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-capture-tiny
   version: "0.50"
-  epoch: 0
+  epoch: 1
   description: Capture STDOUT and STDERR from Perl, XS or external programs
   copyright:
     - license: Apache-2.0

--- a/perl-class-data-inheritable.yaml
+++ b/perl-class-data-inheritable.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-data-inheritable
   version: "0.10"
-  epoch: 0
+  epoch: 1
   description: Inheritable, overridable class data
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-class-inspector.yaml
+++ b/perl-class-inspector.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-inspector
   version: "1.36"
-  epoch: 3
+  epoch: 4
   description: Class::Inspector perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-class-singleton.yaml
+++ b/perl-class-singleton.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-singleton
   version: "1.6"
-  epoch: 3
+  epoch: 4
   description: "Implementation of a Singleton class "
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-class-tiny.yaml
+++ b/perl-class-tiny.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-class-tiny
   version: "1.008"
-  epoch: 0
+  epoch: 1
   description: Minimalist class construction
   copyright:
     - license: Apache-2.0

--- a/perl-clone.yaml
+++ b/perl-clone.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-clone
   version: "0.48.01"
-  epoch: 0
+  epoch: 1
   description: Clone perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-command-runner.yaml
+++ b/perl-command-runner.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-command-runner
   version: "0.201"
-  epoch: 0
+  epoch: 1
   description: run external commands and Perl code refs
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later

--- a/perl-common-sense.yaml
+++ b/perl-common-sense.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-common-sense
   version: "3.75"
-  epoch: 3
+  epoch: 4
   description: Perl module for common-sense
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-cpan-distnameinfo.yaml
+++ b/perl-cpan-distnameinfo.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-cpan-distnameinfo
   version: "0.12"
-  epoch: 0
+  epoch: 1
   description: Perl module for extracting distribution names and versions from a distribution filename
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-cpan-meta-requirements.yaml
+++ b/perl-cpan-meta-requirements.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-cpan-meta-requirements
   version: "2.143"
-  epoch: 3
+  epoch: 4
   description: Perl module for cpan meta requirements
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-cpan-requirements-dynamic.yaml
+++ b/perl-cpan-requirements-dynamic.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-cpan-requirements-dynamic
   version: "0.002"
-  epoch: 0
+  epoch: 1
   description: Perl module for requirements dynamic
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-darwin-initobjc.yaml
+++ b/perl-darwin-initobjc.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-darwin-initobjc
   version: "0.001"
-  epoch: 0
+  epoch: 1
   description: Perl extension for recursively copying files and directories
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-date-format.yaml
+++ b/perl-date-format.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-date-format
   version: "2.33"
-  epoch: 3
+  epoch: 4
   description: Perl - Date formating subroutines
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-datetime-locale.yaml
+++ b/perl-datetime-locale.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-datetime-locale
   version: "1.45"
-  epoch: 0
+  epoch: 1
   description: Localization support for DateTime.pm
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-datetime-timezone.yaml
+++ b/perl-datetime-timezone.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-datetime-timezone
   version: "2.65"
-  epoch: 0
+  epoch: 1
   description: Time zone object base class and factory
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-datetime.yaml
+++ b/perl-datetime.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-datetime
   version: "1.66"
-  epoch: 0
+  epoch: 1
   description: DateTime - A date and time object for Perl
   copyright:
     - license: Artistic-2.0

--- a/perl-dbi.yaml
+++ b/perl-dbi.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-dbi
   version: "1.647"
-  epoch: 0
+  epoch: 1
   description: Database independent interface for Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-devel-checklib.yaml
+++ b/perl-devel-checklib.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-devel-checklib
   version: "1.16"
-  epoch: 1
+  epoch: 2
   description: check that a library is available
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-devel-cover.yaml
+++ b/perl-devel-cover.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-devel-cover
   version: "1.49"
-  epoch: 0
+  epoch: 1
   description: Code coverage metrics for Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-devel-ppport.yaml
+++ b/perl-devel-ppport.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-devel-ppport
   version: "3.68"
-  epoch: 3
+  epoch: 4
   description: Devel::PPPort - Perl/Pollution/Portability
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-devel-stacktrace.yaml
+++ b/perl-devel-stacktrace.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-devel-stacktrace
   version: "2.05"
-  epoch: 2
+  epoch: 3
   description: An object representing a stack trace
   copyright:
     - license: Artistic-2.0

--- a/perl-devel-symdump.yaml
+++ b/perl-devel-symdump.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-devel-symdump
   version: "2.18"
-  epoch: 2
+  epoch: 3
   description: dump symbol names or the symbol table
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-digest-md5.yaml
+++ b/perl-digest-md5.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-digest-md5
   version: "2.59"
-  epoch: 2
+  epoch: 3
   description: Perl interface to the MD-5 algorithm
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-dist-checkconflicts.yaml
+++ b/perl-dist-checkconflicts.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-dist-checkconflicts
   version: "0.11"
-  epoch: 3
+  epoch: 4
   description: declare version conflicts for your dist
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-encode-locale.yaml
+++ b/perl-encode-locale.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-encode-locale
   version: "1.05"
-  epoch: 4
+  epoch: 5
   description: Perl module - Determine the locale encoding
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-eval-closure.yaml
+++ b/perl-eval-closure.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-eval-closure
   version: "0.14"
-  epoch: 3
+  epoch: 4
   description: safely and cleanly create closures via string eval
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-exception-class.yaml
+++ b/perl-exception-class.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-exception-class
   version: "1.45"
-  epoch: 3
+  epoch: 4
   description: A module that allows you to declare real exception classes in Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-extutils-config.yaml
+++ b/perl-extutils-config.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-config
   version: "0.010"
-  epoch: 1
+  epoch: 2
   description: A wrapper for perl's configuration
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-extutils-helpers.yaml
+++ b/perl-extutils-helpers.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-helpers
   version: "0.028"
-  epoch: 1
+  epoch: 2
   description: Various portability utilities for module builders
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-extutils-installpaths.yaml
+++ b/perl-extutils-installpaths.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-installpaths
   version: "0.014"
-  epoch: 1
+  epoch: 2
   description: Build.PL install path logic made easy
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-extutils-makemaker-cpanfile.yaml
+++ b/perl-extutils-makemaker-cpanfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-extutils-makemaker-cpanfile
   version: "0.09"
-  epoch: 0
+  epoch: 1
   description: parses .pm file as PAUSE does
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-copy-recursive.yaml
+++ b/perl-file-copy-recursive.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-copy-recursive
   version: "0.45"
-  epoch: 0
+  epoch: 1
   description: Perl extension for recursively copying files and directories
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-fcntllock.yaml
+++ b/perl-file-fcntllock.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-fcntllock
   version: "0.22"
-  epoch: 3
+  epoch: 4
   description: File-FcntlLock - File locking with fcntl(2)
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-listing.yaml
+++ b/perl-file-listing.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-listing
   version: "6.16"
-  epoch: 3
+  epoch: 4
   description: Parse directory listing
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-next.yaml
+++ b/perl-file-next.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-next
   version: "1.18"
-  epoch: 2
+  epoch: 3
   description: Perl module for taint-safe file-finding
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-pushd.yaml
+++ b/perl-file-pushd.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-pushd
   version: "1.016"
-  epoch: 0
+  epoch: 1
   description: change directory temporarily for a limited scope
   copyright:
     - license: Apache-2.0

--- a/perl-file-remove.yaml
+++ b/perl-file-remove.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-remove
   version: "1.61"
-  epoch: 3
+  epoch: 4
   description: Remove files and directories
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-sharedir-install.yaml
+++ b/perl-file-sharedir-install.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-sharedir-install
   version: "0.14"
-  epoch: 3
+  epoch: 4
   description: Install shared files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-sharedir.yaml
+++ b/perl-file-sharedir.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-sharedir
   version: "1.118"
-  epoch: 3
+  epoch: 4
   description: Locate per-dist and per-module shared files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-file-which.yaml
+++ b/perl-file-which.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-which
   version: "1.27"
-  epoch: 0
+  epoch: 1
   description: Perl module for taint-safe file-finding
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-html-parser.yaml
+++ b/perl-html-parser.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-html-parser
   version: "3.83"
-  epoch: 1
+  epoch: 2
   description: HTML parser class
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-html-tagset.yaml
+++ b/perl-html-tagset.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-html-tagset
   version: "3.24"
-  epoch: 3
+  epoch: 4
   description: data tables useful in parsing HTML
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-http-cookies.yaml
+++ b/perl-http-cookies.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-cookies
   version: "6.11"
-  epoch: 2
+  epoch: 3
   description: HTTP cookie jars
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-http-date.yaml
+++ b/perl-http-date.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-date
   version: "6.06"
-  epoch: 4
+  epoch: 5
   description: Perl module date conversion routines
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-http-message.yaml
+++ b/perl-http-message.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-message
   version: "7.00"
-  epoch: 1
+  epoch: 2
   description: HTTP style message
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-http-negotiate.yaml
+++ b/perl-http-negotiate.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-negotiate
   version: "6.01"
-  epoch: 4
+  epoch: 5
   description: HTTP::Negotiate perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-http-tinyish.yaml
+++ b/perl-http-tinyish.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-tinyish
   version: "0.19"
-  epoch: 0
+  epoch: 1
   description: Tiny compatible HTTP client wrappers
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-importer.yaml
+++ b/perl-importer.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-importer
   version: "0.026"
-  epoch: 4
+  epoch: 5
   description: Alternative but compatible interface to modules that export symbols.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-inc-latest.yaml
+++ b/perl-inc-latest.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-inc-latest
   version: "0.500"
-  epoch: 3
+  epoch: 4
   description: use modules bundled in inc/ if they are newer than installed ones
   copyright:
     - license: Apache-2.0

--- a/perl-io-gzip.yaml
+++ b/perl-io-gzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-io-gzip
   version: "0.20"
-  epoch: 1
+  epoch: 2
   description: Perl extension to provide a PerlIO layer to gzip/gunzip
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-io-html.yaml
+++ b/perl-io-html.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-io-html
   version: "1.004"
-  epoch: 3
+  epoch: 4
   description: Open an HTML file with automatic charset detection
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-io-socket-ssl.yaml
+++ b/perl-io-socket-ssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-io-socket-ssl
   version: "2.089"
-  epoch: 0
+  epoch: 1
   description: Nearly transparent SSL encapsulation for IO::Socket::INET
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-ipc-run3.yaml
+++ b/perl-ipc-run3.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-ipc-run3
   version: "0.049"
-  epoch: 3
+  epoch: 4
   description: IPC::Run3 perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0 OR Artistic-2.0 OR BSD-2-Clause

--- a/perl-json-maybexs.yaml
+++ b/perl-json-maybexs.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-json-maybexs
   version: "1.004008"
-  epoch: 1
+  epoch: 2
   description: Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-json-xs.yaml
+++ b/perl-json-xs.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-json-xs
   version: "4.03"
-  epoch: 3
+  epoch: 4
   description: Perl module for JSON-XS
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-json.yaml
+++ b/perl-json.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-json
   version: "4.10"
-  epoch: 1
+  epoch: 2
   description: Perl module implementing a JSON encoder/decoder
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-libwww.yaml
+++ b/perl-libwww.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-libwww
   version: "6.78"
-  epoch: 0
+  epoch: 1
   description: The World-Wide Web library for Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-local-lib.yaml
+++ b/perl-local-lib.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-local-lib
   version: "2.000029"
-  epoch: 0
+  epoch: 1
   description: Perl module for extracting distribution names and versions from a distribution filename
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-lwp-mediatypes.yaml
+++ b/perl-lwp-mediatypes.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-lwp-mediatypes
   version: "6.04"
-  epoch: 3
+  epoch: 4
   description: Perl module - guess media type for a file or a URL
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-lwp-protocol-https.yaml
+++ b/perl-lwp-protocol-https.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-lwp-protocol-https
   version: "6.14"
-  epoch: 0
+  epoch: 1
   description: Perl extension to provide https support for LWP::UserAgent
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-memory-process.yaml
+++ b/perl-memory-process.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-memory-process
   version: "0.06"
-  epoch: 3
+  epoch: 4
   description: Memory process reporting.
   copyright:
     - license: BSD-2-Clause

--- a/perl-memory-usage.yaml
+++ b/perl-memory-usage.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-memory-usage
   version: "0.201"
-  epoch: 3
+  epoch: 4
   description: Tools to determine actual memory usage
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-menlo-legacy.yaml
+++ b/perl-menlo-legacy.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-menlo-legacy
   version: "1.9022"
-  epoch: 0
+  epoch: 1
   description: cpanm compatible CPAN installer
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-menlo.yaml
+++ b/perl-menlo.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-menlo
   version: "1.9019"
-  epoch: 0
+  epoch: 1
   description: A CPAN client
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-build-tiny.yaml
+++ b/perl-module-build-tiny.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-build-tiny
   version: "0.052"
-  epoch: 0
+  epoch: 1
   description: A tiny replacement for Module::Build
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-build.yaml
+++ b/perl-module-build.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-build
   version: "0.4234"
-  epoch: 3
+  epoch: 4
   description: Build and install Perl modules
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-cpanfile.yaml
+++ b/perl-module-cpanfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-module-cpanfile
   version: "1.1004"
-  epoch: 0
+  epoch: 1
   description: Perl module for parsing cpanfiles
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-cpmfile.yaml
+++ b/perl-module-cpmfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-module-cpmfile
   version: "0.006"
-  epoch: 0
+  epoch: 1
   description: Perl module for parsing cpmfiles
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-implementation.yaml
+++ b/perl-module-implementation.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-implementation
   version: "0.09"
-  epoch: 3
+  epoch: 4
   description: Loads one of several alternate underlying implementations for a module
   copyright:
     - license: Artistic-2.0

--- a/perl-module-install.yaml
+++ b/perl-module-install.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-install
   version: "1.21"
-  epoch: 3
+  epoch: 4
   description: Standalone, extensible Perl module installer
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-pluggable.yaml
+++ b/perl-module-pluggable.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-pluggable
   version: "6.3"
-  epoch: 0
+  epoch: 1
   description: automatically give your module the ability to have plugins
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-runtime.yaml
+++ b/perl-module-runtime.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-runtime
   version: "0.018"
-  epoch: 0
+  epoch: 1
   description: runtime module handling
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-module-scandeps.yaml
+++ b/perl-module-scandeps.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-module-scandeps
   version: "1.37"
-  epoch: 0
+  epoch: 1
   description: Recursively scan Perl code for dependencies
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-mozilla-ca.yaml
+++ b/perl-mozilla-ca.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-mozilla-ca
   version: "20250202"
-  epoch: 0
+  epoch: 1
   description: Mozilla's CA cert bundle in PEM format
   copyright:
     - license: MPL-2.0

--- a/perl-mro-compat.yaml
+++ b/perl-mro-compat.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-mro-compat
   version: "0.15"
-  epoch: 3
+  epoch: 4
   description: mro::* interface compatibility for Perls < 5.9.5
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-namespace-autoclean.yaml
+++ b/perl-namespace-autoclean.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-namespace-autoclean
   version: "0.31"
-  epoch: 1
+  epoch: 2
   description: Keep imports out of your namespace
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-namespace-clean.yaml
+++ b/perl-namespace-clean.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-namespace-clean
   version: "0.27"
-  epoch: 3
+  epoch: 4
   description: Keep imports and functions out of your namespace
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-http.yaml
+++ b/perl-net-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-http
   version: "6.23"
-  epoch: 4
+  epoch: 5
   description: Low-level HTTP connection (client)
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-snmp.yaml
+++ b/perl-net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-snmp
   version: 6.0.1
-  epoch: 2
+  epoch: 3
   description: Object oriented interface to SNMP
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-ssleay.yaml
+++ b/perl-net-ssleay.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-ssleay
   version: "1.94"
-  epoch: 1
+  epoch: 2
   description: Perl extension for using OpenSSL
   copyright:
     - license: Artistic-2.0

--- a/perl-net-telnet.yaml
+++ b/perl-net-telnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-telnet
   version: "3.05"
-  epoch: 4
+  epoch: 5
   description: Interact with TELNET port or other TCP ports
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-package-stash.yaml
+++ b/perl-package-stash.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-package-stash
   version: "0.40"
-  epoch: 3
+  epoch: 4
   description: Routines for manipulating stashes
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-parallel-iterator.yaml
+++ b/perl-parallel-iterator.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parallel-iterator
   version: "1.002"
-  epoch: 3
+  epoch: 4
   description: Simple parallel execution
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-parallel-pipes.yaml
+++ b/perl-parallel-pipes.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parallel-pipes
   version: "0.201"
-  epoch: 0
+  epoch: 1
   description: friendly interface for Parallel::Pipes
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-params-validationcompiler.yaml
+++ b/perl-params-validationcompiler.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-params-validationcompiler
   version: "0.31"
-  epoch: 4
+  epoch: 5
   description: Params::ValidationCompiler perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-parse-pmfile.yaml
+++ b/perl-parse-pmfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parse-pmfile
   version: "0.47"
-  epoch: 0
+  epoch: 1
   description: parses .pm file as PAUSE does
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-parse-yapp.yaml
+++ b/perl-parse-yapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parse-yapp
   version: "1.21"
-  epoch: 1
+  epoch: 2
   description: Perl module for Parse-Yapp
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-pod-coverage.yaml
+++ b/perl-pod-coverage.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-pod-coverage
   version: "0.23"
-  epoch: 5
+  epoch: 6
   description: Perl - Checks if the documentation of a module is comprehensive
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-pod-parser.yaml
+++ b/perl-pod-parser.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-pod-parser
   version: "1.67"
-  epoch: 2
+  epoch: 3
   description: Modules for parsing/translating POD format documents
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-readonly.yaml
+++ b/perl-readonly.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-readonly
   version: "2.05"
-  epoch: 4
+  epoch: 5
   description: Facility for creating read-only scalars, arrays, hashes
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later

--- a/perl-role-tiny.yaml
+++ b/perl-role-tiny.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-role-tiny
   version: "2.002004"
-  epoch: 3
+  epoch: 4
   description: "Roles: a nouvelle cuisine portion size slice of Moose"
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-scope-guard.yaml
+++ b/perl-scope-guard.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-scope-guard
   version: "0.21"
-  epoch: 4
+  epoch: 5
   description: Scope::Guard perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-specio.yaml
+++ b/perl-specio.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-specio
   version: "0.50"
-  epoch: 0
+  epoch: 1
   description: Type constraints and coercions for Perl
   copyright:
     - license: Artistic-2.0

--- a/perl-string-shellquote.yaml
+++ b/perl-string-shellquote.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-string-shellquote
   version: "1.04"
-  epoch: 0
+  epoch: 1
   description: quote strings for passing through the shell
   copyright:
     # License shows up as "unknown" on metacpan but README redistrubites as "the same terms as Perl itself."

--- a/perl-sub-exporter-progressive.yaml
+++ b/perl-sub-exporter-progressive.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-exporter-progressive
   version: "0.001013"
-  epoch: 3
+  epoch: 4
   description: Only use Sub::Exporter if you need it
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-sub-identify.yaml
+++ b/perl-sub-identify.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-identify
   version: "0.14"
-  epoch: 3
+  epoch: 4
   description: Retrieve names of code references
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-sub-info.yaml
+++ b/perl-sub-info.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-info
   version: "0.002"
-  epoch: 3
+  epoch: 4
   description: Tool for inspecting subroutines.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-sub-quote.yaml
+++ b/perl-sub-quote.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-quote
   version: "2.006008"
-  epoch: 3
+  epoch: 4
   description: Efficient generation of subroutines via string eval
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-template-toolkit.yaml
+++ b/perl-template-toolkit.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-template-toolkit
   version: "3.102"
-  epoch: 1
+  epoch: 2
   description: comprehensive template processing system
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-term-table.yaml
+++ b/perl-term-table.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-term-table
   version: "0.024"
-  epoch: 0
+  epoch: 1
   description: Format a header and rows into a table
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-differences.yaml
+++ b/perl-test-differences.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-differences
   version: "0.71"
-  epoch: 2
+  epoch: 3
   description: Test strings and data structures and show differences if not ok
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-fatal.yaml
+++ b/perl-test-fatal.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-fatal
   version: "0.017"
-  epoch: 3
+  epoch: 4
   description: incredibly simple helpers for testing code with exceptions
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-nowarnings.yaml
+++ b/perl-test-nowarnings.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-nowarnings
   version: "1.06"
-  epoch: 3
+  epoch: 4
   description: Test::NoWarnings perl module
   copyright:
     - license: LGPL-2.1-only

--- a/perl-test-pod-coverage.yaml
+++ b/perl-test-pod-coverage.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-pod-coverage
   version: "1.10"
-  epoch: 3
+  epoch: 4
   description: Perl - Check for pod coverage in your distribution.
   copyright:
     - license: Artistic-2.0

--- a/perl-test-pod.yaml
+++ b/perl-test-pod.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test-pod
   version: 1.52
-  epoch: 6
+  epoch: 7
   description: check for POD errors in files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-simple.yaml
+++ b/perl-test-simple.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test-simple
   version: "1.302214"
-  epoch: 0
+  epoch: 1
   description: Basic utilities for writing tests
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-without-module.yaml
+++ b/perl-test-without-module.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-without-module
   version: "0.23"
-  epoch: 2
+  epoch: 3
   description: Test::Without::Module perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-test2-plugin-nowarnings.yaml
+++ b/perl-test2-plugin-nowarnings.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test2-plugin-nowarnings
   version: "0.10"
-  epoch: 3
+  epoch: 4
   description: Test2::Plugin::NoWarnings perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-text-diff.yaml
+++ b/perl-text-diff.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-text-diff
   version: "1.45"
-  epoch: 2
+  epoch: 3
   description: Perform diffs on files and record sets
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-tidy.yaml
+++ b/perl-tidy.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-tidy
   version: "20250311"
-  epoch: 0
+  epoch: 1
   description: Parses and beautifies perl source
   copyright:
     - license: GPL-2.0-only

--- a/perl-time-hires.yaml
+++ b/perl-time-hires.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-time-hires
   version: "1.9764"
-  epoch: 3
+  epoch: 4
   description: High resolution alarm, sleep, gettimeofday, interval timers
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-tk.yaml
+++ b/perl-tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-tk
   version: "804.036"
-  epoch: 5
+  epoch: 6
   description: Tk - a Graphical User Interface Toolkit
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later

--- a/perl-try-tiny.yaml
+++ b/perl-try-tiny.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-try-tiny
   version: "0.32"
-  epoch: 1
+  epoch: 2
   description: Minimal try/catch with proper preservation of $@
   copyright:
     - license: MIT

--- a/perl-types-serialiser.yaml
+++ b/perl-types-serialiser.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-types-serialiser
   version: "1.01"
-  epoch: 3
+  epoch: 4
   description: Perl module for Types-Serialiser
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-uri.yaml
+++ b/perl-uri.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-uri
   version: "5.32"
-  epoch: 0
+  epoch: 1
   description: Uniform Resource Identifiers (absolute and relative)
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-win32-shellquote.yaml
+++ b/perl-win32-shellquote.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-win32-shellquote
   version: "0.003001"
-  epoch: 0
+  epoch: 1
   description: Quote argument lists for Win32
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-www-robotrules.yaml
+++ b/perl-www-robotrules.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-www-robotrules
   version: "6.02"
-  epoch: 5
+  epoch: 6
   description: WWW::RobotRules perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-xml-parser.yaml
+++ b/perl-xml-parser.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-xml-parser
   version: "2.47"
-  epoch: 3
+  epoch: 4
   description: A perl module for parsing XML documents
   copyright:
     - license: Artistic-2.0

--- a/perl-yaml-pp.yaml
+++ b/perl-yaml-pp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yaml-pp
   version: "0.39.0"
-  epoch: 0
+  epoch: 1
   description: YAML 1.2 processor
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yaml-syck
   version: 1.34
-  epoch: 6
+  epoch: 7
   description: Fast, lightweight YAML loader and dumper
   copyright:
     - license: MIT

--- a/perl-yaml-tiny.yaml
+++ b/perl-yaml-tiny.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-yaml-tiny
   version: "1.76"
-  epoch: 0
+  epoch: 1
   description: Read/Write YAML files with as little code as possible
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-yapp.yaml
+++ b/perl-yapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yapp
   version: "1.21"
-  epoch: 2
+  epoch: 3
   description: Yet Another Parser Parser For Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl


### PR DESCRIPTION
## Explanation

Perl v5.42.0 just came out. Rebuilding all perl package with latest perl to fix version mismatch errors.

Example error: 
```shell
 Perl API version v5.40.0 of Net::SSLeay does not match v5.42.0 at /usr/lib/perl5/vendor_perl/Net/SSLeay.pm line 1024.
```