### PR TITLE
cilium 1.17/llvm 17 renames

### DIFF
--- a/cilium-1.17.yaml
+++ b/cilium-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.17
   version: "1.17.5"
-  epoch: 1
+  epoch: 2
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ package:
       - ipset
       - iptables-wrappers
       - kmod
-      - llvm17
+      - llvm-17
       - merged-sbin
       - wolfi-baselayout
     provides:
@@ -34,20 +34,17 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-17
-      - clang-17-dev
       - cmake
       - coreutils # for GNU install
       - git
       - go
       - grep
       - isl-dev
+      - libcxx1-17-dev
       - libtool
-      - llvm-libcxx-17
-      - llvm-libcxx-17-dev
-      - llvm-libcxxabi-17
-      - llvm-lld-17
-      - llvm17
-      - llvm17-dev
+      - lld-17
+      - lld-17-dev
+      - llvm-17-dev
       - mpc-dev
       - openjdk-11
       - patch


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package
