### PR TITLE
cilium envoy 1.17/llvm 17 renames

### DIFF
--- a/cilium-envoy-1.17.yaml
+++ b/cilium-envoy-1.17.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-envoy-1.17
   version: "1.17.5"
-  epoch: 1
+  epoch: 2
   description: Envoy with additional cilium plugins
   copyright:
     - license: Apache-2.0
@@ -36,13 +36,11 @@ environment:
       - glibc-locale-en
       - go
       - isl-dev
+      - libcxx1-17-dev
       - libtool
-      - llvm-libcxx-17
-      - llvm-libcxx-17-dev
-      - llvm-libcxxabi-17
-      - llvm-lld-17
-      - llvm17
-      - llvm17-dev
+      - lld-17
+      - lld-17-dev
+      - llvm-17-dev
       - openjdk-11
       - patch
       - python3-dev

--- a/cilium-envoy-1.17.yaml
+++ b/cilium-envoy-1.17.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: cilium-envoy-1.17
-  version: "1.17.6"
-  epoch: 0
+  version: "1.17.5"
+  epoch: 2
   description: Envoy with additional cilium plugins
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,7 @@ pipeline:
     with:
       repository: https://github.com/cilium/cilium
       tag: v${{package.version}}
-      expected-commit: ee3ca4a7e998da677a9b1c634619a85ce5b0dc64
+      expected-commit: 69aab28cf10174430372aa6fbd7c1e555b267993
       destination: cilium
 
   - uses: go/bump

--- a/cilium-envoy-1.17.yaml
+++ b/cilium-envoy-1.17.yaml
@@ -123,6 +123,7 @@ pipeline:
         --conlyopt="-Wno-strict-prototypes" \
         `# The thread-safety analysis flagged some issue in upstream code` \
         --cxxopt="-Wno-thread-safety" \
+        --action_env=LIBURING_CFLAGS="-ftrivial-auto-var-init=uninitialized" \
         --verbose_failures -c opt //:cilium-envoy
       install -m 755 bazel-bin/cilium-envoy ${{targets.destdir}}/usr/bin/cilium-envoy
 

--- a/cilium-envoy-1.17.yaml
+++ b/cilium-envoy-1.17.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: cilium-envoy-1.17
-  version: "1.17.5"
-  epoch: 2
+  version: "1.17.6"
+  epoch: 0
   description: Envoy with additional cilium plugins
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,7 @@ pipeline:
     with:
       repository: https://github.com/cilium/cilium
       tag: v${{package.version}}
-      expected-commit: 69aab28cf10174430372aa6fbd7c1e555b267993
+      expected-commit: ee3ca4a7e998da677a9b1c634619a85ce5b0dc64
       destination: cilium
 
   - uses: go/bump

--- a/cilium-envoy-1.17.yaml
+++ b/cilium-envoy-1.17.yaml
@@ -29,7 +29,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-17
-      - clang-17-dev
       - cmake
       - coreutils # for GNU install
       - git


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package

