### PR TITLE
openmp 17/llvm 17 renames

### DIFF
--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-17
   version: 17.0.6
-  epoch: 7
+  epoch: 8
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0
@@ -19,12 +19,9 @@ environment:
       - cmake
       - gcc-14-default
       - help2man
-      - libLLVM-17
       - libffi-dev
       - libxml2-dev
-      - llvm-cmake-17
-      - llvm17
-      - llvm17-dev
+      - llvm-17-dev
       - pkgconf
       - python3
       - samurai
@@ -41,12 +38,12 @@ pipeline:
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm17/share/cmake" \
-        -DCMAKE_MODULE_PATH="/usr/lib/llvm17/share/cmake/Modules" \
-        -DLLVM_CONFIG=/usr/lib/llvm17/bin/llvm-config \
-        -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm17/include \
-        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm17/include \
-        -DLIBOMP_CPPFLAGS="-I/usr/lib/llvm17/include" \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-17/share/cmake" \
+        -DCMAKE_MODULE_PATH="/usr/lib/llvm-17/share/cmake/Modules" \
+        -DLLVM_CONFIG=/usr/lib/llvm-17/bin/llvm-config \
+        -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \
+        -DLIBOMP_CPPFLAGS="-I/usr/lib/llvm-17/include" \
         -DLIBOMP_INSTALL_ALIASES=OFF
 
   - runs: |

--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -22,6 +22,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - llvm-17-dev
+      - llvm-cmake-17
       - pkgconf
       - python3
       - samurai

--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -38,8 +38,6 @@ pipeline:
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-17/share/cmake" \
-        -DCMAKE_MODULE_PATH="/usr/lib/llvm-17/share/cmake/Modules" \
         -DLLVM_CONFIG=/usr/lib/llvm-17/bin/llvm-config \
         -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \
         -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \

--- a/openmp-17.yaml
+++ b/openmp-17.yaml
@@ -38,6 +38,8 @@ pipeline:
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-17/share/cmake" \
+        -DCMAKE_MODULE_PATH="/usr/lib/llvm-17/share/cmake/Modules" \
         -DLLVM_CONFIG=/usr/lib/llvm-17/bin/llvm-config \
         -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \
         -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-17/include \


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package
