### PR TITLE
rust 1.73/llvm 17 renames

### DIFF
--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.73
   version: 1.73.0
-  epoch: 3
+  epoch: 4
   description: "Empowering everyone to build reliable and efficient software. (version 1.73.0)"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -12,7 +12,6 @@ package:
     provides:
       - rust=${{package.full-version}}
     runtime:
-      - libLLVM-17
 
 environment:
   contents:
@@ -28,8 +27,7 @@ environment:
       - gcc-14-default
       - libgit2-dev
       - libssh2-dev
-      - llvm17
-      - llvm17-dev
+      - llvm-17-dev
       - ninja
       - openssl-dev
       - patch
@@ -53,13 +51,11 @@ pipeline:
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       export ARCH=${{host.triplet.rust}}
-
       export PKG_CONFIG_LIBDIR="${{vars.PKG_CONFIG_LIBDIR}}"
       export LIBSSH2_SYS_USE_PKG_CONFIG=1
       export CFLAGS="${{vars.CFLAGS}}"
       export CPPFLAGS="${{vars.CPPFLAGS}}"
       export CXXFLAGS="${{vars.CXXFLAGS}}"
-
       ./configure \
         --host="${ARCH}" \
         --target="${ARCH}" \
@@ -91,18 +87,15 @@ pipeline:
       sed 's/#deny-warnings = .*/deny-warnings = false/' -i config.toml
       sed 's|deny(warnings,|deny(|' -i src/bootstrap/lib.rs
       mkdir -p "${{targets.destdir}}/usr"
-
       unset CARGO_PROFILE_RELEASE_LTO
       unset CARGO_PROFILE_RELEASE_OPT_LEVEL
       unset CARGO_PROFILE_RELEASE_PANIC
       unset CARGO_PROFILE_RELEASE_CODEGEN_UNITS
-
       export PKG_CONFIG_LIBDIR="${{vars.PKG_CONFIG_LIBDIR}}"
       export LIBSSH2_SYS_USE_PKG_CONFIG=1
       export CFLAGS="${{vars.CFLAGS}}"
       export CPPFLAGS="${{vars.CPPFLAGS}}"
       export CXXFLAGS="${{vars.CXXFLAGS}}"
-
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs $(nproc)

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -62,8 +62,8 @@ pipeline:
         --prefix="/usr" \
         --local-rust-root="/usr" \
         --release-channel="stable" \
-        --llvm-root="/usr/lib/llvm17" \
-        --llvm-config="/usr/lib/llvm17/bin/llvm-config" \
+        --llvm-root="/usr/lib/llvm-17" \
+        --llvm-config="/usr/lib/llvm-17/bin/llvm-config" \
         --enable-llvm-link-shared \
         --enable-local-rust \
         --disable-docs \

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -9,9 +9,10 @@ package:
     cpu: 16
     memory: 16Gi
   dependencies:
+    runtime:
+      - libLLVM-17
     provides:
       - rust=${{package.full-version}}
-    runtime:
 
 environment:
   contents:


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package
