### PR TITLE
rust-1.77: update LLVM 17 package references

### DIFF
--- a/rust-1.77.yaml
+++ b/rust-1.77.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.77
   version: 1.77.2
-  epoch: 3
+  epoch: 4
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -25,11 +25,9 @@ environment:
       - curl-dev
       - file
       - gcc-14-default
-      - libLLVM-17
       - libgit2-dev
       - libssh2-dev
-      - llvm17
-      - llvm17-dev
+      - llvm-17-dev
       - openssl-dev
       - patch
       - python3
@@ -64,8 +62,8 @@ pipeline:
         --release-channel="stable" \
         --enable-local-rust \
         --local-rust-root="/usr" \
-        --llvm-root="/usr/lib/llvm17" \
-        --llvm-config="/usr/lib/llvm17/bin/llvm-config" \
+        --llvm-root="/usr/lib/llvm-17" \
+        --llvm-config="/usr/lib/llvm-17/bin/llvm-config" \
         --disable-docs \
         --enable-extended \
         --tools="cargo,src" \
@@ -94,8 +92,8 @@ pipeline:
       unset CARGO_PROFILE_RELEASE_OPT_LEVEL
       unset CARGO_PROFILE_RELEASE_PANIC
       unset CARGO_PROFILE_RELEASE_CODEGEN_UNITS
-      export CFLAGS="$CFLAGS -O2 -Iusr/include/llvm17"
-      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm17"
+      export CFLAGS="$CFLAGS -O2 -I/usr/include/llvm-17"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm-17"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs $(nproc)


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package
