### PR TITLE
wasi-libc: update LLVM 17 package references

### DIFF
--- a/wasi-libc.yaml
+++ b/wasi-libc.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasi-libc
   version: 25
-  epoch: 0
+  epoch: 1
   description: "WASI libc implementation for WebAssembly"
   copyright:
     - license: Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND MIT AND CC0-1.0 AND BSD-2-Clause
@@ -13,8 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-17
-      - clang-17-dev
-      - llvm17
+      - llvm-17
       - make
       - wolfi-baselayout
 


### PR DESCRIPTION
Build dependency renames and drops for new single source LLVM 17 package
