### PR TITLE
feat(kafka-4.0): bump deps to remediate GHSA-j288-q9x7-2f5v

### DIFF
--- a/kafka-4.0.yaml
+++ b/kafka-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-4.0
   version: "4.0.0"
-  epoch: 43
+  epoch: 44
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -44,7 +44,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-GHSA-wxr5-93ph-8wr9-update-common-beanutils.patch
+      patches: GHSA-wxr5-93ph-8wr9-GHSA-j288-q9x7-2f5v.patch
 
   - runs: |
       gradle clean releaseTarGz

--- a/kafka-4.0/GHSA-wxr5-93ph-8wr9-GHSA-j288-q9x7-2f5v.patch
+++ b/kafka-4.0/GHSA-wxr5-93ph-8wr9-GHSA-j288-q9x7-2f5v.patch
@@ -1,27 +1,8 @@
-From 83c3f16a0ffe35707a7c4526cc8b270274d567c6 Mon Sep 17 00:00:00 2001
-From: Debasish Biswas <debasishbsws.dev@gmail.com>
-Date: Mon, 2 Jun 2025 10:27:19 +0000
-Subject: [PATCH] fix(CVE): Update commons-beanutils transitive dependency to
- 1.11.0 to address GHSA-wxr5-93ph-8wr9
-
-* commons-beanutils is a transitive dependency of commons-validator: https://commons.apache.org/proper/commons-validator/index.html
-* This patch enforces commons-beanutils version 1.11.0 explicitly to mitigate the CVE.
-* Can be removed once Kafka upstream upgrades commons-validator to a version that depends on commons-beanutils <= 1.11.0.
-  - Current commons-validator version in use: https://github.com/apache/kafka/blob/${{package.version}}/gradle/dependencies.gradle#L60
-  - Future validator versions can be checked for dependency updates: https://github.com/apache/commons-validator/blob/<commons-validator version>/pom.xml#L159-L163 in plugins
-
-Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>
----
- LICENSE-binary             | 2 +-
- build.gradle               | 5 ++++-
- gradle/dependencies.gradle | 2 ++
- 3 files changed, 7 insertions(+), 2 deletions(-)
-
 diff --git a/LICENSE-binary b/LICENSE-binary
-index 030f62b967..605528c2c8 100644
+index 030f62b967..d9416410b3 100644
 --- a/LICENSE-binary
 +++ b/LICENSE-binary
-@@ -206,7 +206,7 @@ This project bundles some components that are also licensed under the Apache
+@@ -206,10 +206,10 @@ This project bundles some components that are also licensed under the Apache
  License Version 2.0:
  
  - caffeine-3.1.1
@@ -29,49 +10,54 @@ index 030f62b967..605528c2c8 100644
 +- commons-beanutils-1.11.0
  - commons-collections-3.2.2
  - commons-digester-2.1
- - commons-lang3-3.12.0
+-- commons-lang3-3.12.0
++- commons-lang3-3.18.0
+ - commons-logging-1.3.2
+ - commons-validator-1.9.0
+ - error_prone_annotations-2.14.0
 diff --git a/build.gradle b/build.gradle
-index 388a85aa85..b6cccfb821 100644
+index 388a85aa85..066f133bed 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -197,7 +197,9 @@ allprojects {
+@@ -197,7 +197,10 @@ allprojects {
            // ensure we have a single version in the classpath despite transitive dependencies
            libs.scalaLibrary,
            libs.scalaReflect,
 -          libs.jacksonAnnotations
 +          libs.jacksonAnnotations,
 +          // Enforce the updated commons-beanutils to address CVE
-+          libs.commonsBeanutils
++          libs.commonsBeanutils,
++          libs.commonsLang3,
          )
        }
      }
-@@ -1084,6 +1086,7 @@ project(':core') {
+@@ -1084,6 +1087,7 @@ project(':core') {
      implementation project(':share-coordinator')
  
      implementation libs.argparse4j
-+    implementation libs.commonsBeanutils // Explicitly adding commons-beanutils to override transitive dependency
++    implementation libs.commonsLang3
      implementation libs.commonsValidator
      implementation libs.jacksonDatabind
      implementation libs.jacksonDataformatCsv
 diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
-index 66eca369aa..cae785a015 100644
+index 66eca369aa..b7a75be8a5 100644
 --- a/gradle/dependencies.gradle
 +++ b/gradle/dependencies.gradle
-@@ -60,6 +60,7 @@ versions += [
+@@ -60,6 +60,8 @@ versions += [
    caffeine: "3.1.1",
    bndlib: "7.0.0",
    checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "10.20.2",
 +  commonsBeanutils: "1.11.0", // Added to address CVE GHSA-wxr5-93ph-8wr9
++  commonsLang3: "3.18.0",
    commonsValidator: "1.9.0",
    classgraph: "4.8.173",
    gradle: "8.10.2",
-@@ -148,6 +149,7 @@ libs += [
+@@ -148,6 +150,8 @@ libs += [
    bndlib:"biz.aQute.bnd:biz.aQute.bndlib:$versions.bndlib",
    caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
    classgraph: "io.github.classgraph:classgraph:$versions.classgraph",
 +  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
++  commonsLang3: "org.apache.commons:commons-lang3:$versions.commonsLang3",
    commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
    jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
    jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
--- 
-2.49.0


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep for https://github.com/advisories/GHSA-j288-q9x7-2f5v
