### PR TITLE
feat(solr-9.8.1): bump deps to remediate GHSA-j288-q9x7-2f5v

### DIFF
--- a/solr.yaml
+++ b/solr.yaml
@@ -1,7 +1,7 @@
 package:
   name: solr
   version: "9.8.1"
-  epoch: 1
+  epoch: 2
   description: Apache Solr open-source search software
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,9 @@ pipeline:
       sed -i -e 's|com.jayway.jsonpath:json-path=2.8.0|com.jayway.jsonpath:json-path=2.9.0|g' versions.props
       # Resolve GHSA-g8m5-722r-8whq
       sed -i -e 's|org.eclipse.jetty\*:\*=10.0.22|org.eclipse.jetty\*:\*=10.0.24|g' versions.props
+      # GHSA-j288-q9x7-2f5v
+      sed -i -e 's|org.apache.commons:commons-lang3=3.15.0|org.apache.commons:commons-lang3=3.18.0|g' versions.props
+
       ./gradlew --write-locks
 
       ./gradlew dependencies


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep for https://github.com/advisories/GHSA-j288-q9x7-2f5v
