### PR TITLE
couchdb-3.3: Upgrade to Erlang 27

### DIFF
--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 8
+  epoch: 9
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0
@@ -19,8 +19,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - erlang-25
-      - erlang-25-dev
+      - erlang-27
+      - erlang-27-dev
       - icu-dev
       - libtool
       - mozjs91


### PR DESCRIPTION
Upstream supports 25-27; lets align to the most recent version.
