### PR TITLE
jenkins-plugin-manager: remediate GHSA-j288-q9x7-2f5v CVE-2025-48924

### DIFF
--- a/jenkins-plugin-manager.yaml
+++ b/jenkins-plugin-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-plugin-manager
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: Plugin Manager CLI tool for Jenkins
   copyright:
     - license: MIT
@@ -23,6 +23,10 @@ pipeline:
       repository: https://github.com/jenkinsci/plugin-installation-manager-tool
       tag: ${{package.version}}
       expected-commit: d3a6ba3f84bf0223870ad9632b0f74bd861b7539
+
+  - uses: maven/pombump
+    with:
+      pom: plugin-management-library/pom.xml
 
   - runs: |
       mvn clean package -DskipTests

--- a/jenkins-plugin-manager/pombump-deps.yaml
+++ b/jenkins-plugin-manager/pombump-deps.yaml
@@ -1,0 +1,4 @@
+patches:
+  - groupId: org.apache.commons
+    artifactId: commons-lang3
+    version: 3.18.0


### PR DESCRIPTION
Bump dependency on commons-lang3 to v3.18.0 to remediate GHSA-j288-q9x7-2f5v CVE-2025-48924.

See also upstream patch:
    https://github.com/jenkinsci/plugin-installation-manager-tool/commit/880049788fbdb012fffc3281051a221027bbe910