### PR TITLE
nrjmx: remediate GHSA-j288-q9x7-2f5v CVE-2025-48924

### DIFF
--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nrjmx
   version: "2.7.0"
-  epoch: 2
+  epoch: 3
   description: Command line tool to connect to a JMX server and retrieve the MBeans it exposes
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 618ca6f63c1e0389b584df5ebff5c3aa91b8cc12
 
-  - uses: maven/configure-mirror
+  - uses: auth/maven
+
+  - uses: maven/pombump
 
   - runs: |
       mvn clean package -P \!deb,\!rpm,\!tarball,\!test -DskipTests

--- a/nrjmx/pombump-deps.yaml
+++ b/nrjmx/pombump-deps.yaml
@@ -1,0 +1,4 @@
+patches:
+  - groupId: org.apache.commons
+    artifactId: commons-lang3
+    version: 3.18.0


### PR DESCRIPTION
Bump dependency on commons-lang3 to v3.18.0 to remediate GHSA-j288-q9x7-2f5v CVE-2025-48924.

See also upstream patch:
    https://github.com/newrelic/nrjmx/pull/175