### PR TITLE
add /data/flux for flux-operator

### DIFF
--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -3,6 +3,9 @@ package:
   version: "0.24.1"
   epoch: 2
   description: Flux Operator creates and manages Flux instances running in Kubernetes
+  dependencies:
+    runtime:
+      - tzdata
   copyright:
     - license: AGPL-3.0-or-later
 

--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-operator
   version: "0.24.1"
-  epoch: 1
+  epoch: 2
   description: Flux Operator creates and manages Flux instances running in Kubernetes
   copyright:
     - license: AGPL-3.0-or-later
@@ -18,6 +18,10 @@ pipeline:
       packages: ./cmd/operator/main.go
       output: flux-operator
       ldflags: -X main.VERSION=${{package.version}}
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/data
+      cp -R config/data/* ${{targets.contextdir}}/data
 
 subpackages:
   - name: ${{package.name}}-mcp
@@ -86,17 +90,6 @@ subpackages:
         - runs: |
             stat /flux-operator
 
-  - name: ${{package.name}}-compat-data
-    description: offline data for ${{package.name}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/data
-          cp -R config/data/* ${{targets.contextdir}}/data
-    test:
-      pipeline:
-        - runs: |
-            stat /data/flux
-
   - name: ${{package.name}}-mcp-compat
     description: compat package for flux-operator-mcp
     pipeline:
@@ -125,6 +118,7 @@ test:
   pipeline:
     - runs: |
         /usr/bin/flux-operator --help 2>&1 | grep metrics-addr
+        stat /flux/data
     - uses: test/kwok/cluster
     - name: "Functional test for operator"
       uses: test/daemon-check-output

--- a/flux-operator.yaml
+++ b/flux-operator.yaml
@@ -86,6 +86,17 @@ subpackages:
         - runs: |
             stat /flux-operator
 
+  - name: ${{package.name}}-compat-data
+    description: offline data for ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/data
+          cp -R config/data/* ${{targets.contextdir}}/data
+    test:
+      pipeline:
+        - runs: |
+            stat /data/flux
+
   - name: ${{package.name}}-mcp-compat
     description: compat package for flux-operator-mcp
     pipeline:


### PR DESCRIPTION
add data compat package for flux-operator to allow deployment of a FluxInstance without specifying `spec.distribution.artifact`