### PR TITLE
nextflow: remediate CVE-2025-48924 GHSA-j288-q9x7-2f5v

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
   version: "25.04.6"
-  epoch: 0
+  epoch: 1
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
@@ -36,6 +36,10 @@ pipeline:
   - uses: patch
     with:
       patches: eclipse-GHSA-vrpq-qp53-qv56-fix.patch
+
+  - runs: |
+      # CVE-2025-48924 GHSA-j288-q9x7-2f5v
+      sed -i -e 's|org.apache.commons:commons-lang3=3.12.0|org.apache.commons:commons-lang3=3.18.0|g' plugins/nf-wave/build.gradle
 
   - runs: |
       sed -i 's/jar\.enabled = false/jar.enabled = true/' build.gradle


### PR DESCRIPTION
Bump dependency to remediate CVE-2025-48924 GHSA-j288-q9x7-2f5v.

See also:
 https://github.com/chainguard-dev/CVE-Dashboard/issues/25956
 https://github.com/nextflow-io/nextflow/commit/b8ccddb5641ff25daef103df83d776b27ede725d