### PR TITLE
cloudnative-pg: Correct plugin name

### DIFF
--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudnative-pg
   version: "1.26.0"
-  epoch: 1
+  epoch: 2
   description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ subpackages:
       - uses: go/build
         with:
           packages: ./cmd/kubectl-cnpg
-          output: plugins
+          output: kubectl-cnpg
           ldflags: |
             -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildVersion=${{package.version}}
             -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildCommit=$(git rev-parse --short=8 HEAD)


### PR DESCRIPTION
We had the go/build pipeline output the incorrect name.  Users expect
the plugin binary to be named `kubectl-cnpg` as per the upstream, so
that it will work automatically with the kubectl plugin ecosystem.

What we were getting was `/usr/bin/plugins`.
