### PR TITLE
jenkins-2: remediate cve

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
-  version: "2.518"
-  epoch: 1
+  version: "2.519"
+  epoch: 0
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -46,7 +46,7 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
-      expected-commit: 0c97647ff143b63d8b1de085a81dd5fc8883dcab
+      expected-commit: 8928ce2f292da0c806dce2d3393be6d0de605168
 
   - uses: patch
     with:

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.518"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -47,6 +47,10 @@ pipeline:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
       expected-commit: 0c97647ff143b63d8b1de085a81dd5fc8883dcab
+
+  - uses: patch
+    with:
+      patches: bump-commons-lang3-api-GHSA-j288-q9x7-2f5v.patch
 
   - uses: maven/pombump
 

--- a/jenkins-2/bump-commons-lang3-api-GHSA-j288-q9x7-2f5v.patch
+++ b/jenkins-2/bump-commons-lang3-api-GHSA-j288-q9x7-2f5v.patch
@@ -1,0 +1,26 @@
+From 54fef927f90009e0eaa0e287fa20f8cb4ef3d414 Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Wed, 16 Jul 2025 16:18:22 +0000
+Subject: [PATCH] bump commons-lang3-api to 3.18.0 to remediate
+ GHSA-j288-q9x7-2f5v
+
+---
+ war/pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/war/pom.xml b/war/pom.xml
+index 1034f9f18d..11c16de7b8 100644
+--- a/war/pom.xml
++++ b/war/pom.xml
+@@ -512,7 +512,7 @@ THE SOFTWARE.
+                   <!-- dependency of bootstrap5-api, checks-api, commons-text-api, echarts-api, font-awesome-api, jquery3-api, and plugin-util-api -->
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>commons-lang3-api</artifactId>
+-                  <version>3.17.0-87.v5cf526e63b_8b_</version>
++		  <version>3.18.0-98.v3a_674c06072d</version>
+                   <type>hpi</type>
+                 </artifactItem>
+                 <artifactItem>
+-- 
+2.47.2
+


### PR DESCRIPTION
Remediate cve GHSA-j288-q9x7-2f5v by bumping commons-lang3-api to 3.18.0-98.v3a_674c06072d which will pull latest commons-lang3.