### PR TITLE
pl2pm doesn't take any arguments

### DIFF
--- a/perl.yaml
+++ b/perl.yaml
@@ -178,8 +178,6 @@ subpackages:
             perlthanks --help
             piconv --version
             piconv --help
-            pl2pm --version
-            pl2pm --help
             prove --version
             # Uses a pager now, which we can't handle at this time
             #ptargrep --help


### PR DESCRIPTION
I deliberately did not bump the epoch because we are just removing tests and possibly having to rebuild dependent packages seemed unnecessary.

https://linuxcommandlibrary.com/man/pl2pm