### PR TITLE
fix: systemd-logs doesn't need qemu

### DIFF
--- a/sonobuoy-systemd-logs.yaml
+++ b/sonobuoy-systemd-logs.yaml
@@ -13,7 +13,6 @@ package:
       - coreutils
       # The pod uses `/bin/sh -c /get_system_logs.sh...`
       - dash-binsh
-      - qemu
       - systemd
 
 environment:
@@ -38,6 +37,7 @@ pipeline:
 
 update:
   enabled: false
+  manual: true
   exclude-reason: No releases or tags on source to watch
 
 test:

--- a/sonobuoy-systemd-logs.yaml
+++ b/sonobuoy-systemd-logs.yaml
@@ -2,7 +2,7 @@
 package:
   name: sonobuoy-systemd-logs
   version: "0.4.0"
-  epoch: 0
+  epoch: 1
   description: Sonobuoy systemd-logs is a plugin for Sonobuoy that collects systemd logs from nodes in a Kubernetes cluster.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Removing qemu dependency from systemd-logs