### PR TITLE
perl 5.42 other rdeps3

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.0"
-  epoch: 0
+  epoch: 3
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-stable
   # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
   version: "1.28.0"
-  epoch: 2
+  epoch: 5
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/openresty.yaml
+++ b/openresty.yaml
@@ -1,7 +1,7 @@
 package:
   name: openresty
   version: "1.27.1.2"
-  epoch: 1
+  epoch: 2
   description: High Performance Web Platform Based on Nginx and LuaJIT
   dependencies:
     runtime:


### PR DESCRIPTION
- **nginx-mainline: Rebuild other perl-dev rdeps for the perl 5.42.0 release**
- **nginx-stable: Rebuild other perl-dev rdeps for the perl 5.42.0 release**
- **openresty: Rebuild other perl-dev rdeps for the perl 5.42.0 release**
