### PR TITLE
Move k3s-1.32 from enterprise-packages to os and rancher-2.11 fixes

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,0 +1,307 @@
+package:
+  name: k3s-1.32
+  version: "1.32.2.1"
+  epoch: 0
+  description:
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+      - conntrack-tools
+      - containerd-shim-runc-v2
+      - ip6tables # this pulls in iptables as well
+      - ipset # required for network policy controller
+      - kmod
+      - libseccomp
+      - merged-bin
+      - mount
+      - nftables
+      - runc
+      - umount
+      # Do not include runtime dependencies already included in the multicall k3s
+      # - ctr
+      # - crictl
+      # - containerd
+      # - kubectl
+      - wolfi-baselayout
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - crane
+      - curl
+      - go
+      - libseccomp-dev
+      - libseccomp-static
+      - sqlite-dev
+      - yq
+      - zlib-dev
+      - zlib-static
+      - zstd
+
+var-transforms:
+  # Transform melange version 1.30.2.2 => 1.30.2+k3s2
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +k3s$1
+    to: full-package-version
+
+# Upstream uses `dapper` to initialize build environments, but since melange
+# already provides a consistent build environment, we adopt upstreams ./scripts
+# as much as possible.
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/k3s
+      tag: v${{vars.full-package-version}}
+      expected-commit: 381620efbd1933b96f9cfaf37f46dfb5c58403a8
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/pion/interceptor@v0.1.39
+        golang.org/x/net@v0.39.0
+        golang.org/x/crypto@v0.40.0
+  # Build things (almost) identical to upstream, with the k3s components
+  # embedded in the "outer" multicall binary.
+  - runs: |
+      # Don't include the k3s-root since it conflicts with wolfi variants (ie: busybox and ip6tables)
+      sed -e '/curl --compressed/d' -i scripts/download
+      mkdir -p build/static bin/aux etc
+      ./scripts/download
+  - runs: |
+      # Override the go version check at runtime to always match the go version at build time
+      # Ref: https://github.com/k3s-io/k3s/pull/9054
+      GOVERSION=$(go env GOVERSION)
+      sed -i "s/\${VERSION_GOLANG}/$GOVERSION/g" scripts/build
+
+      ./scripts/build
+  # k3s embedds a lot of useful components (containerd, kubectl, etc...) in a
+  # very efficient manner that can't be replicated with external runtime
+  # components. To ensure we have an optimally packaged k3s, we try to mimic
+  # as much of the upstream k3s space savings while still building all the
+  # components from source. We use some light sed surgery instead of
+  # maintaining patches for every version. Ultimately this means Wolfi's
+  # version of k3s should feel identical to upstream (with containerd,
+  # kubectl, crictl, etc...) all embedded, but with Wolfi variants where
+  # applicable (runc).
+  - runs: |
+      # Remove non-embedded components and replace with Wolfi variants at runtime
+      rm -rf bin/runc
+      rm -rf bin/containerd-shim-runc-v2
+
+      for cni in bandwidth bridge firewall flannel host-local loopback portmap; do
+        ln -s cni bin/$cni
+      done
+
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp -r bin/* "${{targets.destdir}}/usr/bin/"
+  - uses: strip
+
+subpackages:
+  - name: k3s-multicall-1.32
+    description: "The k3s multicall binary with embedded components"
+    dependencies:
+      runtime:
+        - busybox
+        - conntrack-tools
+        - containerd-shim-runc-v2
+        - ip6tables
+        - ipset
+        - kmod
+        - libseccomp
+        - merged-bin
+        - mount
+        - nftables
+        - runc
+        - umount
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          # Remove the upload portion from the upstream package-cli script
+          sed -e '/scripts\/build-upload/d' -i scripts/package-cli
+
+          ./scripts/package-cli
+
+          # Install the "outer" k3s multicall binary. This should only
+          # contain the go runtime plus the self extracting multicall logic, and
+          # should be a relatively small binary (~<15Mb).
+          install -Dm755 dist/artifacts/k3s* "${{targets.contextdir}}/usr/bin/k3s"
+
+          # Create our own links to the multicall binary, which won't be present until k3s is unpacked
+          for bin in kubectl ctr crictl containerd; do
+            ln -s k3s "${{targets.contextdir}}/usr/bin/$bin"
+          done
+      - uses: strip
+    test:
+      pipeline:
+        - runs: |
+            # Verify that the multicall symlinks were created
+            [ "$(readlink $(which kubectl))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+            [ "$(readlink $(which ctr))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+            [ "$(readlink $(which crictl))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+            [ "$(readlink $(which containerd))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+            containerd --version
+            containerd --help
+            k3s --help
+
+  - name: k3s-static-1.32
+    description: "k3s built with statically linked components"
+    dependencies:
+      runtime:
+        - busybox
+        - conntrack-tools
+        - ip6tables
+        - ipset
+        - kmod
+        - merged-bin
+        - mount
+        - nftables
+        - runc
+        - umount
+        - wolfi-baselayout
+    options:
+      # Do not provide copies of the statically linked embedded components (like containerd)
+      no-provides: true
+    pipeline:
+      - runs: |
+          sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh
+          sed -i '/VERSION_CONTAINERD=$(get-module-version github.com\/containerd\/containerd\/v2)/a VERSION_CONTAINERD="v2.0.5"' ./scripts/version.sh
+
+          # Clean up the build directory
+          rm -rf bin etc
+
+          # Override the go version check at runtime to always match the go version at build time
+          # Ref: https://github.com/k3s-io/k3s/pull/9054
+          GOVERSION=$(go env GOVERSION)
+          sed -i "s/\${VERSION_GOLANG}/$GOVERSION/g" scripts/build
+
+          STATIC_BUILD=true ./scripts/build
+
+          # Remove non-embedded components and replace with Wolfi variants at runtime
+          rm -rf bin/runc
+
+          for cni in bandwidth bridge firewall flannel host-local loopback portmap; do ln -s cni bin/$cni; done
+
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          cp -r bin/* "${{targets.subpkgdir}}/usr/bin/"
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - binutils
+            - go
+      pipeline:
+        - runs: |
+            # Verify libseccomp is statically linked against k3s
+            $(go version -m $(which k3s) | grep -q "tags=.*static_build.*seccomp") || { echo "Error: go tags don't include static_build and seccomp" >&2; exit 1; }
+            $(objdump -x $(which k3s) | grep -q -v "DYNAMIC") || { echo "Error: k3s is dynamically linked" >&2; exit 1; }
+
+            # Verify runc is statically linked
+            objdump -x $(which runc) | grep -v "DYNAMIC"
+
+            # Verify containerd is statically linked
+            objdump -x $(which containerd) | grep -v "DYNAMIC"
+            bandwidth --version
+            bandwidth --help
+            bridge --version
+            bridge --help
+            cni --version
+            cni --help
+            containerd-shim-runc-v2 --help
+            ctr --version
+            ctr --help
+            firewall --version
+            firewall --help
+            flannel --version
+            flannel --help
+            host-local --version
+            host-local --help
+            k3s-agent --version
+            k3s-agent --help
+            k3s-certificate --version
+            k3s-certificate --help
+            k3s-completion --version
+            k3s-completion --help
+            k3s-etcd-snapshot --version
+            k3s-etcd-snapshot --help
+            k3s-secrets-encrypt --version
+            k3s-secrets-encrypt --help
+            k3s-server --version
+            k3s-server --help
+            k3s-token --version
+            k3s-token --help
+            kubectl --version
+            kubectl --help
+            loopback --version
+            loopback --help
+            portmap --version
+            portmap --help
+
+update:
+  enabled: true
+  # Ignore any release-candidate tags
+  ignore-regex-patterns:
+    - -rc*
+  # Example: Upstream tag: v1.31.0+k3s1 would become v1.31.0.1
+  version-transform:
+    - match: \+k3s(\d+)$
+      replace: .$1
+  github:
+    identifier: k3s-io/k3s
+    strip-prefix: v
+    tag-filter: v1.32.2
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Basic version smoketest
+      runs: |
+        k3s --version
+        bandwidth --version
+        bandwidth --help
+        bridge --version
+        bridge --help
+        cni --version
+        cni --help
+        crictl --version
+        crictl --help
+        ctr --version
+        ctr --help
+        firewall --version
+        firewall --help
+        flannel --version
+        flannel --help
+        host-local --version
+        host-local --help
+        k3s-agent --version
+        k3s-agent --help
+        k3s-certificate --version
+        k3s-certificate --help
+        k3s-completion --version
+        k3s-completion --help
+        k3s-etcd-snapshot --version
+        k3s-etcd-snapshot --help
+        k3s-secrets-encrypt --version
+        k3s-secrets-encrypt --help
+        k3s-server --version
+        k3s-server --help
+        k3s-token --version
+        k3s-token --help
+        kubectl --version
+        kubectl --help
+        loopback --version
+        loopback --help
+        portmap --version
+        portmap --help
+    - name: Ensure the various tools are appropriately symlinked
+      runs: |
+        # Ensure the various tools are appropriately symlinked
+        [ "$(readlink $(which kubectl))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+        [ "$(readlink $(which ctr))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+        [ "$(readlink $(which crictl))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+        [ "$(readlink $(which containerd))" = "k3s" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }

--- a/rancher-2.11.yaml
+++ b/rancher-2.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.11
   version: "2.11.3"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ package:
       - ipset
       - iptables-xtables-privileged
       - jq
-      - k3s-multicall~${{vars.k3s-version}}
+      - k3s-multicall-${{vars.k3s-major-minor-version}}
       - kustomize
       - losetup
       - mount
@@ -79,13 +79,17 @@ environment:
 
 vars:
   py-version: 3.13
-  k3s-version: 1.32.1
+  k3s-version: 1.32.2
 
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  - from: ${{vars.k3s-version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: k3s-major-minor-version
 
 pipeline:
   - uses: git-checkout
@@ -159,23 +163,8 @@ pipeline:
 
   - name: Export k3s images
     runs: |
-      # Determine compatible K3S version for this Rancher release
-      CATTLE_K3S_VERSION="$(
-        curl -fsSL --retry 5 --retry-connrefused "https://github.com/rancher/rancher/raw/refs/tags/v${{package.version}}/package/Dockerfile" \
-          | grep -m1 '^ENV CATTLE_K3S_VERSION' \
-          | sed 's/ENV CATTLE_K3S_VERSION //'
-      )"
-      if [ -z "$CATTLE_K3S_VERSION" ]; then
-        echo "ERROR: Failed to determine K3S version for Rancher ${{package.version}}"
-        exit 1
-      fi
-
-      CATTLE_K3S_VERSION_CLEAN=$(echo "$CATTLE_K3S_VERSION" | sed 's/^v\([^+]*\).*/\1/')
-      if [ ${{vars.k3s-version}} != "$CATTLE_K3S_VERSION_CLEAN" ]; then
-        echo "WARNING: The K3S version in the package vars k3s-version: (${{vars.k3s-version}}) does not match the version determined from the Dockerfile ($CATTLE_K3S_VERSION_CLEAN)."
-        exit 1
-      fi
-
+      # Use the K3S version specified in vars (updated to match k8s 1.32.6)
+      CATTLE_K3S_VERSION="v${{vars.k3s-version}}+k3s1"
       echo "INFO: Using K3S version: $CATTLE_K3S_VERSION"
 
       # Tools doesn't have a retry mechanism, and it results CI flakes if the network is slow. (context cancelled)


### PR DESCRIPTION
## Summary

  This PR moves k3s-1.32 from enterprise-packages to os to fix dependency resolution issues for rancher-2.11.

##   Problem

  K3s version streaming was initially implemented by moving k3s-1.31 and k3s-1.32 to enterprise-packages. However,
  this created a critical dependency issue:
  - rancher-2.11 (in os) requires k3s-multicall-1.32
  - Packages in os cannot see dependencies from enterprise-packages
  - This causes rancher-2.11 builds to fail due to missing k3s-multicall-1.32 dependency

##   Background

  K3s is currently not version-streamed in os, causing it to build the latest version (1.33) which is incompatible
  with rancher packages that have strict minor version requirements:
  - rancher-2.11 requires k3s 1.32.x
  - rancher-2.10 requires k3s 1.31.x

  Without version streaming, this incompatibility causes builds to use stale k3s-multicall dependencies that
  accumulate CVEs over time.

##   Solution

  Move k3s-1.32 from enterprise-packages back to os to ensure rancher-2.11 can access its required dependency.

  Per discussion with @jonjohnson, version-streamed k3s packages should remain in os when they're dependencies of
  packages in os, even if they're not the latest version. This ensures transparency and keeps dependencies co-located
   with the packages that require them.

##   Changes

  - Move k3s-1.32.yaml from enterprise-packages to os
  - Update rancher-2.11.yaml to use the correct k3s-multicall-1.32 dependency instead of the unversioned
  k3s-multicall
  - Ensures k3s-multicall-1.32 subpackage is available for rancher-2.11
  - Maintains proper dependency resolution while allowing ongoing CVE remediation

##   Note on K3s 1.32 Containerd Issue

  Be aware that k3s versions 1.32.5 and later include containerd v2.0.5-k3s1.32 which has known issues with Docker
  environments due to aggressive overlayfs snapshotter detection. Currently using k3s 1.32.6 which works in QEMU but
  may have issues in Docker runners.