### PR TITLE
melange/0.29.5 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.29.4"
+  version: "0.29.5"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 113b227a8cf54e98cd9c36b67f478adccc993797
+      expected-commit: e29494b4a40a91619ec1c87a09003c6d5164cea1
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR bumps melange to `0.29.5` to pull in fixes for SBOMs and signatures.