### PR TITLE
perl 5.42 rdeps8

### DIFF
--- a/perl-namespace-autoclean.yaml
+++ b/perl-namespace-autoclean.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-namespace-autoclean
   version: "0.31"
-  epoch: 1
+  epoch: 2
   description: Keep imports out of your namespace
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-namespace-clean.yaml
+++ b/perl-namespace-clean.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-namespace-clean
   version: "0.27"
-  epoch: 3
+  epoch: 4
   description: Keep imports and functions out of your namespace
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-http.yaml
+++ b/perl-net-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-http
   version: "6.23"
-  epoch: 4
+  epoch: 5
   description: Low-level HTTP connection (client)
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-snmp.yaml
+++ b/perl-net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-snmp
   version: 6.0.1
-  epoch: 2
+  epoch: 3
   description: Object oriented interface to SNMP
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-net-telnet.yaml
+++ b/perl-net-telnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-telnet
   version: "3.05"
-  epoch: 4
+  epoch: 5
   description: Interact with TELNET port or other TCP ports
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-package-stash.yaml
+++ b/perl-package-stash.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-package-stash
   version: "0.40"
-  epoch: 3
+  epoch: 4
   description: Routines for manipulating stashes
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-parallel-iterator.yaml
+++ b/perl-parallel-iterator.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parallel-iterator
   version: "1.002"
-  epoch: 3
+  epoch: 4
   description: Simple parallel execution
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-parallel-pipes.yaml
+++ b/perl-parallel-pipes.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parallel-pipes
   version: "0.201"
-  epoch: 0
+  epoch: 1
   description: friendly interface for Parallel::Pipes
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-params-validationcompiler.yaml
+++ b/perl-params-validationcompiler.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-params-validationcompiler
   version: "0.31"
-  epoch: 4
+  epoch: 5
   description: Params::ValidationCompiler perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-parse-pmfile.yaml
+++ b/perl-parse-pmfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-parse-pmfile
   version: "0.47"
-  epoch: 0
+  epoch: 1
   description: parses .pm file as PAUSE does
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl


### PR DESCRIPTION
- **perl-namespace-autoclean: Rebuild perl-* for the perl 5.42.0 release**
- **perl-namespace-clean: Rebuild perl-* for the perl 5.42.0 release**
- **perl-net-http: Rebuild perl-* for the perl 5.42.0 release**
- **perl-net-snmp: Rebuild perl-* for the perl 5.42.0 release**
- **perl-net-telnet: Rebuild perl-* for the perl 5.42.0 release**
- **perl-package-stash: Rebuild perl-* for the perl 5.42.0 release**
- **perl-parallel-iterator: Rebuild perl-* for the perl 5.42.0 release**
- **perl-parallel-pipes: Rebuild perl-* for the perl 5.42.0 release**
- **perl-params-validationcompiler: Rebuild perl-* for the perl 5.42.0 release**
- **perl-parse-pmfile: Rebuild perl-* for the perl 5.42.0 release**
