### PR TITLE
perl 5.42 rdeps10

### DIFF
--- a/perl-sub-info.yaml
+++ b/perl-sub-info.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-info
   version: "0.002"
-  epoch: 3
+  epoch: 4
   description: Tool for inspecting subroutines.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-sub-quote.yaml
+++ b/perl-sub-quote.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-quote
   version: "2.006008"
-  epoch: 3
+  epoch: 4
   description: Efficient generation of subroutines via string eval
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-template-toolkit.yaml
+++ b/perl-template-toolkit.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-template-toolkit
   version: "3.102"
-  epoch: 1
+  epoch: 2
   description: comprehensive template processing system
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-term-table.yaml
+++ b/perl-term-table.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-term-table
   version: "0.024"
-  epoch: 0
+  epoch: 1
   description: Format a header and rows into a table
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-differences.yaml
+++ b/perl-test-differences.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-differences
   version: "0.71"
-  epoch: 2
+  epoch: 3
   description: Test strings and data structures and show differences if not ok
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-fatal.yaml
+++ b/perl-test-fatal.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-fatal
   version: "0.017"
-  epoch: 3
+  epoch: 4
   description: incredibly simple helpers for testing code with exceptions
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-nowarnings.yaml
+++ b/perl-test-nowarnings.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-nowarnings
   version: "1.06"
-  epoch: 3
+  epoch: 4
   description: Test::NoWarnings perl module
   copyright:
     - license: LGPL-2.1-only

--- a/perl-test-pod-coverage.yaml
+++ b/perl-test-pod-coverage.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-pod-coverage
   version: "1.10"
-  epoch: 3
+  epoch: 4
   description: Perl - Check for pod coverage in your distribution.
   copyright:
     - license: Artistic-2.0

--- a/perl-test-pod.yaml
+++ b/perl-test-pod.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test-pod
   version: 1.52
-  epoch: 6
+  epoch: 7
   description: check for POD errors in files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-test-simple.yaml
+++ b/perl-test-simple.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test-simple
   version: "1.302214"
-  epoch: 0
+  epoch: 1
   description: Basic utilities for writing tests
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl


### PR DESCRIPTION
- **perl-sub-info: Rebuild perl-* for the perl 5.42.0 release**
- **perl-sub-quote: Rebuild perl-* for the perl 5.42.0 release**
- **perl-template-toolkit: Rebuild perl-* for the perl 5.42.0 release**
- **perl-term-table: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-differences: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-fatal: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-nowarnings: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-pod-coverage: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-pod: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test-simple: Rebuild perl-* for the perl 5.42.0 release**
