### PR TITLE
perl 5.42 rdeps11

### DIFF
--- a/perl-test-without-module.yaml
+++ b/perl-test-without-module.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-without-module
   version: "0.23"
-  epoch: 2
+  epoch: 3
   description: Test::Without::Module perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-test2-plugin-nowarnings.yaml
+++ b/perl-test2-plugin-nowarnings.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test2-plugin-nowarnings
   version: "0.10"
-  epoch: 3
+  epoch: 4
   description: Test2::Plugin::NoWarnings perl module
   copyright:
     - license: Artistic-2.0

--- a/perl-text-diff.yaml
+++ b/perl-text-diff.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-text-diff
   version: "1.45"
-  epoch: 2
+  epoch: 3
   description: Perform diffs on files and record sets
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-tidy.yaml
+++ b/perl-tidy.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-tidy
   version: "20250311"
-  epoch: 0
+  epoch: 1
   description: Parses and beautifies perl source
   copyright:
     - license: GPL-2.0-only

--- a/perl-time-hires.yaml
+++ b/perl-time-hires.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-time-hires
   version: "1.9764"
-  epoch: 3
+  epoch: 4
   description: High resolution alarm, sleep, gettimeofday, interval timers
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-tk.yaml
+++ b/perl-tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-tk
   version: "804.036"
-  epoch: 5
+  epoch: 6
   description: Tk - a Graphical User Interface Toolkit
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later

--- a/perl-try-tiny.yaml
+++ b/perl-try-tiny.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-try-tiny
   version: "0.32"
-  epoch: 1
+  epoch: 2
   description: Minimal try/catch with proper preservation of $@
   copyright:
     - license: MIT

--- a/perl-types-serialiser.yaml
+++ b/perl-types-serialiser.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-types-serialiser
   version: "1.01"
-  epoch: 3
+  epoch: 4
   description: Perl module for Types-Serialiser
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-uri.yaml
+++ b/perl-uri.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-uri
   version: "5.32"
-  epoch: 0
+  epoch: 1
   description: Uniform Resource Identifiers (absolute and relative)
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/perl-win32-shellquote.yaml
+++ b/perl-win32-shellquote.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-win32-shellquote
   version: "0.003001"
-  epoch: 0
+  epoch: 1
   description: Quote argument lists for Win32
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl


### PR DESCRIPTION
- **perl-test-without-module: Rebuild perl-* for the perl 5.42.0 release**
- **perl-test2-plugin-nowarnings: Rebuild perl-* for the perl 5.42.0 release**
- **perl-text-diff: Rebuild perl-* for the perl 5.42.0 release**
- **perl-tidy: Rebuild perl-* for the perl 5.42.0 release**
- **perl-time-hires: Rebuild perl-* for the perl 5.42.0 release**
- **perl-tk: Rebuild perl-* for the perl 5.42.0 release**
- **perl-try-tiny: Rebuild perl-* for the perl 5.42.0 release**
- **perl-types-serialiser: Rebuild perl-* for the perl 5.42.0 release**
- **perl-uri: Rebuild perl-* for the perl 5.42.0 release**
- **perl-win32-shellquote: Rebuild perl-* for the perl 5.42.0 release**
