### PR TITLE
Split off the libzip docs to their own package

### DIFF
--- a/libzip.yaml
+++ b/libzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: libzip
   version: "1.11.4"
-  epoch: 0
+  epoch: 1
   description: "A C library for reading, creating, and modifying zip archives."
   copyright:
     - license: BSD-3-Clause
@@ -33,6 +33,17 @@ pipeline:
   - uses: cmake/install
 
   - uses: strip
+
+subpackages:
+  - name: libzip-doc
+    description: libzip documentation
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/doc
+          mv "${{targets.destdir}}"/usr/share/doc/libzip/* "${{targets.subpkgdir}}"/usr/share/doc/
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true


### PR DESCRIPTION
I was looking at libzip for other reasons and noticed we did not have a separate documentation package, this fixes that.