### PR TITLE
fix(tileserver-gl): bump epoch to pick up libpng 1.6.50

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 4
+  epoch: 5
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
## Explanation

New version of libpng was added 2 days ago: https://github.com/wolfi-dev/os/pull/58804
Rebuilding tileserver-gl with new libpng to fix this error: 
```
terminate called after throwing an instance of 'std::runtime_error'
what():  libpng version mismatch: headers report 1.6.49, but library reports 1.6.50
```
