### PR TITLE
gradle-8: remediate cve

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -3,7 +3,7 @@ package:
   version: "8.14.3"
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: upgrade-deps.patch fix-CVE-2025-4949.patch
+      patches: upgrade-deps.patch fix-CVE-2025-4949.patch commons-lang3-GHSA-j288-q9x7-2f5v.patch
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/gradle-8/commons-lang3-GHSA-j288-q9x7-2f5v.patch
+++ b/gradle-8/commons-lang3-GHSA-j288-q9x7-2f5v.patch
@@ -1,0 +1,26 @@
+From 75ddda6788051f64bcfa012b1552ac91fbd91ef3 Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Thu, 17 Jul 2025 07:38:22 +0000
+Subject: [PATCH] Remediate GHSA-j288-q9x7-2f5v
+
+Bump commons-lang3 to v3.18.0
+---
+ packaging/distributions-dependencies/build.gradle.kts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packaging/distributions-dependencies/build.gradle.kts b/packaging/distributions-dependencies/build.gradle.kts
+index aa8d03e3d75..314af18fc14 100644
+--- a/packaging/distributions-dependencies/build.gradle.kts
++++ b/packaging/distributions-dependencies/build.gradle.kts
+@@ -68,7 +68,7 @@ dependencies {
+         api(libs.commonsHttpclient)     { version { strictly("4.5.14") } }
+         api(libs.commonsIo)             { version { strictly("2.15.1") }}
+         api(libs.commonsLang)           { version { strictly("2.6") }}
+-        api(libs.commonsLang3)          { version { strictly("3.14.0") }}
++        api(libs.commonsLang3)          { version { strictly("3.18.0") }}
+         api(libs.commonsMath)           { version { strictly("3.6.1") }}
+         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
+         api(libs.errorProneAnnotations) { version { strictly("2.36.0") } } // don't forget to upgrade errorprone in gradlebuild.code-quality.gradle.kts
+-- 
+2.47.2
+


### PR DESCRIPTION
Remediate GHSA-j288-q9x7-2f5v
Bump commons-lang3 to v3.18.0 by patching
packaging/distributions-dependencies/build.gradle.kts

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
