### PR TITLE
melange/0.29.6 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.29.5"
+  version: "0.29.6"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e29494b4a40a91619ec1c87a09003c6d5164cea1
+      expected-commit: b6eaa9d9fd140c1505bd5345a12f76be17fc4f44
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR updates melange to `0.29.6` to pull in some more bumps/fixes.