### PR TITLE
py3-cassandra-medusa: remediate CVE-2025-53643 GHSA-9548-qrrj-x5pj

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.24.1"
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,8 @@ pipeline:
       poetry add "setuptools@^78.1.1"
       # GHSA-9hjg-9r4m-mvj7: requests
       poetry add "requests@^2.32.4"
+      # CVE-2025-53643 GHSA-9548-qrrj-x5pj
+      poetry add "aiohttp@^3.12.14"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
       POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
       poetry build


### PR DESCRIPTION
Bump aiohttp dependency to remediate CVE-2025-53643 GHSA-9548-qrrj-x5pj

See also:
 * https://github.com/chainguard-dev/CVE-Dashboard/issues/26045
