### PR TITLE
melange/0.29.7 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.29.6"
+  version: "0.29.7"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: b6eaa9d9fd140c1505bd5345a12f76be17fc4f44
+      expected-commit: f66cb125a4402285b8ec5df35cd69e76fd842f76
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR updates melange to `0.29.7` to pull in fixes for hanging tests.