### PR TITLE
666 rebuild10

### DIFF
--- a/cbindgen.yaml
+++ b/cbindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: cbindgen
   version: "0.29.0"
-  epoch: 0
+  epoch: 1
   description: Tool to generate C bindings from Rust code
   copyright:
     - license: MPL-2.0

--- a/ccache.yaml
+++ b/ccache.yaml
@@ -1,7 +1,7 @@
 package:
   name: ccache
   version: "4.11.3"
-  epoch: 0
+  epoch: 1
   description: Fast C/C++ compiler cache
   copyright:
     - license: GPL-3.0-or-later

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdrkit
   version: 1.1.11
-  epoch: 1
+  epoch: 2
   description: Suite of programs for CD/DVD recording, ISO image creation, and audio CD extraction
   copyright:
     - license: GPL-2.0-only

--- a/cedar.yaml
+++ b/cedar.yaml
@@ -1,7 +1,7 @@
 package:
   name: cedar
   version: "4.5.0"
-  epoch: 0
+  epoch: 1
   description: "Core implementation of the Cedar language"
   copyright:
     - license: Apache-2.0

--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.2"
   description: Distributed object, block, and file storage
-  epoch: 8
+  epoch: 9
   copyright:
     - license: LGPL-2.1
   resources:

--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.2"
   description: Distributed object, block, and file storage
-  epoch: 9
+  epoch: 8
   copyright:
     - license: LGPL-2.1
   resources:

--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-exporter
   version: "2.15.1"
-  epoch: 0
+  epoch: 1
   description: A Prometheus exporter that publishes cert expirations on disk and in Kubernetes secrets
   copyright:
     - license: Apache-2.0

--- a/cert-manager-cmctl.yaml
+++ b/cert-manager-cmctl.yaml
@@ -3,7 +3,7 @@ package:
   # This got pulled from the cert-manager repo in the 1.15 release, prior to
   # that it was in the cert-manager/cert-manager repo.
   version: "2.3.0"
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
- **cbindgen: No-change rebuild to fix file permissions**
- **ccache: No-change rebuild to fix file permissions**
- **cdrkit: No-change rebuild to fix file permissions**
- **cedar: No-change rebuild to fix file permissions**
- **celeborn-0.5: No-change rebuild to fix file permissions**
- **ceph: No-change rebuild to fix file permissions**
- **cerbos: No-change rebuild to fix file permissions**
- **cert-exporter: No-change rebuild to fix file permissions**
- **cert-manager-1.18: No-change rebuild to fix file permissions**
- **cert-manager-cmctl: No-change rebuild to fix file permissions**
