### PR TITLE
666 rebuild49

### DIFF
--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.2.41
-  epoch: 50
+  epoch: 51
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later

--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutar
   version: "1.35"
-  epoch: 4
+  epoch: 5
   description: "The GNU Tar program"
   copyright:
     - license: GPL-3.0-or-later

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: "3.8.10"
-  epoch: 0
+  epoch: 1
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 7
+  epoch: 8
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: "1.22.12"
-  epoch: 5
+  epoch: 6
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.23
   version: "1.23.11"
-  epoch: 1
+  epoch: 2
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.5"
-  epoch: 1
+  epoch: 2
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-bindata.yaml
+++ b/go-bindata.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-bindata
   version: 3.1.3
-  epoch: 27
+  epoch: 28
   description: A small utility which generates Go code from any file
   copyright:
     - license: Apache-2.0

--- a/go-discover.yaml
+++ b/go-discover.yaml
@@ -2,7 +2,7 @@
 package:
   name: go-discover
   version: "0_git20250717"
-  epoch: 0
+  epoch: 1
   description: go-discover is a Go (golang) library and command line tool to discover ip addresses of nodes in cloud environments based on meta information like tags provided by the environment.
   copyright:
     - license: MPL-2.0

--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-licenses
   version: 1.6.0
-  epoch: 27
+  epoch: 28
   description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
- **gnupg: No-change rebuild to fix file permissions**
- **gnutar: No-change rebuild to fix file permissions**
- **gnutls: No-change rebuild to fix file permissions**
- **go-1.20: No-change rebuild to fix file permissions**
- **go-1.22: No-change rebuild to fix file permissions**
- **go-1.23: No-change rebuild to fix file permissions**
- **go-1.24: No-change rebuild to fix file permissions**
- **go-bindata: No-change rebuild to fix file permissions**
- **go-discover: No-change rebuild to fix file permissions**
- **go-licenses: No-change rebuild to fix file permissions**
