### PR TITLE
666 rebuild77

### DIFF
--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: "1.3.0"
-  epoch: 1
+  epoch: 2
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause

--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbpf
   version: "1.6.0"
-  epoch: 0
+  epoch: 1
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: GPL-2.0-only

--- a/libburn.yaml
+++ b/libburn.yaml
@@ -2,7 +2,7 @@
 package:
   name: libburn
   version: 1.5.6
-  epoch: 2
+  epoch: 3
   description: Library for reading, mastering and writing optical discs
   copyright:
     - license: GPL-2.0-or-later

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.76"
-  epoch: 4
+  epoch: 5
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libcbor.yaml
+++ b/libcbor.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcbor
   version: "0.12.0"
-  epoch: 2
+  epoch: 3
   description: CBOR protocol implementation for C
   copyright:
     - license: MIT

--- a/libcld2.yaml
+++ b/libcld2.yaml
@@ -4,7 +4,7 @@ package:
   description: Compact Language Detector 2
   url: https://github.com/CLD2Owners/cld2
   version: 0_git20240911
-  epoch: 2
+  epoch: 3
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/libcmis.yaml
+++ b/libcmis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcmis
   version: 0.6.2
-  epoch: 3
+  epoch: 4
   description: C/C++ CMIS client library
   copyright:
     - license: GPL-2.0-or-later

--- a/libdaemon.yaml
+++ b/libdaemon.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdaemon
   version: 0.14
-  epoch: 1
+  epoch: 2
   description: A lightweight C library which eases the writing of UNIX daemons
   copyright:
     - license: LGPL-2.1-or-later

--- a/libdeflate.yaml
+++ b/libdeflate.yaml
@@ -2,7 +2,7 @@
 package:
   name: libdeflate
   version: "1.19"
-  epoch: 2
+  epoch: 3
   description: Library for fast, whole-buffer DEFLATE-based compression and decompression
   copyright:
     - license: MIT

--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -2,7 +2,7 @@
 package:
   name: libdrm
   version: "2.4.125"
-  epoch: 1
+  epoch: 2
   description: Userspace interface to kernel DRM services
   copyright:
     - license: MIT


### PR DESCRIPTION
- **libavif: No-change rebuild to fix file permissions**
- **libbpf: No-change rebuild to fix file permissions**
- **libburn: No-change rebuild to fix file permissions**
- **libcap: No-change rebuild to fix file permissions**
- **libcbor: No-change rebuild to fix file permissions**
- **libcld2: No-change rebuild to fix file permissions**
- **libcmis: No-change rebuild to fix file permissions**
- **libdaemon: No-change rebuild to fix file permissions**
- **libdeflate: No-change rebuild to fix file permissions**
- **libdrm: No-change rebuild to fix file permissions**
