### PR TITLE
666 rebuild95

### DIFF
--- a/manifest-tool.yaml
+++ b/manifest-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: manifest-tool
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: "Command line tool to create and query container image manifest list/indexes"
   copyright:
     - license: Apache-2.0

--- a/mariadb-11.8.yaml
+++ b/mariadb-11.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.8
   version: "11.8.2"
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: "3.4.6"
-  epoch: 1
+  epoch: 2
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later

--- a/mariadb-operator.yaml
+++ b/mariadb-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-operator
   version: "0.38.1"
-  epoch: 1
+  epoch: 2
   description: A Go operator that automates the deployment and management of MariaDB databases on Kubernetes
   copyright:
     - license: MIT

--- a/maru.yaml
+++ b/maru.yaml
@@ -1,7 +1,7 @@
 package:
   name: maru
   version: "0.6.0"
-  epoch: 2
+  epoch: 3
   description: a task runner to automate builds and perform common shell tasks. shares a syntax similar to zarf.yaml actions.
   copyright:
     - license: Apache-2.0

--- a/mattermost-10.9.yaml
+++ b/mattermost-10.9.yaml
@@ -3,7 +3,7 @@ package:
   # Note the npm version has been pinned to 10.8.3 to avoid the error:
   # "npm error notsup Required: {"node":">=18.10.0","npm":"^9.0.0 || ^10.0.0"}"
   version: "10.9.3"
-  epoch: 0
+  epoch: 1
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT

--- a/maven-3.9.yaml
+++ b/maven-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven-3.9
   version: "3.9.11"
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/mc.yaml
+++ b/mc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mc
   version: "0.20250521.015954"
-  epoch: 2
+  epoch: 3
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later

--- a/mcp-grafana.yaml
+++ b/mcp-grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: mcp-grafana
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: MCP server for grafana
   dependencies:
     runtime:

--- a/mdbook.yaml
+++ b/mdbook.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdbook
   version: "0.4.52"
-  epoch: 0
+  epoch: 1
   description: "Create book from markdown files. Like Gitbook but implemented in Rust."
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
- **manifest-tool: No-change rebuild to fix file permissions**
- **mariadb-11.8: No-change rebuild to fix file permissions**
- **mariadb-connector-c: No-change rebuild to fix file permissions**
- **mariadb-operator: No-change rebuild to fix file permissions**
- **maru: No-change rebuild to fix file permissions**
- **mattermost-10.9: No-change rebuild to fix file permissions**
- **maven-3.9: No-change rebuild to fix file permissions**
- **mc: No-change rebuild to fix file permissions**
- **mcp-grafana: No-change rebuild to fix file permissions**
- **mdbook: No-change rebuild to fix file permissions**
