### PR TITLE
clickhouse-25.2: fix iamguarded subpackage creating symlinks in bitnami's build directory

### DIFF
--- a/clickhouse-25.2.yaml
+++ b/clickhouse-25.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.2
   version: "25.2.2.39"
-  epoch: 45
+  epoch: 46
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -256,6 +256,8 @@ subpackages:
           sed -i 's|chroot --userspec="$userspec" /|chroot / su-exec "$userspec"|' /opt/iamguarded/scripts/libos.sh
           # Use package path while unpacking
           find /opt/iamguarded/scripts -iname "*.sh" -exec sed -i '/chown/c\continue' -i {} \;
+          # Remove existing symlinks that might conflict
+          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server /var/lib/clickhouse/tmp
           /opt/iamguarded/scripts/clickhouse/postunpack.sh
           # Find all files in /usr/bin that are either named "clickhouse" or symlinks pointing to "clickhouse"
           for file in ${{targets.destdir}}/usr/bin/*; do
@@ -345,6 +347,8 @@ subpackages:
 
           # Use package path while unpacking
           find /opt/iamguarded/scripts -iname "*.sh" -exec sed -i '/chown/c\continue' -i {} \;
+          # Remove existing symlinks that might conflict
+          rm -f /etc/clickhouse-keeper /var/lib/clickhouse /var/log/clickhouse-server
           /opt/iamguarded/scripts/clickhouse-keeper/postunpack.sh
 
           # Find all files in /usr/bin that are either named "clickhouse-keeper" or symlinks pointing to "clickhouse-keeper"


### PR DESCRIPTION
the theory is that the [`postunpack.sh`](https://github.com/chainguard-dev/iamguarded-containers/blob/main/bitnami/clickhouse/25/debian-12/rootfs/opt/bitnami/scripts/clickhouse/postunpack.sh#L67) script creates symlinks that persist between bitnami/iamguarded builds, so running postunpack.sh twice means we just end up modifying where the symlink actually points to