### PR TITLE
update license from Apache-2.0 to LGPL-2.0-or-later in jruby-9.4.yaml

### DIFF
--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: JRuby, an implementation of Ruby on the JVM
   copyright:
-    - license: Apache-2.0
+    - license: LGPL-2.0-or-later
   dependencies:
     provides:
       - jruby=${{package.full-version}}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
jruby - existing package
<!--
Please include references to any related issues or delete this section otherwise.
 -->
Adding correct license for the application as the previous value of Apache-2.0 is incorrect according to https://github.com/jruby/jruby/blob/master/COPYING
