### PR TITLE
font-xorg: additional packages

### DIFF
--- a/font-xorg-bitstream75dpi.yaml
+++ b/font-xorg-bitstream75dpi.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-bitstream-75dpi-${{package.version}}.tar.xz
-      expected-sha256: aaeb34d87424a9c2b0cf0e8590704c90cb5b42c6a3b6a0ef9e4676ef773bf826
+      repository: https://gitlab.freedesktop.org/xorg/font/bitstream-75dpi
+      tag: font-bitstream-75dpi-${{package.version}}
+      expected-commit: 6c4a1c79b3b73c63ee7f9fc52318df3c356f7eb3
 
   - uses: autoconf/configure
 

--- a/font-xorg-bitstream75dpi.yaml
+++ b/font-xorg-bitstream75dpi.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-bitstream75dpi
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Bitstream 75 dpi bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontbitstream75dpi=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-bitstream-75dpi-${{package.version}}.tar.xz
+      expected-sha256: aaeb34d87424a9c2b0cf0e8590704c90cb5b42c6a3b6a0ef9e4676ef773bf826
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-bitstream-75dpi-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-cronyxcyrillic.yaml
+++ b/font-xorg-cronyxcyrillic.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-cronyx-cyrillic-${{package.version}}.tar.xz
-      expected-sha256: dc0781ce0dcbffdbf6aae1a00173a13403f92b0de925bca5a9e117e4e2d6b789
+      repository: https://gitlab.freedesktop.org/xorg/font/cronyx-cyrillic
+      tag: font-cronyx-cyrillic-${{package.version}}
+      expected-commit: b767723353f2691f29a7aa5cd133be202e4b8878
 
   - uses: autoconf/configure
 

--- a/font-xorg-cronyxcyrillic.yaml
+++ b/font-xorg-cronyxcyrillic.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-cronyxcyrillic
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Cronyx Cyrillic bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontcronyxcyrillic=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-cronyx-cyrillic-${{package.version}}.tar.xz
+      expected-sha256: dc0781ce0dcbffdbf6aae1a00173a13403f92b0de925bca5a9e117e4e2d6b789
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-cronyx-cyrillic-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-jismisc.yaml
+++ b/font-xorg-jismisc.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-jis-misc-${{package.version}}.tar.xz
-      expected-sha256: 78d1eff6c471f7aa6802a26d62cccf51d8e5185586406d9b6e1ee691b0bffad0
+      repository: https://gitlab.freedesktop.org/xorg/font/jis-misc
+      tag: font-jis-misc-${{package.version}}
+      expected-commit: 8da1fbf9d2f0b101ff44f044723d9cb09e5fc941
 
   - uses: autoconf/configure
 

--- a/font-xorg-jismisc.yaml
+++ b/font-xorg-jismisc.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-jismisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org JIS bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontjismisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-jis-misc-${{package.version}}.tar.xz
+      expected-sha256: 78d1eff6c471f7aa6802a26d62cccf51d8e5185586406d9b6e1ee691b0bffad0
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-jis-misc-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-micromisc.yaml
+++ b/font-xorg-micromisc.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-micro-misc-${{package.version}}.tar.xz
-      expected-sha256: 2ee0b9d6bd7ae849aff1bd82efab44a1b6b368fbb5e11d12ff7f015a3df6f943
+      repository: https://gitlab.freedesktop.org/xorg/font/micro-misc
+      tag: font-micro-misc-${{package.version}}
+      expected-commit: 0cbba4838a17c19a6aa11958e805fe539459aab6
 
   - uses: autoconf/configure
 

--- a/font-xorg-micromisc.yaml
+++ b/font-xorg-micromisc.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-micromisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Micro Misc bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontmicromisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-micro-misc-${{package.version}}.tar.xz
+      expected-sha256: 2ee0b9d6bd7ae849aff1bd82efab44a1b6b368fbb5e11d12ff7f015a3df6f943
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-micro-misc-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-miscethiopic.yaml
+++ b/font-xorg-miscethiopic.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-ethiopic-${{package.version}}.tar.xz
-      expected-sha256: 4749a7e6e1a1eef6c91fcc9a04e8b1c0ed027d40c1599e5a6c93270d8469b612
+      repository: https://gitlab.freedesktop.org/xorg/font/misc-ethiopic
+      tag: font-misc-ethiopic-${{package.version}}
+      expected-commit: 65a2192f07a2243a6d84a891c9ab6e8a16e6bfa9
 
   - uses: autoconf/configure
 

--- a/font-xorg-miscethiopic.yaml
+++ b/font-xorg-miscethiopic.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-miscethiopic
+  version: 1.0.5
+  epoch: 0
+  description: X.Org Misc Ethiopian bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontmiscethiopic=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-ethiopic-${{package.version}}.tar.xz
+      expected-sha256: 4749a7e6e1a1eef6c91fcc9a04e8b1c0ed027d40c1599e5a6c93270d8469b612
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-misc-ethiopic-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-miscmeltho.yaml
+++ b/font-xorg-miscmeltho.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-miscmeltho
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Misc Meltho bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontmiscmeltho=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-meltho-${{package.version}}.tar.xz
+      expected-sha256: 63be5ec17078898f263c24096a68b43ae5b06b88852e42549afa03d124d65219
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-misc-meltho-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-miscmeltho.yaml
+++ b/font-xorg-miscmeltho.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-meltho-${{package.version}}.tar.xz
-      expected-sha256: 63be5ec17078898f263c24096a68b43ae5b06b88852e42549afa03d124d65219
+      repository: https://gitlab.freedesktop.org/xorg/font/misc-meltho
+      tag: font-misc-meltho-${{package.version}}
+      expected-commit: 2de3debfff98f44b271d1319d2e0aaf63251234f
 
   - uses: autoconf/configure
 

--- a/font-xorg-miscmisc.yaml
+++ b/font-xorg-miscmisc.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-miscmisc
+  version: 1.1.3
+  epoch: 0
+  description: X.Org Misc Misc bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontmiscmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-misc-${{package.version}}.tar.xz
+      expected-sha256: b12359f4e12c23bcfcb448b918297e975fa91bef5293d88d3c25343cc768bb24
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-misc-misc-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg-miscmisc.yaml
+++ b/font-xorg-miscmisc.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-misc-misc-${{package.version}}.tar.xz
-      expected-sha256: b12359f4e12c23bcfcb448b918297e975fa91bef5293d88d3c25343cc768bb24
+      repository: https://gitlab.freedesktop.org/xorg/font/misc-misc
+      tag: font-misc-misc-${{package.version}}
+      expected-commit: c4e2af05583764fae3d0b2aa20d5c93b031cbcbf
 
   - uses: autoconf/configure
 

--- a/font-xorg-muttmisc.yaml
+++ b/font-xorg-muttmisc.yaml
@@ -28,10 +28,11 @@ environment:
       - ttfautohint
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://xorg.freedesktop.org/archive/individual/font/font-mutt-misc-${{package.version}}.tar.xz
-      expected-sha256: b12359f4e12c23bcfcb448b918297e975fa91bef5293d88d3c25343cc768bb24
+      repository: https://gitlab.freedesktop.org/xorg/font/mutt-misc
+      tag: font-mutt-misc-${{package.version}}
+      expected-commit: 5550601d37efee5f29391973a7cd3ae4c837cd2f
 
   - uses: autoconf/configure
 

--- a/font-xorg-muttmisc.yaml
+++ b/font-xorg-muttmisc.yaml
@@ -1,0 +1,76 @@
+package:
+  name: font-xorg-muttmisc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org Misc TTF bitmap fonts
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - fonts-xorg-fontmuttmisc=${{package.full-version}}
+    runtime:
+      - font-xorg-dirs
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://xorg.freedesktop.org/archive/individual/font/font-mutt-misc-${{package.version}}.tar.xz
+      expected-sha256: b12359f4e12c23bcfcb448b918297e975fa91bef5293d88d3c25343cc768bb24
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Strip font indices since it conflicts with other font-xorg packages
+    runs: |
+      find "${{targets.destdir}}/usr/share/fonts/X11" \
+           -type f \( -name 'fonts.dir'   \
+                    -o -name 'fonts.scale' \
+                    -o -name 'fonts.alias' \) -delete
+
+update:
+  enabled: true
+  git:
+    strip-prefix: font-mutt-misc-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently
+
+test:
+  pipeline:
+    - uses: test/fonts

--- a/font-xorg.yaml
+++ b/font-xorg.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-xorg
   version: 1
-  epoch: 1
+  epoch: 2
   description: "Meta package for X.Org fonts"
   dependencies:
     runtime:
@@ -17,12 +17,20 @@ package:
       - font-xorg-bhlucidatypewriter75dpi
       - font-xorg-bhtype1
       - font-xorg-bitstream100dpi
+      - font-xorg-bitstream75dpi
       - font-xorg-bitstreamtype1
+      - font-xorg-cronyxcyrillic
       - font-xorg-cursormisc
       - font-xorg-daewoomisc
       - font-xorg-decmisc
       - font-xorg-ibmtype1
       - font-xorg-isasmisc
+      - font-xorg-jismisc
+      - font-xorg-micromisc
+      - font-xorg-miscethiopic
+      - font-xorg-miscmeltho
+      - font-xorg-miscmisc
+      - font-xorg-muttmisc
       - font-xorg-schumachermisc
       - font-xorg-screencyrillic
       - font-xorg-sonymisc


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
