### PR TITLE
llvm-18: fix a dangling symlink for libclang-cpp.so.18

### DIFF
--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-18
   version: "18.1.8"
-  epoch: 11
+  epoch: 12
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -137,6 +137,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-minor-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: compiler-rt-${{vars.major-version}}
     description: Clang ${{vars.major-version}} compiler runtime


### PR DESCRIPTION
This is specifically causing a problem in bpftrace.