### PR TITLE
xorgproto: enable legacy headers (a.k.a xf86miscproto)

### DIFF
--- a/libx11.yaml
+++ b/libx11.yaml
@@ -1,7 +1,7 @@
 package:
   name: libx11
   version: "1.8.12"
-  epoch: 1
+  epoch: 2
   description: X11 client-side library
   copyright:
     - license: XFree86-1.1
@@ -42,6 +42,12 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Drop headers that are now provided by xorgproto (legacy=true)
+    runs: |
+      for h in XKBgeom.h XKBsrv.h XKBstr.h; do
+        rm -rf "${{targets.destdir}}/usr/include/X11/extensions/$h"
+      done
 
   - uses: strip
 

--- a/xorgproto.yaml
+++ b/xorgproto.yaml
@@ -1,10 +1,13 @@
 package:
   name: xorgproto
   version: "2024.1"
-  epoch: 2
+  epoch: 3
   description: Combined X.Org X11 protocol headers
   copyright:
     - license: BSD-2-Clause AND MIT AND X11
+  dependencies:
+    provides:
+      - xf86miscproto=${{package.full-version}} # With legacy support enabled, it can be drop-in replacement for xf86miscproto
 
 environment:
   contents:
@@ -14,6 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libx11-dev # Sanity check to build libx11 first
       - meson
       - util-macros
 
@@ -24,6 +28,10 @@ pipeline:
       uri: https://xorg.freedesktop.org/archive/individual/proto/xorgproto-${{package.version}}.tar.gz
 
   - uses: meson/configure
+    with:
+      # Building the xf86miscproto requires legacy support
+      opts: |
+        -Dlegacy=true
 
   - uses: meson/compile
 


### PR DESCRIPTION
`xf86miscproto` is deprecated and replaced with `xorgproto`: https://gitlab.freedesktop.org/xorg/proto/xf86miscproto/-/blob/master/autogen.sh?ref_type=heads

To build this: https://github.com/wolfi-dev/os/pull/59993 we do need some headers. It builds if we do enable xorgproto with legacy support. libx11-dev doesn't provide `xf86mscstr.h`.

But some headers like `XKBgeom.h XKBsrv.h XKBstr.h` is still provided by `libx11`, which resulting conflict during install:

```
installing apk packages: installing packages: installing libx11-dev (ver:1.8.12-r1 arch:aarch64): unable to install files for pkg libx11-dev: writing header for "usr/include/X11/extensions/XKBgeom.h": packages map[libx11-dev:libx11 xorgproto:xorgproto] has conflicting file: "usr/include/X11/extensions/XKBgeom.h"
```

So remove those from libx11 and re-build xorgproto with having those headers. So we can build `libXxf86misc`.