### PR TITLE
llvm*: Fix dangling symlink for libclang-cpp

### DIFF
--- a/llvm-15.yaml
+++ b/llvm-15.yaml
@@ -140,6 +140,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: clang-${{vars.major-version}}-analyzer
     description: Clang ${{vars.major-version}} analyzer

--- a/llvm-15.yaml
+++ b/llvm-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-15
   version: 15.0.7
-  epoch: 12
+  epoch: 13
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0

--- a/llvm-16.yaml
+++ b/llvm-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-16
   version: 16.0.6
-  epoch: 11
+  epoch: 12
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -138,6 +138,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: compiler-rt-${{vars.major-version}}
     description: Clang ${{vars.major-version}} compiler runtime

--- a/llvm-17.yaml
+++ b/llvm-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-17
   version: 17.0.6
-  epoch: 6
+  epoch: 7
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -146,6 +146,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: compiler-rt-${{vars.major-version}}
     description: Clang ${{vars.major-version}} compiler runtime

--- a/llvm-19.yaml
+++ b/llvm-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-19
   version: "19.1.7"
-  epoch: 11
+  epoch: 12
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -136,6 +136,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-minor-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: compiler-rt-${{vars.major-version}}
     description: Clang ${{vars.major-version}} compiler runtime

--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-20
   version: "20.1.7"
-  epoch: 0
+  epoch: 1
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -144,6 +144,7 @@ subpackages:
           sonamefull="libclang-cpp.so.${{vars.major-minor-version}}"
           mkdir -p ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull ${{targets.contextdir}}/usr/lib/
+          ln -sf ../../$sonamefull ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/$sonamefull
 
   - name: compiler-rt-${{vars.major-version}}
     description: Clang ${{vars.major-version}} compiler runtime


### PR DESCRIPTION
Ensure that the .so points to a valid target, resolving issues when
building with clang + libclang-cpp.

18 was done independently.