### PR TITLE
add libXxf86misc

### DIFF
--- a/libXxf86misc.yaml
+++ b/libXxf86misc.yaml
@@ -14,15 +14,15 @@ environment:
       - bdftopcf
       - build-base
       - busybox
-      - libxext-dev
-      - pkgconf-dev
-      - xorgproto
-      - libx11-dev
       - glibc-dev
-      - m4
-      - posix-libc-utils
       - libtool
+      - libx11-dev
+      - libxext-dev
+      - m4
+      - pkgconf-dev
+      - posix-libc-utils
       - util-macros
+      - xorgproto
 
 pipeline:
   - uses: git-checkout

--- a/libXxf86misc.yaml
+++ b/libXxf86misc.yaml
@@ -1,0 +1,91 @@
+package:
+  name: libXxf86misc
+  version: 1.0.4
+  epoch: 0
+  description: X.Org X11 XFree86 miscellaneous extensions library
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bdftopcf
+      - build-base
+      - busybox
+      - font-util
+      - font-util-dev
+      - fontconfig
+      - fontforge
+      - libxext-dev
+      - mkfontscale
+      - pkgconf-dev
+      - ttfautohint
+      - xorgproto
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxxf86misc
+      tag: libXxf86misc-${{package.version}}
+      expected-commit: 388f29f98dd264059cc7ee5342e2ca32463de2d3
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: headers for ${{package.name}}
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+          with:
+            packages: libXxf86misc-dev
+    dependencies:
+      runtime:
+        - libXxf86misc
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+    description: ${{package.name}} manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  git:
+    strip-prefix: libXxf86misc-
+  ignore-regex-patterns:
+    - ^XORG-.*
+    - ^CYGWIN-.*
+    - ^lg3d-.*
+    - ^XACE-.*
+    - ^XEVIE-.*
+    - ^DAMAGE-.*
+    - ^COMPOSITE-.*
+    - ^XFIXES-.*
+    - ^sco_port_update-.*
+    - ^MODULAR_COPY$
+    - ^xf86-.*
+    - ^rel-.*
+    - ^IPv6-.*
+    - ^XPRINT.*
+    - ^before_.*
+    - ^xo-.*
+  schedule:
+    period: monthly
+    reason: This project doesn't do releases frequently

--- a/libXxf86misc.yaml
+++ b/libXxf86misc.yaml
@@ -9,18 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
-      - bdftopcf
       - build-base
       - busybox
-      - glibc-dev
       - libtool
       - libx11-dev
       - libxext-dev
-      - m4
       - pkgconf-dev
-      - posix-libc-utils
       - util-macros
       - xorgproto
 
@@ -30,8 +24,6 @@ pipeline:
       repository: https://gitlab.freedesktop.org/xorg/lib/libxxf86misc
       tag: libXxf86misc-${{package.version}}
       expected-commit: 388f29f98dd264059cc7ee5342e2ca32463de2d3
-
-  - runs: autoupdate
 
   - runs: autoreconf -vif
 

--- a/libXxf86misc.yaml
+++ b/libXxf86misc.yaml
@@ -90,6 +90,7 @@ update:
     - ^XPRINT.*
     - ^before_.*
     - ^xo-.*
+    - ^1_0_1
   schedule:
     period: monthly
     reason: This project doesn't do releases frequently

--- a/libXxf86misc.yaml
+++ b/libXxf86misc.yaml
@@ -14,15 +14,15 @@ environment:
       - bdftopcf
       - build-base
       - busybox
-      - font-util
-      - font-util-dev
-      - fontconfig
-      - fontforge
       - libxext-dev
-      - mkfontscale
       - pkgconf-dev
-      - ttfautohint
       - xorgproto
+      - libx11-dev
+      - glibc-dev
+      - m4
+      - posix-libc-utils
+      - libtool
+      - util-macros
 
 pipeline:
   - uses: git-checkout
@@ -30,6 +30,10 @@ pipeline:
       repository: https://gitlab.freedesktop.org/xorg/lib/libxxf86misc
       tag: libXxf86misc-${{package.version}}
       expected-commit: 388f29f98dd264059cc7ee5342e2ca32463de2d3
+
+  - runs: autoupdate
+
+  - runs: autoreconf -vif
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
~BLOCKED by: https://github.com/wolfi-dev/os/pull/59972~

```
configure: error: Package requirements (xproto x11 xextproto xext xf86miscproto) were not met:

Package 'xf86miscproto' not found
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
