### PR TITLE
ruby-3.2: fix CVE-2025-24294 by cherry-picking resolv 0.2.3 update

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: "3.2.8"
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -57,6 +57,8 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.underscore-package-version}}
       expected-commit: 13f495dc2c98d0762d9af37e7143d2e2a07d9926
+      cherry-picks: |
+        ruby_3_2/9f00b8872d3e294312c99150f1c34b6b3fa74985: Bump up resolv-0.2.3 for Ruby 3.2 (CVE-2025-24294)
 
   - runs: |
       # Don't bundle the gems we have separate packages for


### PR DESCRIPTION
Cherry-pick [commit 9f00b8872d3e294312c99150f1c34b6b3fa74985](https://github.com/ruby/ruby/commit/9f00b8872d3e294312c99150f1c34b6b3fa74985) from the ruby_3_2 branch which updates the resolv gem from 0.2.2 to 0.2.3. This fixes CVE-2025-24294 (GHSA-xh69-987w-hrp8), a ReDoS vulnerability in the resolv gem.

Since resolv is a default gem bundled with Ruby, we cannot update it independently and must cherry-pick the fix until Ruby 3.2.9 is released with this update included.

## Test plan
- [ ] Package builds successfully
- [ ] CVE-2025-24294 is resolved in scan results
- [ ] Ruby 3.2 functionality remains intact