### PR TITLE
wolfictl: bump packages 171-175

### DIFF
--- a/vitess-22.yaml
+++ b/vitess-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-22
   version: "22.0.1"
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/wit-bindgen.yaml
+++ b/wit-bindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: wit-bindgen
   version: "0.43.0"
-  epoch: 1
+  epoch: 2
   description: "A language binding generator for WebAssembly interface types"
   copyright:
     - license: Apache-2.0

--- a/xcaddy.yaml
+++ b/xcaddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcaddy
   version: 0.4.4
-  epoch: 5
+  epoch: 6
   description: Build Caddy with plugins
   copyright:
     - license: Apache-2.0

--- a/zellij.yaml
+++ b/zellij.yaml
@@ -1,7 +1,7 @@
 package:
   name: zellij
   version: "0.42.2"
-  epoch: 1
+  epoch: 2
   description: A terminal workspace with batteries included
   copyright:
     - license: MIT

--- a/zoxide.yaml
+++ b/zoxide.yaml
@@ -1,7 +1,7 @@
 package:
   name: zoxide
   version: "0.9.8"
-  epoch: 0
+  epoch: 1
   description: "A smarter cd command. Supports all major shells."
   copyright:
     - license: MIT


### PR DESCRIPTION
This commit bumps the following packages:
- vitess-22
- wit-bindgen
- xcaddy
- zellij
- zoxide