### PR TITLE
wolfictl: bump packages 41-50

### DIFF
--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-firehose
   version: 1.7.2
-  epoch: 17
+  epoch: 18
   description: A Fluent Bit output plugin for Amazon Kinesis Data Firehose
   copyright:
     - license: Apache-2.0

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: 1.10.2
-  epoch: 18
+  epoch: 19
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: "2.13.3"
-  epoch: 1
+  epoch: 2
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0

--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-network-policy-agent
   version: "1.2.3"
-  epoch: 1
+  epoch: 2
   description: Amazon EKS Network Policy Agent is a daemonset that is responsible for enforcing configured network policies on the cluster.
   copyright:
     - license: Apache-2.0

--- a/bank-vaults.yaml
+++ b/bank-vaults.yaml
@@ -1,7 +1,7 @@
 package:
   name: bank-vaults
   version: 1.20.4
-  epoch: 31
+  epoch: 32
   description: A Vault swiss-army knife. A CLI tool to init, unseal and configure Vault (auth methods, secret engines).
   copyright:
     - license: Apache-2.0

--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: "5.3"
-  epoch: 1
+  epoch: 2
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later

--- a/bat.yaml
+++ b/bat.yaml
@@ -1,7 +1,7 @@
 package:
   name: bat
   version: 0.25.0
-  epoch: 4
+  epoch: 5
   description: "A cat(1) clone with wings"
   copyright:
     - license: MIT OR Apache-2.0

--- a/bats.yaml
+++ b/bats.yaml
@@ -1,7 +1,7 @@
 package:
   name: bats
   version: "1.12.0"
-  epoch: 1
+  epoch: 2
   description: Bash Automated Testing System
   copyright:
     - license: MIT

--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: benchmark
   version: "1.9.4"
-  epoch: 1
+  epoch: 2
   description: "microbenchmark support library"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- aws-flb-firehose
- aws-flb-kinesis
- aws-load-balancer-controller
- aws-network-policy-agent
- bank-vaults
- bash
- bat
- bats
- bazel-6
- benchmark