### PR TITLE
wolfictl: bump packages 51-60

### DIFF
--- a/berg.yaml
+++ b/berg.yaml
@@ -1,7 +1,7 @@
 package:
   name: berg
   version: "0.4.11"
-  epoch: 0
+  epoch: 1
   description: "CLI Tool for Codeberg similar to gh and glab"
   copyright:
     - license: AGPL-3.0-only

--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: "9.20.11"
-  epoch: 0
+  epoch: 1
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.44"
-  epoch: 10
+  epoch: 11
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0

--- a/bird.yaml
+++ b/bird.yaml
@@ -1,7 +1,7 @@
 package:
   name: bird
   version: "3.1.2"
-  epoch: 0
+  epoch: 1
   description: BIRD Internet Routing Daemon
   copyright:
     - license: GPL-2.0-or-later

--- a/bison.yaml
+++ b/bison.yaml
@@ -1,7 +1,7 @@
 package:
   name: bison
   version: 3.8.2
-  epoch: 51
+  epoch: 52
   description: "The GNU general-purposes parser generator"
   copyright:
     - license: GPL-3.0-or-later

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.83"
-  epoch: 0
+  epoch: 1
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0 AND LGPL-2.1 AND BSD-2-Clause AND MIT

--- a/bmake.yaml
+++ b/bmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: bmake
   version: "20250618"
-  epoch: 0
+  epoch: 1
   description: Portable version of the NetBSD make build tool
   copyright:
     - license: BSD-2-Clause

--- a/bom.yaml
+++ b/bom.yaml
@@ -1,7 +1,7 @@
 package:
   name: bom
   version: 0.6.0
-  epoch: 21
+  epoch: 22
   description: A utility to generate SPDX-compliant Bill of Materials manifests
   copyright:
     - license: Apache-2.0

--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: "1.88.0"
-  epoch: 4
+  epoch: 5
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"

--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: "0.16.4"
-  epoch: 2
+  epoch: 3
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT


### PR DESCRIPTION
This commit bumps the following packages:
- berg
- bind
- binutils
- bird
- bison
- bluez
- bmake
- bom
- boost
- boring-registry