### PR TITLE
wolfictl: bump packages 61-70

### DIFF
--- a/botan.yaml
+++ b/botan.yaml
@@ -1,7 +1,7 @@
 package:
   name: botan
   version: "3.8.1"
-  epoch: 0
+  epoch: 1
   description: "Cryptography Toolkit"
   copyright:
     - license: BSD-2-Clause

--- a/bpftool.yaml
+++ b/bpftool.yaml
@@ -1,7 +1,7 @@
 package:
   name: bpftool
   version: 7.5.0
-  epoch: 41
+  epoch: 42
   description: A collection of tool to inspect and manipulate eBPF programs
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: 1.1.0
-  epoch: 5
+  epoch: 6
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -1,7 +1,7 @@
 package:
   name: btrfs-progs
   version: "6.15"
-  epoch: 0
+  epoch: 1
   description: BTRFS filesystem utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/buck2.yaml
+++ b/buck2.yaml
@@ -1,7 +1,7 @@
 package:
   name: buck2
   version: 20250401
-  epoch: 1
+  epoch: 2
   description: "Build system, successor to Buck"
   copyright:
     - license: MIT

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 package:
   name: buf
   version: "1.55.1"
-  epoch: 1
+  epoch: 2
   description: A new way of working with Protocol Buffers.
   copyright:
     - license: Apache-2.0

--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: "0.23.2"
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 46
+  epoch: 47
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 19
+  epoch: 20
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -2,7 +2,7 @@ package:
   name: ca-certificates
   # manual: update java-cacerts
   version: "20250619"
-  epoch: 2
+  epoch: 3
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT


### PR DESCRIPTION
This commit bumps the following packages:
- botan
- bpftool
- brotli
- btrfs-progs
- buck2
- buf
- buildkitd
- busybox
- bzip2
- ca-certificates