### PR TITLE
wolfictl: bump packages 71-80

### DIFF
--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: "1.34.5"
-  epoch: 1
+  epoch: 2
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT

--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: "2.10.0"
-  epoch: 3
+  epoch: 4
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0

--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: "0.53.0"
-  epoch: 2
+  epoch: 3
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0

--- a/cbindgen.yaml
+++ b/cbindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: cbindgen
   version: "0.29.0"
-  epoch: 0
+  epoch: 1
   description: Tool to generate C bindings from Rust code
   copyright:
     - license: MPL-2.0

--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.5
   version: 0.5.4
-  epoch: 5
+  epoch: 6
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0

--- a/cilium-1.17.yaml
+++ b/cilium-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.17
   version: "1.17.6"
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0

--- a/clickhouse-25.2.yaml
+++ b/clickhouse-25.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.2
   version: "25.2.2.39"
-  epoch: 46
+  epoch: 47
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0

--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: "0.13.2"
-  epoch: 1
+  epoch: 2
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.136
-  epoch: 3
+  epoch: 4
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT


### PR DESCRIPTION
This commit bumps the following packages:
- caddy
- cadvisor
- c-ares
- cbindgen
- celeborn-0.5
- cilium-1.17
- clang-15
- clickhouse-25.2
- cue
- dotnet-6