### PR TITLE
wolfictl: bump packages 81-90

### DIFF
--- a/dotnet-bootstrap-8.yaml
+++ b/dotnet-bootstrap-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-bootstrap-8
   version: "8.0.18"
-  epoch: 0
+  epoch: 1
   description: ".NET 8 SDK Bootstrap"
   copyright:
     - license: MIT

--- a/dotnet-bootstrap-9.yaml
+++ b/dotnet-bootstrap-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-bootstrap-9
   version: "9.0.7"
-  epoch: 0
+  epoch: 1
   description: ".NET 9 SDK Bootstrap"
   copyright:
     - license: MIT

--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: "33.0.0"
-  epoch: 6
+  epoch: 7
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0

--- a/drupal-11.yaml
+++ b/drupal-11.yaml
@@ -2,7 +2,7 @@ package:
   name: drupal-11
   description: Drupal is an open source content management platform powering millions of websites and applications.
   version: "11.2.2"
-  epoch: 2
+  epoch: 3
   resources:
     cpu: 17
     memory: 32Gi

--- a/dumb-init.yaml
+++ b/dumb-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: dumb-init
   version: 1.2.5
-  epoch: 7
+  epoch: 8
   description: "minimal init system for Linux containers"
   copyright:
     - license: MIT

--- a/font-noto.yaml
+++ b/font-noto.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-noto
   version: "2025.07.01"
-  epoch: 1
+  epoch: 2
   description: Noto fonts
   dependencies:
     runtime:

--- a/font-twemoji-colr.yaml
+++ b/font-twemoji-colr.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-twemoji-colr
   version: 13.0.0
-  epoch: 1
+  epoch: 2
   description: Color emoji font from the Twemoji project
   copyright:
     - license: Apache-2.0

--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: "5.3"
-  epoch: 40
+  epoch: 41
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 15.1.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1


### PR DESCRIPTION
This commit bumps the following packages:
- dotnet-bootstrap-8
- dotnet-bootstrap-9
- druid
- drupal-11
- dumb-init
- font-noto
- font-twemoji-colr
- fping
- gcc
- gcc-14