### PR TITLE
wolfictl: bump packages 271-277

### DIFF
--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: "2.19.0"
-  epoch: 3
+  epoch: 2
   copyright:
     - license: Apache-2.0
   resources:

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: "2.19.0"
-  epoch: 2
+  epoch: 3
   copyright:
     - license: Apache-2.0
   resources:

--- a/x265.yaml
+++ b/x265.yaml
@@ -1,7 +1,7 @@
 package:
   name: x265
   version: "4.1"
-  epoch: 4
+  epoch: 5
   description: H.265/HEVC encoder
   copyright:
     - license: GPL-2.0-only

--- a/x265.yaml
+++ b/x265.yaml
@@ -11,7 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake
+      - cmake-3
       - coreutils
       - gcc-14-default
       - nasm

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: "2.1.5"
-  epoch: 1
+  epoch: 2
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: "1.5.7"
-  epoch: 2
+  epoch: 3
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only

--- a/ztunnel-1.26.yaml
+++ b/ztunnel-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: ztunnel-1.26
   version: "1.26.2"
-  epoch: 0
+  epoch: 1
   description: The `ztunnel` component of istio ambient mesh.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- tekton-pipelines
- teleport
- tensorflow-core
- x265
- zot
- zstd
- ztunnel-1.26

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
