### PR TITLE
wolfictl: bump packages 171-180

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.5_p20250621
-  epoch: 0
+  epoch: 1
   description: "console display library"
   copyright:
     - license: MIT

--- a/ndctl.yaml
+++ b/ndctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: ndctl
   version: "82"
-  epoch: 0
+  epoch: 1
   description: "Utility library for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel."
   copyright:
     - license: "GPL-2.0-only AND LGPL-2.1-only"

--- a/neo4j-5.26.yaml
+++ b/neo4j-5.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-5.26
   version: "5.26.9"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-3.0-or-later

--- a/neo4j-browser-2025.05.yaml
+++ b/neo4j-browser-2025.05.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-browser-2025.05
   version: 2025.05.0
-  epoch: 0
+  epoch: 1
   description: Neo4j Browser is the general purpose user interface for working with Neo4j.
   dependencies:
     provides:

--- a/neovim.yaml
+++ b/neovim.yaml
@@ -1,7 +1,7 @@
 package:
   name: neovim
   version: "0.11.3"
-  epoch: 0
+  epoch: 1
   description: "Vim-fork focused on extensibility and agility"
   copyright:
     - license: Apache-2.0 AND Vim

--- a/nerdctl.yaml
+++ b/nerdctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: nerdctl
   version: "2.1.3"
-  epoch: 0
+  epoch: 1
   description: Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...
   copyright:
     - license: Apache-2.0

--- a/netavark.yaml
+++ b/netavark.yaml
@@ -1,7 +1,7 @@
 package:
   name: netavark
   version: "1.15.2"
-  epoch: 0
+  epoch: 1
   description: "Container network stack"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- ncurses
- ndctl
- neo4j-5.26
- neo4j-browser-2025.04
- neo4j-browser-2025.05
- neo4j-browser-5.26
- neovim
- nerdctl
- net-kourier
- netavark

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
