### PR TITLE
wolfictl: bump packages 111-120

### DIFF
--- a/kine.yaml
+++ b/kine.yaml
@@ -1,7 +1,7 @@
 package:
   name: kine
   version: "0.13.17"
-  epoch: 0
+  epoch: 1
   description: Run Kubernetes on MySQL, Postgres, sqlite, dqlite, not etcd.
   copyright:
     - license: Apache-2.0

--- a/knative-client.yaml
+++ b/knative-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-client
   version: "1.18.0"
-  epoch: 1
+  epoch: 2
   description: Knative CLI implementation
   dependencies:
     provides:

--- a/knative-eventing-1.18.yaml
+++ b/knative-eventing-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-eventing-1.18
   version: "1.18.2"
-  epoch: 0
+  epoch: 1
   description: Event-driven application platform for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/knative-operator-1.18.yaml
+++ b/knative-operator-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-operator-1.18
   version: "1.18.1"
-  epoch: 2
+  epoch: 3
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/knative-serving-1.18.yaml
+++ b/knative-serving-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-serving-1.18
   version: "1.18.1"
-  epoch: 2
+  epoch: 3
   description: Kubernetes-based, scale-to-zero, request-driven compute
   copyright:
     - license: Apache-2.0

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: "0.18.0"
-  epoch: 2
+  epoch: 3
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/kong-entrypoint.yaml
+++ b/kong-entrypoint.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong-entrypoint
   version: "3.9.1"
-  epoch: 1
+  epoch: 2
   description: "Provides entrypoint for kong"
   copyright:
     - license: Apache-2.0

--- a/kong.yaml
+++ b/kong.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong
   version: "3.9.1"
-  epoch: 1
+  epoch: 2
   description: "The Kong Gateway - an API Gateway built on Nginx and OpenResty"
   copyright:
     - license: Apache-2.0

--- a/kor.yaml
+++ b/kor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kor
   version: "0.6.2"
-  epoch: 1
+  epoch: 2
   description: A Golang Tool to discover unused Kubernetes Resources
   copyright:
     - license: MIT

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: "1.124.18"
-  epoch: 2
+  epoch: 3
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- kine
- knative-client
- knative-eventing-1.18
- knative-operator-1.18
- knative-serving-1.18
- ko
- kong
- kong-entrypoint
- kor
- kots

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
