### PR TITLE
wolfictl: bump packages 91-100

### DIFF
--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-operator
   version: "1.41.1"
-  epoch: 0
+  epoch: 1
   description: open source toolkit to manage Kubernetes native applications.
   copyright:
     - license: Apache-2.0

--- a/helm-push.yaml
+++ b/helm-push.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-push
   version: 0.10.4
-  epoch: 30
+  epoch: 31
   description: Helm plugin to push chart package to ChartMuseum
   copyright:
     - license: Apache-2.0

--- a/help2man.yaml
+++ b/help2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: help2man
   version: 1.49.3
-  epoch: 4
+  epoch: 5
   description: "Create simple man pages from --help output"
   copyright:
     - license: GPL-3.0-or-later

--- a/hey.yaml
+++ b/hey.yaml
@@ -1,7 +1,7 @@
 package:
   name: hey
   version: 0.1.4
-  epoch: 24
+  epoch: 25
   description: HTTP load generator, ApacheBench (ab) replacement
   copyright:
     - license: Apache-2.0

--- a/hickory-dns.yaml
+++ b/hickory-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: hickory-dns
   version: "0.25.2"
-  epoch: 0
+  epoch: 1
   description: "A Rust based DNS client, server, and resolver"
   copyright:
     - license: MIT

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,7 +1,7 @@
 package:
   name: hiredis
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: Minimalistic C client for Redis
   copyright:
     - license: BSD-3-Clause

--- a/ipfs-cluster.yaml
+++ b/ipfs-cluster.yaml
@@ -82,9 +82,9 @@ test:
         IPFS_DAEMON_PID=$!
 
         wait-for-it -t 10 127.0.0.1:5001
-        ipfs-cluster-service init --consensus=crdt
+        ipfs-cluster-service init --consensus=crdt > /dev/null 2>&1
         IPFS_CLUSTER_LOGFILE=$(mktemp)
-        ipfs-cluster-service daemon &> "${IPFS_CLUSTER_LOGFILE}" 2>&1 &
+        ipfs-cluster-service daemon > "${IPFS_CLUSTER_LOGFILE}" 2>&1 &
         IPFS_CLUSTER_PID=$!
 
         MAX_RETRIES=10

--- a/ipfs-cluster.yaml
+++ b/ipfs-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs-cluster
   version: "1.1.4"
-  epoch: 3
+  epoch: 4
   description: Pinset orchestration for IPFS
   copyright:
     - license: Apache-2.0 AND MIT

--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: "6.15.0"
-  epoch: 1
+  epoch: 2
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
This commit bumps the following packages:
- helm-operator
- helm-push
- help2man
- hey
- hickory-dns
- hiredis
- influxd
- ipfs
- ipfs-cluster
- iproute2

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
