### PR TITLE
wolfictl: bump packages 71-80

### DIFF
--- a/erl27-elixir-1.17.yaml
+++ b/erl27-elixir-1.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: erl27-elixir-1.17
   version: "1.17.3"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/erl27-elixir-1.18.yaml
+++ b/erl27-elixir-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: erl27-elixir-1.18
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/ffmpeg-7.1.yaml
+++ b/ffmpeg-7.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ffmpeg-7.1
   version: "7.1.1"
-  epoch: 9
+  epoch: 10
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -2,7 +2,7 @@
 package:
   name: ffmpeg-7
   version: "7.1.1"
-  epoch: 7
+  epoch: 8
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/file.yaml
+++ b/file.yaml
@@ -1,7 +1,7 @@
 package:
   name: file
   version: "5.46"
-  epoch: 3
+  epoch: 4
   description: "file-type identification utility"
   copyright:
     - license: BSD-2-Clause

--- a/filebrowser.yaml
+++ b/filebrowser.yaml
@@ -2,7 +2,7 @@ package:
   name: filebrowser
   version: "2.38.0"
   description: "Web File Browser"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
 

--- a/fio.yaml
+++ b/fio.yaml
@@ -1,7 +1,7 @@
 package:
   name: fio
   version: "3.40"
-  epoch: 0
+  epoch: 1
   description: Flexible I/O Tester
   copyright:
     - license: GPL-2.0-or-later

--- a/firefox.yaml
+++ b/firefox.yaml
@@ -1,7 +1,7 @@
 package:
   name: firefox
   version: "140.0.4"
-  epoch: 1
+  epoch: 2
   description: Firefox web browser
   copyright:
     - license: GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MPL-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- erl27-elixir-1.17
- erl27-elixir-1.18
- external-secrets-operator
- ffmpeg
- ffmpeg-7
- ffmpeg-7.1
- file
- filebrowser
- fio
- firefox

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
