### PR TITLE
wolfictl: bump packages 51-60

### DIFF
--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -2,7 +2,7 @@
 package:
   name: conda-build
   version: "25.5.0"
-  epoch: 0
+  epoch: 1
   description: tools for building conda packages
   copyright:
     - license: BSD-3-Clause

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: "1.23.0"
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/crossplane-provider-azure.yaml
+++ b/crossplane-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-azure
   version: "1.13.0"
-  epoch: 1
+  epoch: 2
   description: Official Azure Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/crossplane-provider-gcp.yaml
+++ b/crossplane-provider-gcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-gcp
   version: "1.14.0"
-  epoch: 1
+  epoch: 2
   description: Official GCP Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/custom-pod-autoscaler-operator.yaml
+++ b/custom-pod-autoscaler-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: custom-pod-autoscaler-operator
   version: "1.4.2"
-  epoch: 0
+  epoch: 1
   description: Operator for managing Kubernetes Custom Pod Autoscalers (CPA).
   copyright:
     - license: Apache-2.0

--- a/cxxopts.yaml
+++ b/cxxopts.yaml
@@ -2,7 +2,7 @@
 package:
   name: cxxopts
   version: "3.3.1"
-  epoch: 2
+  epoch: 3
   description: Lightweight C++ command line option parser as a header only library
   copyright:
     - license: MIT

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 42
+  epoch: 43
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause

--- a/dagdotdev.yaml
+++ b/dagdotdev.yaml
@@ -1,7 +1,7 @@
 package:
   name: dagdotdev
   version: "0.0.17"
-  epoch: 0
+  epoch: 1
   description: oci and apk explorer
   copyright:
     - license: Apache-2.0

--- a/dart.yaml
+++ b/dart.yaml
@@ -1,7 +1,7 @@
 package:
   name: dart
   version: "3.8.1"
-  epoch: 0
+  epoch: 1
   description: The Dart SDK, including the VM, JS and Wasm compilers, analysis, core libraries, and more.
   copyright:
     - license: BSD-3-Clause

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: "2025.4.0"
-  epoch: 1
+  epoch: 2
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This commit bumps the following packages:
- conda-build
- crossplane-provider-aws
- crossplane-provider-azure
- crossplane-provider-gcp
- custom-pod-autoscaler-operator
- cxxopts
- cyrus-sasl
- dagdotdev
- dart
- dask-gateway

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
