### PR TITLE
wolfictl: bump packages 41-50

### DIFF
--- a/clickhouse-operator.yaml
+++ b/clickhouse-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-operator
   version: "0.25.2"
-  epoch: 0
+  epoch: 1
   description: Altinity Kubernetes Operator for ClickHouse creates, configures and manages ClickHouse® clusters running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cmake-bootstrap.yaml
+++ b/cmake-bootstrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-bootstrap
   version: 4.0.3
-  epoch: 0
+  epoch: 1
   description: "Bootstrap CMake without using system libraries, enabling to use CMake to build system libraries used by CMake"
   dependencies:
     provider-priority: 5

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 4.0.3
-  epoch: 0
+  epoch: 1
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: "1.7.1"
-  epoch: 1
+  epoch: 2
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0

--- a/composer.yaml
+++ b/composer.yaml
@@ -1,7 +1,7 @@
 package:
   name: composer
   version: "2.8.10"
-  epoch: 0
+  epoch: 1
   description: "the PHP package manager"
   copyright:
     - license: MIT

--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda-base
   version: "25.5.1"
-  epoch: 0
+  epoch: 1
   description: "Base environment for conda."
   copyright:
     - license: BSD-3-Clause

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: "25.5.1"
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This commit bumps the following packages:
- clang-17
- clang-18
- clickhouse-operator
- cloud-sql-proxy
- cmake
- cmake-bootstrap
- cni-plugins
- composer
- conda
- conda-base

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
