### PR TITLE
wolfictl: bump packages 31-40

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,7 +1,7 @@
 package:
   name: checkov
   version: "3.2.451"
-  epoch: 1
+  epoch: 2
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT

--- a/checksec.yaml
+++ b/checksec.yaml
@@ -1,7 +1,7 @@
 package:
   name: checksec
   version: "3.0.2"
-  epoch: 3
+  epoch: 4
   description: Binary security checker
   copyright:
     - license: BSD-3-Clause

--- a/chezmoi.yaml
+++ b/chezmoi.yaml
@@ -1,7 +1,7 @@
 package:
   name: chezmoi
   version: "2.63.0"
-  epoch: 1
+  epoch: 2
   description: Manage your dotfiles across multiple diverse machines, securely.
   copyright:
     - license: MIT

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -8,7 +8,7 @@
 package:
   name: chromium
   version: "138.0.7204.157"
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause

--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.7"
-  epoch: 1
+  epoch: 2
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.4"
-  epoch: 1
+  epoch: 2
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later

--- a/cilium-cli.yaml
+++ b/cilium-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-cli
   version: "0.18.5"
-  epoch: 2
+  epoch: 3
   description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
   copyright:
     - license: Apache-2.0

--- a/cis-operator-1.4.yaml
+++ b/cis-operator-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: cis-operator-1.4
   version: "1.4.1"
-  epoch: 2
+  epoch: 3
   description: Helps to enable running CIS benchmark security scans on a Kubernetes cluster and generate compliance reports that can be downloaded
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This commit bumps the following packages:
- checkov
- checksec
- chezmoi
- chromium
- chrony
- cifs-utils
- cilium-cli
- cis-operator
- cis-operator-1.4
- clang-16

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
