### PR TITLE
py3-pefile: initial package 2024.8.26

### DIFF
--- a/py3-pefile.yaml
+++ b/py3-pefile.yaml
@@ -1,0 +1,78 @@
+package:
+  name: py3-pefile
+  version: "2024.8.26"
+  epoch: 0
+  description: Python module to read and work with PE (Portable Executable) files
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-supported-flit-core
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+
+vars:
+  pypi-package: pefile
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/p/pefile/pefile-${{package.version}}.tar.gz
+      expected-sha512: 62781f2ab84040a13304ce550dd1e943991df152c5f2951281906e837b1659694051a074ff49cd08d5d508e9b70009b56418a4237511c4464c4eba9bda4bccf7
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-future
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - runs: |
+          docdir="/usr/share/doc/${{package.name}}"
+          mkdir -p "$docdir"
+          cp -R docs "$docdir"/ || true
+          install -m 644 -D LICENSE /usr/share/licenses/${{package.name}}/LICENSE
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 201044


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
py3-pefile: new package

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #60136 

py3-pefile is used by packagers to bundle Python applications into a single portable executable.  This allows you to not require the Python3 runtime on hosts or images.

Personally, I will be using this for running systemd-ukify from within Melange to generate UKIs.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
