### PR TITLE
Replace copying with HOME for amazon-cloudwatch-agent-operator test

### DIFF
--- a/amazon-cloudwatch-agent-operator.yaml
+++ b/amazon-cloudwatch-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-cloudwatch-agent-operator
   version: "3.1.0"
-  epoch: 3
+  epoch: 4
   description: Software developed to manage the CloudWatch Agent on kubernetes.
   copyright:
     - license: Apache-2.0
@@ -80,16 +80,10 @@ test:
       uses: test/daemon-check-output
       with:
         setup: |
-          # The Docker runner points to /home/build; QEMU uses /root
-          # Move the kubeconfig file to where the start directive expects it to be
-          if [[ "${HOME}" == "/home/build" ]]; then
-            mkdir -p /root/.kwok/clusters/kwok/
-            cp /home/build/.kwok/clusters/kwok/kubeconfig.yaml /root/.kwok/clusters/kwok/
-          fi
           mkdir -p /tmp/k8s-webhook-server/serving-certs/
           mkcert -install
           mkcert -key-file /tmp/k8s-webhook-server/serving-certs/tls.key -cert-file /tmp/k8s-webhook-server/serving-certs/tls.crt localhost
-        start: /usr/bin/manager --kubeconfig /root/.kwok/clusters/kwok/kubeconfig.yaml
+        start: /usr/bin/manager --kubeconfig $HOME/.kwok/clusters/kwok/kubeconfig.yaml
         timeout: 30
         expected_output: |
           starting manager


### PR DESCRIPTION
This is the preferred way of supporting cross-runner filepaths.