### PR TITLE
libx11: drop some headers provided by xorgproto

### DIFF
--- a/libx11.yaml
+++ b/libx11.yaml
@@ -1,7 +1,7 @@
 package:
   name: libx11
   version: "1.8.12"
-  epoch: 2
+  epoch: 3
   description: X11 client-side library
   copyright:
     - license: XFree86-1.1
@@ -42,6 +42,12 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Drop headers that are now provided by xorgproto (legacy=true)
+    runs: |
+      for h in XKBgeom.h XKBsrv.h XKBstr.h; do
+        rm -rf "${{targets.destdir}}/usr/include/X11/extensions/$h"
+      done
 
   - uses: strip
 


### PR DESCRIPTION
Part 1/2:

`xf86miscproto` is deprecated and replaced with `xorgproto`: https://gitlab.freedesktop.org/xorg/proto/xf86miscproto/-/blob/master/autogen.sh?ref_type=heads

To build this: https://github.com/wolfi-dev/os/pull/59993 we do need some headers. It builds if we do enable xorgproto with legacy support. libx11-dev doesn't provide `xf86mscstr.h`.

But some headers like `XKBgeom.h XKBsrv.h XKBstr.h` is still provided by `libx11`, which resulting conflict during install:

```
installing apk packages: installing packages: installing libx11-dev (ver:1.8.12-r1 arch:aarch64): unable to install files for pkg libx11-dev: writing header for "usr/include/X11/extensions/XKBgeom.h": packages map[libx11-dev:libx11 xorgproto:xorgproto] has conflicting file: "usr/include/X11/extensions/XKBgeom.h"
```

So remove those from libx11 and re-build xorgproto with having those headers. So we can build `libXxf86misc`.