### PR TITLE
xorgproto: enable legacy headers

### DIFF
--- a/xorgproto.yaml
+++ b/xorgproto.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorgproto
   version: "2024.1"
-  epoch: 2
+  epoch: 3
   description: Combined X.Org X11 protocol headers
   copyright:
     - license: BSD-2-Clause AND MIT AND X11
@@ -24,6 +24,10 @@ pipeline:
       uri: https://xorg.freedesktop.org/archive/individual/proto/xorgproto-${{package.version}}.tar.gz
 
   - uses: meson/configure
+    with:
+      # Building the xf86miscproto requires legacy support
+      opts: |
+        -Dlegacy=true
 
   - uses: meson/compile
 


### PR DESCRIPTION
Part 1/2: https://github.com/wolfi-dev/os/pull/60251

Part 2/2:

`xf86miscproto` is deprecated and replaced with `xorgproto`: https://gitlab.freedesktop.org/xorg/proto/xf86miscproto/-/blob/master/autogen.sh?ref_type=heads

To build this: https://github.com/wolfi-dev/os/pull/59993 we do need some headers. It builds if we do enable xorgproto with legacy support. libx11-dev doesn't provide `xf86mscstr.h`.

But some headers like `XKBgeom.h XKBsrv.h XKBstr.h` is still provided by `libx11`, which resulting conflict during install:

```
installing apk packages: installing packages: installing libx11-dev (ver:1.8.12-r1 arch:aarch64): unable to install files for pkg libx11-dev: writing header for "usr/include/X11/extensions/XKBgeom.h": packages map[libx11-dev:libx11 xorgproto:xorgproto] has conflicting file: "usr/include/X11/extensions/XKBgeom.h"
```

So remove those from libx11 and re-build xorgproto with having those headers. So we can build `libXxf86misc`.