### PR TITLE
cluster-api: move clusterctl to it's own subpackage

### DIFF
--- a/cluster-api-1.10.yaml
+++ b/cluster-api-1.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-1.10
   version: "1.10.4"
-  epoch: 1
+  epoch: 2
   description: Cluster API meta package
   dependencies:
     provides:
@@ -21,7 +21,6 @@ data:
     items:
       kubeadm-bootstrap-controller: bootstrap/kubeadm
       kubeadm-control-plane-controller: controlplane/kubeadm
-      clusterctl: cmd/clusterctl
       controller: .
 
 subpackages:
@@ -42,17 +41,37 @@ subpackages:
             -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
             -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
 
+  - name: ${{package.name}}-clusterctl
+    description: cluster-api clusterctl CLI
+    dependencies:
+      provides:
+        - cluster-api-clusterctl=${{package.full-version}}
+        - clusterctl=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: clusterctl
+          packages: ./cmd/clusterctl
+          ldflags: |
+            -X sigs.k8s.io/cluster-api/version.gitVersion=${{package.version}} \
+            -X sigs.k8s.io/cluster-api/version.gitCommit=${GIT_COMMIT} \
+            -X sigs.k8s.io/cluster-api/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean") \
+            -X sigs.k8s.io/cluster-api/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
+
   - range: backends-go-builds
     name: ${{package.name}}-${{range.key}}-compat
     description: cluster-api core ${{range.key}} compat packages
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/
-          if [[ "${{range.key}}" == "clusterctl" ]]; then
-              ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/${{range.key}}
-          else
-              ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/manager
-          fi
+          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/manager
+
+  - name: ${{package.name}}-clusterctl-compat
+    description: cluster-api clusterctl compat package
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/clusterctl ${{targets.contextdir}}/clusterctl
 
 ## The package requires a full blown kubernetes cluster for complete testing so most of the tests are just to test the execution of the binaries for each component
 test:


### PR DESCRIPTION
we wanted to have a provides of clusterctl so migrate this to it's
own subpackage and add another clusterctl provides in there.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
