### PR TITLE
DRAFT: feat: add rke2-runtime package

### DIFF
--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -83,14 +83,29 @@ pipeline:
         -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:v${{vars.image-version}}
         -X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${CCM_VERSION}
 
+# Patch: modifies build-chart.sh to be compatible with BusyBox
+# REF: https://github.com/rancher/rke2/blob/9f193e62d788b09bf0a9705c90336cd295b9974f/charts/build-chart.sh
+# 
+# Changes:
+# 1. original mktemp commands use --suffix, not supported by BusyBox.
+#    replaced with BusyBox-compatible pattern:
+#      - mktemp /tmp/tmpchart.XXXXXX).tar
+#      - mktemp /tmp/tmpvalues.XXXXXX).yaml
+#
+# 2. replace tar --delete and tar -rf steps, BusyBox tar does not support '--delete' option.
+#    we now unpack, modify, and repack the chart tarball instead:
+#      - Extract chart to temp dir
+#      - Replace chart.yaml
+#      - Recreate the tar archive
+#
+# 3. Remove tar --transform, not supported in BusyBox.
+#    since we already updated the chart.yaml during repack, '--transform' is unnecessary.
+  - uses: patch
+    with:
+      patches: build-chart-sh.patch
+
   - name: Generate Charts
     runs: |
-      # Modify CHART_TMP and YAML_TMP to work with busybox mktemp
-      # REF: https://github.com/rancher/rke2/blob/master/charts/build-chart.sh#L11-L12
-      sed -i 's|: "${CHART_TMP:=.*|: "${CHART_TMP:=$(mktemp /tmp/tmpchart.XXXXXX).tar}"|' charts/build-chart.sh
-      sed -i 's|: "${YAML_TMP:=.*|: "${YAML_TMP:=$(mktemp /tmp/tmpvalues.XXXXXX).yaml}"|' charts/build-chart.sh
-
-      # Generate charts
       bash charts/build-charts.sh
 
   - uses: strip

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -83,23 +83,23 @@ pipeline:
         -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:v${{vars.image-version}}
         -X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${CCM_VERSION}
 
-# Patch: modifies build-chart.sh to be compatible with BusyBox
-# REF: https://github.com/rancher/rke2/blob/9f193e62d788b09bf0a9705c90336cd295b9974f/charts/build-chart.sh
-# 
-# Changes:
-# 1. original mktemp commands use --suffix, not supported by BusyBox.
-#    replaced with BusyBox-compatible pattern:
-#      - mktemp /tmp/tmpchart.XXXXXX).tar
-#      - mktemp /tmp/tmpvalues.XXXXXX).yaml
-#
-# 2. replace tar --delete and tar -rf steps, BusyBox tar does not support '--delete' option.
-#    we now unpack, modify, and repack the chart tarball instead:
-#      - Extract chart to temp dir
-#      - Replace chart.yaml
-#      - Recreate the tar archive
-#
-# 3. Remove tar --transform, not supported in BusyBox.
-#    since we already updated the chart.yaml during repack, '--transform' is unnecessary.
+  # Patch: modifies build-chart.sh to be compatible with BusyBox
+  # REF: https://github.com/rancher/rke2/blob/9f193e62d788b09bf0a9705c90336cd295b9974f/charts/build-chart.sh
+  #
+  # Changes:
+  # 1. original mktemp commands use --suffix, not supported by BusyBox.
+  #    replaced with BusyBox-compatible pattern:
+  #      - mktemp /tmp/tmpchart.XXXXXX).tar
+  #      - mktemp /tmp/tmpvalues.XXXXXX).yaml
+  #
+  # 2. replace tar --delete and tar -rf steps, BusyBox tar does not support '--delete' option.
+  #    we now unpack, modify, and repack the chart tarball instead:
+  #      - Extract chart to temp dir
+  #      - Replace chart.yaml
+  #      - Recreate the tar archive
+  #
+  # 3. Remove tar --transform, not supported in BusyBox.
+  #    since we already updated the chart.yaml during repack, '--transform' is unnecessary.
   - uses: patch
     with:
       patches: build-chart-sh.patch

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -48,9 +48,9 @@ environment:
     K3S_PKG: "github.com/k3s-io/k3s"
     RKE2_PKG: "github.com/rancher/rke2"
     REGISTRY: "docker.io"
-    ETCD_VERSION: "v3.5.21-k3s1"
+    ETCD_VERSION: "v3.5.21-k3s1-build20250612"
     PAUSE_VERSION: "3.6"
-    KUBERNETES_IMAGE_TAG: "v1.33.3-rke2r1"
+    KUBERNETES_IMAGE_TAG: "v1.33.3-rke2r1-build20250716"
     REPO: "rancher"
     CCM_VERSION: "v1.33.1-0.20250516163953-99d91538b132-build20250612"
 
@@ -77,7 +77,7 @@ pipeline:
         -X ${K3S_PKG}/pkg/version.Version=${{vars.tag-version}}
         -X ${K3S_PKG}/pkg/version.UpstreamGolang=$(go env GOVERSION)
         -X ${RKE2_PKG}/pkg/images.DefaultRegistry=${REGISTRY}
-        -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-build20250612
+        -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}
         -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
         -X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${PAUSE_VERSION}
         -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:v${{vars.image-version}}

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -15,7 +15,6 @@ package:
       - kubectl
       - kubelet
       - runc
-      - runc
 
 # using apk-v2 friendly spec version format for package version string
 # need to transform version (1.33.2.2.1) to match upstream tag: '1.33.2+rke2r1'

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -1,6 +1,6 @@
 package:
   name: rke2-runtime
-  version: 1.33.2_rke2r1
+  version: 1.33.2.2.1
   epoch: 0
   description: Rancher Kubernetes Engine 2 (RKE2) is a fully conformant Kubernetes distribution with minimal dependencies
   copyright:
@@ -18,12 +18,12 @@ package:
       - runc
 
 # using apk-v2 friendly spec version format for package version string
-# need to transform version to match upstream tag: '1.33.2+rke2r1'
+# need to transform version (1.33.2.2.1) to match upstream tag: '1.33.2+rke2r1'
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+)\.(\d+)\.(\d+)_([a-zA-Z]+\d*)([a-zA-Z]+\d+)$
-    replace: ${1}.${2}.${3}+${4}${5}
-    to: mangled-package-version
+    match: ^(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)$
+    replace: ${1}.${2}.${3}+rke${4}r${5}
+    to: tag-version
 
 environment:
   contents:
@@ -34,13 +34,23 @@ environment:
   environment:
     CGO_ENABLED: "1"
     CGO_CFLAGS: "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
+    # Hardcoded values set by upstream 'version.sh' script
+    # REF: https://github.com/rancher/rke2/blob/master/scripts/version.sh
     PROG: "rke2"
-
+    K3S_PKG: "github.com/k3s-io/k3s"
+    RKE2_PKG: "github.com/rancher/rke2"
+    REGISTRY: "docker.io"
+    VERSION_GOLANG: "go1.24.4"
+    ETCD_VERSION: "v3.5.21-k3s1"
+    PAUSE_VERSION: "3.6"
+    KUBERNETES_IMAGE_TAG: "v1.33.3-rke2r1"
+    REPO: "rancher"
+    CCM_VERSION: "v1.33.1-0.20250516163953-99d91538b132-build20250612"
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/rancher/rke2
-      tag: v${{vars.mangled-package-version}}
+      tag: v${{vars.tag-version}}
       expected-commit: 62de1b13c6405a51bb4804a1dae6c2a5a17cc090
 
   - uses: go/build
@@ -48,16 +58,16 @@ pipeline:
       packages: .
       output: rke2
       ldflags: |
-        -X github.com/k3s-io/k3s/pkg/version.GitCommit=$(git rev-parse HEAD)
-        -X github.com/k3s-io/k3s/pkg/version.Program=$PROG
-        -X github.com/k3s-io/k3s/pkg/version.Version=v1.33.3+dev.9f193e62
-        -X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go1.24.4
-        -X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io
-        -X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:v3.5.21-k3s1-build20250612
-        -X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:v1.33.3-rke2r1-build20250716
-        -X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:3.6
-        -X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:v1.33.3-dev.9f193e62
-        -X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:v1.33.1-0.20250516163953-99d91538b132-build20250612
+        -X ${K3S_PKG}/pkg/version.GitCommit=$(git rev-parse HEAD)
+        -X ${K3S_PKG}/pkg/version.Program=${PROG}
+        -X ${K3S_PKG}/pkg/version.Version=${{vars.tag-version}}
+        -X ${K3S_PKG}/pkg/version.UpstreamGolang=${VERSION_GOLANG}
+        -X ${RKE2_PKG}/pkg/images.DefaultRegistry=${REGISTRY}
+        -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-build20250612
+        -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
+        -X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${PAUSE_VERSION}
+        -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:${{vars.tag-version}}
+        -X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${CCM_VERSION}
 
   - uses: strip
 
@@ -66,10 +76,18 @@ test:
     - name: Test rke2 binary exists and runs
       runs: |
         rke2 --version
+        rke2 --help
 
+# Matching upstream tag and transforming it back to apkv2 friendly format
+# EX: '1.33.2+rke2r1' --> '1.33.2.2.1'
 update:
   enabled: true
+  version-transform:
+    - match: ^(\d+)\.(\d+)\.(\d+)\+([a-zA-Z]+)(\d+)([a-zA-Z]+)(\d+)$
+      replace: "${1}.${2}.${3}.${5}.${7}"
+  ignore-regex-patterns:
+    - '-rc'
   github:
     identifier: rancher/rke2
     strip-prefix: v
-    tag-filter: v1.33
+    use-tag: true

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -1,0 +1,75 @@
+package:
+  name: rke2-runtime
+  version: 1.33.2_rke2r1
+  epoch: 0
+  description: Rancher Kubernetes Engine 2 (RKE2) is a fully conformant Kubernetes distribution with minimal dependencies
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - containerd
+      - containerd-shim-runc-v2
+      - crictl
+      - ctr
+      - kubectl
+      - kubelet
+      - runc
+      - runc
+
+# using apk-v2 friendly spec version format for package version string
+# need to transform version to match upstream tag: '1.33.2+rke2r1'
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\.(\d+)\.(\d+)_([a-zA-Z]+\d*)([a-zA-Z]+\d+)$
+    replace: ${1}.${2}.${3}+${4}${5}
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+  environment:
+    CGO_ENABLED: "1"
+    CGO_CFLAGS: "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
+    PROG: "rke2"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/rke2
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: 62de1b13c6405a51bb4804a1dae6c2a5a17cc090
+
+  - uses: go/build
+    with:
+      packages: .
+      output: rke2
+      ldflags: |
+        -X github.com/k3s-io/k3s/pkg/version.GitCommit=$(git rev-parse HEAD)
+        -X github.com/k3s-io/k3s/pkg/version.Program=$PROG
+        -X github.com/k3s-io/k3s/pkg/version.Version=v1.33.3+dev.9f193e62
+        -X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go1.24.4
+        -X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io
+        -X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:v3.5.21-k3s1-build20250612
+        -X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:v1.33.3-rke2r1-build20250716
+        -X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:3.6
+        -X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:v1.33.3-dev.9f193e62
+        -X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:v1.33.1-0.20250516163953-99d91538b132-build20250612
+
+  - uses: strip
+
+test:
+  pipeline:
+    - name: Test rke2 binary exists and runs
+      runs: |
+        rke2 --version
+
+update:
+  enabled: true
+  github:
+    identifier: rancher/rke2
+    strip-prefix: v
+    tag-filter: v1.33

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -31,6 +31,9 @@ environment:
       - bash
       - build-base
       - ca-certificates-bundle
+      - curl
+      - pigz
+      - yq
   environment:
     CGO_ENABLED: "1"
     CGO_CFLAGS: "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
@@ -77,7 +80,31 @@ pipeline:
         -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:${{vars.tag-version}}
         -X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${CCM_VERSION}
 
+  - name: Generate Charts
+    runs: |
+      # Modify CHART_TMP and YAML_TMP to work with busybox mktemp
+      # REF: https://github.com/rancher/rke2/blob/master/charts/build-chart.sh#L11-L12
+      sed -i 's|: "${CHART_TMP:=.*|: "${CHART_TMP:=$(mktemp /tmp/tmpchart.XXXXXX).tar}"|' charts/build-chart.sh
+      sed -i 's|: "${YAML_TMP:=.*|: "${YAML_TMP:=$(mktemp /tmp/tmpvalues.XXXXXX).yaml}"|' charts/build-chart.sh
+
+      # Generate charts
+      bash charts/build-charts.sh
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: compatibility package for rke2-runtime
+    pipeline:
+      - runs: |
+          # Setup compat dirs
+          mkdir -p ${{targets.contextdir}}/charts
+
+          # Copy over generated chart files files
+          cp -r /home/build/charts/*.yaml  ${{targets.contextdir}}/charts
+
+          # cleanup
+          rm ${{targets.contextdir}}/charts/chart_versions.yaml
 
 test:
   pipeline:

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -23,6 +23,10 @@ var-transforms:
     match: ^(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)$
     replace: ${1}.${2}.${3}+rke${4}r${5}
     to: tag-version
+  - from: ${{package.version}}
+    match: ^(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)$
+    replace: ${1}.${2}.${3}-rke${4}r${5}
+    to: image-version
 
 environment:
   contents:
@@ -76,7 +80,7 @@ pipeline:
         -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-build20250612
         -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}
         -X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${PAUSE_VERSION}
-        -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:${{vars.tag-version}}
+        -X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=${REPO}/${PROG}-runtime:v${{vars.image-version}}
         -X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${CCM_VERSION}
 
   - name: Generate Charts

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -46,6 +46,7 @@ environment:
     KUBERNETES_IMAGE_TAG: "v1.33.3-rke2r1"
     REPO: "rancher"
     CCM_VERSION: "v1.33.1-0.20250516163953-99d91538b132-build20250612"
+
 pipeline:
   - uses: git-checkout
     with:

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -34,6 +34,7 @@ environment:
   environment:
     CGO_ENABLED: "1"
     CGO_CFLAGS: "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
+    GOEXPERIMENT: boringcrypto
     BUILD_TAGS: "selinux,netgo,osusergo,no_stage,static_build,sqlite_omit_load_extension,no_embedded_executor,no_cri_dockerd"
     # Hardcoded values set by upstream 'version.sh' script
     # REF: https://github.com/rancher/rke2/blob/master/scripts/version.sh
@@ -41,7 +42,6 @@ environment:
     K3S_PKG: "github.com/k3s-io/k3s"
     RKE2_PKG: "github.com/rancher/rke2"
     REGISTRY: "docker.io"
-    VERSION_GOLANG: "go1.24.4"
     ETCD_VERSION: "v3.5.21-k3s1"
     PAUSE_VERSION: "3.6"
     KUBERNETES_IMAGE_TAG: "v1.33.3-rke2r1"
@@ -69,7 +69,7 @@ pipeline:
         -X ${K3S_PKG}/pkg/version.GitCommit=$(git rev-parse HEAD)
         -X ${K3S_PKG}/pkg/version.Program=${PROG}
         -X ${K3S_PKG}/pkg/version.Version=${{vars.tag-version}}
-        -X ${K3S_PKG}/pkg/version.UpstreamGolang=${VERSION_GOLANG}
+        -X ${K3S_PKG}/pkg/version.UpstreamGolang=$(go env GOVERSION)
         -X ${RKE2_PKG}/pkg/images.DefaultRegistry=${REGISTRY}
         -X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${ETCD_VERSION}-build20250612
         -X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${KUBERNETES_IMAGE_TAG}

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -54,6 +54,11 @@ pipeline:
       tag: v${{vars.tag-version}}
       expected-commit: 62de1b13c6405a51bb4804a1dae6c2a5a17cc090
 
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/pion/interceptor@v0.1.39
+
   - uses: go/build
     with:
       packages: .

--- a/rke2-runtime.yaml
+++ b/rke2-runtime.yaml
@@ -34,6 +34,7 @@ environment:
   environment:
     CGO_ENABLED: "1"
     CGO_CFLAGS: "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1"
+    BUILD_TAGS: "selinux,netgo,osusergo,no_stage,static_build,sqlite_omit_load_extension,no_embedded_executor,no_cri_dockerd"
     # Hardcoded values set by upstream 'version.sh' script
     # REF: https://github.com/rancher/rke2/blob/master/scripts/version.sh
     PROG: "rke2"
@@ -62,6 +63,7 @@ pipeline:
   - uses: go/build
     with:
       packages: .
+      tags: $BUILD_TAGS
       output: rke2
       ldflags: |
         -X ${K3S_PKG}/pkg/version.GitCommit=$(git rev-parse HEAD)

--- a/rke2-runtime/build-chart-sh.patch
+++ b/rke2-runtime/build-chart-sh.patch
@@ -1,0 +1,34 @@
+diff --git a/charts/build-chart.sh b/charts/build-chart.sh
+index db9ecc80..915bc665 100755
+--- a/charts/build-chart.sh
++++ b/charts/build-chart.sh
+@@ -8,8 +8,8 @@ set -eux -o pipefail
+ : "${CHART_PACKAGE:="${CHART_NAME%%-crd}"}"
+ : "${TAR_OPTS:=--owner=0 --group=0 --mode=gou-s+r --numeric-owner --no-acls --no-selinux --no-xattrs}"
+ : "${CHART_URL:="${CHART_REPO:="https://rke2-charts.rancher.io"}/assets/${CHART_PACKAGE}/${CHART_NAME}-${CHART_VERSION:="0.0.0"}.tgz"}"
+-: "${CHART_TMP:=$(mktemp --suffix .tar)}"
+-: "${YAML_TMP:=$(mktemp --suffix .yaml)}"
++: "${CHART_TMP:=$(mktemp /tmp/tmpchart.XXXXXX).tar}"
++: "${YAML_TMP:=$(mktemp /tmp/tmpvalues.XXXXXX).yaml}"
+ 
+ cleanup() {
+   exit_code=$?
+@@ -29,8 +29,16 @@ curl -fsSL "${CHART_URL}" | pigz -dc > "${CHART_TMP}"
+ # Extract out Chart.yaml, inject a version requirement and bundle-id annotation, and delete/replace the one in the original tarball
+ tar -xOf ${CHART_TMP} ${CHART_NAME}/Chart.yaml > ${YAML_TMP}
+ yq -i e ".kubeVersion = \">= ${KUBERNETES_VERSION}\" | .annotations.\"fleet.cattle.io/bundle-id\" = \"rke2\"" ${YAML_TMP}
+-tar --delete -b 8192 -f ${CHART_TMP} ${CHART_NAME}/Chart.yaml
+-tar --transform="s|.*|${CHART_NAME}/Chart.yaml|" ${TAR_OPTS} -vrf ${CHART_TMP} ${YAML_TMP}
++# BEGIN BusyBox tar-compatible repack workaround
++TMP_REPACK_DIR="$(mktemp -d)"
++tar -xf "${CHART_TMP}" -C "${TMP_REPACK_DIR}"
++CHART_NAME="$(basename "${CHART_FILE}" .yaml)"
++cp "${YAML_TMP}" "${TMP_REPACK_DIR}/${CHART_NAME}/Chart.yaml"
++tar -cf "${CHART_TMP}" -C "${TMP_REPACK_DIR}" .
++rm -rf "${TMP_REPACK_DIR}"
++# END repack workaround
++# Chart.yaml was already replaced inside the archive, no need to re-add it with transform
++#tar --transform="s|.*|${CHART_NAME}/Chart.yaml|" ${TAR_OPTS} -vrf ${CHART_TMP} ${YAML_TMP}
+ 
+ pigz -11 ${CHART_TMP}
+ 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
WIP

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
