### PR TITLE
feat: llvm-20: enable mlir

### DIFF
--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-20
   version: "20.1.8"
-  epoch: 0
+  epoch: 1
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -74,7 +74,7 @@ pipeline:
         -DLLVM_ENABLE_FFI=ON \
         -DLLVM_ENABLE_LIBCXX=ON \
         -DLLVM_ENABLE_PIC=ON \
-        -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
+        -DLLVM_ENABLE_PROJECTS="clang;lld;mlir;clang-tools-extra" \
         -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
         -DLLVM_ENABLE_RTTI=ON \
         -DLLVM_ENABLE_SPHINX=OFF \
@@ -590,6 +590,74 @@ subpackages:
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/lib/${{build.arch}}-unknown-linux-gnu/libunwind.so ${{targets.contextdir}}/usr/lib/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/include/*unwind* ${{targets.contextdir}}/usr/include/
           mv ${{targets.destdir}}/${{vars.llvm-prefix}}/include/mach-o/*unwind* ${{targets.contextdir}}/usr/include/mach-o/
+
+  - name: libmlir-${{vars.major-version}}
+    description: LLVM libmlir
+    dependencies:
+      runtime:
+        - libmlir-${{vars.major-version}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          libdir="/usr/lib/llvm-${{vars.major-version}}/lib"
+          mkdir -p "${{targets.contextdir}}${libdir}"
+          mv "${{targets.destdir}}${libdir}"/libMLIR* \
+            "${{targets.contextdir}}${libdir}"
+          mv "${{targets.destdir}}${libdir}"/libmlir* \
+            "${{targets.contextdir}}${libdir}"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: libmlir-${{vars.major-version}}-dev
+    description: Development files for LLVM libmlir
+    dependencies:
+      provides:
+        - libmlir-dev=${{package.full-version}}
+      runtime:
+        - libmlir-${{vars.major-version}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          move_to_subpkg() {
+            local what="$1"
+            local src="${{targets.destdir}}/${what}"
+            local dest="${{targets.contextdir}}/${what}"
+
+            mkdir -p "$(dirname "$dest")"
+            mv "$src" "$(dirname "$dest")"
+          }
+          for d in mlir mlir-c; do
+            move_to_subpkg "/usr/lib/llvm-${{vars.major-version}}/include/${d}"
+          done
+          move_to_subpkg "/usr/lib/llvm-${{vars.major-version}}/lib/cmake"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: mlir-${{vars.major-version}}-tools
+    description: LLVM mlir tools
+    dependencies:
+      runtime:
+        - libmlir-${{vars.major-version}}=${{package.full-version}}
+    options:
+      # melange doesn't currently add so:* provides to libmlir, but
+      # wants to add so: dependencies to them here
+      no-depends: true
+    pipeline:
+      - runs: |
+          bindir="/usr/lib/llvm-${{vars.major-version}}/bin"
+          mkdir -p "${{targets.contextdir}}${bindir}"
+          mv "${{targets.destdir}}${bindir}"/mlir-* \
+            "${{targets.contextdir}}${bindir}"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: |
+            cmd_suffixes="linalg-ods-yaml-gen lsp-server opt pdll pdll-lsp-server query reduce rewrite runner tblgen translate"
+            for suffix in $cmd_suffixes; do
+              cmd="/usr/lib/llvm-${{vars.major-version}}/bin/mlir-${suffix}"
+              "$cmd" --help
+              "$cmd" --version
+            done
 
   - name: llvm-cmake-${{vars.major-version}}
     description: CMake macros for LLVM ${{vars.major-version}}

--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -594,8 +594,8 @@ subpackages:
   - name: libmlir-${{vars.major-version}}
     description: LLVM libmlir
     dependencies:
-      runtime:
-        - libmlir-${{vars.major-version}}=${{package.full-version}}
+      provides:
+        - libmlir=${{package.full-version}}
     pipeline:
       - runs: |
           libdir="/usr/lib/llvm-${{vars.major-version}}/lib"


### PR DESCRIPTION
mlir is needed for some AIML builds; enable it for our llvm builds.

Start with llvm-20. Once merged there, we can backport as far back as needed.