### PR TITLE
fix: add missing glibc-iconv dependency to dosfstools

### DIFF
--- a/dosfstools.yaml
+++ b/dosfstools.yaml
@@ -2,12 +2,13 @@
 package:
   name: dosfstools
   version: "4.2"
-  epoch: 40
+  epoch: 41
   description: DOS filesystem utilities
   copyright:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
+      - glibc-iconv
       - merged-usrsbin
       - wolfi-baselayout
 


### PR DESCRIPTION
Missing dependency at runtime