### PR TITLE
kubeflow-centraldashboard/GHSA-76c9-3jph-rj3q fix

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -60,9 +60,8 @@ pipeline:
         "@grpc/grpc-js": "^1.10.9",
         "serve-static": "^1.16.0",
         "cookie": "0.7.0",
-        "jsonpath-plus": "10.3.0",
-        "compression": "^1.8.1",
-        "response-time": "^2.3.4"
+        "on-headers": "1.1.0",
+        "jsonpath-plus": "10.3.0"
       }'
 
       # Apply the overrides

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 2
+  epoch: 3
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -60,7 +60,9 @@ pipeline:
         "@grpc/grpc-js": "^1.10.9",
         "serve-static": "^1.16.0",
         "cookie": "0.7.0",
-        "jsonpath-plus": "10.3.0"
+        "jsonpath-plus": "10.3.0",
+        "compression": "^1.8.1",
+        "response-time": "^2.3.4"
       }'
 
       # Apply the overrides


### PR DESCRIPTION
The affected dependency on-headers @ 1.0.2 is a transitive dependency from compression and response-time. Updating these to fix versions resolves the vulnerability.