### PR TITLE
chainguard-security-guide/3.2.5 package update

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "3.2.4"
+  version: "3.2.5"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: a2ba57b99777ec0d21cabbe938290e86edd54fca
+      expected-commit: d48d779140087bfed04633e1f2f2d86831052ee4
       tag: v${{package.version}}
 
   - runs: |
@@ -43,13 +43,13 @@ test:
         oscap info /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
     - name: Verify that the trust anchor check passes
       runs: |
-        if ! oscap xccdf eval --verbose WARNING --rule xccdf_._rule_V_263659 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
+        if ! oscap xccdf eval --verbose WARNING --rule xccdf_mil.disa.stig_rule_SV-263659r982563_rule /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
             # if we failed, then re-run more verbosely to help make diagnosing easier
-            oscap xccdf eval --verbose INFO --rule xccdf_._rule_V_263659 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+            oscap xccdf eval --verbose INFO --rule xccdf_mil.disa.stig_rule_SV-263659r982563_rule /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
         fi
     - name: Verify that the remote service check passes, even with python-3.12 (telnetlib.py) installed
       runs: |
-        if ! oscap xccdf eval --verbose WARNING --rule xccdf_._rule_V_203736 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
+        if ! oscap xccdf eval --verbose WARNING --rule xccdf_mil.disa.stig_rule_SV-203736r958848_rule /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml ; then
             # if we failed, then re-run more verbosely to help make diagnosing easier
-            oscap xccdf eval --verbose INFO --rule xccdf_._rule_V_203736 /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
+            oscap xccdf eval --verbose INFO --rule xccdf_mil.disa.stig_rule_SV-203736r958848_rule /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml
         fi


### PR DESCRIPTION
This PR bumps `chainguard-security-guide` to `3.2.5` to pull in the latest changes around STIGViewer compatibility and general improvements.