### PR TITLE
add helm-set-status plugin package

### DIFF
--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -1,0 +1,72 @@
+package:
+  name: helm-set-status
+  version: 0.3.0
+  epoch: 0
+  description: Helm plugin to set release status
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/helm-set-status.git
+      tag: v${{package.version}}
+      expected-commit: 260bbd88a52aba1a76d44ed2ae66dccf5615dbf3
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/containerd/containerd@v1.7.27
+        github.com/docker/docker@v26.1.5
+        golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
+        helm.sh/helm/v3@v3.17.4
+
+  - runs: |
+      cat Makefile
+      make build
+      mkdir -p "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status"
+      install -Dm755 ./bin/helm-set-status "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status/helm-set-status"
+      install -Dm644 plugin.yaml "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status/plugin.yaml"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: k3s-io/helm-set-status
+    strip-prefix: v
+
+test:
+  environment:
+    accounts:
+      run-as: 0
+    contents:
+      packages:
+        - helm
+  pipeline:
+    # Skipping full test for now due to incompatibility in github runners in CI for aarrch64.
+    # The test passes locally when using MELANGE_RUNNER=docker
+    # - uses: test/kwok/cluster
+    # - name: "Install test chart and change status"
+    #   runs: |
+    #     helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+    #     helm repo update
+    #     helm install test-dashboard kubernetes-dashboard/kubernetes-dashboard --wait --timeout 2m
+    #     helm status test-dashboard | grep "STATUS: deployed"
+    #     helm set-status test-dashboard failed
+    #     helm status test-dashboard | grep "STATUS: failed"
+    - runs: |
+        helm plugin list | grep -i 'set-status' > out.log 2>&1

--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -40,7 +40,6 @@ pipeline:
   # Installers of this package will have to set this environment var
   # HELM_PLUGINS=/usr/libexec/helm-plugins
   - runs: |
-      cat Makefile
       make build
       INSTALL_DIR="${{targets.destdir}}/usr/libexec/helm-plugins/${{package.name}}"
       mkdir -p "${INSTALL_DIR}"

--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -69,4 +69,4 @@ test:
     #     helm set-status test-dashboard failed
     #     helm status test-dashboard | grep "STATUS: failed"
     - runs: |
-        helm plugin list | grep -i 'set-status' > out.log 2>&1
+        helm plugin list 2>&1 | grep -i 'set-status'

--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -44,10 +44,7 @@ pipeline:
       make build
       INSTALL_DIR="${{targets.destdir}}/usr/libexec/helm-plugins/${{package.name}}"
       mkdir -p "${INSTALL_DIR}"
-      mkdir -p "${INSTALL_DIR}/bin"
-      mkdir -p "${INSTALL_DIR}/config"
-
-      install -Dm755 ./bin/helm-set-status "${INSTALL_DIR}/bin/helm-set-status"
+      install -Dm755 ./bin/helm-set-status "${INSTALL_DIR}/helm-set-status"
       install -Dm644 plugin.yaml "${INSTALL_DIR}/plugin.yaml"
 
   - uses: strip

--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -34,12 +34,21 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
         helm.sh/helm/v3@v3.17.4
 
+  # Dropping helm plugins in /usr/libexec since they are binaries and
+  # configuration intended to be run by the helm command.
+  # See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html
+  # Installers of this package will have to set this environment var
+  # HELM_PLUGINS=/usr/libexec/helm-plugins
   - runs: |
       cat Makefile
       make build
-      mkdir -p "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status"
-      install -Dm755 ./bin/helm-set-status "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status/helm-set-status"
-      install -Dm644 plugin.yaml "${{targets.contextdir}}/root/.local/share/helm/plugins/helm-set-status/plugin.yaml"
+      INSTALL_DIR="${{targets.destdir}}/usr/libexec/helm-plugins/${{package.name}}"
+      mkdir -p "${INSTALL_DIR}"
+      mkdir -p "${INSTALL_DIR}/bin"
+      mkdir -p "${INSTALL_DIR}/config"
+
+      install -Dm755 ./bin/helm-set-status "${INSTALL_DIR}/bin/helm-set-status"
+      install -Dm644 plugin.yaml "${INSTALL_DIR}/plugin.yaml"
 
   - uses: strip
 
@@ -51,22 +60,22 @@ update:
 
 test:
   environment:
-    accounts:
-      run-as: 0
     contents:
       packages:
         - helm
+    environment:
+      KUBERNETES_SERVICE_HOST: "127.0.0.1"
+      KUBERNETES_SERVICE_PORT: 32764
+      HELM_PLUGINS: "/usr/libexec/helm-plugins"
   pipeline:
-    # Skipping full test for now due to incompatibility in github runners in CI for aarrch64.
-    # The test passes locally when using MELANGE_RUNNER=docker
-    # - uses: test/kwok/cluster
-    # - name: "Install test chart and change status"
-    #   runs: |
-    #     helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
-    #     helm repo update
-    #     helm install test-dashboard kubernetes-dashboard/kubernetes-dashboard --wait --timeout 2m
-    #     helm status test-dashboard | grep "STATUS: deployed"
-    #     helm set-status test-dashboard failed
-    #     helm status test-dashboard | grep "STATUS: failed"
     - runs: |
         helm plugin list 2>&1 | grep -i 'set-status'
+    - uses: test/kwok/cluster
+    - name: "Install test chart and change status"
+      runs: |
+        helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+        helm repo update
+        helm install test-dashboard kubernetes-dashboard/kubernetes-dashboard --wait --timeout 2m
+        helm status test-dashboard | grep "STATUS: deployed"
+        helm set-status test-dashboard failed
+        helm status test-dashboard | grep "STATUS: failed"

--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -5,18 +5,6 @@ package:
   description: Helm plugin to set release status
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - ca-certificates-bundle
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -39,14 +27,19 @@ pipeline:
   # See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html
   # Installers of this package will have to set this environment var
   # HELM_PLUGINS=/usr/libexec/helm-plugins
+  - uses: go/build
+    with:
+      packages: ./cmd/helm-set-status
+      output: helm-set-status
+      tags: static_build,osusergo
+      ldflags: |
+        -X main.version=v${{package.version}}
+
   - runs: |
-      make build
       INSTALL_DIR="${{targets.destdir}}/usr/libexec/helm-plugins/${{package.name}}"
       mkdir -p "${INSTALL_DIR}"
-      install -Dm755 ./bin/helm-set-status "${INSTALL_DIR}/helm-set-status"
+      ln -sf /usr/bin/helm-set-status "${INSTALL_DIR}/helm-set-status"
       install -Dm644 plugin.yaml "${INSTALL_DIR}/plugin.yaml"
-
-  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/k3s-io/helm-set-status

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
