### PR TITLE
unbreak cycle

### DIFF
--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,7 +1,7 @@
 package:
   name: gettext
   version: 0.22.5
-  epoch: 4
+  epoch: 5
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT

--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,7 +1,7 @@
 package:
   name: gettext
   version: 0.22.5
-  epoch: 5
+  epoch: 4
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 55
+  epoch: 56
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -588,20 +588,6 @@ subpackages:
     dependencies:
       runtime:
         - glibc=${{package.full-version}}
-        - merged-lib
-        - merged-sbin
-        - merged-usrsbin
-        - wolfi-baselayout
-
-  - name: "libcrypt1"
-    description: "Password hashing library included with glibc"
-    dependencies:
-      provider-priority: 10
-      provides:
-        - so:libcrypt.so.1=1
-      runtime:
-        - glibc=${{package.full-version}}
-        - libxcrypt
         - merged-lib
         - merged-sbin
         - merged-usrsbin

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -195,7 +195,7 @@ pipeline:
     runs: |
       make -C build -j$(nproc) localedata/install-locale-files DESTDIR="${{targets.destdir}}"
 
-  - name: "Usrmerge /usr/sbin" # Some binaries ignore --sbindir for some reason
+  - name: 'Usrmerge /usr/sbin' # Some binaries ignore --sbindir for some reason
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       mv "${{targets.destdir}}"/usr/sbin/* "${{targets.destdir}}"/usr/bin

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 55
+  epoch: 56
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 56
+  epoch: 55
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -195,7 +195,7 @@ pipeline:
     runs: |
       make -C build -j$(nproc) localedata/install-locale-files DESTDIR="${{targets.destdir}}"
 
-  - name: 'Usrmerge /usr/sbin' # Some binaries ignore --sbindir for some reason
+  - name: "Usrmerge /usr/sbin" # Some binaries ignore --sbindir for some reason
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       mv "${{targets.destdir}}"/usr/sbin/* "${{targets.destdir}}"/usr/bin

--- a/libcrypt1.yaml
+++ b/libcrypt1.yaml
@@ -1,0 +1,18 @@
+package:
+  name: libcrypt1
+  # Higher than last include in glibc.yaml
+  version: "2.42"
+  epoch: 0
+  description: "meta package for password hashing library split from glibc"
+  copyright:
+    - license: LGPL-2.1-or-later
+  dependencies:
+    provider-priority: 10
+    provides:
+      - so:libcrypt.so.1=1
+    runtime:
+      - libxcrypt
+
+test:
+  pipeline:
+    - uses: test/emptypackage

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: "4.4.38"
-  epoch: 2
+  epoch: 3
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: "4.4.38"
-  epoch: 1
+  epoch: 2
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later


### PR DESCRIPTION
- **libxcrypt: No-change rebuild to fix file permissions**
  Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
  

- **Bump epoch to 3**
  Context: https://github.com/wolfi-dev/os/pull/55104/files#diff-0ff5f988fb16e36ee75593b2e438956b3406f109e0510a0d656ed8e039ae3d82R4
  
  Signed-off-by: Evan Gibler <20933572+egibs@users.noreply.github.com>

- **Try bumping gettext**
  Signed-off-by: egibs <20933572+egibs@users.noreply.github.com>
  

- **glibc as well?**
  Signed-off-by: egibs <20933572+egibs@users.noreply.github.com>
  

- **Back to where we started. This is a known issue**
  Signed-off-by: egibs <20933572+egibs@users.noreply.github.com>
  

- **Formatting**
  Signed-off-by: egibs <20933572+egibs@users.noreply.github.com>
  

- **Unbreak build cycle**
  