### PR TITLE
kube-fluentd-operator/cve remediation

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 41
+  epoch: 42
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT


### PR DESCRIPTION
cve: bump kube-fluentd-operator to pull in latest ruby-3.2