### PR TITLE
fix(mosquitto): rebuild with libwebsockets.so.20

### DIFF
--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -1,7 +1,7 @@
 package:
   name: mosquitto
   version: "2.0.22"
-  epoch: 1
+  epoch: 2
   description: open source MQTT broker
   copyright:
     - license: EPL-1.0


### PR DESCRIPTION
## Changes

Current version of `mosquitto` uses [old `libwebsockets`](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/mosquitto-2.0.22-r1.apk@sha1:a90bf1d4f77dc3b27f88256463b57ddccf7a2349/.PKGINFO). A new version of this [came out few days ago](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz@etag:aff82e1489cc7cbf6b54a78c8c4935de/APKINDEX?full=true&search=&depend=&provide=so%3Alibwebsockets.so.20). Rebuilding to pick up latest changes