### PR TITLE
haproxy-3.2: build from the git checkout rather than release tarball

### DIFF
--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.3"
-  epoch: 1
+  epoch: 2
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -36,22 +36,11 @@ environment:
       - pcre2-dev
 
 pipeline:
-  # Using this git to get the correct version using GitMonitor
   - uses: git-checkout
     with:
       repository: https://git.haproxy.org/git/haproxy-${{vars.major-minor-version}}.git
       tag: v${{package.version}}
       expected-commit: 1844da7c65c5655d93c79925ed2244ca8cda9822
-      destination: /home/build/nothing
-
-  - runs: rm -rf /home/build/nothing # we do not use this source to build
-
-  # We have to use fetch, as there are issues cloning from: 'https://git.haproxy.org/git/haproxy-3.0.git'.
-  # Namely: 'failed to validate pipeline git-checkout: failed to list refs for https://git.haproxy.org/git/haproxy-3.0.git/: pkt-line 1: invalid hash text: encoding/hex: invalid byte'
-  - uses: fetch
-    with:
-      uri: https://www.haproxy.org/download/${{vars.major-minor-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: af8ef64286bdddc93232c5dbe4ea436a8ccb5dc8417cfa1e885bec52884f9347
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
Our build now already depends on being able to clone the upstream git repo reliably, so there's no reason not to build directly from it.

I've compared the release tarball and the tagged tree, and this is the only difference between the two:

```diff
diff --color -ru haproxy-3.2.3/SUBVERS haproxy-3.2/SUBVERS
--- haproxy-3.2.3/SUBVERS	2025-07-09 04:25:50.000000000 -0400
+++ haproxy-3.2/SUBVERS	2025-07-23 11:05:33.108406780 -0400
@@ -1,2 +1,2 @@
--1844da7
+-$Format:%h$

diff --color -ru haproxy-3.2.3/VERDATE haproxy-3.2/VERDATE
--- haproxy-3.2.3/VERDATE	2025-07-09 04:25:50.000000000 -0400
+++ haproxy-3.2/VERDATE	2025-07-23 11:05:33.108406780 -0400
@@ -1,2 +1,2 @@
-2025-07-09 10:25:50 +0200
+$Format:%ci$
 2025/07/09
```