### PR TITLE
rust-analyzer: convert to `git` update backend

### DIFF
--- a/rust-analyzer.yaml
+++ b/rust-analyzer.yaml
@@ -43,6 +43,9 @@ update:
   enabled: true
   ignore-regex-patterns:
     - "nightly"
+  version-transform:
+    - match: '-'
+      replace: ''
   git: {}
 
 test:

--- a/rust-analyzer.yaml
+++ b/rust-analyzer.yaml
@@ -43,8 +43,7 @@ update:
   enabled: true
   ignore-regex-patterns:
     - "nightly"
-  github:
-    identifier: rust-lang/rust-analyzer
+  git: {}
 
 test:
   pipeline:


### PR DESCRIPTION
Automation appears to be failing to find new version using the `github` backend.