### PR TITLE
kserve: update starlette to fix CVE by adding version constraint

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: "0.15.2"
-  epoch: 3
+  epoch: 4
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -111,6 +111,9 @@ subpackages:
           # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v
           poetry add \
             "urllib3=^2.5.0"
+
+          poetry add \
+            "starlette=^0.47.2"
 
           poetry run pip freeze | grep -v kserve > requirements.txt
           poetry build


### PR DESCRIPTION
## Summary

Updates kserve package to fix a Starlette CVE by adding a version constraint that ensures a secure version is installed.

## Changes

- **Increment epoch**: 3 → 4 to force package rebuild  
- **Add starlette constraint**: `poetry add "starlette=^0.47.2"` to ensure secure version
- **CVE remediation**: Addresses vulnerability in Starlette dependency

## Technical Details

The fix adds a Poetry dependency constraint for Starlette that ensures version 0.47.2 or higher is installed, which contains the security fix for the detected CVE. This follows the same pattern used for other CVE fixes in this package (urllib3, protobuf).

## Testing

The package will need to be built and tested to ensure:
- The starlette version constraint is applied correctly
- No dependency conflicts are introduced
- All existing functionality continues to work

## Build Command

```bash
make package/kserve
```