### PR TITLE
glibc: cherry-pick fix for CVE-2025-8058

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.41"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 55
+  epoch: 56
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -111,6 +111,7 @@ pipeline:
         release/2.41/master/515d4166f4dbcf43b1568e3f63a19d9a92b2d50e: elf: Fix subprocess status handling for tst-dlopen-sgid (bug 32987)
         master/81467d4b6168c7ce40d951d6b32e387109c0e5ae: elf: Add optimization barrier for __ehdr_start and _end
         master/681a24ae4d0cb8ed92de98b4da660308840b09ba: AArch64: Avoid memset ifunc in cpu-features.c [BZ #33112]
+        master/7ea06e994093fa0bcca0d0ee2c1db271d8d7885d: posix: Fix double-free after allocation failure in regcomp (bug 33185)
 
   - uses: patch
     with:


### PR DESCRIPTION
I confirmed that the test results recorded in the `glibc-testresults` apk shows the following for both archs:

```
$ cat usr/share/glibc-testresults/posix/tst-regcomp-bracket-free.test-result
PASS: posix/tst-regcomp-bracket-free
original exit status 0
```