### PR TITLE
logstash-9: fix GHSA-353f-x4gh-cqq8 by updating nokogiri to 1.18.9

### DIFF
--- a/logstash-9.yaml
+++ b/logstash-9.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9
   version: "9.0.3"
-  epoch: 2
+  epoch: 3
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -101,6 +101,7 @@ pipeline:
       echo "gem 'rack', '3.1.16'" >> Gemfile.template
       echo "gem 'rack-session', '2.1.1'" >> Gemfile.template
       echo "gem 'net-imap', '0.5.8'" >> Gemfile.template
+      echo "gem 'nokogiri', '1.18.9'" >> Gemfile.template
       # Fix GHSA-xc9x-jj77-9p9j
       sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"
 


### PR DESCRIPTION
## Summary

Fixes critical GHSA-353f-x4gh-cqq8 in logstash-9 by updating nokogiri from 1.18.8 to 1.18.9.

## Vulnerability Details

- **CVE**: GHSA-353f-x4gh-cqq8 
- **Severity**: Critical (CVSS scores up to 9.1)
- **Component**: nokogiri 1.18.8 (gem)
- **Affected**: Multiple vulnerabilities in vendored libxml2 library
- **Impact**: Buffer overflows, use-after-free vulnerabilities, NULL pointer dereferences

## Changes

- **Increment epoch**: 2 → 3 to force package rebuild
- **Add nokogiri constraint**: `gem 'nokogiri', '1.18.9'` in Gemfile.template
- **Fix version**: nokogiri 1.18.9+ contains patches for libxml2 vulnerabilities

## Technical Details

The fix adds nokogiri 1.18.9 to the Gemfile.template, following the same pattern as other gem version constraints in the package. This ensures the secure version is used instead of the vulnerable 1.18.8.

This is the same fix as applied to logstash-8 in https://github.com/chainguard-dev/enterprise-packages/pull/28410

## Additional CVEs in Package

Remote scan shows multiple other CVEs that could be addressed in follow-up PRs:
- nimbus-jose-jwt (Medium)
- cgi, uri gems (Medium/Low) 
- jruby-openssl (Medium)

## Testing

The package should be built and scanned to verify:
- nokogiri 1.18.9 is correctly installed
- GHSA-353f-x4gh-cqq8 is resolved
- No dependency conflicts are introduced

## Build Command

```bash
make package/logstash-9
wolfictl scan --remote logstash-9
```