### PR TITLE
JuiceFS Compat: Update runtime dependency

### DIFF
--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -49,6 +49,7 @@ subpackages:
         - openssh-client
         - bash # As per upstream entrypoint
         - coreutils # Needed for working with volumes
+        - dash-binsh # Need for entrypoint when deployed by juicefs-csi-driver helm chart
       provides:
         - juicefs-compat=${{package.full-version}}
     pipeline:

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
- Add `dash-binsh` package which is needed in entrypoint when deployed in `k8s` runtime by `juicefs-csi-driver` helm chart.