### PR TITLE
add minio-object-browser

### DIFF
--- a/minio-object-browser.yaml
+++ b/minio-object-browser.yaml
@@ -6,9 +6,6 @@ package:
   copyright:
     - license: AGPL-3.0-only
 
-# Create a new major-version variable that contains only the major version
-# to use in the bitnami/compat pipeline to find out the correct folder for the image.
-# e.g. 2.0.2 will create a new var major-version=2
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+).*

--- a/minio-object-browser.yaml
+++ b/minio-object-browser.yaml
@@ -35,52 +35,32 @@ update:
     strip-prefix: v
 
 subpackages:
-  - name: ${{package.name}}-bitnami-compat
-    description: "Compatibility package for usage with the Bitnami Helm Chart"
+  - name: ${{package.name}}-iamguarded-compat
+    description: "compat package for iamguarded"
+    dependencies:
+      runtime:
+        - ${{package.name}}
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: ${{package.name}}
-          version-path: ${{vars.major-version}}/debian-12
       - runs: |
-          # https://github.com/bitnami/containers/blob/main/bitnami/minio-object-browser/2/debian-12/Dockerfile
-          # Delete the ca-certificates.crt file to avoid conflicts with the one in /etc/ssl/certs
-          rm -rf ${{targets.contextdir}}/etc/ssl/certs/ca-certificates.crt
-          mkdir -p ${{targets.contextdir}}/opt/bitnami/minio-object-browser/bin
-          ln -sf /usr/bin/console ${{targets.contextdir}}/opt/bitnami/minio-object-browser/bin/console
+          mkdir -p /opt/iamguarded/minio-object-browser/bin/
+          ln -sf /usr/bin/console /opt/iamguarded/minio-object-browser/bin/console
+      - uses: iamguarded/build-compat
+        with:
+          package: minio-object-browser
+          version: ${{vars.major-version}}
+      - uses: iamguarded/finalize-compat
+        with:
+          package: minio-object-browser
+          version: ${{vars.major-version}}
     test:
-      environment:
-        contents:
-          packages:
-            - ${{package.name}}
-            - wait-for-it
-        environment:
-          BITNAMI_APP_NAME: minio-object-browser
-          PATH: /opt/bitnami/minio-object-browser/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        accounts:
-          groups:
-            - groupname: nonroot
-              gid: 1001
-          users:
-            - username: nonroot
-              gid: 1001
-              uid: 1001
-          run-as: 1001
       pipeline:
-        - working-directory: /tmp # Workaround for "can't cd to /home/build: Permission denied" error
-          pipeline:
-            - runs: |
-                test "$(readlink /opt/bitnami/minio-object-browser/bin/console)" = "/usr/bin/console"
-                /opt/bitnami/minio-object-browser/bin/console --version
-            - name: Launch operator with dummy kubeconfig
-              uses: test/daemon-check-output
-              with:
-                start: console server
-                timeout: 30
-                expected_output: |
-                  Serving console
-                post: |
-                  wait-for-it -t 5 --strict localhost:9090 -- echo "Server is up"
+        - runs: |
+            test "$(readlink /opt/iamguarded/minio-object-browser/bin/console)" = "/usr/bin/console"
+            /opt/iamguarded/minio-object-browser/bin/console --version
+        - uses: iamguarded/test-compat
+          with:
+            package: minio-object-browser
+            version: ${{vars.major-version}}
 
 test:
   environment:

--- a/minio-object-browser.yaml
+++ b/minio-object-browser.yaml
@@ -1,0 +1,109 @@
+package:
+  name: minio-object-browser
+  version: "2.0.2"
+  epoch: 0
+  description: Simple UI for MinIO Object Storage
+  copyright:
+    - license: AGPL-3.0-only
+
+# Create a new major-version variable that contains only the major version
+# to use in the bitnami/compat pipeline to find out the correct folder for the image.
+# e.g. 2.0.2 will create a new var major-version=2
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/minio/object-browser
+      tag: v${{package.version}}
+      expected-commit: 2595faf715eab7788deb19c63eff84c6a791aa1a
+
+  - uses: go/build
+    with:
+      packages: ./cmd/console
+      output: console
+      tags: kqueue
+
+update:
+  enabled: true
+  github:
+    identifier: minio/object-browser
+    strip-prefix: v
+
+subpackages:
+  - name: ${{package.name}}-bitnami-compat
+    description: "Compatibility package for usage with the Bitnami Helm Chart"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: ${{package.name}}
+          version-path: ${{vars.major-version}}/debian-12
+      - runs: |
+          # https://github.com/bitnami/containers/blob/main/bitnami/minio-object-browser/2/debian-12/Dockerfile
+          # Delete the ca-certificates.crt file to avoid conflicts with the one in /etc/ssl/certs
+          rm -rf ${{targets.contextdir}}/etc/ssl/certs/ca-certificates.crt
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/minio-object-browser/bin
+          ln -sf /usr/bin/console ${{targets.contextdir}}/opt/bitnami/minio-object-browser/bin/console
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - wait-for-it
+        environment:
+          BITNAMI_APP_NAME: minio-object-browser
+          PATH: /opt/bitnami/minio-object-browser/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        accounts:
+          groups:
+            - groupname: nonroot
+              gid: 1001
+          users:
+            - username: nonroot
+              gid: 1001
+              uid: 1001
+          run-as: 1001
+      pipeline:
+        - working-directory: /tmp # Workaround for "can't cd to /home/build: Permission denied" error
+          pipeline:
+            - runs: |
+                test "$(readlink /opt/bitnami/minio-object-browser/bin/console)" = "/usr/bin/console"
+                /opt/bitnami/minio-object-browser/bin/console --version
+            - name: Launch operator with dummy kubeconfig
+              uses: test/daemon-check-output
+              with:
+                start: console server
+                timeout: 30
+                expected_output: |
+                  Serving console
+                post: |
+                  wait-for-it -t 5 --strict localhost:9090 -- echo "Server is up"
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - wait-for-it
+    environment:
+      CONSOLE_ACCESS_KEY: TEST
+      CONSOLE_SECRET_KEY: TEST
+      CONSOLE_MINIO_SERVER: <minio-server-endpoint>
+      CONSOLE_DEV_MODE: on
+  pipeline:
+    - runs: |
+        console --version
+        console --help
+    - name: Launch operator with dummy kubeconfig
+      uses: test/daemon-check-output
+      with:
+        start: console server
+        timeout: 30
+        expected_output: |
+          Serving console
+        post: |
+          wait-for-it -t 5 --strict localhost:9090 -- echo "Server is up"
+          curl -sfSL http://localhost:9090 | grep "You need to enable JavaScript"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
