### PR TITLE
rabbitmq-server: update symlink to use nonroot user

### DIFF
--- a/rabbitmq-server-4.1.yaml
+++ b/rabbitmq-server-4.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-4.1
   version: "4.1.2"
-  epoch: 1
+  epoch: 2
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -83,8 +83,8 @@ pipeline:
       cp -a ./deps/rabbit/docs/* "${{targets.contextdir}}"/usr/share/doc/"${{package.name}}"/
       cp -a ./deps/rabbitmq_sharding/docs/* "${{targets.contextdir}}"/usr/share/doc/"${{package.name}}"/
 
-      mkdir -p ${{targets.contextdir}}/root
-      ln -sf /var/lib/rabbitmq/.erlang.cookie ${{targets.contextdir}}/root/.erlang.cookie
+      mkdir -p ${{targets.contextdir}}/home/rabbitmq
+      ln -sf /var/lib/rabbitmq/.erlang.cookie ${{targets.contextdir}}/home/rabbitmq/.erlang.cookie
 
   - uses: strip
 


### PR DESCRIPTION
by default image cannot access /root and it's not looking for symlink at
/root but rather at /home/rabbitmq.

this commit updates the symlink to be at the new location.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
