### PR TITLE
feat(kube-fluentd-operator): bump dep to remediate CVE-2025-54314

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 42
+  epoch: 43
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -92,6 +92,9 @@ pipeline:
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       # bump net-imap to mitigate GHSA-j3g3-5qv5-52mj
       bundle update rack net-imap --patch
+
+      # bump webrick to mitigate GHSA-6f62-3596-g6w7
+      echo "gem 'thor', '1.4.0'" >> Gemfile
 
 
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump deps to remediate https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
