### PR TITLE
crac-criu: ignore ~25.04 backport versions

### DIFF
--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -78,6 +78,8 @@ update:
   ignore-regex-patterns:
     - import/.* # Not the relevant tags
     - upstream/.* # Not the relevant tags
+    # Ignore backports to 25.04, the non-backport version is the one we want
+    - _25.04(.\d+)?$
 
 test:
   pipeline:


### PR DESCRIPTION
Ubuntu policy generally requires software to land in the development release before it is backported to stable releases, so we shouldn't miss any actually new versions this way.  (Backport git tags will sort higher than non-backport git tags, which is why we need this at all.)

Closes: #60518 