### PR TITLE
postgresql-{16,17}: Drop direct BD on icu-data-full

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.9"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -31,7 +31,6 @@ environment:
       - execline-dev
       - flex
       - gawk
-      - icu-data-full
       - icu-dev
       - krb5-dev
       - libedit-dev

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.5"
-  epoch: 5
+  epoch: 6
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -31,7 +31,6 @@ environment:
       - execline-dev
       - flex
       - gawk
-      - icu-data-full
       - icu-dev
       - krb5-dev
       - libedit-dev


### PR DESCRIPTION
Dependency chain: icu-dev -> icu -> icu-libs -> icu-data-full

This package will automatically be generated as a dependency via
icu-libs, and is due to move a versioned named with the upcoming
icu transition to 77.1; drop BD as its not required.
