### PR TITLE
test/vercheck.yaml: Add version check test pipeline

### DIFF
--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-stable
   # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
   version: "1.28.0"
-  epoch: 6
+  epoch: 7
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -37,6 +37,9 @@ environment:
       - pkgconf
       - zeromq-dev
       - zlib-dev
+
+vars:
+  bin-name: nginx
 
 var-transforms:
   - from: ${{package.version}}
@@ -275,11 +278,13 @@ test:
         - ${{package.name}}-config-compat
   pipeline:
     - runs: |
-        nginx -v
         head -n 5 /etc/nginx/nginx.conf
         head -n 5 /etc/nginx/conf.d/nginx.default.conf
         head -n 5 /etc/nginx/conf.d/default.conf
         nginx -h
+    - uses: test/vercheck
+      with:
+        bin: ${{vars.bin-name}}
 
 update:
   enabled: true

--- a/pipelines/test/vercheck.yaml
+++ b/pipelines/test/vercheck.yaml
@@ -19,9 +19,10 @@ inputs:
   version-flag:
     description: |
       Command line flag used to get version information.
-      Common values: --version, -version, -V, -v, version
+      Use 'auto' to try common flags automatically: --version, -version, -V, -v, version
+      Or specify exact flag like: --version, -V, etc.
     required: false
-    default: "--version"
+    default: "auto"
   match-type:
     description: |
       How to match the version string:
@@ -59,7 +60,6 @@ pipeline:
 
         echo "   Checking version for binary: $binary"
         echo "   Expected version: $expected_version"
-        echo "   Version flag: $version_flag"
         echo "   Match type: $match_type"
 
         # Check if binary exists in PATH
@@ -70,16 +70,34 @@ pipeline:
         fi
         echo "Binary '$binary' found in PATH"
 
-        # Get version output (capture both stdout and stderr)
-        echo "   Running: $binary $version_flag"
-        output=$($binary $version_flag 2>&1)
-        exit_code=$?
+        # Auto-detect version flag if not specified
+        if [ "$version_flag" = "auto" ]; then
+          echo "   Auto-detecting version flag..."
+          for flag in --version -version -V -v version; do
+            echo "   Trying: $binary $flag"
+            if output=$($binary $flag 2>&1) && [ $? -eq 0 ] && [ -n "$output" ]; then
+              version_flag="$flag"
+              echo "   Success with: $flag"
+              break
+            fi
+          done
 
-        if [ $exit_code -ne 0 ]; then
-          echo "ERROR: '$binary $version_flag' failed with exit code $exit_code"
-          echo "   Command output:"
-          echo "$output" | sed 's/^/     /'
-          exit 1
+          if [ "$version_flag" = "auto" ]; then
+            echo "ERROR: Could not auto-detect version flag"
+            echo "   Tried: --version, -version, -V, -v, version"
+            exit 1
+          fi
+        else
+          echo "   Using specified version flag: $version_flag"
+          output=$($binary $version_flag 2>&1)
+          exit_code=$?
+
+          if [ $exit_code -ne 0 ]; then
+            echo "ERROR: '$binary $version_flag' failed with exit code $exit_code"
+            echo "   Command output:"
+            echo "$output" | sed 's/^/     /'
+            exit 1
+          fi
         fi
 
         # Perform version matching based on match-type

--- a/pipelines/test/vercheck.yaml
+++ b/pipelines/test/vercheck.yaml
@@ -1,0 +1,119 @@
+name: vercheck
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  bin:
+    description: |
+      Name of the binary to check for version.
+      Conventionally provided as ${{vars.bin-name}} from package definition.
+    required: true
+  version:
+    description: |
+      Expected version string to match in the binary's version output.
+      Defaults to package version. Can be overridden for specific version formats.
+    required: false
+    default: ${{package.version}}
+  version-flag:
+    description: |
+      Command line flag used to get version information.
+      Common values: --version, -version, -V, -v, version
+    required: false
+    default: "--version"
+  match-type:
+    description: |
+      How to match the version string:
+      - 'contains': Check if version string appears anywhere in output (default)
+      - 'exact': Require exact match of entire output
+      - 'regex': Use version as regex pattern
+    required: false
+    default: "contains"
+
+# USAGE EXAMPLES:
+#
+# Minimal usage (uses package.version by default):
+#   - uses: vercheck
+#     with:
+#       bin: ${{vars.bin-name}}
+#
+# With custom version format:
+#   - uses: vercheck
+#     with:
+#       bin: nginx
+#       version: "nginx/${{package.version}}"
+#       version-flag: "-v"
+#
+# EXPECTED VARS:
+#   - bin-name: Primary binary name
+#
+pipeline:
+  - runs: |
+      vercheck() {
+        local binary="$1"
+        local expected_version="$2"
+        local version_flag="$3"
+        local match_type="$4"
+        local output exit_code
+
+        echo "   Checking version for binary: $binary"
+        echo "   Expected version: $expected_version"
+        echo "   Version flag: $version_flag"
+        echo "   Match type: $match_type"
+
+        # Check if binary exists in PATH
+        if ! command -v "$binary" >/dev/null 2>&1; then
+          echo "ERROR: Binary '$binary' not found in PATH"
+          echo "   Make sure the package installed correctly and binary is in PATH"
+          exit 1
+        fi
+        echo "Binary '$binary' found in PATH"
+
+        # Get version output (capture both stdout and stderr)
+        echo "   Running: $binary $version_flag"
+        output=$($binary $version_flag 2>&1)
+        exit_code=$?
+
+        if [ $exit_code -ne 0 ]; then
+          echo "ERROR: '$binary $version_flag' failed with exit code $exit_code"
+          echo "   Command output:"
+          echo "$output" | sed 's/^/     /'
+          exit 1
+        fi
+
+        # Perform version matching based on match-type
+        local match_success=false
+        case "$match_type" in
+          "exact")
+            if [ "$output" = "$expected_version" ]; then
+              match_success=true
+            fi
+            ;;
+          "regex")
+            if echo "$output" | grep -E "$expected_version" >/dev/null; then
+              match_success=true
+            fi
+            ;;
+          "contains"|*)
+            if echo "$output" | grep -F "$expected_version" >/dev/null; then
+              match_success=true
+            fi
+            ;;
+        esac
+
+        if [ "$match_success" = "false" ]; then
+          echo "ERROR: Version check failed"
+          echo "   Match type: $match_type"
+          echo "   Expected: '$expected_version'"
+          echo "   Got output:"
+          echo "$output" | sed 's/^/     /'
+          exit 1
+        fi
+
+        echo "Version check passed for '$binary'"
+        echo "   Output: $output"
+        echo ""
+      }
+
+      vercheck "${{inputs.bin}}" "${{inputs.version}}" "${{inputs.version-flag}}" "${{inputs.match-type}}"

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.15.0"
-  epoch: 2
+  epoch: 3
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -123,18 +123,14 @@ subpackages:
           packages:
             - busybox
       pipeline:
-        - name: "Check -V for programs"
-          runs: |
-            fail() { echo "FATAL:" "$@" 1>&2; exit 1; }
-            vercheck() {
-              local p="$1" out="" ver="${{package.version}}"
-              out=$($p -V) || fail "$p -V exited $?"
-              echo "$out" | grep -F "$ver" ||
-                fail "output of '$p -V' did not contain '$ver'"
-            }
-
-            vercheck mkfs.xfs
-            vercheck xfs_repair
+        - name: "Check mkfs.xfs"
+          uses: test/vercheck
+          with:
+            bin: mkfs.xfs
+        - name: "Check xfs_repair"
+          uses: test/vercheck
+          with:
+            bin: xfs_repair
         - name: "Check fsck.xfs executes"
           runs: |
             fsck.xfs || fail "fsck.xfs exited $?"


### PR DESCRIPTION
Adding `test/vercheck.yaml` step to validate that installed binaries return the expected version output.

- Ensures binary is in `$PATH`
- Runs version command (e.g. `--version`, `-v`, etc.), auto-detects by default
- Verifies output using `contains`, `exact`, or `regex` match, `contains` is set by default
- Defaults to `package.version` unless overridden

Examples:
`clickhouse-operator.yaml: usage`
```
    - uses: test/vercheck
       with:
         bin: ${{vars.bin-name}}
         version-flag: -version
```

`nginx-stable.yaml: usage`
```
    - uses: test/vercheck
       with:
         bin: ${{vars.bin-name}}
```

Output log `nginx-stable.yaml`:
```
2025/07/24 18:38:34 INFO running step "test/vercheck"

2025/07/24 18:38:34 WARN + '[' -d /home/build ]
2025/07/24 18:38:34 WARN + cd /home/build
2025/07/24 18:38:34 WARN + exit 0

2025/07/24 18:38:34 WARN + '[' -d /home/build ]
2025/07/24 18:38:34 WARN + cd /home/build

2025/07/24 18:38:34 WARN + vercheck nginx 1.28.0 auto contains
2025/07/24 18:38:34 WARN + local 'binary=nginx'
2025/07/24 18:38:34 WARN + local 'expected_version=1.28.0'
2025/07/24 18:38:34 WARN + local 'version_flag=auto'
2025/07/24 18:38:34 WARN + local 'match_type=contains'
2025/07/24 18:38:34 WARN + local output exit_code

2025/07/24 18:38:34 WARN + echo '   Checking version for binary: nginx'
2025/07/24 18:38:34 WARN + echo '   Expected version: 1.28.0'
2025/07/24 18:38:34 WARN + echo '   Match type: contains'

2025/07/24 18:38:34 WARN + command -v nginx
2025/07/24 18:38:34 WARN + echo 'Binary '"'"'nginx'"'"' found in PATH'

2025/07/24 18:38:34 WARN + '[' auto '=' auto ]
2025/07/24 18:38:34 WARN + echo '   Auto-detecting version flag...'
2025/07/24 18:38:34 WARN + echo '   Trying: nginx --version'

2025/07/24 18:38:34 INFO    Checking version for binary: nginx
2025/07/24 18:38:34 INFO    Expected version: 1.28.0
2025/07/24 18:38:34 INFO    Match type: contains
2025/07/24 18:38:34 INFO Binary 'nginx' found in PATH
2025/07/24 18:38:34 INFO    Auto-detecting version flag...
2025/07/24 18:38:34 INFO    Trying: nginx --version

2025/07/24 18:38:34 WARN + nginx --version
2025/07/24 18:38:34 WARN + output='nginx: invalid option: "-"'

2025/07/24 18:38:34 WARN + echo '   Trying: nginx -version'
2025/07/24 18:38:34 INFO    Trying: nginx -version

2025/07/24 18:38:34 WARN + nginx -version
2025/07/24 18:38:34 INFO    Success with: -version

2025/07/24 18:38:34 WARN + output='nginx version: nginx/1.28.0'
2025/07/24 18:38:34 WARN + '[' 0 -eq 0 ]
2025/07/24 18:38:34 WARN + '[' -n 'nginx version: nginx/1.28.0' ]
2025/07/24 18:38:34 WARN + version_flag=-version
2025/07/24 18:38:34 WARN + echo '   Success with: -version'
2025/07/24 18:38:34 WARN + break

2025/07/24 18:38:34 WARN + '[' -version '=' auto ]
2025/07/24 18:38:34 WARN + local 'match_success=false'
2025/07/24 18:38:34 WARN + echo 'nginx version: nginx/1.28.0'
2025/07/24 18:38:34 WARN + grep -F 1.28.0

2025/07/24 18:38:34 INFO Version check passed for 'nginx'
2025/07/24 18:38:34 INFO    Output: nginx version: nginx/1.28.0

2025/07/24 18:38:34 WARN + match_success=true
2025/07/24 18:38:34 WARN + '[' true '=' false ]
2025/07/24 18:38:34 WARN + echo 'Version check passed for '"'"'nginx'"'"
2025/07/24 18:38:34 WARN + echo '   Output: nginx version: nginx/1.28.0'
2025/07/24 18:38:34 WARN + echo 
2025/07/24 18:38:34 WARN + exit 0
```