### PR TITLE
argo-workflows: re-enable automatic updates

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -161,9 +161,6 @@ subpackages:
 
 update:
   enabled: true
-  # The most recent releases have been marked "do not use": ensure we should be
-  # using releases before landing
-  manual: true
   github:
     identifier: argoproj/argo-workflows
     strip-prefix: v


### PR DESCRIPTION
The past few releases have been in a good state, so there's no longer a need for manual review.