### PR TITLE
kube-fluentd-operator: epoch bump to re-build

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 43
+  epoch: 44
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -100,7 +100,6 @@ pipeline:
 
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'thor', '1.4.0'" >> Gemfile
-
 
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin
       mv ./plugins/* ${{targets.destdir}}/etc/fluent/plugin


### PR DESCRIPTION
Had near-simultaneous bumps to `-r43` that prevented it from being built/published - bumping to `-r44` to get it built.