### PR TITLE
juicefs-1.3: Upgrade github.com/coredns/coredns to v1.12.2

### DIFF
--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -26,6 +26,7 @@ pipeline:
         github.com/tidwall/gjson@v1.9.3
         golang.org/x/oauth2@v0.27.0
         github.com/coredns/coredns@v1.12.2
+        github.com/go-jose/go-jose/v4@v4.0.5
       replaces: google.golang.org/grpc/stats/opentelemetry=google.golang.org/grpc@v1.74.2
 
   - uses: go/build

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -26,6 +26,7 @@ pipeline:
         github.com/tidwall/gjson@v1.9.3
         golang.org/x/oauth2@v0.27.0
         github.com/coredns/coredns@v1.12.2
+      replaces: google.golang.org/grpc/stats/opentelemetry=google.golang.org/grpc@v1.74.2
 
   - uses: go/build
     with:

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.0"
-  epoch: 1
+  epoch: 2
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ pipeline:
         github.com/golang/glog@v1.2.4
         github.com/tidwall/gjson@v1.9.3
         golang.org/x/oauth2@v0.27.0
+        github.com/coredns/coredns@v1.12.2
 
   - uses: go/build
     with:


### PR DESCRIPTION
This bumps coredns to the latest available version and remediates a lot of CVEs.
