### PR TITLE
pipelines/test/virtualpackage: extend to verify APK declares virtual packages as expected

### DIFF
--- a/gi-docgen.yaml
+++ b/gi-docgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: gi-docgen
   version: "2025.4"
-  epoch: 2
+  epoch: 3
   description: A documentation generator for GObject-based libraries
   copyright:
     - license: Apache-2.0 OR GPL-3.0-or-later

--- a/pipelines/test/virtualpackage.yaml
+++ b/pipelines/test/virtualpackage.yaml
@@ -13,7 +13,7 @@ inputs:
     default: ''
 
 pipeline:
-  - name: virtual package checks
+  - name: virtual package installation checks
     description: Check that a virtual package does not install itself
     runs: |
       get_installed_version() {
@@ -40,4 +40,25 @@ pipeline:
           echo "FAIL: No real package ${{inputs.real-pkg-name}} installed for virtual package ${{inputs.virtual-pkg-name}}." >&2
           exit 1
         fi
+      fi
+
+  - name: virtual package configuration checks
+    description: Check that a real package declares it provides the expected virtual package
+    runs: |
+      virtual_pkg="${{inputs.virtual-pkg-name}}"
+      real_pkg="${{inputs.real-pkg-name}}"
+
+      if [ "$real_pkg" = "" ] ; then
+        echo "SKIP: no 'real-pkg-name' was set, so skipping evaluation."
+        exit 0
+      fi
+
+      declared_provides=$(apk info --installed --provides --quiet "$real_pkg" | grep -v '^$')
+
+      if echo "$declared_provides" | grep -qx "$virtual_pkg" ; then
+        echo "PASS: real package [$real_pkg] correctly declares virtual package [$virtual_pkg]."
+        exit 0
+      else
+        echo "FAIL: real package [$real_pkg] does not declare virtual package [$virtual_pkg] in 'provides'." >&2
+        exit 1
       fi

--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zipp
   version: "3.23.0"
-  epoch: 3
+  epoch: 4
   description: Backport of pathlib-compatible object wrapper for zip files
   copyright:
     - license: MIT


### PR DESCRIPTION
Extend the virtualpackage test to verify the APK declares the virtual package as expected.
