### PR TITLE
add klipper-helm package

### DIFF
--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: 0.9.8-build20250709
+  version: '0.9.8-build20250709'
   epoch: 0
   description: Klipper helm integration job image
   copyright:

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "0.9.8"
+  version: "0.9.8.20250709"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -18,11 +18,17 @@ environment:
       - build-base
       - busybox
 
+var-transforms:
+  - from: ${{package.version}}
+    match: '^(\d+[.]\d+[.]\d+)[.](\d{8})$'
+    replace: '$1-build$2'
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{package.version}}-build20250709
+      tag: v${{vars.mangled-package-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,8 @@
 package:
   name: klipper-helm
   version: "0.9.8.20250709"
+  # Version format: <base-version>.<build-date> (e.g., 0.9.8.20250709)
+  # This gets transformed to upstream tag format: v<base-version>-build<build-date>
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -19,6 +21,7 @@ environment:
       - busybox
 
 var-transforms:
+  # Transform package version from "0.9.8.20250709" to "0.9.8-build20250709" to match upstream tag format at https://github.com/k3s-io/klipper-helm/tags
   - from: ${{package.version}}
     match: '^(\d+[.]\d+[.]\d+)[.](\d{8})$'
     replace: '$1-build$2'

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "20250709"
+  version: "0.9.8"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -18,20 +18,11 @@ environment:
       - build-base
       - busybox
 
-vars:
-  upstream-base-version: 0.9.8
-
-var-transforms:
-  - from: ${{package.version}}
-    match: (\d{4})(\d{2})(\d{2})
-    replace: ${{vars.upstream-base-version}}-build$1$2$3
-    to: upstream-version
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.upstream-version}}
+      tag: v${{package.version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -28,7 +28,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.build-date}}
+      tag: v0.9.8-${{vars.build-date}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,0 +1,51 @@
+package:
+  name: klipper-helm
+  version: 0.9.8-build20250709
+  epoch: 0
+  description: Klipper helm integration job image
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+      - helm
+      - helm-mapkubeapis
+      # - helm-set-status
+
+environment:
+  contents:
+    packages:
+      - binutils-gold
+      - build-base
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/klipper-helm
+      tag: v${{package.version}}
+      expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
+
+  - runs: |
+      install -Dm755 entry "${{targets.destdir}}"/usr/bin/entry
+      mkdir -p "${{targets.destdir}}"/home/klipper-helm/.local/share/helm/plugins
+      ln -sf /usr/libexec/helm-plugins/helm-mapkubeapis "${{targets.destdir}}"/home/klipper-helm/.local/share/helm/plugins/helm-mapkubeapis
+
+update:
+  enabled: true
+  github:
+    identifier: k3s-io/klipper-helm
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - helm
+    environment:
+      KUBERNETES_SERVICE_HOST: "127.0.0.1"
+      KUBERNETES_SERVICE_PORT: 32764
+      HELM_PLUGINS: "/home/klipper-helm/.local/share/helm/plugins"
+  pipeline:
+    - runs: |
+        helm plugin list

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -53,7 +53,6 @@ test:
   environment:
     contents:
       packages:
-        - helm
         - jq
     environment:
       KUBERNETES_SERVICE_HOST: "127.0.0.1"

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -28,7 +28,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v0.9.8-build${{vars.build-date}}
+      tag: v${{vars.build-date}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "0.9.8"
+  version: "20250709"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -18,11 +18,14 @@ environment:
       - build-base
       - busybox
 
+vars:
+  upstream-base-version: 0.9.8
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{package.version}}
+      tag: v${{vars.upstream-base-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "20250709"
+  version: "0.9.8"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -19,13 +19,20 @@ environment:
       - busybox
 
 vars:
-  upstream-base-version: 0.9.8
+  # This will hold the build date for the specific release
+  build-date: "20250709"
+
+var-transforms:
+  - from: ${{package.version}}
+    match: (.*)
+    replace: $1-build${{vars.build-date}}
+    to: upstream-version
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.upstream-base-version}}
+      tag: v${{vars.upstream-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |
@@ -39,6 +46,7 @@ update:
   github:
     identifier: k3s-io/klipper-helm
     strip-prefix: v
+    use-tag: true
 
 test:
   environment:

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -21,14 +21,14 @@ environment:
 var-transforms:
   - from: ${{package.version}}
     match: (\d{4})(\d{2})(\d{2})
-    replace: 0.9.8-build$1$2$3
-    to: upstream-version
+    replace: $1$2$3
+    to: build-date
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.upstream-version}}
+      tag: v0.9.8-build${{vars.build-date}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -18,21 +18,11 @@ environment:
       - build-base
       - busybox
 
-vars:
-  # This will hold the build date for the specific release
-  build-date: "20250709"
-
-var-transforms:
-  - from: ${{package.version}}
-    match: (.*)
-    replace: $1-build${{vars.build-date}}
-    to: upstream-version
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.upstream-version}}
+      tag: v${{package.version}}-build20250709
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |
@@ -43,6 +33,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: true
   github:
     identifier: k3s-io/klipper-helm
     strip-prefix: v

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "0.9.8"
+  version: "20250709"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -18,11 +18,14 @@ environment:
       - build-base
       - busybox
 
+vars:
+  upstream-base-version: 0.9.8
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{package.version}}-build20250709
+      tag: v${{vars.upstream-base-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -47,6 +47,7 @@ update:
     identifier: k3s-io/klipper-helm
     strip-prefix: v
     use-tag: true
+    strip-suffix: -.*
 
 test:
   environment:

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -18,17 +18,20 @@ environment:
       - build-base
       - busybox
 
+vars:
+  upstream-base-version: 0.9.8
+
 var-transforms:
   - from: ${{package.version}}
     match: (\d{4})(\d{2})(\d{2})
-    replace: $1$2$3
-    to: build-date
+    replace: ${{vars.upstream-base-version}}-build$1$2$3
+    to: upstream-version
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v0.9.8-${{vars.build-date}}
+      tag: v${{vars.upstream-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,16 +1,15 @@
 package:
   name: klipper-helm
-  version: '0.9.8-build20250709'
+  version: "20250709"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - busybox
       - helm
       - helm-mapkubeapis
-      # - helm-set-status
+      - helm-set-status
 
 environment:
   contents:
@@ -19,16 +18,23 @@ environment:
       - build-base
       - busybox
 
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d{4})(\d{2})(\d{2})
+    replace: 0.9.8-build$1$2$3
+    to: upstream-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{package.version}}
+      tag: v${{vars.upstream-version}}
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |
       install -Dm755 entry "${{targets.destdir}}"/usr/bin/entry
       mkdir -p "${{targets.destdir}}"/home/klipper-helm/.local/share/helm/plugins
+      ln -sf /usr/libexec/helm-plugins/helm-set-status "${{targets.destdir}}"/home/klipper-helm/.local/share/helm/plugins/helm-set-status
       ln -sf /usr/libexec/helm-plugins/helm-mapkubeapis "${{targets.destdir}}"/home/klipper-helm/.local/share/helm/plugins/helm-mapkubeapis
 
 update:
@@ -42,10 +48,26 @@ test:
     contents:
       packages:
         - helm
+        - jq
     environment:
       KUBERNETES_SERVICE_HOST: "127.0.0.1"
       KUBERNETES_SERVICE_PORT: 32764
       HELM_PLUGINS: "/home/klipper-helm/.local/share/helm/plugins"
   pipeline:
+    - name: "Test helm-plugins"
+      runs: |
+        helm plugin list | grep -E 'mapkubeapis|set-status'
+    - uses: test/kwok/cluster
     - runs: |
-        helm plugin list
+        helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+        helm repo update
+    - name: "Test klipper-helm package"
+      runs: |
+        export NAME=test-dashboard
+        export TARGET_NAMESPACE=default
+        export CHART=kubernetes-dashboard/kubernetes-dashboard
+        NAME=test-dashboard TARGET_NAMESPACE=default CHART=kubernetes-dashboard/kubernetes-dashboard /usr/bin/entry install
+    - runs: |
+        echo "Verifying Helm release status..."
+        helm status test-dashboard --namespace default | tee status.txt
+        grep -q "STATUS: deployed" status.txt

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,6 +1,6 @@
 package:
   name: klipper-helm
-  version: "20250709"
+  version: "0.9.8"
   epoch: 0
   description: Klipper helm integration job image
   copyright:
@@ -18,14 +18,11 @@ environment:
       - build-base
       - busybox
 
-vars:
-  upstream-base-version: 0.9.8
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k3s-io/klipper-helm
-      tag: v${{vars.upstream-base-version}}
+      tag: v${{package.version}}-build20250709
       expected-commit: bd2f4cf869ef030c4bee3accc64d234fc9f1de0f
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/k3s-io/klipper-helm

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
