### PR TITLE
melange/0.30.0 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
-  version: "0.29.7"
-  epoch: 1
+  version: "0.30.0"
+  epoch: 0
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: f66cb125a4402285b8ec5df35cd69e76fd842f76
+      expected-commit: 4a077cfcdb7c2c2d31ed2f99644cb7c9f33c3ac8
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR bumps melange to 0.30.0 to pull in an SSH session fix for QEMU which is blocking https://github.com/wolfi-dev/os/pull/59973.