### PR TITLE
gnupg: add patch to not use 3DES in FIPS mode

### DIFF
--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.2.41
-  epoch: 51
+  epoch: 52
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -81,6 +81,10 @@ pipeline:
   - uses: patch
     with:
       patches: fix-i18n.patch
+
+  - uses: patch
+    with:
+      patches: make-aes-default-for-fips.patch
 
   - uses: autoconf/configure
     with:

--- a/gnupg/make-aes-default-for-fips.patch
+++ b/gnupg/make-aes-default-for-fips.patch
@@ -1,0 +1,26 @@
+# When by any chance we're in FIPS mode, use AES256 instead of 3DES by default.
+diff -urN a/g10/main.h b/g10/main.h
+--- a/g10/main.h	2025-07-25 14:40:12.734987947 +0200
++++ b/g10/main.h	2025-07-25 14:41:34.321706126 +0200
+@@ -38,7 +38,7 @@
+ #elif GPG_USE_CAST5
+ # define DEFAULT_CIPHER_ALGO     CIPHER_ALGO_CAST5
+ #else
+-# define DEFAULT_CIPHER_ALGO     CIPHER_ALGO_3DES
++# define DEFAULT_CIPHER_ALGO     (gcry_fips_mode_active() ? CIPHER_ALGO_AES256 : CIPHER_ALGO_3DES)
+ #endif
+ 
+ #define DEFAULT_DIGEST_ALGO     ((GNUPG)? DIGEST_ALGO_SHA512:DIGEST_ALGO_SHA1)
+diff -urN a/g10/pkclist.c b/g10/pkclist.c
+--- a/g10/pkclist.c	2022-11-30 11:01:41.000000000 +0100
++++ b/g10/pkclist.c	2025-07-25 14:53:24.470084462 +0200
+@@ -1487,6 +1487,9 @@
+              implicit algorithm here.   */
+           if (opt.compliance == CO_DE_VS)
+             implicit = CIPHER_ALGO_AES;
++          else if (gcry_fips_mode_active ())
++            /* In FIPS mode, use AES256 as 3DES is not FIPS-approved */
++            implicit = CIPHER_ALGO_AES256;
+           else
+             implicit=CIPHER_ALGO_3DES;
+ 


### PR DESCRIPTION
Might be useful when working with more restrictive libgcrypt libraries.