### PR TITLE
knative-serving v1.19 package addition

### DIFF
--- a/knative-serving-1.19.yaml
+++ b/knative-serving-1.19.yaml
@@ -124,7 +124,7 @@ update:
   github:
     identifier: knative/serving
     strip-prefix: knative-v
-    tag-filter: knative-v1.18.
+    tag-filter: knative-v1.19.
 
 # Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
 test:

--- a/knative-serving-1.19.yaml
+++ b/knative-serving-1.19.yaml
@@ -1,0 +1,132 @@
+package:
+  name: knative-serving-1.19
+  version: "1.19.0"
+  epoch: 0
+  description: Kubernetes-based, scale-to-zero, request-driven compute
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - knative-serving=${{package.full-version}}
+
+data:
+  - name: components
+    items:
+      queue: queue
+      activator: activator
+      autoscaler: autoscaler
+      controller: controller
+      webhook: webhook
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 57652008edeac497ca37ba3766c1e9973ea37521
+      repository: https://github.com/knative/serving
+      tag: knative-v${{package.version}}
+
+subpackages:
+  - range: components
+    name: "${{package.name}}-${{range.key}}"
+    dependencies:
+      provides:
+        - knative-serving-${{range.key}}=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          output: ${{range.value}}
+          packages: ./cmd/${{range.value}}
+    test:
+      environment:
+        environment:
+          WEBHOOK_NAME: test
+          SERVING_NAMESPACE: foo
+          SERVING_SERVICE: ""
+          SERVING_CONFIGURATION: ""
+          SERVING_REVISION: bar
+          QUEUE_SERVING_PORT: 8012 # This is the port that the queue will listen on
+          QUEUE_SERVING_TLS_PORT: 8112
+          CONTAINER_CONCURRENCY: 0
+          REVISION_TIMEOUT_SECONDS: 45
+          REVISION_RESPONSE_START_TIMEOUT_SECONDS: 0
+          REVISION_IDLE_TIMEOUT_SECONDS: 0
+          SERVING_POD: static-pod-name
+          SERVING_POD_IP: 192.168.1.100
+          SERVING_LOGGING_CONFIG: ""
+          SERVING_LOGGING_LEVEL: ""
+          SERVING_REQUEST_LOG_TEMPLATE: ""
+          SERVING_ENABLE_REQUEST_LOG: false
+          SERVING_REQUEST_METRICS_BACKEND: ""
+          SERVING_REQUEST_METRICS_REPORTING_PERIOD_SECONDS: 0
+          TRACING_CONFIG_BACKEND: ""
+          TRACING_CONFIG_ZIPKIN_ENDPOINT: ""
+          TRACING_CONFIG_DEBUG: false
+          TRACING_CONFIG_SAMPLE_RATE: 0
+          USER_PORT: 8080
+          SYSTEM_NAMESPACE: knative-serving
+          METRICS_DOMAIN: default-metrics-domain
+          SERVING_READINESS_PROBE: '{"tcpSocket":{"port":8080,"host":"127.0.0.1"}}'
+          ENABLE_PROFILING: false
+          SERVING_ENABLE_PROBE_REQUEST_LOG: false
+          METRICS_COLLECTOR_ADDRESS: ""
+          HOST_IP: 192.168.1.1
+          ENABLE_HTTP2_AUTO_DETECTION: false
+          ENABLE_HTTP_FULL_DUPLEX: false
+          ROOT_CA: ""
+          ENABLE_MULTI_CONTAINER_PROBES: false
+          POD_NAME: default-pod
+          POD_IP: 192.168.1.200
+      pipeline:
+        - runs: |
+            # queue binary just runs the server on help
+            [[ ${{range.key}} != 'queue' ]] && ${{range.value}} --help
+        - uses: test/kwok/cluster
+          with:
+            serviceaccount: true
+        - name: "start daemon on localhost for ${{range.key}}"
+          uses: test/daemon-check-output
+          with:
+            setup: |
+              kubectl create namespace knative-serving || true
+              kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${{package.version}}/serving-crds.yaml
+              kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${{package.version}}/serving-core.yaml
+              kubectl wait --for=condition=Available deploy/autoscaler -n knative-serving --timeout=90s
+            start: "${{range.value}}"
+            timeout: 60
+            # Omit 'ERROR':
+            # * webhook: throws "please apply your changes to the latest version and try again" FP error
+            # * activator: throws "Websocket connection could not be established" error, possibly due to kwok or some other issue
+            error_strings: |
+              FATAL
+              FAIL
+              Traceback.*most.recent.call
+              Exception in thread
+              panic
+              command not found
+            expected_output: |
+              Starting
+
+  - range: components
+    name: "${{package.name}}-${{range.key}}-compat"
+    dependencies:
+      provides:
+        - knative-serving-${{range.key}}-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/ko-app
+          ln -sf /usr/bin/${{range.value}} ${{targets.contextdir}}/ko-app/${{range.value}}
+    test:
+      pipeline:
+        - runs: test "$(readlink /ko-app/${{range.value}})" = "/usr/bin/${{range.value}}"
+
+update:
+  enabled: true
+  github:
+    identifier: knative/serving
+    strip-prefix: knative-v
+    tag-filter: knative-v1.18.
+
+# Based on package size if was determined that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is not longer empty (contains more than an SBOM)
+test:
+  pipeline:
+    - uses: test/emptypackage


### PR DESCRIPTION
**knative-serving-1.19** `Current version: v1.19.0`
- Kubernetes-based, scale-to-zero, request-driven compute

**Type**: Go binaries
**REF**: https://github.com/knative/serving

**Tests:**
- Functional tests for components