### PR TITLE
bump epochs on packages which have failed to publish

### DIFF
--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: "1.3.2"
-  epoch: 1
+  epoch: 2
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0

--- a/flux-image-automation-controller.yaml
+++ b/flux-image-automation-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-automation-controller
   version: "0.41.2"
-  epoch: 2
+  epoch: 3
   description: GitOps Toolkit controller that patches container image tags in Git
   copyright:
     - license: Apache-2.0

--- a/git-credential-oauth.yaml
+++ b/git-credential-oauth.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-credential-oauth
   version: "0.15.1"
-  epoch: 2
+  epoch: 3
   description: "A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth"
   copyright:
     - license: Apache-2.0

--- a/gitea.yaml
+++ b/gitea.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitea
   version: "1.24.3"
-  epoch: 1
+  epoch: 2
   description: self-hosted git service
   copyright:
     - license: MIT

--- a/inih.yaml
+++ b/inih.yaml
@@ -1,7 +1,7 @@
 package:
   name: inih
   version: "61"
-  epoch: 0
+  epoch: 1
   description: Simple .INI file parser for embedded systems
   copyright:
     - license: BSD-3-Clause

--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-latest
   version: 0
-  epoch: 9
+  epoch: 10
   description: "Compatibility infrastructure for Kubernetes components"
   copyright:
     - license: GPL-2.0-or-later

--- a/kyverno-1.14.yaml
+++ b/kyverno-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.14
   version: "1.14.4"
-  epoch: 2
+  epoch: 3
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0

--- a/modelmesh-runtime-adapter.yaml
+++ b/modelmesh-runtime-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: modelmesh-runtime-adapter
   version: 0.12.0
-  epoch: 15
+  epoch: 16
   description: Unified runtime-adapter package of the sidecar containers which run in the modelmesh pods
   copyright:
     - license: Apache-2.0

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.33"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/py3-aiobotocore.yaml
+++ b/py3-aiobotocore.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-aiobotocore
   version: "2.23.2"
-  epoch: 0
+  epoch: 1
   description: asyncio support for botocore library using aiohttp
   copyright:
     - license: Apache-2.0

--- a/py3-aiodataloader.yaml
+++ b/py3-aiodataloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-aiodataloader
   version: 0.4.2
-  epoch: 2
+  epoch: 3
   description: Asyncio DataLoader for Python3
   copyright:
     - license: MIT

--- a/py3-aiofiles.yaml
+++ b/py3-aiofiles.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-aiofiles
   version: 24.1.0
-  epoch: 5
+  epoch: 6
   description: File support for asyncio.
   copyright:
     - license: Apache-2.0

--- a/py3-aioitertools.yaml
+++ b/py3-aioitertools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-aioitertools
   version: 0.12.0
-  epoch: 2
+  epoch: 3
   description: itertools and builtins for AsyncIO and mixed iterables
   copyright:
     - license: MIT

--- a/py3-aiostream.yaml
+++ b/py3-aiostream.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-aiostream
   version: "0.7.0"
-  epoch: 2
+  epoch: 3
   description: Generator-based operators for asynchronous iteration
   copyright:
     - license: GPL-3.0

--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-anyio
   version: "4.9.0"
-  epoch: 3
+  epoch: 4
   description: High level compatibility layer for multiple asynchronous event loop implementations
   copyright:
     - license: MIT

--- a/py3-appdirs.yaml
+++ b/py3-appdirs.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-appdirs
   version: 1.4.4
-  epoch: 8
+  epoch: 9
   description: a small python module for appdir support
   copyright:
     - license: MIT

--- a/py3-argon2-cffi.yaml
+++ b/py3-argon2-cffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-argon2-cffi
   version: "25.1.0"
-  epoch: 3
+  epoch: 4
   description: Argon2 for Python
   copyright:
     - license: MIT

--- a/py3-asttokens.yaml
+++ b/py3-asttokens.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-asttokens
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: Annotate AST trees with source code positions
   copyright:
     - license: Apache-2.0

--- a/py3-async-generator.yaml
+++ b/py3-async-generator.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-async-generator
   version: 1.10
-  epoch: 4
+  epoch: 5
   description: Async generators and context managers for Python 3.5+
   copyright:
     - license: MIT OR Apache-2.0

--- a/py3-async-lru.yaml
+++ b/py3-async-lru.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-async-lru
   version: "2.0.5"
-  epoch: 1
+  epoch: 2
   description: Simple LRU cache for asyncio
   copyright:
     - license: MIT

--- a/py3-azure-storage-blob.yaml
+++ b/py3-azure-storage-blob.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-azure-storage-blob
   version: "12.26.0"
-  epoch: 1
+  epoch: 2
   description: Microsoft Azure Blob Storage Client Library for Python
   copyright:
     - license: MIT

--- a/py3-backoff.yaml
+++ b/py3-backoff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-backoff
   version: 2.2.1
-  epoch: 5
+  epoch: 6
   description: Function decoration for backoff and retry
   copyright:
     - license: MIT

--- a/py3-backports.tarfile.yaml
+++ b/py3-backports.tarfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-backports.tarfile
   version: 1.2.0
-  epoch: 3
+  epoch: 4
   description: Backport of CPython tarfile module
   copyright:
     - license: MIT

--- a/py3-bcrypt.yaml
+++ b/py3-bcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-bcrypt
   version: "4.3.0"
-  epoch: 3
+  epoch: 4
   description: Modern password hashing for your software and your servers
   copyright:
     - license: Apache-2.0

--- a/py3-beartype.yaml
+++ b/py3-beartype.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-beartype
   version: "0.21.0"
-  epoch: 2
+  epoch: 3
   description: Unbearably fast runtime type checking in pure Python.
   copyright:
     - license: MIT

--- a/py3-breezy.yaml
+++ b/py3-breezy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-breezy
   version: "3.3.12"
-  epoch: 3
+  epoch: 4
   description: Friendly distributed version control system
   copyright:
     - license: GPL-2.0-or-later

--- a/py3-calver.yaml
+++ b/py3-calver.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-calver
   version: "2025.04.17"
-  epoch: 2
+  epoch: 3
   description: Setuptools extension for CalVer package versions
   copyright:
     - license: Apache-2.0

--- a/py3-certipy.yaml
+++ b/py3-certipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-certipy
   version: "0.2.2"
-  epoch: 1
+  epoch: 2
   description: Utility to create and sign CAs and certificates
   copyright:
     - license: BSD-3-Clause

--- a/py3-changelog-chug.yaml
+++ b/py3-changelog-chug.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-changelog-chug
   version: 0.0.3
-  epoch: 3
+  epoch: 4
   description: Parser library for project Change Log documents.
   copyright:
     - license: AGPL-3.0-only

--- a/py3-chardet.yaml
+++ b/py3-chardet.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-chardet
   version: 5.2.0
-  epoch: 5
+  epoch: 6
   description: Universal encoding detector for Python 3
   copyright:
     - license: LGPL-2.1-or-later

--- a/py3-charset-normalizer.yaml
+++ b/py3-charset-normalizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-charset-normalizer
   version: "3.4.2"
-  epoch: 2
+  epoch: 3
   description: offers you an alternative to Universal Charset Encoding Detector, also known as Chardet
   copyright:
     - license: MIT

--- a/py3-cleo.yaml
+++ b/py3-cleo.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cleo
   version: 2.2.1
-  epoch: 3
+  epoch: 4
   description: Cleo allows you to create beautiful and testable command-line interfaces.
   copyright:
     - license: MIT

--- a/py3-cli-helpers.yaml
+++ b/py3-cli-helpers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cli-helpers
   version: "2.6.0"
-  epoch: 2
+  epoch: 3
   description: Helpers for building command-line apps
   copyright:
     - license: BSD-3-Clause

--- a/py3-click-option-group.yaml
+++ b/py3-click-option-group.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-click-option-group
   version: "0.5.7"
-  epoch: 1
+  epoch: 2
   description: Option groups missing in Click.
   copyright:
     - license: BSD-3-Clause

--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-click
   version: "8.2.1"
-  epoch: 2
+  epoch: 3
   description: Composable command line interface toolkit
   copyright:
     - license: BSD-3-Clause

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cloudpickle
   version: "3.1.1"
-  epoch: 1
+  epoch: 2
   description: Extended pickling support for Python objects
   copyright:
     - license: BSD-3-Clause

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: "0.12.0"
-  epoch: 1
+  epoch: 2
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-codespell
   version: "2.4.1"
-  epoch: 1
+  epoch: 2
   description: 'checker for common misspellings '
   copyright:
     - license: GPL-2.0-or-later

--- a/py3-colorama.yaml
+++ b/py3-colorama.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-colorama
   version: 0.4.6
-  epoch: 9
+  epoch: 10
   description: Simple cross-platform colored terminal text
   copyright:
     - license: BSD-3-Clause

--- a/py3-commonmark.yaml
+++ b/py3-commonmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-commonmark
   version: 0.9.1
-  epoch: 4
+  epoch: 5
   description: Python parser for the CommonMark Markdown spec
   copyright:
     - license: BSD-3-Clause

--- a/py3-conda-index.yaml
+++ b/py3-conda-index.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-index
   version: "0.6.1"
-  epoch: 2
+  epoch: 3
   description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
   copyright:
     - license: BSD-3-Clause

--- a/py3-conda-package-handling.yaml
+++ b/py3-conda-package-handling.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-package-handling
   version: 2.4.0
-  epoch: 2
+  epoch: 3
   description: Create and extract conda packages of various formats
   copyright:
     - license: BSD-3-Clause

--- a/py3-conda-package-streaming.yaml
+++ b/py3-conda-package-streaming.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-package-streaming
   version: "0.12.0"
-  epoch: 2
+  epoch: 3
   description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
   copyright:
     - license: BSD-3-Clause

--- a/py3-configargparse.yaml
+++ b/py3-configargparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-configargparse
   version: "1.7.1"
-  epoch: 2
+  epoch: 3
   description: A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.
   copyright:
     - license: MIT

--- a/py3-configobj.yaml
+++ b/py3-configobj.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-configobj
   version: 5.0.9
-  epoch: 3
+  epoch: 4
   description: Config file reading, writing and validation.
   copyright:
     - license: BSD-2-Clause

--- a/py3-contextlib2.yaml
+++ b/py3-contextlib2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contextlib2
   version: 21.6.0
-  epoch: 8
+  epoch: 9
   description: backports of the contextlib module from newer versions of python
   copyright:
     - license: PSF-2.0 AND Apache-2.0

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: "1.3.2"
-  epoch: 2
+  epoch: 3
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause

--- a/py3-cppy.yaml
+++ b/py3-cppy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cppy
   version: "1.3.1"
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-3-Clause
   dependencies:

--- a/py3-crashtest.yaml
+++ b/py3-crashtest.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-crashtest
   version: 0.4.1
-  epoch: 7
+  epoch: 8
   description: Manage Python errors with ease
   copyright:
     - license: MIT

--- a/py3-crcmod.yaml
+++ b/py3-crcmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-crcmod
   version: '1.7'
-  epoch: 7
+  epoch: 8
   description: Cyclic Redundancy Check (CRC) implementation in Python
   copyright:
     - license: MIT

--- a/py3-datadog.yaml
+++ b/py3-datadog.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-datadog
   version: "0.52.0"
-  epoch: 2
+  epoch: 3
   description: The Datadog Python library
   copyright:
     - license: BSD-3-Clause

--- a/py3-defusedxml.yaml
+++ b/py3-defusedxml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-defusedxml
   version: 0.7.1
-  epoch: 5
+  epoch: 6
   description: XML bomb protection for Python stdlib modules
   copyright:
     - license: PSF-2.0

--- a/py3-deprecation.yaml
+++ b/py3-deprecation.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-deprecation
   version: 2.1.0
-  epoch: 6
+  epoch: 7
   description: A library to handle automated deprecations
   copyright:
     - license: Apache-2.0

--- a/py3-distributed.yaml
+++ b/py3-distributed.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distributed
   version: "2025.7.0"
-  epoch: 2
+  epoch: 3
   description: A distributed task scheduler for Dask
   annotations:
     cgr.dev/ecosystem: python

--- a/py3-distro.yaml
+++ b/py3-distro.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distro
   version: 1.9.0
-  epoch: 5
+  epoch: 6
   description: A Linux OS platform information API
   copyright:
     - license: Apache-2.0

--- a/py3-django.yaml
+++ b/py3-django.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-django
   version: "5.2.4"
-  epoch: 2
+  epoch: 3
   description: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
   copyright:
     - license: BSD-3-Clause

--- a/py3-dnspython.yaml
+++ b/py3-dnspython.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dnspython
   version: 2.7.0
-  epoch: 3
+  epoch: 4
   description: DNS toolkit
   copyright:
     - license: ISC

--- a/py3-docopt.yaml
+++ b/py3-docopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-docopt
   version: 0.6.2
-  epoch: 4
+  epoch: 5
   description: Pythonic argument parser, that will make you smile
   copyright:
     - license: MIT

--- a/py3-editables.yaml
+++ b/py3-editables.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-editables
   version: '0.5'
-  epoch: 5
+  epoch: 6
   description: Editable installations
   copyright:
     - license: MIT

--- a/py3-escapism.yaml
+++ b/py3-escapism.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-escapism
   version: 1.0.1
-  epoch: 4
+  epoch: 5
   description: Simple, generic API for escaping strings.
   copyright:
     - license: MIT

--- a/py3-evalidate.yaml
+++ b/py3-evalidate.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-evalidate
   version: "2.0.5"
-  epoch: 2
+  epoch: 3
   description: Discover and load entry points from installed packages.
   copyright:
     - license: MIT

--- a/py3-filelock.yaml
+++ b/py3-filelock.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-filelock
   version: "3.18.0"
-  epoch: 1
+  epoch: 2
   description: A platform independent file lock.
   copyright:
     - license: Unlicense

--- a/py3-flask-cors.yaml
+++ b/py3-flask-cors.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-flask-cors
   version: "6.0.1"
-  epoch: 2
+  epoch: 3
   description: A Flask extension adding a decorator for CORS support
   copyright:
     - license: MIT

--- a/py3-google-api-python-client.yaml
+++ b/py3-google-api-python-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-api-python-client
   version: "2.177.0"
-  epoch: 1
+  epoch: 2
   description: Google API Client Library for Python
   copyright:
     - license: Apache-2.0

--- a/py3-gpep517.yaml
+++ b/py3-gpep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gpep517
   version: "19"
-  epoch: 2
+  epoch: 3
   description: PEP517 build system support for distros
   copyright:
     - license: GPL-2.0

--- a/py3-greenlet.yaml
+++ b/py3-greenlet.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-greenlet
   version: "3.2.3"
-  epoch: 2
+  epoch: 3
   description: Lightweight in-process concurrent programming
   copyright:
     - license: MIT

--- a/py3-h11.yaml
+++ b/py3-h11.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-h11
   version: "0.16.0"
-  epoch: 2
+  epoch: 3
   description: A pure-Python, bring-your-own-I/O implementation of HTTP/1.1
   copyright:
     - license: MIT

--- a/py3-hyperlink.yaml
+++ b/py3-hyperlink.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperlink
   version: 21.0.0
-  epoch: 5
+  epoch: 6
   description: A featureful, immutable, and correct URL for Python.
   copyright:
     - license: MIT

--- a/py3-jaeger-client.yaml
+++ b/py3-jaeger-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jaeger-client
   version: 4.8.0
-  epoch: 7
+  epoch: 8
   description: Jaeger Python OpenTracing Tracer implementation
   copyright:
     - license: Apache-2.0

--- a/py3-json5.yaml
+++ b/py3-json5.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-json5
   version: "0.12.0"
-  epoch: 2
+  epoch: 3
   description: A Python implementation of the JSON5 data format.
   copyright:
     - license: Apache-2.0

--- a/py3-jsondiff.yaml
+++ b/py3-jsondiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsondiff
   version: 2.2.1
-  epoch: 3
+  epoch: 4
   description: Diff JSON and JSON-like structures in Python
   copyright:
     - license: MIT

--- a/py3-jsonpointer.yaml
+++ b/py3-jsonpointer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsonpointer
   version: 3.0.0
-  epoch: 3
+  epoch: 4
   description: Identify specific nodes in a JSON document (RFC 6901)
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyter-core.yaml
+++ b/py3-jupyter-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-core
   version: "5.8.1"
-  epoch: 2
+  epoch: 3
   description: Jupyter core package. A base package on which Jupyter projects rely.
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-server-fileid
   version: 0.9.3
-  epoch: 3
+  epoch: 4
   description: An extension that maintains file IDs for documents in a running Jupyter Server
   annotations:
     cgr.dev/ecosystem: python

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-server
   version: "2.16.0"
-  epoch: 2
+  epoch: 3
   description: The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyter-telemetry.yaml
+++ b/py3-jupyter-telemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-telemetry
   version: 0.1.0
-  epoch: 3
+  epoch: 4
   description: Jupyter telemetry library
   copyright:
     - license: BSD-3-Clause

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: "4.4.0"
-  epoch: 2
+  epoch: 3
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT

--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pdm-backend
   version: "2.4.5"
-  epoch: 2
+  epoch: 3
   description: The build backend used by PDM that supports latest packaging standards.
   annotations:
     cgr.dev/ecosystem: python

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-peewee
   version: "3.18.1"
-  epoch: 2
+  epoch: 3
   description: a little orm
   copyright:
     - license: MIT

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: "6.31.1"
-  epoch: 3
+  epoch: 4
   copyright:
     - license: BSD-3-Clause
   dependencies:

--- a/py3-pytest.yaml
+++ b/py3-pytest.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytest
   version: "8.4.1"
-  epoch: 3
+  epoch: 4
   description: 'pytest: simple powerful testing with Python'
   copyright:
     - license: MIT

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-gitlab
   version: "6.1.0"
-  epoch: 2
+  epoch: 3
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:

--- a/py3-snowballstemmer.yaml
+++ b/py3-snowballstemmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-snowballstemmer
   version: "3.0.1"
-  epoch: 2
+  epoch: 3
   description: This package provides 29 stemmers for 28 languages generated from Snowball algorithms.
   copyright:
     - license: BSD-3-Clause

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.1"
-  epoch: 3
+  epoch: 4
   description: "built-package format for Python"
   copyright:
     - license: MIT

--- a/ruby3.2-multi_xml.yaml
+++ b/ruby3.2-multi_xml.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-multi_xml
   version: "0.7.2"
-  epoch: 1
+  epoch: 2
   description: Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.
   copyright:
     - license: MIT

--- a/slirp4netns.yaml
+++ b/slirp4netns.yaml
@@ -1,7 +1,7 @@
 package:
   name: slirp4netns
   version: "1.3.3"
-  epoch: 2
+  epoch: 3
   description: User-mode networking for unprivileged network namespaces
   copyright:
     - license: GPL-2.0-or-later

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 9
+  epoch: 10
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: tofu-controller
   version: "0.16.0_rc5"
-  epoch: 2
+  epoch: 3
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -1,7 +1,7 @@
 package:
   name: x11vnc
   version: "0.9.17"
-  epoch: 1
+  epoch: 2
   description: VNC server for real X displays
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Due to an issue with the APK copier, some events were dropped.  Work is ongoing to enable us to easily requeue such events, but to avoid any possible fallout from not having these packages published, we're going to rebuild them to ensure publication.