### PR TITLE
bump epochs on packages which have failed to publish (batch 5/5)

### DIFF
--- a/py3-jupyter-core.yaml
+++ b/py3-jupyter-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-core
   version: "5.8.1"
-  epoch: 2
+  epoch: 3
   description: Jupyter core package. A base package on which Jupyter projects rely.
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyter-server-fileid.yaml
+++ b/py3-jupyter-server-fileid.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-server-fileid
   version: 0.9.3
-  epoch: 3
+  epoch: 4
   description: An extension that maintains file IDs for documents in a running Jupyter Server
   annotations:
     cgr.dev/ecosystem: python

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-server
   version: "2.16.0"
-  epoch: 2
+  epoch: 3
   description: The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyter-telemetry.yaml
+++ b/py3-jupyter-telemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-telemetry
   version: 0.1.0
-  epoch: 3
+  epoch: 4
   description: Jupyter telemetry library
   copyright:
     - license: BSD-3-Clause

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: "4.4.0"
-  epoch: 2
+  epoch: 3
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT

--- a/py3-pdm-backend.yaml
+++ b/py3-pdm-backend.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pdm-backend
   version: "2.4.5"
-  epoch: 2
+  epoch: 3
   description: The build backend used by PDM that supports latest packaging standards.
   annotations:
     cgr.dev/ecosystem: python

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-peewee
   version: "3.18.1"
-  epoch: 2
+  epoch: 3
   description: a little orm
   copyright:
     - license: MIT

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: "6.31.1"
-  epoch: 3
+  epoch: 4
   copyright:
     - license: BSD-3-Clause
   dependencies:

--- a/py3-pytest.yaml
+++ b/py3-pytest.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytest
   version: "8.4.1"
-  epoch: 3
+  epoch: 4
   description: 'pytest: simple powerful testing with Python'
   copyright:
     - license: MIT

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-gitlab
   version: "6.1.0"
-  epoch: 2
+  epoch: 3
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:

--- a/py3-snowballstemmer.yaml
+++ b/py3-snowballstemmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-snowballstemmer
   version: "3.0.1"
-  epoch: 2
+  epoch: 3
   description: This package provides 29 stemmers for 28 languages generated from Snowball algorithms.
   copyright:
     - license: BSD-3-Clause

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.1"
-  epoch: 3
+  epoch: 4
   description: "built-package format for Python"
   copyright:
     - license: MIT

--- a/ruby3.2-multi_xml.yaml
+++ b/ruby3.2-multi_xml.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-multi_xml
   version: "0.7.2"
-  epoch: 1
+  epoch: 2
   description: Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.
   copyright:
     - license: MIT

--- a/slirp4netns.yaml
+++ b/slirp4netns.yaml
@@ -1,7 +1,7 @@
 package:
   name: slirp4netns
   version: "1.3.3"
-  epoch: 2
+  epoch: 3
   description: User-mode networking for unprivileged network namespaces
   copyright:
     - license: GPL-2.0-or-later

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.3.1"
-  epoch: 9
+  epoch: 10
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: tofu-controller
   version: "0.16.0_rc5"
-  epoch: 2
+  epoch: 3
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -1,7 +1,7 @@
 package:
   name: x11vnc
   version: "0.9.17"
-  epoch: 1
+  epoch: 2
   description: VNC server for real X displays
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
This is part 5/5 of the split PR from https://github.com/wolfi-dev/os/pull/60773

This batch contains 17 files with epoch bumps for packages that have failed to publish.

Part of the effort to split the large PR into manageable chunks for CI processing.