### PR TITLE
temporarily pin yam to 0.2.25

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: 1.23
-      - run: go install github.com/chainguard-dev/yam@latest
+      - run: go install github.com/chainguard-dev/yam@v0.2.25
       - run: ./lint.sh
       - run: git diff --exit-code


### PR DESCRIPTION
    temporarily pin yam to 0.2.25

    this is very temporary until we release new sdk
    image with new wolfictl in it.

    we landed some sorting changes which sorts the dependencies
    alphabetically and that requires more changes in melange config
    in this repo. Pin yam to v0.2.25 for now.