### PR TITLE
gitlab-cng-18.2: remediate cves

### DIFF
--- a/gitlab-cng-18.2.yaml
+++ b/gitlab-cng-18.2.yaml
@@ -26,7 +26,7 @@ package:
   name: gitlab-cng-18.2
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "18.2.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -306,6 +306,10 @@ subpackages:
           tag: ${{vars.exporter-tag}}
           expected-commit: ${{vars.exporter-commit}}
           destination: ./exporter
+      - uses: patch
+        with:
+          patches: ../puma-sinatra-cve-remediation.patch
+          working-directory: ./exporter
       - uses: ruby/build
         with:
           gem: gitlab-exporter

--- a/gitlab-cng-18.2/puma-sinatra-cve-remediation.patch
+++ b/gitlab-cng-18.2/puma-sinatra-cve-remediation.patch
@@ -1,0 +1,32 @@
+From 5cfb8d35fe3ab1b4eddb7702cee044ea11f2826e Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Mon, 28 Jul 2025 08:17:02 +0000
+Subject: [PATCH] gitlab-cng-18.1: remediate cves
+
+Fix CVE-2024-45614 and CVE-2024-21510 by bumping puma to ~> 5.6.9 and sinatra to ~> 4.1.0
+---
+ gitlab-exporter.gemspec | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gitlab-exporter.gemspec b/gitlab-exporter.gemspec
+index 7db2e93..f7345d3 100644
+--- a/gitlab-exporter.gemspec
++++ b/gitlab-exporter.gemspec
+@@ -26,12 +26,12 @@ Gem::Specification.new do |s|
+   # https://github.com/rubygems/rubygems/issues/7374
+   s.add_runtime_dependency "faraday", [">= 1.8.0", "<= 2.8.1"]
+   s.add_runtime_dependency "pg", "1.5.9"
+-  s.add_runtime_dependency "puma", "5.6.8"
++  s.add_runtime_dependency "puma", "~> 5.6.9"
+   s.add_runtime_dependency "quantile", "0.2.1"
+   s.add_runtime_dependency "redis", "4.5.0"
+   s.add_runtime_dependency "redis-namespace", "1.9.0"
+   s.add_runtime_dependency "sidekiq", "6.5.12"
+-  s.add_runtime_dependency "sinatra", "~> 2.2.0"
++  s.add_runtime_dependency "sinatra", "~> 4.1.0"
+   s.add_runtime_dependency "webrick", "~> 1.7"
+ 
+   s.add_development_dependency "rspec", "~> 3.12.0"
+-- 
+2.47.2
+


### PR DESCRIPTION
Fix CVE-2024-45614 and CVE-2024-21510 by bumping puma to ~> 5.6.9 and sinatra to ~> 4.1.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
