### PR TITLE
gitlab-cng-18.2: remediate cve

### DIFF
--- a/gitlab-cng-18.2.yaml
+++ b/gitlab-cng-18.2.yaml
@@ -26,7 +26,7 @@ package:
   name: gitlab-cng-18.2
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "18.2.1"
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -306,6 +306,10 @@ subpackages:
           tag: ${{vars.exporter-tag}}
           expected-commit: ${{vars.exporter-commit}}
           destination: ./exporter
+      - uses: patch
+        working-directory: ./exporter
+        with:
+          patches: ../puma-cve-remediation.patch
       - uses: ruby/build
         with:
           gem: gitlab-exporter

--- a/gitlab-cng-18.2/puma-cve-remediation.patch
+++ b/gitlab-cng-18.2/puma-cve-remediation.patch
@@ -1,0 +1,26 @@
+From d4f3b6e309fef942202b0af63f413352261374c1 Mon Sep 17 00:00:00 2001
+From: David Negreira <david.negreira@chainguard.dev>
+Date: Mon, 28 Jul 2025 08:49:58 +0000
+Subject: [PATCH] gitlab-cng-18.1: remediate cve
+
+Fix CVE-2024-45614 by bumping puma to ~> 5.6.9
+---
+ gitlab-exporter.gemspec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gitlab-exporter.gemspec b/gitlab-exporter.gemspec
+index 7db2e93..a719561 100644
+--- a/gitlab-exporter.gemspec
++++ b/gitlab-exporter.gemspec
+@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
+   # https://github.com/rubygems/rubygems/issues/7374
+   s.add_runtime_dependency "faraday", [">= 1.8.0", "<= 2.8.1"]
+   s.add_runtime_dependency "pg", "1.5.9"
+-  s.add_runtime_dependency "puma", "5.6.8"
++  s.add_runtime_dependency "puma", "~> 5.6.9"
+   s.add_runtime_dependency "quantile", "0.2.1"
+   s.add_runtime_dependency "redis", "4.5.0"
+   s.add_runtime_dependency "redis-namespace", "1.9.0"
+-- 
+2.47.2
+


### PR DESCRIPTION
Fix CVE-2024-45614 by bumping puma to ~> 5.6.9

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
