### PR TITLE
teleport-17: convert to git update backend

### DIFF
--- a/teleport-17.yaml
+++ b/teleport-17.yaml
@@ -121,11 +121,9 @@ update:
     - ".*gus.*"
     - ".*wasm.*"
     - ".*fred.*"
-  github:
-    identifier: gravitational/teleport
+  git:
     strip-prefix: v
-    use-tag: true
-    tag-filter: v17.
+    tag-filter-prefix: v17.
 
 test:
   environment:


### PR DESCRIPTION
The `github` backend can't look back far enough to find the most recent 17.x tag.