### PR TITLE
external-dns: rename to fit version stream

### DIFF
--- a/external-dns-0.18.yaml
+++ b/external-dns-0.18.yaml
@@ -91,7 +91,7 @@ update:
   github:
     identifier: kubernetes-sigs/external-dns
     strip-prefix: v
-    tag-filter: v
+    tag-filter: v0.18.
 
 test:
   pipeline:

--- a/external-dns-0.18.yaml
+++ b/external-dns-0.18.yaml
@@ -1,5 +1,5 @@
 package:
-  name: external-dns
+  name: external-dns-0.18
   version: "0.18.0"
   epoch: 2
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.

--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,12 +1,15 @@
 package:
   name: external-dns
   version: "0.18.0"
-  epoch: 1
+  epoch: 2
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
     - paths:
         - '*'
       license: Apache-2.0
+  dependencies:
+    provides:
+      - external-dns=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
Rename external-dns to external-dns-0.18 after manual version stream creation. Add dependencies.provides, update tag filter, and bump epoch to resolve image build failure
