### PR TITLE
yunikorn-k8shim: fix Kubernetes CVE by updating to v1.32.6

### DIFF
--- a/yunikorn-k8shim.yaml
+++ b/yunikorn-k8shim.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-k8shim
   version: "1.7.0"
-  epoch: 0
+  epoch: 1
   description: Apache YuniKorn K8shim
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
+        k8s.io/kubernetes@v1.32.6
         golang.org/x/net@v0.38.0
       modroot: .
 


### PR DESCRIPTION
## Summary
- Fixes Kubernetes CVE by updating k8s.io/kubernetes dependency to v1.32.6
- Increments epoch to force rebuild with updated dependency

## Test plan
- [ ] Build package successfully
- [ ] Verify CVE is resolved via wolfictl scan

🤖 Generated with [Claude Code](https://claude.ai/code)