### PR TITLE
postfix: Remove explicit runtime dep on postfix (for postfix-stone)

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.3"
-  epoch: 2
+  epoch: 3
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -223,7 +223,6 @@ subpackages:
     dependencies:
       runtime:
         - merged-usrsbin
-        - postfix=${{package.full-version}}
         - wolfi-baselayout
 
   - range: _subpackages


### PR DESCRIPTION
With
https://github.com/chainguard-dev/melange/commit/6b78277c45de0f61c78070fd916ff1eebdd29b66, it's not necessary to explicitly add a runtime dependency on postfix for postfix-stone.

This is also needed because one of melange's CI check expects this dependency to be automatically created.