### PR TITLE
add config-reloader sub-pkg to kube-logging-operator

### DIFF
--- a/kube-logging-operator.yaml
+++ b/kube-logging-operator.yaml
@@ -1,17 +1,10 @@
 package:
   name: kube-logging-operator
   version: "6.0.1"
-  epoch: 0
+  epoch: 1
   description: Logging operator for Kubernetes
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -20,12 +13,10 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 42ef5a2e0beabfd41628962ac5f9d7c708ea73d4
 
-  - runs: |
-      CGO_ENABLED=0 GO111MODULE=on go build -o bin/manager main.go
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -Dm755 ./bin/manager ${{targets.destdir}}/usr/bin/manager
-
-  - uses: strip
+  - uses: go/build
+    with:
+      packages: .
+      output: manager
 
 subpackages:
   - name: "kube-logging-operator-compat"
@@ -33,9 +24,38 @@ subpackages:
     pipeline:
       - runs: |
           # The helm chart expects the logging-operator binaries to be in / instead of /usr/bin
-          mkdir -p "${{targets.subpkgdir}}"
-          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
-      - uses: strip
+          mkdir -p "${{targets.contextdir}}"
+          ln -sf /usr/bin/manager ${{targets.contextdir}}/manager
+    test:
+      pipeline:
+        - runs: test "$(readlink /manager)" = "/usr/bin/manager"
+
+  - name: ${{package.name}}-config-reloader
+    description: "config-reloader is a simple binary to trigger a reload when Kubernetes ConfigMaps or Secrets are updated"
+    pipeline:
+      - working-directory: ./images/config-reloader
+        uses: go/build
+        with:
+          packages: ./cmd/configreloader
+          output: config-reloader
+    test:
+      pipeline:
+        - runs: |
+            # Ensure the binary is executable
+            test -x /usr/bin/config-reloader
+            # Check that it can be run without arguments
+            /usr/bin/config-reloader --help
+
+  # create a similar compat package for config-reloader
+  - name: ${{package.name}}-config-reloader-compat
+    description: "Compat package for config-reloader"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/config-reloader ${{targets.contextdir}}/config-reloader
+    test:
+      pipeline:
+        - runs: test "$(readlink /config-reloader)" = "/usr/bin/config-reloader"
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
