### PR TITLE
WIP Fix cve: CVE-2022-1471

### DIFF
--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: "9.20.11"
-  epoch: 1
+  epoch: 2
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.4"
-  epoch: 2
+  epoch: 3
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later

--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: "3.16.0"
-  epoch: 1
+  epoch: 2
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: 1.21.3
-  epoch: 43
+  epoch: 44
   description: The Kerberos network authentication system
   copyright:
     - license: MIT

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra-4.1
   version: "0.3.6"
-  epoch: 2
+  epoch: 3
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -33,10 +33,6 @@ pipeline:
       tag: v${{package.version}}
 
   - uses: auth/maven
-
-  # DO NOT bump snakeyaml to v2.0, as this version has breaking changes. This
-  # needs to remain on v1.x
-  - uses: maven/pombump
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -32,7 +32,7 @@ pipeline:
       expected-commit: 7b7bbf2d3081e80e5148711696cb1408e212fd48
       tag: v${{package.version}}
 
-  - uses: auth/maven
+  # - uses: auth/maven
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -32,7 +32,7 @@ pipeline:
       expected-commit: 7b7bbf2d3081e80e5148711696cb1408e212fd48
       tag: v${{package.version}}
 
-   - uses: auth/maven
+  - uses: auth/maven
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -32,7 +32,7 @@ pipeline:
       expected-commit: 7b7bbf2d3081e80e5148711696cb1408e212fd48
       tag: v${{package.version}}
 
-  # - uses: auth/maven
+   - uses: auth/maven
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector

--- a/nfs-ganesha.yaml
+++ b/nfs-ganesha.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-ganesha
   version: "6.5"
-  epoch: 5
+  epoch: 6
   description: NFS-Ganesha is an NFSv3,v4,v4.1 fileserver that runs in user mode on most UNIX/Linux systems
   copyright:
     - license: GPL-3.0-or-later

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-utils
   version: "2.8.3"
-  epoch: 2
+  epoch: 3
   description: kernel-mode NFS
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 9
+  epoch: 10
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.452.09 # this corresponds to same release as jdk8u452-ga / jdk8u452-b09
-  epoch: 2
+  epoch: 3
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-with-classpath-exception

--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.1
   version: "9.1.0.1"
-  epoch: 4
+  epoch: 5
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later

--- a/redpanda-25.1.yaml
+++ b/redpanda-25.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: redpanda-25.1
   version: "25.1.9"
-  epoch: 0
+  epoch: 1
   description: "Redpanda is a streaming platform based on Apache Kafka API"
   resources:
     cpu: 63


### PR DESCRIPTION
added the marker `<!--ci-cve-scan:must-fix: GHSA-mjmj-j48q-9wg2-->`
<!--ci-cve-scan:must-fix: GHSA-mjmj-j48q-9wg2-->


