### PR TITLE
pipelines/test/virtualpackage: sync with other repos

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.15.0"
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -121,6 +121,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: "libcurl-abi"
+            real-pkg-name: "${{subpkg.name}}"
 
 update:
   enabled: true

--- a/pipelines/test/virtualpackage.yaml
+++ b/pipelines/test/virtualpackage.yaml
@@ -55,7 +55,7 @@ pipeline:
 
       declared_provides=$(apk info --installed --provides --quiet "$real_pkg" | grep -v '^$')
 
-      if echo "$declared_provides" | grep -qx "$virtual_pkg" ; then
+      if echo "$declared_provides" | awk -F'=' '{print $1}' | grep -qx "${virtual_pkg}" ; then
         echo "PASS: real package [$real_pkg] correctly declares virtual package [$virtual_pkg]."
         exit 0
       else


### PR DESCRIPTION
The primary change is a better parsing to support virtual packages declared with
a version string (package=version).

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
