### PR TITLE
add missing runtime dependency for klipper-helm

### DIFF
--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -9,9 +9,11 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - busybox
       - helm
       - helm-mapkubeapis
       - helm-set-status
+      - jq
 
 environment:
   contents:
@@ -52,8 +54,6 @@ update:
 test:
   environment:
     contents:
-      packages:
-        - jq
     environment:
       KUBERNETES_SERVICE_HOST: "127.0.0.1"
       KUBERNETES_SERVICE_PORT: 32764

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -53,7 +53,6 @@ update:
 
 test:
   environment:
-    contents:
     environment:
       KUBERNETES_SERVICE_HOST: "127.0.0.1"
       KUBERNETES_SERVICE_PORT: 32764

--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.9.8.20250709"
   # Version format: <base-version>.<build-date> (e.g., 0.9.8.20250709)
   # This gets transformed to upstream tag format: v<base-version>-build<build-date>
-  epoch: 0
+  epoch: 1
   description: Klipper helm integration job image
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/k3s-io/klipper-helm

The `klipper-helm` entry script requires few utilities that were missing from runtime dependencies, updated the PR and added missing `busybox` since `grep` and `tr` used by the entry script and `jq`: required for JSON processing in helm operations

These dependencies resolve test failures during k8s testing.
