### PR TITLE
management-api-for-apache-cassandra-5.0: update to v0.1.106

### DIFF
--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
-  version: "0.1.105"
-  epoch: 1
+  version: "0.1.106"
+  epoch: 0
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/k8ssandra/management-api-for-apache-cassandra
-      expected-commit: 996babcfdfccb40786c16dbb142ce024c43c80ee
+      expected-commit: c4d0b5d8317291d9f17f2710bd61f1ba8b1efc19
       tag: v${{package.version}}
 
   # We can't (currently), use pombump, as this repo places license info as
@@ -36,7 +36,7 @@ pipeline:
   - uses: patch
     with:
       patches: |
-        20250221-consolidated-cve-patches.patch
+        20250729-consolidated-cve-patches-v0.1.106.patch
 
   - runs: |
       echo "Running build..."

--- a/management-api-for-apache-cassandra-5.0/20250729-consolidated-cve-patches-v0.1.106.patch
+++ b/management-api-for-apache-cassandra-5.0/20250729-consolidated-cve-patches-v0.1.106.patch
@@ -1,24 +1,37 @@
 From 0709dae3a8f8d930ecd3472a28584d4dba141405 Mon Sep 17 00:00:00 2001
 From: Kyle Steere <kyle.steere@chainguard.dev>
 Date: Fri, 21 Feb 2025 10:53:39 -0600
-Subject: [PATCH] consolidated cve patches
+Subject: [PATCH] consolidated cve patches for v0.1.106
+
+Updated patch for version 0.1.106 to resolve Maven dependency convergence
+issues with SLF4J. This patch addresses CVE-related dependency bumps and
+ensures all modules use SLF4J 2.0.16 consistently.
+
+Key changes:
+- Update SLF4J version from 2.0.9 to 2.0.16
+- Update Logback version from 1.5.13 to 1.5.16  
+- Update driver version from 4.15.0 to 4.17.0
+- Add Netty dependencies to prevent version conflicts
+- Add SLF4J exclusion to swagger dependencies to prevent convergence errors
+- Update Netty HTTP codec version in 5.0.x agent
 
 Signed-off-by: Kyle Steere <kyle.steere@chainguard.dev>
+Co-authored-by: Claude <noreply@anthropic.com>
 ---
  management-api-agent-4.1.x/pom.xml  | 10 ++++++++++
  management-api-agent-4.x/pom.xml    | 10 ++++++++++
  management-api-agent-5.0.x/pom.xml  | 12 +++++++++++-
  management-api-agent-common/pom.xml | 10 ++++++++++
- management-api-server/pom.xml       | 12 +++++++++++-
+ management-api-server/pom.xml       | 14 ++++++++++++-
  pom.xml                             |  8 ++++----
- 6 files changed, 56 insertions(+), 6 deletions(-)
+ 6 files changed, 58 insertions(+), 6 deletions(-)
 
 diff --git a/management-api-agent-4.1.x/pom.xml b/management-api-agent-4.1.x/pom.xml
-index 3ffe2dd..a0bb29d 100644
+index c7ab82d..2c20ac5 100644
 --- a/management-api-agent-4.1.x/pom.xml
 +++ b/management-api-agent-4.1.x/pom.xml
 @@ -19,6 +19,16 @@
-     <cassandra4.version>4.1.8</cassandra4.version>
+     <cassandra4.version>4.1.9</cassandra4.version>
    </properties>
    <dependencies>
 +    <dependency>
@@ -56,7 +69,7 @@ index d0deb5d..5d87d29 100644
      <dependency>
        <groupId>org.slf4j</groupId>
 diff --git a/management-api-agent-5.0.x/pom.xml b/management-api-agent-5.0.x/pom.xml
-index 63f9330..2c81dcb 100644
+index 63f9330..ec1b6ad 100644
 --- a/management-api-agent-5.0.x/pom.xml
 +++ b/management-api-agent-5.0.x/pom.xml
 @@ -17,9 +17,19 @@
@@ -81,7 +94,7 @@ index 63f9330..2c81dcb 100644
      <dependency>
        <groupId>org.slf4j</groupId>
 diff --git a/management-api-agent-common/pom.xml b/management-api-agent-common/pom.xml
-index b08c09a..907171f 100644
+index a92fcee..9d0ad5c 100644
 --- a/management-api-agent-common/pom.xml
 +++ b/management-api-agent-common/pom.xml
 @@ -22,6 +22,16 @@
@@ -102,7 +115,7 @@ index b08c09a..907171f 100644
            <groupId>io.k8ssandra</groupId>
            <artifactId>datastax-mgmtapi-common</artifactId>
 diff --git a/management-api-server/pom.xml b/management-api-server/pom.xml
-index 2b473f1..543fc3c 100644
+index 3c27bee..1432fb9 100644
 --- a/management-api-server/pom.xml
 +++ b/management-api-server/pom.xml
 @@ -29,6 +29,16 @@
@@ -122,9 +135,9 @@ index 2b473f1..543fc3c 100644
      <dependency>
        <groupId>io.k8ssandra</groupId>
        <artifactId>datastax-mgmtapi-common</artifactId>
-@@ -142,6 +152,10 @@
-           <groupId>com.fasterxml.jackson.datatype</groupId>
-           <artifactId>*</artifactId>
+@@ -146,6 +156,10 @@
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-lang3</artifactId>
          </exclusion>
 +        <exclusion>
 +          <groupId>org.slf4j</groupId>
@@ -156,6 +169,5 @@ index efc5c6d..a85f479 100644
      <netty.version>4.1.119.Final</netty.version>
      <mockito.version>3.5.13</mockito.version>
      <prometheus.version>0.16.0</prometheus.version>
-
---
+-- 
 2.43.0


### PR DESCRIPTION
Updated package to version 0.1.106 to address CVE-related dependency issues.
Fixed Maven dependency convergence error with SLF4J by updating patch file
for v0.1.106 compatibility.

Key changes:
- Update version from 0.1.105 to 0.1.106
- Update expected commit hash for v0.1.106
- Replace patch file with v0.1.106 compatible version
- Fix SLF4J dependency convergence (2.0.9 → 2.0.16)
- Update Logback (1.5.13 → 1.5.16) and driver (4.15.0 → 4.17.0)
- Add SLF4J exclusion to swagger dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
