### PR TITLE
grafana-12.1: switch to vars.mangled-package-version

### DIFF
--- a/grafana-12.1.yaml
+++ b/grafana-12.1.yaml
@@ -32,14 +32,14 @@ var-transforms:
   - from: ${{package.version}}
     match: ^(\d+\.\d+\.\d+)\.(\d+)$
     replace: "${1}+security-${2}"
-    to: upstream-package-version
+    to: mangled-package-version
 
 pipeline:
   - uses: git-checkout
     with:
       expected-commit: a513fe0b7752b4cc79f3715f44b7bc29042046c0
       repository: https://github.com/grafana/grafana
-      tag: v${{vars.upstream-package-version}}
+      tag: v${{vars.mangled-package-version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
To match the new `melange` behaviour.

Closes: #61028 