### PR TITLE
Fix CVE: CVE-2022-1471 cassandra-reaper

### DIFF
--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: "3.8.0"
-  epoch: 8
+  epoch: 9
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/cassandra-reaper/src/server/pombump-deps.yaml
+++ b/cassandra-reaper/src/server/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
   - groupId: org.yaml
     artifactId: snakeyaml
-    version: "1.33"
+    version: "2.0"
   - groupId: io.netty
     artifactId: netty-handler
     version: 4.1.118.Final


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: VE-2022-1471-->
