### PR TITLE
chore(ingress-nginx-controller): align build.sh with 1.13 release

### DIFF
--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.13
   version: "1.13.0"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -306,7 +306,7 @@ pipeline:
       strip-components: 0
 
   - runs: |
-      rm -rf v0.33.tar.gz
+      rm -rf v${{vars.SETMISC_VERSION}}.tar.gz
 
   - uses: fetch
     with:
@@ -380,29 +380,28 @@ pipeline:
       git clone -b v${{vars.OWASP_MODSECURITY_CRS_VERSION}} https://github.com/coreruleset/coreruleset owasp-modsecurity-crs
       cd owasp-modsecurity-crs
 
+      # https://github.com/kubernetes/ingress-nginx/blob/release-1.13/images/nginx/rootfs/build.sh#L376-L411
       mv crs-setup.conf.example crs-setup.conf
       mv rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
       mv rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+      cd ..
 
-      # OWASP CRS v3 rules
-      echo '
+      # OWASP CRS v4 rules
+      echo "
       Include /etc/nginx/owasp-modsecurity-crs/crs-setup.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-901-INITIALIZATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-910-IP-REPUTATION.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-912-DOS-PROTECTION.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-913-SCANNER-DETECTION.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-922-MULTIPART-ATTACK.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -413,10 +412,11 @@ pipeline:
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-955-WEB-SHELLS.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-980-CORRELATION.conf
       Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
-      ' > ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
+      " > ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
 
 
       echo "::::::::::::::::::::::::::::::::::::::"
@@ -441,6 +441,7 @@ pipeline:
       --with-http_gzip_static_module \
       --with-http_sub_module \
       --with-http_v2_module \
+      --with-http_v3_module \
       --with-stream \
       --with-stream_ssl_module \
       --with-stream_realip_module \


### PR DESCRIPTION
Align our build steps with the upstream 1.13 build.sh:

https://github.com/kubernetes/ingress-nginx/blob/release-1.13/images/nginx/rootfs/build.sh