### PR TITLE
openjdk-24: revert cacerts location back to /etc like before

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: "20250619"
-  epoch: 3
+  epoch: 4
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
@@ -35,45 +35,6 @@ pipeline:
       EOF
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
 
-subpackages:
-  - name: java-cacerts-default
-    description: symlink to default jvm cacerts with JEP-493
-    dependencies:
-      runtime:
-        - ca-certificates
-        - p11-kit-trust
-    pipeline:
-      - runs: |
-          # Note that symlink replaces currently doesn't work in apko,
-          # hence duplicating the update.d hook for now. Stop gap to
-          # make update-ca-certificates still work.
-          mkdir -p "${{targets.contextdir}}"/etc/ssl/certs/java
-          ln -s /usr/lib/jvm/default-jvm/lib/security/cacerts "${{targets.contextdir}}"/etc/ssl/certs/java/cacerts
-          mkdir -p "${{targets.contextdir}}"/etc/ca-certificates/update.d
-          cat > "${{targets.contextdir}}"/etc/ca-certificates/update.d/java-cacerts <<EOF
-          exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors \
-            --purpose server-auth /usr/lib/jvm/default-jvm/lib/security/cacerts
-          EOF
-          chmod +x "${{targets.contextdir}}"/etc/ca-certificates/update.d/java-cacerts
-    test:
-      environment:
-        contents:
-          packages:
-            - openssl
-            - openjdk-23
-      pipeline:
-        - runs: |
-            test -x /etc/ca-certificates/update.d/java-cacerts
-        - runs: |
-            /etc/ca-certificates/update.d/java-cacerts
-            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout
-            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----BEGIN PUBLIC KEY-----$"
-            openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----END PUBLIC KEY-----$"
-        - runs: |
-            openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -out /usr/local/share/ca-certificates/server.crt -subj "/CN=someteststring/"
-            update-ca-certificates
-            /usr/lib/jvm/java-23-openjdk/bin/keytool  -v -list -cacerts -storepass changeit | grep someteststring
-
 update:
   enabled: true
   release-monitor:
@@ -84,9 +45,14 @@ test:
     contents:
       packages:
         - openssl
+        - openjdk-23
   pipeline:
     - runs: |
+        test -x /etc/ca-certificates/update.d/java-cacerts
         /etc/ca-certificates/update.d/java-cacerts
         openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout
         openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----BEGIN PUBLIC KEY-----$"
         openssl pkey -pubin -in /etc/ssl/certs/java/cacerts -pubout | grep -q "^-----END PUBLIC KEY-----$"
+        openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -out /usr/local/share/ca-certificates/server.crt -subj "/CN=someteststring/"
+        update-ca-certificates
+        /usr/lib/jvm/java-23-openjdk/bin/keytool  -v -list -cacerts -storepass changeit | grep someteststring

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 1
+  epoch: 2
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -10,6 +10,7 @@ package:
       - alsa-lib
       - freetype
       - giflib
+      - java-cacerts
       - lcms2
       - libfontconfig1
       - libjpeg-turbo
@@ -120,6 +121,10 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
+      # symlink to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      ln -sf /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
       # symlink for `java-common` to work (which expects jre in $_java_home/jre)
       ln -sf . "${{targets.contextdir}}/$_java_home/jre"
 
@@ -172,7 +177,6 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM"
     dependencies:
       runtime:
-        - java-cacerts-default
         - java-common-jre
         - ${{package.name}}-jre
       provides:
@@ -186,7 +190,6 @@ subpackages:
     description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - java-cacerts-default
         - java-common
         - ${{package.name}}
       provider-priority: 5


### PR DESCRIPTION
In all JDK/JRE releases, historically the cacerts real location was in
/etc, and a symlink pointing to /etc location was in JAVA_HOME.

In 24.0.1-r2 build of OpenJDK this was inverted, to support
implementation of [JEP 493](https://openjdk.org/jeps/493) which has
reduced jdk-dev image size by 34%. As at the time that feature
prohibited any updates or upgrades of any files compared to the
original JDK build. See:
- https://github.com/wolfi-dev/os/pull/50581

Unfortunately initial implementation of that also broke
update-ca-certificates integration, which was then subsequently
fixed. Nonetheless, the inversion of cacerts location has also caused
a lot friection.

Upstream also recognized that it is a powerful concept to allow
certain files to be upgradable. And a concept of upgrdable files was
added in the context of JEP 493:
- https://bugs.openjdk.org/browse/JDK-8353185
- https://bugs.openjdk.org/browse/JDK-8354936

Which has been backported to 24.0.2 release. This enables Wolfi to
also revert back to shipping the real cacerts store file in /etc like
it is shipped in JDK 23 and earlier, and reintroduce symlink from
JAVA_HOME to /etc.

Separately all test cases are preserved to verify and maintain
update-ca-certitifcates functionality and prevent it from regressing
ever again.

For refence:
- `/etc/ssl/certs/java/cacerts` is now once again canonical location of the java cacerts trust store
- `JAVA_HOME/lib/security/cacerts` is now once again a symlink to the above
- Above matches all other JDK builds 23 and earlier

Between 24.0.1-r2 and 24.0.2-r1, inclusive:
- `/etc/ssl/certs/java/cacerts` was a symlink pointing at below
- `JAVA_HOME/lib/security/cacerts` was a real file
