### PR TITLE
gradle-8: do not use hardcoded keystore type

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -40,7 +40,11 @@ pipeline:
 
   - uses: patch
     with:
-      patches: upgrade-deps.patch fix-CVE-2025-4949.patch commons-lang3-GHSA-j288-q9x7-2f5v.patch 0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
+      patches: |
+        upgrade-deps.patch
+        fix-CVE-2025-4949.patch
+        commons-lang3-GHSA-j288-q9x7-2f5v.patch
+        0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -3,7 +3,7 @@ package:
   version: "8.14.3"
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 2
+  epoch: 3
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: upgrade-deps.patch fix-CVE-2025-4949.patch commons-lang3-GHSA-j288-q9x7-2f5v.patch
+      patches: upgrade-deps.patch fix-CVE-2025-4949.patch commons-lang3-GHSA-j288-q9x7-2f5v.patch 0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/gradle-8/0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
+++ b/gradle-8/0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
@@ -1,0 +1,25 @@
+From 7785ced3caa2a7b79c7d483eb233c01bdbac645b Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 29 Jul 2025 19:57:20 +0100
+Subject: [PATCH] Backport 9.1 feature to honor default keystore type
+
+---
+ .../org/gradle/internal/encryption/impl/KeyStoreKeySource.kt    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
+index 515b831ffb0..20949dcec1f 100644
+--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
++++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
+@@ -121,7 +121,7 @@ class KeyStoreKeySource(
+ 
+     companion object {
+         // JKS does not support non-PrivateKeys
+-        const val KEYSTORE_TYPE = "pkcs12"
++        val KEYSTORE_TYPE = KeyStore.getDefaultType()
+         val KEYSTORE_PASSWORD = charArrayOf('c', 'c')
+     }
+ }
+-- 
+2.48.1
+


### PR DESCRIPTION
Currently gradle uses a hardcoded keystore type for configuration
cache. Instead dynamically query the default one, which currently is
"pkcs12".

This is a minimal backport of this feature from gradle 9.1.
