### PR TITLE
k3s-1.32: remediate cve

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.7.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,7 @@ pipeline:
       deps: |-
         github.com/pion/interceptor@v0.1.39
         golang.org/x/crypto@v0.40.0
+        golang.org/x/net@v0.36.0
       replaces: gopkg.in/go-jose/go-jose.v2=gopkg.in/go-jose/go-jose.v2@v2.6.3
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.


### PR DESCRIPTION
We remediated the cve CVE-2025-22870 by bumping dependency
golang.org/x/net to version v0.36.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
