### PR TITLE
k3s-1.32: remediate cve

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.7.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -120,6 +120,10 @@ subpackages:
         - umount
         - wolfi-baselayout
     pipeline:
+      - uses: go/bump
+        with:
+          deps: |-
+            golang.org/x/net@v0.36.0
       - runs: |
           # Remove the upload portion from the upstream package-cli script
           sed -e '/scripts\/build-upload/d' -i scripts/package-cli


### PR DESCRIPTION
We remediated the cve CVE-2025-22870 by bumping dependency golang.org/x/net to version v0.36.0 in multicall subpackage
