### PR TITLE
chor: Using git monitor as a update monitor

### DIFF
--- a/vcluster.yaml
+++ b/vcluster.yaml
@@ -60,8 +60,9 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: loft-sh/vcluster
+  ignore-regex-patterns:
+    - 'next' # Ignore next tags like v0.26.0-next.1
+  git:
     strip-prefix: v
 
 test:


### PR DESCRIPTION
The upstream has released alpha and beta version from last 20 releases, using git monitor to use tag and ignore unwanted regex pattern

**This do not required an `epoch` bump.**