### PR TITLE
add container-object-storage-interface-{controller, sidecar}

### DIFF
--- a/container-object-storage-interface.yaml
+++ b/container-object-storage-interface.yaml
@@ -28,6 +28,12 @@ subpackages:
     name: "${{package.name}}-${{range.key}}"
     description: COSI's ${{range.key}} binary
     pipeline:
+      - uses: go/bump
+        with:
+          deps: |-
+            golang.org/x/net@v0.38.0
+            golang.org/x/oauth2@v0.27.0
+          modroot: ./${{range.key}}
       - uses: go/build
         with:
           packages: ./cmd

--- a/container-object-storage-interface.yaml
+++ b/container-object-storage-interface.yaml
@@ -1,0 +1,84 @@
+package:
+  name: container-object-storage-interface
+  version: "0.2.1"
+  epoch: 0
+  description: Container Object Storage Interface (COSI) responsible for defining COSI spec and APIs, interfacing with COSI drivers, and managing the lifecycle of COSI objects
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - container-object-storage-interface-controller
+      - container-object-storage-interface-sidecar
+
+data:
+  - name: binaries
+    items:
+      sidecar:
+      controller:
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/container-object-storage-interface
+      tag: v${{package.version}}
+      expected-commit: f1f392110e45b4f407aa214380eda16b118db31d
+
+subpackages:
+  - range: binaries
+    name: "${{package.name}}-${{range.key}}"
+    description: COSI's ${{range.key}} binary
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd
+          output: ${{range.key}}
+          modroot: ./${{range.key}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}-${{range.key}}-compat
+      pipeline:
+        - runs: |
+            ${{range.key}} --help
+
+  - range: binaries
+    name: "${{package.name}}-${{range.key}}-compat"
+    description: Compatibility package to place binaries in the location expected by upstream
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/
+          ln -sf /usr/bin/${{range.key}} "${{targets.contextdir}}"/${{range.key}}
+    test:
+      pipeline:
+        - runs: test "$(readlink /${{range.key}})" = "/usr/bin/${{range.key}}"
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/container-object-storage-interface
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - container-object-storage-interface-controller
+        - container-object-storage-interface-controller-compat
+        - container-object-storage-interface-sidecar
+        - container-object-storage-interface-sidecar-compat
+    environment:
+      KUBERNETES_SERVICE_HOST: "127.0.0.1"
+      KUBERNETES_SERVICE_PORT: 32764
+  pipeline:
+    - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
+    - uses: test/daemon-check-output
+      with:
+        start: /controller -v=9
+        timeout: 15
+        expected_output: |
+          acquire leader lease
+          Response Headers
+          failed to acquire lease


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
