### PR TITLE
autoconf-archive: new upstream release

### DIFF
--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/autoconf-archive/APKBUILD
 package:
   name: autoconf-archive
-  version: 2023.02.20
-  epoch: 2
+  version: 2024.10.16
+  epoch: 0
   description: Collection of re-usable GNU Autoconf macros
   copyright:
     - license: GPL-3.0-or-later
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33
+      expected-sha256: 7bcd5d001916f3a50ed7436f4f700e3d2b1bade3ed803219c592d62502a57363
       uri: https://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
@@ -37,5 +37,6 @@ subpackages:
     description: autoconf-archive manpages
 
 update:
+  enabled: true
   release-monitor:
     identifier: 142


### PR DESCRIPTION
And while at it, explicitly enable automatic updates.

See also:
  https://github.com/chainguard-dev/internal-dev/issues/13110

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
