### PR TITLE
py3-psycopg: decouple from specific libpq version

### DIFF
--- a/py3-psycopg.yaml
+++ b/py3-psycopg.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psycopg
   version: "3.2.9"
-  epoch: 1
+  epoch: 2
   description: PostgreSQL database adapter for Python
   copyright:
     - license: LGPL-3.0-only
@@ -50,7 +50,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - libpq-17
+        - libpq
         - py${{range.key}}-typing-extensions
         - py${{range.key}}-tzdata
     pipeline:


### PR DESCRIPTION
This causes problems when trying to use patroni with older (or newer) postgresql versions than what py3-psycopg expects. It seems to be backwards compatible anyways so I don't see why we should couple the package that tightly to a specific libpq version

```
make local-wolfi
```
```
# apk add libpq-16 postgresql-16
(1/27) Installing krb5-conf (1.0-r7)
(2/27) Installing libcom_err (1.47.3-r0)
(3/27) Installing keyutils-libs (1.6.3-r36)
(4/27) Installing libverto (0.3.2-r6)
(5/27) Installing krb5-libs (1.21.3-r45)
(6/27) Installing gdbm (1.26-r0)
# ...

# apk add py3.13-psycopg # It successfully installs now!
(1/9) Installing py3-pip-wheel (25.2-r0)
(2/9) Installing libbz2-1 (1.0.8-r21)
(3/9) Installing libexpat1 (2.7.1-r2)
# ...
```

