### PR TITLE
grafana-image-renderer: Remove bogus prebuilt binaries

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: "4.0.9"
-  epoch: 0
+  epoch: 1
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,16 @@ pipeline:
       cp -r ./node_modules ${{targets.destdir}}/usr/src/app/
       cp ./default.json ${{targets.destdir}}/usr/src/app/config.json
       cp ./plugin.json ${{targets.destdir}}/usr/src/app/
+
+      # These prebuilt binaries depend on shlibs that we don't ship/support.
+      rm -rf "${{targets.destdir}}"/usr/src/app/node_modules/bare-fs/prebuilds/android-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-fs/prebuilds/darwin-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-fs/prebuilds/ios-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-fs/prebuilds/win32-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-os/prebuilds/android-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-os/prebuilds/darwin-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-os/prebuilds/ios-* \
+        "${{targets.destdir}}"/usr/src/app/node_modules/bare-os/prebuilds/win32-*
 
 update:
   enabled: true


### PR DESCRIPTION
These binaries are compiled for other systems and depend on libraries that we don't ship or support.