### PR TITLE
fix: file permissions for entrypoint script

### DIFF
--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apicurio-registry
   version: "3.0.9"
-  epoch: 0
+  epoch: 8
   description: An API/Schema registry - stores APIs and Schemas
   copyright:
     - license: Apache-2.0

--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -92,8 +92,8 @@ subpackages:
           config_dest="${{targets.contextdir}}/usr/local/bin/"
           install -Dm644 .docker-scripts/create-config.cjs "${config_dest}/create-config.cjs"
           install -Dm644 .docker-scripts/update-base-href.cjs "${config_dest}/update-base-href.cjs"
-          install -Dm644 .docker-scripts/entrypoint.sh "${config_dest}/entrypoint.sh"
           install -Dm644 .docker-scripts/nginx.conf "${config_dest}/etc/nginx/nginx.conf"
+          install -Dm755 .docker-scripts/entrypoint.sh "${config_dest}/entrypoint.sh"
 
 update:
   enabled: true

--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apicurio-registry
   version: "3.0.9"
-  epoch: 7
+  epoch: 0
   description: An API/Schema registry - stores APIs and Schemas
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Fixing the permissions for an entrypoint script that we are installing since this needs to be executable