### PR TITLE
Remove musl-linked prebuilt binaries from packages

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: "3.7.0"
-  epoch: 0
+  epoch: 1
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -145,6 +145,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/argo-workflows-ui
           cp -ar ui/ ${{targets.subpkgdir}}/usr/lib/argo-workflows-ui
+          # Remove musl-linked prebuilt binaries.
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/argo-workflows-ui/ui/node_modules/@parcel/watcher-linux-*-musl/
       # Mitigate CVE-2025-22866
       - assertions:
           required-steps: 1

--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: "5.14.2"
-  epoch: 4
+  epoch: 5
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:
@@ -60,6 +60,9 @@ pipeline:
       # Create a link to the cli binary
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -sf /usr/src/prism/packages/cli/dist/index.js ${{targets.destdir}}/usr/bin/prism
+
+      # Remove musl-linked prebuilt binaries.
+      rm -rf "${{targets.destdir}}"/usr/src/prism/node_modules/@nx/nx-linux-*-musl/
 
 update:
   enabled: true


### PR DESCRIPTION
These binaries are causing melange to generate bogus dependencies.