### PR TITLE
add extra functionality to ip and friends

### DIFF
--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: "6.17.0"
-  epoch: 0
+  epoch: 1
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -22,9 +22,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - db-dev
       - elfutils-dev
       - flex
       - iptables-dev
+      - libbpf-dev
+      - libcap-dev
+      - libmnl-dev
+      - libtirpc-dev
 
 pipeline:
   - uses: git-checkout
@@ -136,6 +141,7 @@ test:
         ip tunnel show
     - name: "Test adding dummy interface"
       runs: |
+        # this is messy, but qemu x86_64, and docker arm64 behave differently with dummy module
         cmd="ip link add dev myinterface type dummy"
-        $cmd || $cmd 2>&1 | grep 'RTNETLINK answers: Operation not supported'
+        $cmd || $cmd 2>&1 | egrep 'RTNETLINK answers: Operation not permitted|Error: Unknown device type'
     - uses: test/no-docs


### PR DESCRIPTION
Add libbpf (modernized bpf code in `ip`/`tc`), berkely db etc. support to iproute2 to align with other distros, e.g:
```
ip -V
ip utility, iproute2-6.16.0, libbpf 1.6.1
```