### PR TITLE
k3s-1.32/cve remediation

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.7.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -59,14 +59,14 @@ pipeline:
       repository: https://github.com/k3s-io/k3s
       tag: v${{vars.full-package-version}}
       expected-commit: ab99e9da82c7072e4d9efbfa9464e343846fae72
-
+  - runs: |
+      sed -i 's|golang.org/x/net v0.30.0|golang.org/x/net v0.39.0|' go.mod
   - uses: go/bump
     with:
       deps: |-
         github.com/pion/interceptor@v0.1.39
         golang.org/x/crypto@v0.40.0
       replaces: gopkg.in/go-jose/go-jose.v2=gopkg.in/go-jose/go-jose.v2@v2.6.3
-
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.
   - runs: |
@@ -74,7 +74,6 @@ pipeline:
       sed -e '/curl --compressed/d' -i scripts/download
       mkdir -p build/static bin/aux etc
       ./scripts/download
-
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054
@@ -82,8 +81,7 @@ pipeline:
       sed -i "s/\${VERSION_GOLANG}/$GOVERSION/g" scripts/build
 
       ./scripts/build
-
-  # k3s embedds a lot of useful components (containerd, kubectl, etc...) in a
+  # k3s embeds a lot of useful components (containerd, kubectl, etc...) in a
   # very efficient manner that can't be replicated with external runtime
   # components. To ensure we have an optimally packaged k3s, we try to mimic
   # as much of the upstream k3s space savings while still building all the
@@ -103,7 +101,6 @@ pipeline:
 
       mkdir -p "${{targets.destdir}}/usr/bin"
       cp -r bin/* "${{targets.destdir}}/usr/bin/"
-
   - uses: strip
 
 subpackages:


### PR DESCRIPTION
cve: update replace golang.org/x/net v0.30.0 with v0.39.0