### PR TITLE
Added env var to skip pre-commit check on CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pre-commit: Skip epoch bump check as that's intended as a local developer helpful hint.
+  SKIP: check-for-epoch-bump
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Aligns with the other repos, quiets up the logs a bit. 