### PR TITLE
Adjust the memory per job so we can run more in parallel

### DIFF
--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -94,7 +94,8 @@ subpackages:
 
           # Arbitrary amount of memory to reserve per-thread
           # https://salsa.debian.org/python-team/packages/graph-tool/-/blob/master/debian/rules?ref_type=heads
-          MEM_PER_JOB=13000
+          # Reduced from 13000 to 8000 to allow more parallel jobs (16 vs 9 on 128GB)
+          MEM_PER_JOB=8000
 
           # Calculate number of jobs
           NJOBS=$(( MEM_MB / MEM_PER_JOB ))

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-graph-tool
   version: 2.97
-  epoch: 6
+  epoch: 7
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65


### PR DESCRIPTION
This should allow the package to build more quickly - it used to take almost 4 hours.