### PR TITLE
openssf-compiler-options: Consolidate x86 GCC flags

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 26
+  epoch: 27
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
@@ -1,5 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
@@ -1,5 +1,5 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
 
 *link:
 + --as-needed -O1 --sort-common -z noexecstack -z relro -z now


### PR DESCRIPTION
We're using different flags between different versions of GCC on x86. For example, GCC 14 and 15 are missing `-fcf-protection=full`.  Let's consolidate things.