### PR TITLE
pre-commit: use shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,15 @@
 # See https://eng.inky.wtf/docs/technical/git/pre-commit for info on how to edit this file.
 repos:
   - repo: https://github.com/chainguard-dev/pre-commit-hooks
-    rev: 71fca50bcd1006b5cbcf71f03a3b493f48c4af7f
+    rev: b016305382e40f8345f1251180420364034fd316
     hooks:
-      # Not quite ready for prime time yet, due to a tool dependency outside the pre-commit managed environment.
-      #- id: shellcheck-run-steps
+      - id: shellcheck-run-steps
+        files: '^[^.][^/]*\.yaml$' # matches non-hidden .yaml files at the top level only
+        args:
+          - "--" # options to hook before this, options to shellcheck after
+          - "-S"
+          - "error"
+          - "--" # terminates shellcheck options, rest will be filenames
       - id: check-for-epoch-bump
         files: |
           (?x)^(


### PR DESCRIPTION
Add a pre-commit check that extracts the code from each `runs:` snippet and runs it through `shellcheck`, configured to only report errors. There are still some false positives, but not a terrible percentage.

There are PRs open to fix all existing failures.