### PR TITLE
add headlamp-plugin-flux package

### DIFF
--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -43,7 +43,7 @@ update:
   manual: true
   github:
     identifier: headlamp-k8s/plugins
-    strip-prefix: v
+    strip-prefix: flux-
     use-tag: true
     strip-suffix: -.*
   ignore-regex-patterns:

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -54,12 +54,6 @@ update:
     - ^prometheus-.*
 
 test:
-  environment:
-    contents:
-      packages:
-        - busybox
   pipeline:
-    - name: "Test headlamp flux plugin"
-      runs: |
+    - runs: |
         grep -q '"name": "@headlamp-k8s/flux"' /plugins/package.json
-        test -f /plugins/package.json

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -46,6 +46,12 @@ update:
     strip-prefix: v
     use-tag: true
     strip-suffix: -.*
+  ignore-regex-patterns:
+    - ^app-catalog-.*
+    - ^cert-manager-.*
+    - ^minikube-.*
+    - ^plugin-catalog-.*
+    - ^prometheus-.*
 
 test:
   pipeline:

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -1,0 +1,55 @@
+package:
+  name: headlamp-plugin-flux
+  version: "0.4.0"
+  epoch: 0
+  description: Flux plugin for Headlamp that provides a way to visualize Flux resources.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - nodejs
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - nodejs
+      - npm
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '^(.+)$'
+    replace: 'flux-$1'
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/headlamp-k8s/plugins
+      tag: ${{vars.mangled-package-version}}
+      expected-commit: fb090a0ee368bae009a05408ab0652a0c58b86d4
+
+  - runs: |
+      cd flux
+      npm ci
+      npm run build
+      mkdir -p "${{targets.destdir}}"/plugins
+      cp -r dist/* "${{targets.destdir}}"/plugins/
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: true
+  github:
+    identifier: headlamp-k8s/plugins
+    strip-prefix: v
+    use-tag: true
+    strip-suffix: -.*
+
+test:
+  pipeline:
+    - name: "Test headlamp flux plugin"
+      runs: |
+        grep -q '"name": "@headlamp-k8s/flux"' /plugins/package.json
+        test -f /plugins/package.json

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -33,9 +33,10 @@ pipeline:
       cd flux
       npm ci
       npm run build
-      mkdir -p "${{targets.destdir}}"/plugins
-      cp -r dist/* "${{targets.destdir}}"/plugins/
-      npx --no-install headlamp-plugin extract . "${{targets.destdir}}"/plugins/
+      mkdir -p "${{targets.destdir}}"/plugins/flux
+      cp -r dist/* "${{targets.destdir}}"/plugins/flux
+      npx --no-install headlamp-plugin extract . "${{targets.destdir}}"/plugins/flux
+      chmod -R 755 "${{targets.destdir}}"/plugins
 
   - uses: strip
 
@@ -57,5 +58,6 @@ update:
 test:
   pipeline:
     - runs: |
-        grep -q '"name": "@headlamp-k8s/flux"' /plugins/package.json
-        test -f /plugins/package.json
+        test -d /plugins/flux
+        grep -q '"name": "@headlamp-k8s/flux"' /plugins/flux/package.json
+        test -f /plugins/flux/package.json

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -35,6 +35,7 @@ pipeline:
       npm run build
       mkdir -p "${{targets.destdir}}"/plugins
       cp -r dist/* "${{targets.destdir}}"/plugins/
+      npx --no-install headlamp-plugin extract . "${{targets.destdir}}"/plugins/
 
   - uses: strip
 
@@ -57,3 +58,4 @@ test:
   pipeline:
     - runs: |
         grep -q '"name": "@headlamp-k8s/flux"' /plugins/package.json
+        test -f /plugins/package.json

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -54,6 +54,10 @@ update:
     - ^prometheus-.*
 
 test:
+  environment:
+    contents:
+      packages:
+        - busybox
   pipeline:
     - name: "Test headlamp flux plugin"
       runs: |

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -29,8 +29,8 @@ pipeline:
       tag: ${{vars.mangled-package-version}}
       expected-commit: fb090a0ee368bae009a05408ab0652a0c58b86d4
 
-  - runs: |
-      cd flux
+  - working-directory: flux
+    runs: |
       npm ci
       npm run build
       mkdir -p "${{targets.destdir}}"/plugins/flux


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/headlamp-k8s/plugins

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
