### PR TITLE
feat: add logging-operator-node-exporter and logging-operator-custom-runner

### DIFF
--- a/kube-logging-operator-custom-runner.yaml
+++ b/kube-logging-operator-custom-runner.yaml
@@ -1,0 +1,56 @@
+package:
+  name: kube-logging-operator-custom-runner
+  version: "0.13.0"
+  epoch: 0
+  description: Logging operator for Kubernetes - go custom runner
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kube-logging/custom-runner
+      tag: v${{package.version}}
+      expected-commit: c84cc3094a4677d55642855c14d2d5821d36f7e8
+
+  - uses: go/build
+    with:
+      packages: .
+      output: logging-operator-custom-runner
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for ${{package.name}}"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s ../usr/bin/logging-operator-custom-runner ${{targets.subpkgdir}}/runner
+    dependencies:
+      provides:
+        - ${{package.name}}-entrypoint=${{package.full-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: test/tw/symlink-check
+        - runs: |
+            /runner --help
+
+update:
+  enabled: true
+  github:
+    identifier: kube-logging/custom-runner
+    strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/daemon-check-output
+      with:
+        start: |
+          logging-operator-custom-runner -cfgjson '{"events": {"onStart": [{"exec": {"command": "echo ONSTART"}}]}}'
+        timeout: 60
+        expected_output: |
+          listening on port
+          ONSTART

--- a/kube-logging-operator-node-exporter.yaml
+++ b/kube-logging-operator-node-exporter.yaml
@@ -1,0 +1,65 @@
+package:
+  name: kube-logging-operator-node-exporter
+  version: "6.0.1"
+  epoch: 0
+  description: Logging operator for Kubernetes - node exporter helper files
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kube-logging/logging-operator
+      tag: ${{package.version}}
+      expected-commit: 42ef5a2e0beabfd41628962ac5f9d7c708ea73d4
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/usr/bin
+      install -m755 ./images/node-exporter/buffer-size.sh ${{targets.contextdir}}/usr/bin/logging-operator-node-exporter-buffer-size.sh
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for ${{package.name}}"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/prometheus/node_exporter/textfile_collector
+          ln -s ../usr/bin/logging-operator-node-exporter-buffer-size.sh ${{targets.subpkgdir}}/prometheus/buffer-size.sh
+    dependencies:
+      provides:
+        - ${{package.name}}-entrypoint=${{package.full-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: test/tw/symlink-check
+        - runs: |
+            grep BUFFER_PATH /prometheus/buffer-size.sh
+
+update:
+  enabled: true
+  github:
+    identifier: kube-logging/logging-operator
+
+test:
+  pipeline:
+    - runs: |
+        mkdir -p /buffers /prometheus/node_exporter/textfile_collector
+        /usr/bin/logging-operator-node-exporter-buffer-size.sh </dev/null >/dev/null 2>/dev/null &
+        for attempt in $(seq 1 10); do
+          if [ -f /prometheus/node_exporter/textfile_collector/buffer_size.prom ]; then
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Node exporter textfile collector file not created after 10 attempts"
+        exit 1


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
