### PR TITLE
feat: add cluster-api-gcp-controller

### DIFF
--- a/cluster-api-gcp-controller.yaml
+++ b/cluster-api-gcp-controller.yaml
@@ -1,0 +1,59 @@
+package:
+  name: cluster-api-gcp-controller
+  version: "1.10.0"
+  epoch: 2
+  description: The GCP provider implementation for Cluster API
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/cluster-api-provider-gcp
+      tag: v${{package.version}}
+      expected-commit: 6518ef9b44cfc4f8c3f7139b2ce4ae71523deff6
+
+  - uses: go/build
+    with:
+      packages: .
+      output: cluster-api-gcp-controller
+      ldflags: |
+        -buildid= ""
+        -X sigs.k8s.io/cluster-api-provider-gcp/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
+        -X sigs.k8s.io/cluster-api-provider-gcp/version.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/cluster-api-provider-gcp/version.gitVersion=$(git describe --dirty --tags --always)
+        -X sigs.k8s.io/cluster-api-provider-gcp/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean")
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for cluster-api-gcp-controller"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s ./usr/bin/cluster-api-gcp-controller ${{targets.subpkgdir}}/manager
+    dependencies:
+      provides:
+        - ${{package.name}}-entrypoint=${{package.full-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: test/tw/symlink-check
+        - runs: |
+            (/manager --help || true) | grep 'help requested'
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/cluster-api-provider-gcp
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        (cluster-api-gcp-controller version --help || true) | grep 'help requested'


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
