### PR TITLE
gradle-8: also support OpenJDK 8 correctly

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -3,7 +3,7 @@ package:
   version: "8.14.3"
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 3
+  epoch: 4
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/gradle-8/0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
+++ b/gradle-8/0001-Backport-9.1-feature-to-honor-default-keystore-type.patch
@@ -16,7 +16,7 @@ index 515b831ffb0..20949dcec1f 100644
      companion object {
          // JKS does not support non-PrivateKeys
 -        const val KEYSTORE_TYPE = "pkcs12"
-+        val KEYSTORE_TYPE = KeyStore.getDefaultType()
++        val KEYSTORE_TYPE = if (KeyStore.getDefaultType() == "jks") "pkcs12" else KeyStore.getDefaultType()
          val KEYSTORE_PASSWORD = charArrayOf('c', 'c')
      }
  }


### PR DESCRIPTION
Previous backport regressed gradle support on OpenJDK 8, fix it.

This should resolve gradle image release for jdk 8, tested locally it works correctly now.