### PR TITLE
py3-*: Fix shellcheck false-positive in cargo-culted non-test test pattern

### DIFF
--- a/py3-antlr4-python3-runtime.yaml
+++ b/py3-antlr4-python3-runtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-antlr4-python3-runtime
   version: 4.13.2
-  epoch: 4
+  epoch: 5
   description: ANTLR runtime for Python 3
   copyright:
     - license: BSD-3-Clause
@@ -86,8 +86,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-archspec.yaml
+++ b/py3-archspec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-archspec
   version: 0.2.5
-  epoch: 3
+  epoch: 4
   description: A library to query system architecture
   copyright:
     - license: Apache-2.0 OR MIT
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-argcomplete.yaml
+++ b/py3-argcomplete.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-argcomplete
   version: "3.6.2"
-  epoch: 2
+  epoch: 3
   description: Bash/zsh tab completion for argparse
   copyright:
     - license: Apache-2.0
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-avro-python3.yaml
+++ b/py3-avro-python3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-avro-python3
   version: 1.10.2
-  epoch: 5
+  epoch: 6
   description: Avro is a serialization and RPC framework.
   copyright:
     - license: Apache-2.0
@@ -82,8 +82,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-babel.yaml
+++ b/py3-babel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-babel
   version: "2.17.0"
-  epoch: 1
+  epoch: 2
   description: Python3 i18n tool
   copyright:
     - license: BSD-3-Clause
@@ -81,8 +81,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-chardet.yaml
+++ b/py3-chardet.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-chardet
   version: 5.2.0
-  epoch: 6
+  epoch: 7
   description: Universal encoding detector for Python 3
   copyright:
     - license: LGPL-2.1-or-later
@@ -83,8 +83,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-commonmark.yaml
+++ b/py3-commonmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-commonmark
   version: 0.9.1
-  epoch: 5
+  epoch: 6
   description: Python parser for the CommonMark Markdown spec
   copyright:
     - license: BSD-3-Clause
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-conda-package-handling.yaml
+++ b/py3-conda-package-handling.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-package-handling
   version: 2.4.0
-  epoch: 3
+  epoch: 4
   description: Create and extract conda packages of various formats
   copyright:
     - license: BSD-3-Clause
@@ -84,8 +84,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-debugpy.yaml
+++ b/py3-debugpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-debugpy
   version: "1.8.15"
-  epoch: 2
+  epoch: 3
   description: An implementation of the Debug Adapter Protocol for Python
   copyright:
     - license: MIT
@@ -83,8 +83,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -4,7 +4,7 @@ package:
   # if https://github.com/goldmann/docker-squash/pull/234 was merged
   # and released.
   version: 1.2.2
-  epoch: 2
+  epoch: 3
   description: Docker layer squashing tool
   copyright:
     - license: MIT
@@ -88,8 +88,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-docutils.yaml
+++ b/py3-docutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-docutils
   version: "0.22"
-  epoch: 0
+  epoch: 1
   description: Documentation Utilities for Python3
   copyright:
     - license: BSD-2-Clause AND GPL-3.0-or-later AND Python-2.0
@@ -82,8 +82,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-future.yaml
+++ b/py3-future.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-future
   version: 1.0.0
-  epoch: 3
+  epoch: 4
   description: Clean single-source support for Python 3 and 2
   copyright:
     - license: MIT
@@ -84,8 +84,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-gcovr.yaml
+++ b/py3-gcovr.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gcovr
   version: "8.3"
-  epoch: 1
+  epoch: 2
   description: Generate C/C++ code coverage reports with gcov
   copyright:
     - license: BSD-3-Clause # according to https://github.com/gcovr/gcovr/tree/master#license
@@ -90,8 +90,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-git-filter-repo.yaml
+++ b/py3-git-filter-repo.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-git-filter-repo
   version: 2.47.0
-  epoch: 2
+  epoch: 3
   description: Quickly rewrite git repository history
   copyright:
     - license: MIT
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-glom.yaml
+++ b/py3-glom.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-glom
   version: 24.11.0
-  epoch: 2
+  epoch: 3
   description: Python's nested data operator (and CLI), for all your declarative restructuring needs. Got data? Glom it!
   copyright:
     - license: BSD-3-Clause
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-google-auth-oauthlib.yaml
+++ b/py3-google-auth-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-auth-oauthlib
   version: "1.2.2"
-  epoch: 2
+  epoch: 3
   description: Google Authentication Library
   copyright:
     - license: Apache-2.0
@@ -86,8 +86,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-google-cloud-bigquery-storage.yaml
+++ b/py3-google-cloud-bigquery-storage.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-cloud-bigquery-storage
   version: "2.32.0"
-  epoch: 2
+  epoch: 3
   description: Google Cloud Bigquery Storage API client library
   copyright:
     - license: Apache-2.0
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-google-cloud-datastore.yaml
+++ b/py3-google-cloud-datastore.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-cloud-datastore
   version: "2.21.0"
-  epoch: 2
+  epoch: 3
   description: Google Cloud Datastore API client library
   copyright:
     - license: Apache-2.0
@@ -86,8 +86,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-gyp-next.yaml
+++ b/py3-gyp-next.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gyp-next
   version: "0.20.2"
-  epoch: 2
+  epoch: 3
   description: A fork of the GYP build system for use in the Node.js projects
   copyright:
     - license: BSD-3-Clause
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-hatch-jupyter-builder.yaml
+++ b/py3-hatch-jupyter-builder.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hatch-jupyter-builder
   version: 0.9.1
-  epoch: 3
+  epoch: 4
   description: A hatch plugin to help build Jupyter packages
   copyright:
     - license: BSD-3-Clause
@@ -86,8 +86,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-invoke.yaml
+++ b/py3-invoke.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-invoke
   version: 2.2.0
-  epoch: 4
+  epoch: 5
   description: Pythonic task management & command execution.
   copyright:
     - license: BSD-2-Clause
@@ -83,8 +83,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-jmespath.yaml
+++ b/py3-jmespath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jmespath
   version: 1.0.1
-  epoch: 7
+  epoch: 8
   description: JMESPath is a query language for JSON
   copyright:
     - license: MIT
@@ -82,8 +82,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-json5.yaml
+++ b/py3-json5.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-json5
   version: "0.12.0"
-  epoch: 3
+  epoch: 4
   description: A Python implementation of the JSON5 data format.
   copyright:
     - license: Apache-2.0
@@ -83,8 +83,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-jsondiff.yaml
+++ b/py3-jsondiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsondiff
   version: 2.2.1
-  epoch: 4
+  epoch: 5
   description: Diff JSON and JSON-like structures in Python
   copyright:
     - license: MIT
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-jupyter-events.yaml
+++ b/py3-jupyter-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyter-events
   version: "0.12.0"
-  epoch: 1
+  epoch: 2
   description: Jupyter Event System library
   copyright:
     - license: BSD-3-Clause
@@ -95,8 +95,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-jupyterhub.yaml
+++ b/py3-jupyterhub.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jupyterhub
   version: "5.3.0"
-  epoch: 2
+  epoch: 3
   description: 'JupyterHub: A multi-user server for Jupyter notebooks'
   copyright:
     - license: BSD-3-Clause
@@ -106,8 +106,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-mako.yaml
+++ b/py3-mako.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-mako
   version: "1.3.10"
-  epoch: 2
+  epoch: 3
   description: Python3 fast templating language
   copyright:
     - license: MIT
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-markdown.yaml
+++ b/py3-markdown.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-markdown
   version: "3.8.2"
-  epoch: 2
+  epoch: 3
   description: Python implementation of John Gruber's Markdown.
   copyright:
     - license: BSD-3-Clause
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-merge3.yaml
+++ b/py3-merge3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-merge3
   version: 0.0.15
-  epoch: 3
+  epoch: 4
   description: Python implementation of 3-way merge
   copyright:
     - license: GPL-2.0-or-later
@@ -82,8 +82,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-nbclient.yaml
+++ b/py3-nbclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nbclient
   version: 0.10.2
-  epoch: 1
+  epoch: 2
   description: A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor.
   copyright:
     - license: BSD-3-Clause
@@ -88,8 +88,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-nbformat.yaml
+++ b/py3-nbformat.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nbformat
   version: 5.10.4
-  epoch: 3
+  epoch: 4
   description: The Jupyter Notebook format
   copyright:
     - license: BSD-3-Clause
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-patiencediff.yaml
+++ b/py3-patiencediff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-patiencediff
   version: 0.2.15
-  epoch: 3
+  epoch: 4
   description: Python implementation of the patiencediff algorithm
   copyright:
     - license: GPL-2.0-or-later
@@ -82,8 +82,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-gitlab
   version: "6.2.0"
-  epoch: 0
+  epoch: 1
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-python-slugify.yaml
+++ b/py3-python-slugify.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-slugify
   version: 8.0.4
-  epoch: 4
+  epoch: 5
   description: A Python slugify application that also handles Unicode
   copyright:
     - license: MIT
@@ -85,8 +85,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-rdflib.yaml
+++ b/py3-rdflib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rdflib
   version: "7.1.4"
-  epoch: 1
+  epoch: 2
   description: RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information.
   copyright:
     - license: BSD-3-Clause
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-recommonmark.yaml
+++ b/py3-recommonmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-recommonmark
   version: 0.7.1
-  epoch: 3
+  epoch: 4
   description: A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects.
   copyright:
     - license: MIT
@@ -86,8 +86,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-reno.yaml
+++ b/py3-reno.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-reno
   version: 4.1.0
-  epoch: 4
+  epoch: 5
   description: RElease NOtes manager
   copyright:
     - license: Apache-2.0
@@ -87,8 +87,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-send2trash.yaml
+++ b/py3-send2trash.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-send2trash
   version: 1.8.3
-  epoch: 4
+  epoch: 5
   description: Send file to trash natively under Mac OS X, Windows and Linux
   copyright:
     - license: BSD-3-Clause
@@ -83,8 +83,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-spdx-tools.yaml
+++ b/py3-spdx-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-spdx-tools
   version: 0.8.3
-  epoch: 3
+  epoch: 4
   description: SPDX parser and tools.
   copyright:
     - license: Apache-2.0
@@ -96,8 +96,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: "8.2.3"
-  epoch: 3
+  epoch: 4
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -103,8 +103,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-sqlparse.yaml
+++ b/py3-sqlparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlparse
   version: 0.5.3
-  epoch: 2
+  epoch: 3
   description: A non-validating SQL parser.
   copyright:
     - license: BSD-3-Clause
@@ -88,8 +88,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-sshtunnel.yaml
+++ b/py3-sshtunnel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sshtunnel
   version: 0.4.0
-  epoch: 4
+  epoch: 5
   description: Pure python SSH tunnels
   copyright:
     - license: MIT
@@ -88,8 +88,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
+              echo "== $line =="
+              /"$line" --help && echo exited 0 || echo "exited $?"
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-tabulate.yaml
+++ b/py3-tabulate.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tabulate
   version: 0.9.0
-  epoch: 6
+  epoch: 7
   description: Pretty-print tabular data
   copyright:
     - license: MIT
@@ -84,8 +84,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}

--- a/py3-websocket-client.yaml
+++ b/py3-websocket-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-websocket-client
   version: 1.8.0
-  epoch: 3
+  epoch: 4
   description: WebSocket client for Python with low level API options
   copyright:
     - license: Apache-2.0
@@ -84,8 +84,8 @@ subpackages:
             sed 's,^,> ,' bins.list
 
             while read line; do
-              echo == /$line ==
-              /$line --help || :
+              echo "== $line =="
+              /"$line" --help || :
             done < bins.list
 
   - name: py3-supported-${{vars.pypi-package}}


### PR DESCRIPTION
Generated with:
```
    sed -i 's/              echo == \/$line ==/              echo \"== $line ==\"/' *.yaml
    sed -i 's/              \/$line --help || :/              \/\"$line\" --help || :/' *.yaml
    sed -i 's/              \/$line --help \&\& echo exited 0/              \/\"$line\" --help \&\& echo exited 0/' *.yaml
```