### PR TITLE
Bump setuptools to >=77 for pip-zipapp

### DIFF
--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: pip-zipapp
   version: "25.2"
-  epoch: 0
+  epoch: 1
   description: "Pip as a python zipapp"
   copyright:
     - license: MIT
@@ -38,8 +38,8 @@ pipeline:
 
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-72.1.0-py3-none-any.whl"
-      expected-sha256: "5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"
+      uri: "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-77.0.3-py3-none-any.whl"
+      expected-sha256: "67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c"
       extract: false
 
   - uses: fetch


### PR DESCRIPTION
Unblocks: https://github.com/wolfi-dev/os/pull/61235

pip `25.2` requires that `pip-zipapp` use `setuptools>=77`:
```
2025/07/31 11:53:11 WARN   Running command pip subprocess to install build dependencies subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   Using pip 25.2 from /usr/share/pip-zipapp/pip-zipapp.pyz/pip (python 3.10) subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   Looking in links: /usr/share/pip-zipapp/wheels subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   ERROR: Could not find a version that satisfies the requirement setuptools>=77 (from versions: 72.1.0) subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   ERROR: No matching distribution found for setuptools>=77 subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   error: subprocess-exited-with-error subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN    subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   × pip subprocess to install build dependencies did not run successfully. subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   │ exit code: 1 subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   ╰─> See above for output. subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN    subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   note: This error originates from a subprocess, and is likely not a problem with pip. subpackage=py3.10-pip-base
2025/07/31 11:53:11 WARN   full command: /usr/bin/python3.10 /usr/share/pip-zipapp/pip-zipapp.pyz/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-1yam4pv9/overlay --no-warn-script-location --disable-pip-version-check --no-compile --target '' -v --no-binary :none: --only-binary :none: --no-index --find-links /usr/share/pip-zipapp/wheels -- 'setuptools>=77' subpackage=py3.10-pip-base
2025/07/31 11:53:11 INFO   Installing build dependencies: finished with status 'error' subpackage=py3.10-pip-base
```