### PR TITLE
gcp-compute-persistent-disk-csi-driver-1.16/cve-remediation

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver-1.16.yaml
+++ b/gcp-compute-persistent-disk-csi-driver-1.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcp-compute-persistent-disk-csi-driver-1.16
   version: "1.16.2"
-  epoch: 2 # GHSA-vvgc-356p-c3xw
+  epoch: 3
   description: The Google Compute Engine Persistent Disk (GCE PD) Container Storage Interface (CSI) Storage Plugin.
   copyright:
     - license: Apache-2.0
@@ -65,6 +65,7 @@ pipeline:
       deps: |-
         golang.org/x/crypto@v0.35.0
         golang.org/x/net@v0.38.0
+        golang.org/x/oauth2@v0.27.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
fix: gcp-compute-persistent-disk-csi-driver-1.16 - GHSA-6v2p-p543-phr9, GHSA-hcg3-q754-cr77, GHSA-qxp5-gwg8-xv66, GHSA-vvgc-356p-c3xw