### PR TITLE
openjdk-24: also correctly use system cacerts in jre

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 2
+  epoch: 3
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -136,6 +136,7 @@ subpackages:
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -151,6 +152,11 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"


### PR DESCRIPTION
Previous commit restored symlink direction for jdk, and ensured that
jdk uses system cacerts.

But that was not also applied to the jre, which too needs a symlink
override instead of shipping a vendored copy of cacerts.
