### PR TITLE
python-3.13: fix CVE-2025-8194 by adding tarfile validation cherry-pick

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.5"
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -57,6 +57,7 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.13/4455cbabf991e202185a25a631af206f60bbc949: Fix quadratic complexity in processing special input in HTMLParser (CVE-2025-6069)
+        3.13/cdae923ffe187d6ef916c0f665a31249619193fe: CVE-2025-8194 fix gh-130577: tarfile now validates archives to ensure member offsets are non-negative
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Adds cherry-pick from CPython commit cdae923ffe187d6ef916c0f665a31249619193fe to fix CVE-2025-8194.
https://github.com/python/cpython/issues/130577
This commit adds validation to ensure tar archive member offsets are non-negative in the tarfile module, preventing processing of potentially malformed archives.

- Incremented epoch from 4 to 5
- Added cherry-pick for gh-130577 tarfile validation fix