### PR TITLE
fix grafana pyroscope 1.13 cve

### DIFF
--- a/grafana-pyroscope-1.13.yaml
+++ b/grafana-pyroscope-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-pyroscope-1.13
   version: "1.13.5"
-  epoch: 1
+  epoch: 2
   description: Continuous Profiling Platform. Debug performance issues down to a single line of code
   copyright:
     - license: AGPL-3.0-only
@@ -25,6 +25,12 @@ pipeline:
       expected-commit: 73ae7cf6d4f3c6724b07f437345bd201b5382d23
       repository: https://github.com/grafana/pyroscope
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/oauth2-proxy/oauth2-proxy/v7@v7.11.0
+        github.com/prometheus/common@v0.64.0
 
   - runs: |
       # https://github.com/grafana/pyroscope/blob/3da96b8e449de267d4663e14207b8b272f9edc6d/.github/workflows/release.yml#L48C14-L48C33


### PR DESCRIPTION
We remediated the cve CVE-https://github.com/advisories/GHSA-7rh7-c77v-6434 by bumping dependency
github.com/oauth2-proxy/oauth2-proxy/v7 to version v7.11.0 and
constraining github.com/prometheus/common to v0.64.0