### PR TITLE
Add mod-auth-openidc and cjose for apache

### DIFF
--- a/cjose.yaml
+++ b/cjose.yaml
@@ -9,16 +9,9 @@ package:
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
       - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
       - jansson-dev
-      - libtool
       - openssl-dev
-      - pkgconf-dev
 
 pipeline:
   - uses: git-checkout

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -79,6 +79,7 @@ subpackages:
             - pkgconf
             - cjose-dev
       pipeline:
+      	- uses: test/pkgconf
         - runs: |
             pkg-config --modversion cjose |grep "${{package.version}}"
 

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -1,0 +1,93 @@
+package:
+  name: cjose
+  version: 0.6.2.4
+  epoch: 0
+  description: "C library implementing the Javascript Object Signing and Encryption (JOSE) standard"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - jansson-dev
+      - libtool
+      - openssl-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openidc/cjose
+      tag: v${{package.version}}
+      expected-commit: 8d94c3ad3237ab6a83d2e92fa541542b1b92c023
+
+  - uses: autoconf/configure
+    with:
+      opts: --enable-shared --disable-static
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - cjose-dev
+        - pkgconf
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        cat > test_cjose.c << 'EOF'
+        #include <cjose/cjose.h>
+        #include <stdio.h>
+
+        int main() {
+            cjose_err err;
+
+            // Create a simple JWK
+            cjose_jwk_t *jwk = cjose_jwk_create_oct_spec((const uint8_t*)"test-secret-key", 15, &err);
+            if (!jwk) {
+                printf("Failed to create JWK\n");
+                return 1;
+            }
+
+            printf("CJOSE library test passed\n");
+            cjose_jwk_release(jwk);
+            return 0;
+        }
+        EOF
+
+        gcc -o test_cjose test_cjose.c $(pkg-config --cflags --libs cjose)
+        ./test_cjose
+
+subpackages:
+  - name: cjose-dev
+    description: cjose dev
+    pipeline:
+      - uses: split/dev
+    test:
+      environment:
+        contents:
+          packages:
+            - pkgconf
+            - cjose-dev
+      pipeline:
+        - runs: |
+            pkg-config --modversion cjose |grep "${{package.version}}"
+
+update:
+  enabled: true
+  github:
+    identifier: openidc/cjose
+    strip-prefix: v
+    use-tag: true

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -22,7 +22,7 @@ pipeline:
 
   - uses: autoconf/configure
     with:
-      opts: --enable-shared --disable-static
+      opts: --enable-shared
 
   - uses: autoconf/make
 

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -68,6 +68,7 @@ subpackages:
     description: cjose static
     pipeline:
       - uses: split/static
+
   - name: cjose-dev
     description: cjose dev
     pipeline:

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -79,7 +79,7 @@ subpackages:
             - pkgconf
             - cjose-dev
       pipeline:
-      	- uses: test/pkgconf
+        - uses: test/pkgconf
         - runs: |
             pkg-config --modversion cjose |grep "${{package.version}}"
 

--- a/cjose.yaml
+++ b/cjose.yaml
@@ -64,6 +64,10 @@ test:
         ./test_cjose
 
 subpackages:
+  - name: cjose-static
+    description: cjose static
+    pipeline:
+      - uses: split/static
   - name: cjose-dev
     description: cjose dev
     pipeline:

--- a/mod-auth-openidc.yaml
+++ b/mod-auth-openidc.yaml
@@ -36,6 +36,9 @@ pipeline:
 
 test:
   environment:
+    environment:
+      APACHE_ENDPOINT: 8080
+      AUTH_ENDPOINT: 8081
     contents:
       packages:
         - apache2
@@ -47,11 +50,16 @@ test:
   pipeline:
     - uses: test/tw/ldd-check
     - runs: |
-        # set -euo pipefail
-        # Create a simple oidc response to parse with the module
-        echo '{"issuer":"", "authorization_endpoint":"http://localhost:8081"}' > /tmp/index.html
+        set -euo pipefail
+        TEST_CONFIG=$(mktemp)
+        chmod -v 0644 "${TEST_CONFIG}"
 
-        cat > /tmp/test.conf << 'EOF'
+        # Create a simple oidc response to parse with the module
+        tee /tmp/index.html <<EOF
+        {"issuer":"", "authorization_endpoint":"http://localhost:${AUTH_ENDPOINT}"}
+        EOF
+
+        tee "${TEST_CONFIG}" <<EOF
         ServerName localhost
         ErrorLog /tmp/error.log
         LogLevel warn
@@ -63,34 +71,34 @@ test:
         LoadModule unixd_module /usr/lib/apache2/modules/mod_unixd.so
         LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
         DirectoryIndex index.html
-        Listen 8080
-        Listen 8081
-        <VirtualHost *:8080>
+        Listen ${APACHE_ENDPOINT}
+        Listen ${AUTH_ENDPOINT}
+        <VirtualHost *:${APACHE_ENDPOINT}>
           DocumentRoot /tmp
-          OIDCProviderMetadataURL http://localhost:8081
+          OIDCProviderMetadataURL http://localhost:${AUTH_ENDPOINT}
           OIDCClientID test
           OIDCClientSecret secret
-          OIDCRedirectURI http://localhost:8080/redirect_uri
+          OIDCRedirectURI http://localhost:${APACHE_ENDPOINT}/redirect_uri
           OIDCCryptoPassphrase test
           <Location />
             AuthType openid-connect
             Require valid-user
           </Location>
         </VirtualHost>
-        <VirtualHost *:8081>
+        <VirtualHost *:${AUTH_ENDPOINT}>
           DocumentRoot /tmp
         </VirtualHost>
         EOF
 
-        apachectl -f /tmp/test.conf -k start
-        wait-for-it localhost:8080 -t 10
+        apachectl -f "${TEST_CONFIG}" -k start
+        trap 'apachectl -f "${TEST_CONFIG}" -k stop' EXIT
+
+        wait-for-it localhost:${APACHE_ENDPOINT} -t 10
 
         # Test OIDC headers - cookie and redirect can only come from working module
-        RESPONSE=$(curl -f -s -i http://localhost:8080)
-        echo "$RESPONSE" | grep 'Set-Cookie: mod_auth_openidc_state'
-        echo "$RESPONSE" | grep 'Location: http://localhost:8081?response_type=code&scope=openid'
-
-        apachectl -f /tmp/test.conf -k stop
+        RESPONSE=$(curl -f -s -i "http://localhost:${APACHE_ENDPOINT}")
+        echo "$RESPONSE" | grep -F -e 'Set-Cookie: mod_auth_openidc_state'
+        echo "$RESPONSE" | grep -F -e "Location: http://localhost:${AUTH_ENDPOINT}?response_type=code&scope=openid"
 
 subpackages:
   - name: mod-auth-openidc-dev

--- a/mod-auth-openidc.yaml
+++ b/mod-auth-openidc.yaml
@@ -1,0 +1,121 @@
+package:
+  name: mod-auth-openidc
+  version: 2.4.17.2
+  epoch: 0
+  description: "Apache module for OpenID Connect authentication"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - apache2-dev
+      - apr-util-dev
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cjose-dev
+      - curl-dev
+      - git
+      - hiredis-dev
+      - jansson-dev
+      - libapr-dev
+      - libtool
+      - openssl-dev
+      - pcre2-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openidc/mod_auth_openidc
+      tag: v${{package.version}}
+      expected-commit: 72304a45eb3d3b5caa42ec5ee2e0cc81ad5b1f38
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - apache2
+        - apache2-dev
+        - curl
+        - pkgconf
+        - mod-auth-openidc-dev
+        - wait-for-it
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        # set -euo pipefail
+        # Create a simple oidc response to parse with the module
+        echo '{"issuer":"", "authorization_endpoint":"http://localhost:8081"}' > /tmp/index.html
+
+        cat > /tmp/test.conf << 'EOF'
+        ServerName localhost
+        ErrorLog /tmp/error.log
+        LogLevel warn
+        LoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so
+        LoadModule authz_core_module /usr/lib/apache2/modules/mod_authz_core.so
+        LoadModule authn_core_module /usr/lib/apache2/modules/mod_authn_core.so
+        LoadModule authz_user_module /usr/lib/apache2/modules/mod_authz_user.so
+        LoadModule dir_module /usr/lib/apache2/modules/mod_dir.so
+        LoadModule unixd_module /usr/lib/apache2/modules/mod_unixd.so
+        LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
+        DirectoryIndex index.html
+        Listen 8080
+        Listen 8081
+        <VirtualHost *:8080>
+          DocumentRoot /tmp
+          OIDCProviderMetadataURL http://localhost:8081
+          OIDCClientID test
+          OIDCClientSecret secret
+          OIDCRedirectURI http://localhost:8080/redirect_uri
+          OIDCCryptoPassphrase test
+          <Location />
+            AuthType openid-connect
+            Require valid-user
+          </Location>
+        </VirtualHost>
+        <VirtualHost *:8081>
+          DocumentRoot /tmp
+        </VirtualHost>
+        EOF
+
+        apachectl -f /tmp/test.conf -k start
+        wait-for-it localhost:8080 -t 10
+
+        # Test OIDC headers - cookie and redirect can only come from working module
+        RESPONSE=$(curl -f -s -i http://localhost:8080)
+        echo "$RESPONSE" | grep 'Set-Cookie: mod_auth_openidc_state'
+        echo "$RESPONSE" | grep 'Location: http://localhost:8081?response_type=code&scope=openid'
+
+        apachectl -f /tmp/test.conf -k stop
+
+subpackages:
+  - name: mod-auth-openidc-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - mod-auth-openidc
+        - apache2-dev
+        - cjose-dev
+        - jansson-dev
+        - openssl-dev
+    description: mod-auth-openidc dev
+
+update:
+  enabled: true
+  github:
+    identifier: openidc/mod_auth_openidc
+    strip-prefix: v
+    use-tag: true

--- a/mod-auth-openidc.yaml
+++ b/mod-auth-openidc.yaml
@@ -10,20 +10,12 @@ environment:
   contents:
     packages:
       - apache2-dev
-      - apr-util-dev
       - autoconf
-      - automake
       - build-base
-      - busybox
-      - ca-certificates-bundle
       - cjose-dev
       - curl-dev
-      - git
-      - hiredis-dev
       - jansson-dev
-      - libapr-dev
       - libtool
-      - openssl-dev
       - pcre2-dev
       - pkgconf-dev
 


### PR DESCRIPTION
Adds mod-auth-openidc for Apache - cjose is maintained fork that include openssl 3.x support.

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates


**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```
