### PR TITLE
openjdk-8: fix shellcheck errors

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.452.09 # this corresponds to same release as jdk8u452-ga / jdk8u452-b09
-  epoch: 3
+  epoch: 4
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -140,9 +140,14 @@ pipeline:
       esac
 
       # Remove extras not needed for headless installs
-      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/{libjsound,libjsoundalsa,libsplashscreen,libawt*,libfontmanager}.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/libjsound.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/libjsoundalsa.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/libsplashscreen.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/libawt*.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/libfontmanager.so
       rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/bin/policytool
-      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/{policytool,appletviewer}
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/policytool
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/appletviewer
 
   - uses: strip
 


### PR DESCRIPTION
This is a functional change. Here's the shellcheck error:

```
In openjdk-8zr4dmprv line 13:
rm -f "/home/build/melange-out/openjdk-8"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/{libjsound,libjsoundalsa,libsplashscreen,libawt*,libfontmanager}.so
                                                                                       ^-- SC3009 (error): In dash, brace expansion is not supported.

In openjdk-8zr4dmprv line 15:
rm -f "/home/build/melange-out/openjdk-8"/usr/lib/jvm/java-1.8-openjdk/bin/{policytool,appletviewer}
                                                                           ^-----------------------^ SC3009 (error): In dash, brace expansion is not supported.

For more information:
  https://www.shellcheck.net/wiki/SC3009 -- In dash, brace expansion is not s...
```

shellcheck is correct, which mean these files weren't actually getting rm'd.
Here's a before/after diff that shows that they are now being removed:

```
$ for lst in openjdk-*-r3.apk.lst; do diff -u $lst $(echo $lst | sed 's/r3/r4/'); done
--- openjdk-8-8.452.09-r3.apk.lst
+++ openjdk-8-8.452.09-r4.apk.lst
@@ -9,7 +9,6 @@
 usr/lib/jvm/java-1.8-openjdk/LICENSE
 usr/lib/jvm/java-1.8-openjdk/THIRD_PARTY_README
 usr/lib/jvm/java-1.8-openjdk/bin
-usr/lib/jvm/java-1.8-openjdk/bin/appletviewer
 usr/lib/jvm/java-1.8-openjdk/bin/clhsdb
 usr/lib/jvm/java-1.8-openjdk/bin/extcheck
 usr/lib/jvm/java-1.8-openjdk/bin/hsdb
@@ -37,7 +36,6 @@
 usr/lib/jvm/java-1.8-openjdk/bin/jstat
 usr/lib/jvm/java-1.8-openjdk/bin/jstatd
 usr/lib/jvm/java-1.8-openjdk/bin/native2ascii
-usr/lib/jvm/java-1.8-openjdk/bin/policytool
 usr/lib/jvm/java-1.8-openjdk/bin/rmic
 usr/lib/jvm/java-1.8-openjdk/bin/schemagen
 usr/lib/jvm/java-1.8-openjdk/bin/serialver
@@ -144,4 +142,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/openjdk-8-8.452.09-r3.spdx.json
+var/lib/db/sbom/openjdk-8-8.452.09-r4.spdx.json
--- openjdk-8-default-jdk-8.452.09-r3.apk.lst
+++ openjdk-8-default-jdk-8.452.09-r4.apk.lst
@@ -5,4 +5,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/openjdk-8-default-jdk-8.452.09-r3.spdx.json
+var/lib/db/sbom/openjdk-8-default-jdk-8.452.09-r4.spdx.json
--- openjdk-8-default-jvm-8.452.09-r3.apk.lst
+++ openjdk-8-default-jvm-8.452.09-r4.apk.lst
@@ -9,4 +9,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/openjdk-8-default-jvm-8.452.09-r3.spdx.json
+var/lib/db/sbom/openjdk-8-default-jvm-8.452.09-r4.spdx.json
--- openjdk-8-demos-8.452.09-r3.apk.lst
+++ openjdk-8-demos-8.452.09-r4.apk.lst
@@ -563,4 +563,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/openjdk-8-demos-8.452.09-r3.spdx.json
+var/lib/db/sbom/openjdk-8-demos-8.452.09-r4.spdx.json
--- openjdk-8-jre-8.452.09-r3.apk.lst
+++ openjdk-8-jre-8.452.09-r4.apk.lst
@@ -36,11 +36,7 @@
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/jli/libjli.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/jvm.cfg
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libattach.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libawt.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libawt_headless.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libawt_xawt.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libdt_socket.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libfontmanager.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libhprof.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libinstrument.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libj2gss.so
@@ -57,15 +53,12 @@
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjdwp.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjsdt.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjsig.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjsound.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libjsoundalsa.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libmanagement.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libmlib_image.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libnet.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libnio.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libnpt.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libsaproc.so
-usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libsplashscreen.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libsunec.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libunpack.so
 usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/libverify.so
@@ -164,4 +157,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/openjdk-8-jre-8.452.09-r3.spdx.json
+var/lib/db/sbom/openjdk-8-jre-8.452.09-r4.spdx.json
```

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
