### PR TITLE
open-webui: fix shellcheck errors

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.18"
-  epoch: 1
+  epoch: 2
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -102,10 +102,13 @@ pipeline:
       for bin in ${{targets.contextdir}}/usr/share/${{package.name}}/bin/*
       do
         # Don't link venv python - clashes with runtime python dep
-        if [[ $bin != *"python"* ]]
-        then
-          ln -sf "/usr/share/${{package.name}}/bin/${bin##*/}" "${{targets.contextdir}}/usr/bin/${bin##*/}"
-        fi
+        case $bin in
+          *"python"*)
+            ;;
+          *)
+            ln -sf "/usr/share/${{package.name}}/bin/${bin##*/}" "${{targets.contextdir}}/usr/bin/${bin##*/}"
+            ;;
+        esac
       done
 
   - name: Copy files from repo
@@ -155,10 +158,13 @@ test:
       runs: |
         for bin in /usr/share/${{package.name}}/bin/*
         do
-          if [[ $bin != *"python"* ]]
-          then
-            readlink -f "/usr/bin/${bin##*/}" | grep "/usr/share/${{package.name}}/bin/${bin##*/}"
-          fi
+          case $bin in
+            *"python"*)
+              ;;
+            *)
+              readlink -f "/usr/bin/${bin##*/}" | grep "/usr/share/${{package.name}}/bin/${bin##*/}"
+              ;;
+          esac
         done
     - uses: test/daemon-check-output
       working-directory: /app/backend


### PR DESCRIPTION
```
In open-webuiilush5c_ line 4:
	if [[ $bin != *"python"* ]]; then
                      ^--------^ SC2330 (error): BusyBox [[ .. ]] does not support glob matching. Use a case statement.

In open-webuinu3vx969 line 2:
	if [[ $bin != *"python"* ]]; then
                      ^--------^ SC2330 (error): BusyBox [[ .. ]] does not support glob matching. Use a case statement.

For more information:
  https://www.shellcheck.net/wiki/SC2330 -- BusyBox [[ .. ]] does not support...
```
Demonstration that this did not change file manifests:

```
$ for pkg in open-webui-*.apk; do tar tfz $pkg > $pkg.lst 2> /dev/null; done
$ for lst in open-webui-*-r1.apk.lst; do diff -u $lst $(echo $lst | sed 's/r1/r2/'); done
--- open-webui-0.6.18-r1.apk.lst
+++ open-webui-0.6.18-r2.apk.lst
@@ -55105,4 +55105,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/open-webui-0.6.18-r1.spdx.json
+var/lib/db/sbom/open-webui-0.6.18-r2.spdx.json
--- open-webui-compat-0.6.18-r1.apk.lst
+++ open-webui-compat-0.6.18-r2.apk.lst
@@ -13,4 +13,4 @@
 var/lib
 var/lib/db
 var/lib/db/sbom
-var/lib/db/sbom/open-webui-compat-0.6.18-r1.spdx.json
+var/lib/db/sbom/open-webui-compat-0.6.18-r2.spdx.json
```

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
