### PR TITLE
gcc(-14): fix shellcheck issue and a bug it found 

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -220,7 +220,9 @@ subpackages:
           done
           mv "${{targets.destdir}}"/usr/bin/*fortran* "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/libgfortran* "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/
-          [ -f "${{targets.destdir}}"/usr/lib/libquadmath* ] && mv "${{targets.destdir}}"/usr/lib/libquadmath* "${{targets.subpkgdir}}"/usr/lib
+          for f in "${{targets.destdir}}"/usr/lib/libquadmath*; do
+            [ -f "$f" ] && mv "$f" "${{targets.subpkgdir}}"/usr/lib
+          done
 
           mv "${{targets.destdir}}"/$_libdir/finclude "${{targets.subpkgdir}}"/$_libdir
           mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 15.1.0
-  epoch: 3
+  epoch: 4
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -207,7 +207,9 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/bin/*fortran "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/lib/libgfortran* "${{targets.subpkgdir}}"/usr/lib
-          [ -f "${{targets.destdir}}"/usr/lib/libquadmath* ] && mv "${{targets.destdir}}"/usr/lib/libquadmath* "${{targets.subpkgdir}}"/usr/lib
+          for f in "${{targets.destdir}}"/usr/lib/libquadmath*; do
+            [ -f "$f" ] && mv "$f" "${{targets.subpkgdir}}"/usr/lib
+          done
 
           mv "${{targets.destdir}}"/$_libdir/finclude "${{targets.subpkgdir}}"/$_libdir
           mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir


### PR DESCRIPTION
This fixes the same shellcheck-detected issue in both `gcc` and `gcc-14`. For `gcc`, this actually fixes a bug where we were putting `libquadmath*` in the `gcc` package instead of the `gfortran` package.

