### PR TITLE
keycloak-config-cli: fix shellcheck errors

### DIFF
--- a/keycloak-config-cli.yaml
+++ b/keycloak-config-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-config-cli
   version: 6.4.0
-  epoch: 46
+  epoch: 47
   description: Import YAML/JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
   copyright:
     - license: Apache-2.0
@@ -95,10 +95,11 @@ subpackages:
 
           for versions in 26.0.5,26.0.2 25.0.1,25.0.1 24.0.5,24.0.5
           do
-            IFS=, read -ra keycloak_versions <<< "${versions}"
-            IFS=. read -ra keycloak_semver <<< "${keycloak_versions[0]}"
+            keycloak_version="${versions%%,*}"
+            keycloak_major_version="${keycloak_version%%.*}"
+            keycloak_client_version="${versions##*,}"
 
-            if [ "${keycloak_semver[0]}" -lt 26 ]
+            if [ "${keycloak_major_version}" -lt 26 ]
             then
               compatibility='-Ppre-keycloak26'
             else
@@ -107,8 +108,8 @@ subpackages:
 
             ./mvnw ${MAVEN_CLI_OPTS} clean package \
               -Dcheckstyle.skip \
-              -Dkeycloak.client.version="${keycloak_versions[1]}" \
-              -Dkeycloak.version="${keycloak_versions[0]}" \
+              -Dkeycloak.client.version="${keycloak_client_version}" \
+              -Dkeycloak.version="${keycloak_version}" \
               -Dlicense.skipCheckLicense \
               -Dmaven.gitcommitid.skip=true \
               -Dmaven.javadoc.skip=true \
@@ -117,7 +118,7 @@ subpackages:
               -DskipTests \
               $compatibility
 
-            cp ./target/${{package.name}}.jar ${{targets.contextdir}}/usr/share/java/${{package.name}}/${{package.name}}-${keycloak_versions[0]}.jar
+            cp ./target/${{package.name}}.jar ${{targets.contextdir}}/usr/share/java/${{package.name}}/${{package.name}}-${keycloak_version}.jar
           done
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami
@@ -186,10 +187,11 @@ subpackages:
 
           for versions in 26.0.5,26.0.2 25.0.1,25.0.1 24.0.5,24.0.5
           do
-            IFS=, read -ra keycloak_versions <<< "${versions}"
-            IFS=. read -ra keycloak_semver <<< "${keycloak_versions[0]}"
+            keycloak_version="${versions%%,*}"
+            keycloak_major_version="${keycloak_version%%.*}"
+            keycloak_client_version="${versions##*,}"
 
-            if [ "${keycloak_semver[0]}" -lt 26 ]
+            if [ "${keycloak_major_version}" -lt 26 ]
             then
               compatibility='-Ppre-keycloak26'
             else
@@ -198,8 +200,8 @@ subpackages:
 
             ./mvnw ${MAVEN_CLI_OPTS} clean package \
               -Dcheckstyle.skip \
-              -Dkeycloak.client.version="${keycloak_versions[1]}" \
-              -Dkeycloak.version="${keycloak_versions[0]}" \
+              -Dkeycloak.client.version="${keycloak_client_version}" \
+              -Dkeycloak.version="${keycloak_version}" \
               -Dlicense.skipCheckLicense \
               -Dmaven.gitcommitid.skip=true \
               -Dmaven.javadoc.skip=true \
@@ -208,7 +210,7 @@ subpackages:
               -DskipTests \
               $compatibility
 
-            cp ./target/${{package.name}}.jar ${{targets.contextdir}}/usr/share/java/${{package.name}}/${{package.name}}-${keycloak_versions[0]}.jar
+            cp ./target/${{package.name}}.jar ${{targets.contextdir}}/usr/share/java/${{package.name}}/${{package.name}}-${keycloak_version}.jar
           done
       - runs: |
           mkdir -p /opt/iamguarded


### PR DESCRIPTION
```
In keycloak-config-clijzaxo45o line 3:
	IFS=, read -ra keycloak_versions <<<"${versions}"
                   ^-^ SC3045 (error): In dash, read -a is not supported.
                                         ^-^ SC3011 (error): In dash, here-strings are not supported.

In keycloak-config-clijzaxo45o line 4:
	IFS=. read -ra keycloak_semver <<<"${keycloak_versions[0]}"
                   ^-^ SC3045 (error): In dash, read -a is not supported.
                                       ^-^ SC3011 (error): In dash, here-strings are not supported.
                                           ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clijzaxo45o line 6:
	if [ "${keycloak_semver[0]}" -lt 26 ]; then
              ^-------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clijzaxo45o line 14:
		-Dkeycloak.client.version="${keycloak_versions[1]}" \
                                           ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clijzaxo45o line 15:
		-Dkeycloak.version="${keycloak_versions[0]}" \
                                    ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clijzaxo45o line 24:
	cp ./target/keycloak-config-cli.jar /home/build/melange-out/keycloak-config-cli-bitnami-compat/usr/share/java/keycloak-config-cli/keycloak-config-cli-${keycloak_versions[0]}.jar
                                                                                                                                                              ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clibdpj3g3n line 3:
	IFS=, read -ra keycloak_versions <<<"${versions}"
                   ^-^ SC3045 (error): In dash, read -a is not supported.
                                         ^-^ SC3011 (error): In dash, here-strings are not supported.

In keycloak-config-clibdpj3g3n line 4:
	IFS=. read -ra keycloak_semver <<<"${keycloak_versions[0]}"
                   ^-^ SC3045 (error): In dash, read -a is not supported.
                                       ^-^ SC3011 (error): In dash, here-strings are not supported.
                                           ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clibdpj3g3n line 6:
	if [ "${keycloak_semver[0]}" -lt 26 ]; then
              ^-------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clibdpj3g3n line 14:
		-Dkeycloak.client.version="${keycloak_versions[1]}" \
                                           ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clibdpj3g3n line 15:
		-Dkeycloak.version="${keycloak_versions[0]}" \
                                    ^---------------------^ SC3054 (error): In dash, array references are not supported.

In keycloak-config-clibdpj3g3n line 24:
	cp ./target/keycloak-config-cli.jar /home/build/melange-out/keycloak-config-cli-iamguarded-compat/usr/share/java/keycloak-config-cli/keycloak-config-cli-${keycloak_versions[0]}.jar
                                                                                                                                                                 ^---------------------^ SC3054 (error): In dash, array references are not supported.

For more information:
  https://www.shellcheck.net/wiki/SC3011 -- In dash, here-strings are not sup...
  https://www.shellcheck.net/wiki/SC3045 -- In dash, read -a is not supported.
  https://www.shellcheck.net/wiki/SC3054 -- In dash, array references are not...
```

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
