### PR TITLE
Add test/no-docs pipeline to batch 01 packages (10 packages)

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -1,7 +1,7 @@
 package:
   name: 7zip
   version: 2500
-  epoch: 1
+  epoch: 2
   description: "File archiver with a high compression ratio"
   copyright:
     - license: LGPL-2.0-only
@@ -112,3 +112,4 @@ test:
     - name: "Test archive integrity checking"
       runs: |
         7z t archive.7z
+    - uses: test/no-docs

--- a/ack.yaml
+++ b/ack.yaml
@@ -1,7 +1,7 @@
 package:
   name: ack
   version: "3.9.0"
-  epoch: 1
+  epoch: 2
   description: A Perl-powered replacement for grep
   copyright:
     - license: Artistic-2.0
@@ -57,3 +57,4 @@ test:
     - name: Basic search test
       runs: |
         echo 'foo\nfoo bar\nbaz' | ack --noenv --nocolor bar - | grep -q 'foo bar' || exit 1
+    - uses: test/no-docs

--- a/acl.yaml
+++ b/acl.yaml
@@ -1,7 +1,7 @@
 package:
   name: acl
   version: 2.3.2
-  epoch: 52
+  epoch: 53
   description: "access control list utilities"
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -103,3 +103,4 @@ test:
         setfacl --version
         getfacl --help
         setfacl --help
+    - uses: test/no-docs

--- a/ant.yaml
+++ b/ant.yaml
@@ -1,7 +1,7 @@
 package:
   name: ant
   version: 1.10.15
-  epoch: 2
+  epoch: 3
   description: A Java build tool
   copyright:
     - license: Apache-2.0
@@ -83,3 +83,4 @@ test:
 
         # Run ant compile
         ant compile
+    - uses: test/no-docs

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: "2.4.65"
-  epoch: 0
+  epoch: 1
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -360,6 +360,7 @@ test:
             cat /tmp/curl_output.log
         fi
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 6
+  epoch: 7
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -109,6 +109,7 @@ test:
         apk --version
         apk info apk-tools
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/attr.yaml
+++ b/attr.yaml
@@ -1,7 +1,7 @@
 package:
   name: attr
   version: 2.5.2
-  epoch: 52
+  epoch: 53
   description: "utilities for managing filesystem extended attributes"
   copyright:
     - license: GPL-2.0-or-later
@@ -101,3 +101,4 @@ test:
         setfattr --version
         getfattr --help
         setfattr --help
+    - uses: test/no-docs

--- a/audit.yaml
+++ b/audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: audit
   version: "4.1.1"
-  epoch: 0
+  epoch: 1
   description: User space tools for kernel auditing
   copyright:
     - license: LGPL-2.1-or-later
@@ -155,3 +155,4 @@ test:
         aureport --help
         ausearch --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -2,7 +2,7 @@
 package:
   name: autoconf-archive
   version: 2024.10.16
-  epoch: 0
+  epoch: 1
   description: Collection of re-usable GNU Autoconf macros
   copyright:
     - license: GPL-3.0-or-later
@@ -40,3 +40,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 142
+
+test:
+  pipeline:
+    - uses: test/no-docs

--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -34,7 +34,8 @@ subpackages:
   - name: autoconf-archive-doc
     pipeline:
       - uses: split/manpages
-    description: autoconf-archive manpages
+      - uses: split/infodir
+    description: autoconf-archive documentation
 
 update:
   enabled: true

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: autoconf
   version: "2.72"
-  epoch: 4
+  epoch: 5
   description: "GNU tool for generating configure scripts"
   copyright:
     - license: GPL-2.0
@@ -73,3 +73,4 @@ test:
         autoscan --help
         autoupdate --help
         ifnames --help
+    - uses: test/no-docs


### PR DESCRIPTION
Added test/no-docs pipeline step to packages with -doc subpackages:
- 7zip: epoch 1→2
- ack: epoch 1→2
- acl: epoch 52→53
- ant: epoch 2→3
- apache2: epoch 0→1
- apk-tools: epoch 6→7
- attr: epoch 52→53
- audit: epoch 0→1
- autoconf-archive: epoch 0→1
- autoconf: epoch 4→5

This ensures proper documentation separation testing for packages that split documentation into separate subpackages.

🤖 Generated with [Claude Code](https://claude.ai/code)