### PR TITLE
Add test/no-docs pipeline to batch 4 packages

### DIFF
--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: "1.34.5"
-  epoch: 2
+  epoch: 3
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT
@@ -66,3 +66,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/cairomm-1.16.yaml
+++ b/cairomm-1.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: cairomm-1.16
   version: 1.16.2
-  epoch: 1
+  epoch: 2
   description: This library provides a C++ interface to cairo.
   copyright:
     - license: LGPL-2.1-or-later
@@ -74,3 +74,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/cairomm.yaml
+++ b/cairomm.yaml
@@ -1,7 +1,7 @@
 package:
   name: cairomm
   version: 1.18.0
-  epoch: 2
+  epoch: 3
   description: This library provides a C++ interface to cairo.
   copyright:
     - license: LGPL-2.1-or-later
@@ -76,3 +76,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/cargo-audit.yaml
+++ b/cargo-audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-audit
   version: "0.21.2"
-  epoch: 5
+  epoch: 6
   description: Audit your dependencies for crates with security vulnerabilities reported to the RustSec Advisory Database.
   copyright:
     - license: MIT OR Apache-2.0
@@ -54,3 +54,4 @@ test:
       runs: |
         cargo-audit --version || exit 1
         cargo-audit --help
+    - uses: test/no-docs

--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-auditable
   version: "0.7.0"
-  epoch: 1
+  epoch: 2
   description: Cargo wrapper for embedding auditing data
   copyright:
     - license: MIT OR Apache-2.0
@@ -59,3 +59,7 @@ update:
     identifier: rust-secure-code/cargo-auditable
     use-tag: true
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/no-docs

--- a/ccache.yaml
+++ b/ccache.yaml
@@ -1,7 +1,7 @@
 package:
   name: ccache
   version: "4.11.3"
-  epoch: 2
+  epoch: 3
   description: Fast C/C++ compiler cache
   copyright:
     - license: GPL-3.0-or-later
@@ -55,6 +55,7 @@ test:
     - runs: |
         ccache --version
         ccache --help
+    - uses: test/no-docs
 
 subpackages:
   - name: ccache-doc

--- a/cdparanoia.yaml
+++ b/cdparanoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdparanoia
   version: 10.2
-  epoch: 6
+  epoch: 7
   description: An audio CD extraction application
   copyright:
     - license: GPL-2.0-or-later
@@ -103,3 +103,4 @@ test:
     - runs: |
         cdparanoia --version
         cdparanoia --help
+    - uses: test/no-docs

--- a/cdrkit.yaml
+++ b/cdrkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdrkit
   version: 1.1.11
-  epoch: 3
+  epoch: 4
   description: Suite of programs for CD/DVD recording, ISO image creation, and audio CD extraction
   copyright:
     - license: GPL-2.0-only
@@ -118,3 +118,4 @@ test:
         mkdir input && echo "hello" > input/file.txt
         genisoimage -o out.iso input
         file out.iso | grep -q "ISO 9660"
+    - uses: test/no-docs

--- a/ceph.yaml
+++ b/ceph.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph
   version: "19.2.3"
   description: Distributed object, block, and file storage
-  epoch: 2
+  epoch: 3
   copyright:
     - license: LGPL-2.1
   resources:
@@ -368,6 +368,7 @@ test:
         ceph osd pool autoscale-status
 
         ceph -s
+    - uses: test/no-docs
 
 ## Currently, version 19.2.1 is the latest active version for ceph.
 ## While 20.0.0 is available, it is still early days. Therefore, we are not updating the version to 20.0.0.

--- a/check.yaml
+++ b/check.yaml
@@ -1,7 +1,7 @@
 package:
   name: check
   version: 0.15.2
-  epoch: 3
+  epoch: 4
   description: A unit test framework for C
   copyright:
     - license: LGPL-2.1-or-later
@@ -65,3 +65,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
Batch 4 includes 10 packages with -doc subpackages:
- cairomm-1.16: 1.16.2-r1 → r2
- cairomm: 1.18.0-r2 → r3
- c-ares: 1.34.5-r2 → r3
- cargo-auditable: 0.7.0-r1 → r2
- cargo-audit: 0.21.2-r5 → r6
- ccache: 4.11.3-r2 → r3
- cdparanoia: 10.2-r6 → r7
- cdrkit: 1.1.11-r3 → r4
- ceph: 19.2.3-r2 → r3
- check: 0.15.2-r3 → r4

All packages tested successfully. This continues the systematic addition of test/no-docs pipeline to packages with -doc subpackages.

🤖 Generated with [Claude Code](https://claude.ai/code)