### PR TITLE
Add test/no-docs pipeline to batch 5 packages

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -8,7 +8,7 @@
 package:
   name: chromium
   version: "138.0.7204.183"
-  epoch: 2
+  epoch: 3
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -435,3 +435,4 @@ test:
         chromium --version
         chromium-browser --version
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.7"
-  epoch: 2
+  epoch: 3
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -118,3 +118,4 @@ test:
         chronyc --version
         chronyc --help
         chronyd --help
+    - uses: test/no-docs

--- a/chrpath.yaml
+++ b/chrpath.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrpath
   version: 0.16
-  epoch: 1
+  epoch: 2
   description: "Modify rpath of compiled programs"
   copyright:
     - license: GPL-2.0-or-later
@@ -49,3 +49,4 @@ test:
     - runs: |
         chrpath --version
         chrpath --help
+    - uses: test/no-docs

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.4"
-  epoch: 3
+  epoch: 4
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later
@@ -89,3 +89,4 @@ test:
         setcifsacl -h
         cifs.idmap --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: "1.4.3"
-  epoch: 1
+  epoch: 2
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -407,3 +407,4 @@ test:
         clamsubmit --version
         clamsubmit --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/collectd.yaml
+++ b/collectd.yaml
@@ -6,7 +6,7 @@
 package:
   name: collectd
   version: 5.12.0
-  epoch: 43
+  epoch: 44
   description: "The system statistics collection daemon."
   copyright:
     - license: MIT
@@ -190,6 +190,7 @@ test:
         collectdmon --version
         collectdmon --help
     - uses: test/pkgconf
+    - uses: test/no-docs
 
 subpackages:
   - name: collectd-doc

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-common-docker
   version: 7.6.0
-  epoch: 17
+  epoch: 18
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0
@@ -68,3 +68,4 @@ test:
   pipeline:
     - runs: |
         ub -h
+    - uses: test/no-docs

--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-docker-utils
   version: "0.0.162"
-  epoch: 2
+  epoch: 3
   description: This package provides Docker Utility Belt (dub) and Confluent Platform Utility Belt (cub).
   copyright:
     - license: Apache-2.0
@@ -99,3 +99,4 @@ test:
       with:
         import: confluent.docker_utils
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/conmon.yaml
+++ b/conmon.yaml
@@ -1,7 +1,7 @@
 package:
   name: conmon
   version: "2.1.13"
-  epoch: 2
+  epoch: 3
   description: OCI container runtime monitor
   copyright:
     - license: Apache-2.0
@@ -52,3 +52,4 @@ test:
     - name: Verify conmon installation
       runs: |
         conmon --version || exit 1
+    - uses: test/no-docs

--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: conntrack-tools
   version: "1.4.8"
-  epoch: 40
+  epoch: 41
   description: Connection tracking userspace tools
   copyright:
     - license: GPL-2.0-or-later
@@ -84,3 +84,4 @@ test:
         conntrack --help
         conntrackd --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
Batch 5 includes 10 packages with -doc subpackages:
- chromium: 138.0.7204.183-r2 → r3
- chrony: 4.7-r2 → r3
- chrpath: 0.16-r1 → r2
- cifs-utils: 7.4-r3 → r4
- clamav-1.4: 1.4.3-r1 → r2
- collectd: 5.12.0-r43 → r44
- confluent-common-docker: 7.6.0-r17 → r18
- confluent-docker-utils: 0.0.162-r2 → r3
- conmon: 2.1.13-r2 → r3
- conntrack-tools: 1.4.8-r40 → r41

9/10 packages tested successfully (conntrack-tools has known test failure). This continues the systematic addition of test/no-docs pipeline to packages with -doc subpackages.

🤖 Generated with [Claude Code](https://claude.ai/code)