### PR TITLE
Add test/no-docs pipeline to batch 07 packages

### DIFF
--- a/dash.yaml
+++ b/dash.yaml
@@ -3,7 +3,7 @@
 package:
   name: dash
   version: 0.5.12
-  epoch: 30
+  epoch: 31
   description: Small and fast POSIX-compliant shell
   copyright:
     - license: BSD-3-Clause AND GPL-2.0-or-later
@@ -54,6 +54,7 @@ test:
         [ -n "$$" ] || fail "env var \$\$ not set"
         EOF
         dash -v
+    - uses: test/no-docs
 
 subpackages:
   - name: dash-doc

--- a/db.yaml
+++ b/db.yaml
@@ -1,7 +1,7 @@
 package:
   name: db
   version: 5.3.28
-  epoch: 5
+  epoch: 6
   description: The Berkeley DB embedded database system
   copyright:
     - license: LicenseRef-berkeley-db
@@ -105,3 +105,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/dbus-glib.yaml
+++ b/dbus-glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: dbus-glib
   version: "0.114"
-  epoch: 0
+  epoch: 1
   description: GLib bindings for DBUS
   copyright:
     - license: AFL-2.1 OR GPL-2.0-or-later
@@ -63,3 +63,4 @@ test:
         dbus-binding-tool --version
         dbus-binding-tool --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/dbus.yaml
+++ b/dbus.yaml
@@ -1,7 +1,7 @@
 package:
   name: dbus
   version: "1.16.2"
-  epoch: 2
+  epoch: 3
   description: Freedesktop.org message bus system
   copyright:
     - license: AFL-2.1 OR GPL-2.0-or-later
@@ -114,3 +114,4 @@ test:
         dbus-cleanup-sockets --help
         dbus-run-session --help
         dbus-uuidgen --help
+    - uses: test/no-docs

--- a/dhclient.yaml
+++ b/dhclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: dhclient
   version: 4.4.3
-  epoch: 42
+  epoch: 43
   description: dhcp client program
   copyright:
     - license: BSD-2-Clause
@@ -81,6 +81,7 @@ test:
         dhcpd --help
         dhcrelay --version
         dhcrelay --help
+    - uses: test/no-docs
 
 subpackages:
   - name: dhclient-doc

--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -1,7 +1,7 @@
 package:
   name: dhcping
   version: 1.2
-  epoch: 4
+  epoch: 5
   description: dhcp daemon ping program
   copyright:
     - license: BSD-2-Clause
@@ -49,6 +49,7 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: false

--- a/dieharder.yaml
+++ b/dieharder.yaml
@@ -1,7 +1,7 @@
 package:
   name: dieharder
   version: 3.31.1.4
-  epoch: 2
+  epoch: 3
   description: Random-number generator test front-end
   copyright:
     - license: GPL-2.0-or-later
@@ -57,3 +57,4 @@ test:
     - runs: |
         dieharder --version
         dieharder --help
+    - uses: test/no-docs

--- a/diffutils.yaml
+++ b/diffutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: diffutils
   version: "3.12"
-  epoch: 2
+  epoch: 3
   description: "GNU diff utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -63,3 +63,4 @@ test:
         diff --help
         diff3 --help
         sdiff --help
+    - uses: test/no-docs

--- a/dmidecode.yaml
+++ b/dmidecode.yaml
@@ -2,7 +2,7 @@
 package:
   name: dmidecode
   version: "3.6"
-  epoch: 40
+  epoch: 41
   description: A utility for reporting system hardware as described by BIOS
   copyright:
     - license: GPL-2.0-or-later
@@ -119,6 +119,7 @@ test:
           dmidecode --from-dump $bin > "$test_out"
           diff -u "$test_out" "$expected_out"
         done
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/dnsmasq.yaml
+++ b/dnsmasq.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnsmasq
   version: "2.91"
-  epoch: 40
+  epoch: 41
   description: dnsmasq provides Domain Name System caching, a Dynamic Host Configuration Protocol server, router advertisement and network boot features
   copyright:
     - license: GPL-2.0-or-later
@@ -65,3 +65,4 @@ test:
         dnsmasq -v
         dnsmasq --version
         dnsmasq --help
+    - uses: test/no-docs


### PR DESCRIPTION
Batch 07 includes 10 packages with -doc subpackages:
- dash: 0.5.12-r30 → r31
- db: 5.3.28-r5 → r6
- dbus-glib: 0.114-r0 → r1
- dbus: 1.16.2-r2 → r3
- dhclient: 4.4.3-r42 → r43
- dhcping: 1.2-r4 → r5
- dieharder: 3.31.1.4-r2 → r3
- diffutils: 3.12-r2 → r3
- dmidecode: 3.6-r40 → r41
- dnsmasq: 2.91-r40 → r41

All packages tested successfully. This continues the systematic addition of test/no-docs pipeline to packages with -doc subpackages.

🤖 Generated with [Claude Code](https://claude.ai/code)