### PR TITLE
adds libpostal package

### DIFF
--- a/libpostal.yaml
+++ b/libpostal.yaml
@@ -47,6 +47,11 @@ pipeline:
 
   - uses: autoconf/make-install
 
+  - name: Create symlink for canonical share dir
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/share
+      ln -sf /usr/lib/libpostal ${{targets.destdir}}/usr/share/libpostal
+
   - uses: strip
 
 subpackages:
@@ -69,3 +74,36 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - libpostal-dev
+    environment:
+      LIBPOSTAL_DATA_DIR: /usr/share/libpostal
+  pipeline:
+    - name: Compile & run minimal parser
+      runs: |
+        cat > test_parse.c <<'EOF'
+        #include <libpostal/libpostal.h>
+        int main(void) {
+            if (!libpostal_setup() || !libpostal_setup_parser()) return 1;
+            char address[] = "781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA";
+            libpostal_address_parser_options_t opts =
+                libpostal_get_address_parser_default_options();
+            libpostal_address_parser_response_t *r =
+                libpostal_parse_address(address, opts);
+            if (!r || r->num_components == 0) return 1;
+            libpostal_address_parser_response_destroy(r);
+            libpostal_teardown_parser();
+            libpostal_teardown();
+            return 0;
+        }
+        EOF
+        gcc test_parse.c $(pkg-config --cflags --libs libpostal) -o test_parse
+        # This is a negative test, we expect an error when trying to load the transliteration module
+        # without having downloaded or installed the data.
+        set -e
+        ./test_parse 2>&1 | grep -q "Error loading transliteration module"

--- a/libpostal.yaml
+++ b/libpostal.yaml
@@ -1,0 +1,71 @@
+package:
+  name: libpostal
+  version: 1.1
+  epoch: 0
+  description: A C library for parsing/normalizing street addresses around the world. Powered by statistical NLP and open geo data-j8
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - file
+      - libtool
+      - mtdev-dev
+      - pkgconf-dev
+  environment:
+    CFLAGS: -Wno-incompatible-pointer-types # https://github.com/openvenues/libpostal/issues/677
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openvenues/libpostal
+      expected-commit: 9c975972985b54491e756efd70e416f18ff97958
+      tag: v${{package.version}}
+
+  - runs: ./bootstrap.sh
+
+  - assertions:
+      required-steps: 1
+    pipeline:
+      - if: ${{build.arch}} == "x86_64"
+        uses: autoconf/configure
+        with:
+          opts: |
+            --disable-data-download
+      - if: ${{build.arch}} == "aarch64"
+        uses: autoconf/configure
+        with:
+          opts: |
+            --disable-sse2 \
+            --disable-data-download
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libpostal-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libpostal
+    description: libpostal dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: openvenues/libpostal
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
Needed for amaas 5.x build https://github.com/wolfi-dev/os/pull/61542

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
