### PR TITLE
feat: add cluster-api-aws-controller package

### DIFF
--- a/cluster-api-aws-controller.yaml
+++ b/cluster-api-aws-controller.yaml
@@ -25,7 +25,7 @@ pipeline:
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitCommit=$(git rev-parse HEAD)
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitVersion=$(git describe --dirty --tags --always)
-        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 && echo "clean" || echo "dirty")
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitTreeState=$(git diff --quiet >/dev/null 2>&1 && echo "clean" || echo "dirty")
 
 subpackages:
   - name: ${{package.name}}-compat

--- a/cluster-api-aws-controller.yaml
+++ b/cluster-api-aws-controller.yaml
@@ -25,7 +25,7 @@ pipeline:
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitCommit=$(git rev-parse HEAD)
         -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitVersion=$(git describe --dirty --tags --always)
-        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean")
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 && echo "clean" || echo "dirty")
 
 subpackages:
   - name: ${{package.name}}-compat

--- a/cluster-api-aws-controller.yaml
+++ b/cluster-api-aws-controller.yaml
@@ -1,0 +1,59 @@
+package:
+  name: cluster-api-aws-controller
+  version: "2.8.4"
+  epoch: 0
+  description: Kubernetes Cluster API Provider AWS provides consistent deployment and day 2 operations of "self-managed" and EKS Kubernetes clusters on AWS
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/cluster-api-provider-aws
+      tag: v${{package.version}}
+      expected-commit: 49658babd14cb9590f9fef8330243d530f7d6602
+
+  - uses: go/build
+    with:
+      packages: .
+      output: cluster-api-aws-controller
+      ldflags: |
+        -buildid= ""
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitVersion=$(git describe --dirty --tags --always)
+        -X sigs.k8s.io/cluster-api-provider-aws/v2/version.gitTreeState=$(shell git diff --quiet >/dev/null 2>&1 || echo "dirty" || echo "clean")
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for cluster-api-aws-controller"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s ./usr/bin/cluster-api-aws-controller ${{targets.subpkgdir}}/manager
+    dependencies:
+      provides:
+        - ${{package.name}}-entrypoint=${{package.full-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: test/tw/symlink-check
+        - runs: |
+            (/manager --help || true) | grep 'help requested'
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/cluster-api-provider-aws
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        (cluster-api-aws-controller version --help || true) | grep 'help requested'


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
