### PR TITLE
toml11 package: Temporary downgrade to release v3.4.0

### DIFF
--- a/toml11.yaml
+++ b/toml11.yaml
@@ -1,7 +1,7 @@
 package:
   name: toml11
-  version: 4.4.0
-  epoch: 1
+  version: 3.4.0
+  epoch: 0
   description: toml11 is a feature-rich TOML language library for C++11/14/17/20.
   copyright:
     - license: MIT
@@ -11,19 +11,23 @@ environment:
     packages:
       - build-base
       - busybox
+      - ca-certificates-bundle
+      - cmake-3
+      - gcc-14-default
       - glibc-dev
+      - samurai
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/ToruNiina/toml11
       tag: v${{package.version}}
-      expected-commit: be08ba2be2a964edcdb3d3e3ea8d100abc26f286
-
-  - name: "Clone submodules" # Only needed for tests and docs
-    runs: git submodule update --init --recursive
+      expected-commit: 31826b55ce7bbd5c1c4a2433a4f26b69f70a081c
 
   - uses: cmake/configure
+    with:
+      opts: |
+        -Dtoml11_BUILD_TEST=OFF
 
   - uses: cmake/build
 


### PR DESCRIPTION
- **toml11** `v3.4.0` is needed for building packages like `FoundationDB`.