### PR TITLE
No change rebuild of packages not built recently

### DIFF
--- a/check.yaml
+++ b/check.yaml
@@ -1,7 +1,7 @@
 package:
   name: check
   version: 0.15.2
-  epoch: 3
+  epoch: 4
   description: A unit test framework for C
   copyright:
     - license: LGPL-2.1-or-later
@@ -64,4 +64,5 @@ update:
 
 test:
   pipeline:
+    - uses: test/no-docs
     - uses: test/tw/ldd-check

--- a/libpfm.yaml
+++ b/libpfm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpfm
   version: 4.13.0
-  epoch: 0
+  epoch: 1
   description: "perfmon libraries"
   copyright:
     - license: MIT


### PR DESCRIPTION
These packages have not been rebuild recently and subsequently do not have .melange.yaml files and are missing some package SBOM features. Let's fix that by rebuilding them.