### PR TITLE
fix(clickhouse-25.5): remove unnecessary symlink

### DIFF
--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -181,6 +181,8 @@ subpackages:
           # Restore path
           find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
 
+          # Remove existing symlinks that might conflict
+          rm -f /bitnami/clickhouse/data/tmp
           # Find all files in /usr/bin that are either named "clickhouse" or symlinks pointing to "clickhouse"
           for file in ${{targets.destdir}}/usr/bin/*; do
               if [ -f "$file" ] && [ "$(basename "$file")" = "clickhouse" ]; then

--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -181,8 +181,6 @@ subpackages:
           # Restore path
           find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
 
-          # Remove existing symlinks that might conflict
-          rm -f /bitnami/clickhouse/data/tmp
           # Find all files in /usr/bin that are either named "clickhouse" or symlinks pointing to "clickhouse"
           for file in ${{targets.destdir}}/usr/bin/*; do
               if [ -f "$file" ] && [ "$(basename "$file")" = "clickhouse" ]; then
@@ -198,6 +196,8 @@ subpackages:
               fi
           done
 
+          # Remove existing symlinks that might conflict
+          rm -f /bitnami/clickhouse/data/tmp
           ln -s /dev/stdout ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse.log
           ln -s /dev/stderr ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
           mkdir -p ${{targets.contextdir}}/var/lib

--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.5
   version: "25.5.9.14"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
## Changes

This symlink causes failures while using this package: [apk.dag.dev](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/clickhouse-25.5-bitnami-compat-25.5.9.14-r0.apk@sha1:c1cabcc21d9af86cd961bd53db64323c95a92a6f/bitnami/clickhouse/data/). Removing it to fix the image