### PR TITLE
grafana-pyroscope-1.13: remediate cve

### DIFF
--- a/grafana-pyroscope-1.13.yaml
+++ b/grafana-pyroscope-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-pyroscope-1.13
   version: "1.13.5"
-  epoch: 1
+  epoch: 2
   description: Continuous Profiling Platform. Debug performance issues down to a single line of code
   copyright:
     - license: AGPL-3.0-only
@@ -25,6 +25,16 @@ pipeline:
       expected-commit: 73ae7cf6d4f3c6724b07f437345bd201b5382d23
       repository: https://github.com/grafana/pyroscope
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches:
+        remove-oauth2-proxy.patch
+
+  - name: remove oauth2-references
+    runs: |
+      sed -i '/oauth2-proxy/d' go.mod
+      sed -i '/oauth2-proxy/d' go.sum
 
   - runs: |
       # https://github.com/grafana/pyroscope/blob/3da96b8e449de267d4663e14207b8b272f9edc6d/.github/workflows/release.yml#L48C14-L48C33

--- a/grafana-pyroscope-1.13.yaml
+++ b/grafana-pyroscope-1.13.yaml
@@ -28,8 +28,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches:
-        remove-oauth2-proxy.patch
+      patches: remove-oauth2-proxy.patch
 
   - name: remove oauth2-references
     runs: |

--- a/grafana-pyroscope-1.13/remove-oauth2-proxy.patch
+++ b/grafana-pyroscope-1.13/remove-oauth2-proxy.patch
@@ -1,0 +1,99 @@
+diff --git a/pkg/frontend/vcs/encryption.go b/pkg/frontend/vcs/encryption.go
+index b5152efd9..a7b142134 100644
+--- a/pkg/frontend/vcs/encryption.go
++++ b/pkg/frontend/vcs/encryption.go
+@@ -1,53 +1,76 @@
+ package vcs
+ 
+ import (
++	"crypto/aes"
++	"crypto/cipher"
++	"crypto/rand"
+ 	"encoding/base64"
+ 	"encoding/json"
+ 	"errors"
++	"io"
+ 
+-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
+ 	"golang.org/x/oauth2"
+ )
+ 
+-const gcmNonceSize = 12
+-
+ func encryptToken(token *oauth2.Token, key []byte) (string, error) {
+-	cipher, err := encryption.NewGCMCipher(key)
++	plaintext, err := json.Marshal(token)
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	textBytes, err := json.Marshal(token)
++
++	block, err := aes.NewCipher(key)
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	enc, err := cipher.Encrypt(textBytes)
++
++	gcm, err := cipher.NewGCM(block)
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return base64.StdEncoding.EncodeToString(enc), nil
++
++	nonce := make([]byte, gcm.NonceSize())
++	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
++		return "", err
++	}
++
++	// Using nonce as Seal's dst argument results in it being the first
++	// chunk of bytes in the ciphertext. Decrypt retrieves the nonce/IV from this.
++	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
++
++	return base64.StdEncoding.EncodeToString(ciphertext), nil
+ }
+ 
+-func decryptToken(encodedText string, key []byte) (*oauth2.Token, error) {
+-	encryptedData, err := base64.StdEncoding.DecodeString(encodedText)
++func decryptToken(ciphertextBase64 string, key []byte) (*oauth2.Token, error) {
++	ciphertext, err := base64.StdEncoding.DecodeString(ciphertextBase64)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	if len(encryptedData) < gcmNonceSize {
+-		return nil, errors.New("malformed token")
++	block, err := aes.NewCipher(key)
++	if err != nil {
++		return nil, err
+ 	}
+ 
+-	cipher, err := encryption.NewGCMCipher(key)
++	gcm, err := cipher.NewGCM(block)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	plaintext, err := cipher.Decrypt(encryptedData)
++	nonceSize := gcm.NonceSize()
++	if len(ciphertext) < nonceSize {
++		return nil, errors.New("malformed token")
++	}
++	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
++
++	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+ 	var token oauth2.Token
+-	err = json.Unmarshal(plaintext, &token)
+-	return &token, err
++	if err = json.Unmarshal(plaintext, &token); err != nil {
++		return nil, err
++	}
++
++	return &token, nil
+ }
+-- 
+2.50.1
+


### PR DESCRIPTION
remediate CVE-2025-54576
Upstream has pushed a fix to remove oauth2-proxy from their code
https://github.com/grafana/pyroscope/pull/4345

We cherry-pick this fix in order to not have the package vulnerable
anymore.
