### PR TITLE
Bump the version of docker-library

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.3.3"
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -97,11 +97,11 @@ pipeline:
     pipeline:
       - uses: fetch
         with:
-          uri: https://github.com/docker-library/docker/archive/273a2df601253b25e8e98dda8f6675346d7338b8.zip
-          expected-sha256: 6ce21996f0b98a850d01de6f8f9f79e54c8a72a83fabfde6e228d2c43e2567d6
+          uri: https://github.com/docker-library/docker/archive/7d789f6d3ca9d6cef6c7cbcbbefbd6483ee3d2cd.zip
+          expected-sha256: a324d2e31bda34998f6366977812db4bbe5118def671703498bb1ac19d329cfc
           extract: false
       - runs: |
-          unzip -q 273a2df601253b25e8e98dda8f6675346d7338b8.zip
+          unzip -q 7d789f6d3ca9d6cef6c7cbcbbefbd6483ee3d2cd.zip
           mv */** .
 
   # Docker is vehemenetly against stripping the resulting binary


### PR DESCRIPTION
Get the new version of docker-library.
The dockerd-entrypoint,sh includes `-addext  keyUsage=critical,digitalSignature,keyCertSign`
Which Python now requires to be set on CA certificates.