### PR TITLE
glu, glew: split glu package into `-dev` variant + clean deps

### DIFF
--- a/glew.yaml
+++ b/glew.yaml
@@ -1,7 +1,7 @@
 package:
   name: glew
   version: 2.2.0
-  epoch: 6
+  epoch: 7
   description: "A cross-platform C/C++ extension loading library"
   copyright:
     - license: GPL-2.0-or-later
@@ -11,7 +11,7 @@ environment:
     packages:
       - build-base
       - cmake-3
-      - glu
+      - glu-dev
       - libLLVM-16
       - libx11-dev
       - libxi-dev

--- a/glu.yaml
+++ b/glu.yaml
@@ -1,21 +1,16 @@
 package:
   name: glu
   version: 9.0.3
-  epoch: 3
+  epoch: 4
   description: "Mesa OpenGL Utility library"
   copyright:
     - license: SGI-B-1.1
-  dependencies:
-    runtime:
 
 environment:
   contents:
     packages:
       - build-base
       - mesa-dev
-      - meson
-      - ninja
-      - wolfi-base
 
 pipeline:
   - uses: fetch
@@ -37,8 +32,17 @@ pipeline:
 
 test:
   pipeline:
-    - uses: test/pkgconf
     - uses: test/tw/ldd-check
+
+subpackages:
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+    description: ${{package.name}} development libraries
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION

Makes sense as we are shipping pkgconf configs on the main package as well
