### PR TITLE
fix(clickhouse-25.5): broken symlinks to build targets

### DIFF
--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -153,6 +153,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/logs
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/licenses
+          mkdir -p ${{targets.contextdir}}/etc
           mkdir -p ${{targets.contextdir}}/var/lib
           mkdir -p ${{targets.contextdir}}/var/log
 
@@ -204,7 +205,7 @@ subpackages:
           ln -sf /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
           ln -sf /opt/bitnami/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
           ln -sf /opt/bitnami/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
-          ln -sf /opt/bitnami/clickhouse/tmp ${{targets.contextdir}}/var/lib/clickhouse/tmp
+          ln -sf /opt/bitnami/clickhouse/tmp ${{targets.contextdir}}/bitnami/clickhouse/data/tmp
     test:
       environment:
         contents:
@@ -243,6 +244,7 @@ subpackages:
           mkdir -p /opt/iamguarded/clickhouse/logs
           mkdir -p /opt/iamguarded/clickhouse/tmp
           mkdir -p /opt/iamguarded/clickhouse/licenses
+          mkdir -p ${{targets.contextdir}}/etc
           mkdir -p ${{targets.contextdir}}/var/lib
           mkdir -p ${{targets.contextdir}}/var/log
 
@@ -288,7 +290,7 @@ subpackages:
           ln -sf /iamguarded/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
           ln -sf /opt/iamguarded/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
           ln -sf /opt/iamguarded/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
-          ln -sf /opt/iamguarded/clickhouse/tmp ${{targets.contextdir}}/var/lib/clickhouse/tmp
+          ln -sf /opt/iamguarded/clickhouse/tmp /iamguarded/clickhouse/data/tmp
       - uses: iamguarded/finalize-compat
         with:
           package: clickhouse

--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -153,9 +153,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/logs
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/licenses
-          mkdir -p ${{targets.contextdir}}/etc
           mkdir -p ${{targets.contextdir}}/var/lib
-          mkdir -p ${{targets.contextdir}}/var/log
+          mkdir -p ${{targets.contextdir}}/var/log/clickhouse-server
 
           mkdir ${{targets.contextdir}}/docker-entrypoint-initdb.d
           mkdir ${{targets.contextdir}}/docker-entrypoint-startdb.d
@@ -180,7 +179,7 @@ subpackages:
           find . -iname "*.sh" -exec sed 's#"/bitnami/clickhouse"#"${{targets.contextdir}}/bitnami/clickhouse"#g' -i {} \;
 
           # Remove potentially conflicting symlinks from other subpkg builds that utilize postunpack.sh
-          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server
+          rm -f /etc/clickhouse-server /var/lib/clickhouse/tmp /var/lib/clickhouse /var/log/clickhouse-server
           ${{targets.contextdir}}/opt/bitnami/scripts/clickhouse/postunpack.sh
 
           # Restore path
@@ -202,10 +201,11 @@ subpackages:
           done
 
           # recreate symlinks from postunpack.sh with absolute target paths to ensure no contextdir prefixes
-          ln -sf /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
-          ln -sf /opt/bitnami/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
-          ln -sf /opt/bitnami/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
-          ln -sf /opt/bitnami/clickhouse/tmp ${{targets.contextdir}}/bitnami/clickhouse/data/tmp
+          rm -f ${{targets.contextdir}}/bitnami/clickhouse/data/tmp
+          ln -s /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+          ln -s /opt/bitnami/clickhouse/tmp ${{targets.contextdir}}/bitnami/clickhouse/data/tmp
+          ln -s /opt/bitnami/clickhouse/logs/clickhouse.log ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse.log
+          ln -s /opt/bitnami/clickhouse/logs/clickhouse_error.log ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
     test:
       environment:
         contents:
@@ -244,9 +244,8 @@ subpackages:
           mkdir -p /opt/iamguarded/clickhouse/logs
           mkdir -p /opt/iamguarded/clickhouse/tmp
           mkdir -p /opt/iamguarded/clickhouse/licenses
-          mkdir -p ${{targets.contextdir}}/etc
           mkdir -p ${{targets.contextdir}}/var/lib
-          mkdir -p ${{targets.contextdir}}/var/log
+          mkdir -p ${{targets.contextdir}}/var/log/clickhouse-server
 
           mkdir ${{targets.contextdir}}/docker-entrypoint-initdb.d
           mkdir ${{targets.contextdir}}/docker-entrypoint-startdb.d
@@ -268,7 +267,7 @@ subpackages:
           find /opt/iamguarded/scripts -iname "*.sh" -exec sed -i '/chown/c\continue' -i {} \;
 
           # Remove potentially conflicting symlinks from other subpkg builds that utilize postunpack.sh
-          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server
+          rm -f /etc/clickhouse-server /var/lib/clickhouse/tmp /var/lib/clickhouse /var/log/clickhouse-server
           /opt/iamguarded/scripts/clickhouse/postunpack.sh
 
           # Find all files in /usr/bin that are either named "clickhouse" or symlinks pointing to "clickhouse"
@@ -287,10 +286,11 @@ subpackages:
           done
 
           # recreate symlinks from postunpack.sh with absolute target paths to ensure no contextdir prefixes
-          ln -sf /iamguarded/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
-          ln -sf /opt/iamguarded/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
-          ln -sf /opt/iamguarded/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
-          ln -sf /opt/iamguarded/clickhouse/tmp /iamguarded/clickhouse/data/tmp
+          rm -f /iamguarded/clickhouse/data/tmp
+          ln -s /iamguarded/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+          ln -s /opt/iamguarded/clickhouse/tmp /iamguarded/clickhouse/data/tmp
+          ln -s /opt/iamguarded/clickhouse/logs/clickhouse.log ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse.log
+          ln -s /opt/iamguarded/clickhouse/logs/clickhouse_error.log ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
       - uses: iamguarded/finalize-compat
         with:
           package: clickhouse

--- a/clickhouse-25.5.yaml
+++ b/clickhouse-25.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.5
   version: "25.5.9.14"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -58,6 +58,8 @@ pipeline:
       patches: allow_cflags.patch
 
   - runs: |
+      # parallel submodule fetch saves ~10 min during build; '0' tells git to use a reasonable value.
+      git config --global submodule.fetchJobs 0
       git submodule update --init
 
       # Overwrite VERSION_STRING to properly set the version of the binary.
@@ -151,7 +153,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/logs
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/clickhouse/licenses
-          mkdir -p ${{targets.contextdir}}/var/log/clickhouse-server
+          mkdir -p ${{targets.contextdir}}/var/lib
+          mkdir -p ${{targets.contextdir}}/var/log
 
           mkdir ${{targets.contextdir}}/docker-entrypoint-initdb.d
           mkdir ${{targets.contextdir}}/docker-entrypoint-startdb.d
@@ -159,8 +162,6 @@ subpackages:
           install -m755 ${{targets.destdir}}/etc/clickhouse-keeper/keeper_config.xml ${{targets.contextdir}}/opt/bitnami/clickhouse/etc/keeper_config.xml
           install -m755 ${{targets.destdir}}/etc/clickhouse-server/users.xml ${{targets.contextdir}}/opt/bitnami/clickhouse/etc/users.xml
           install -m755 ${{targets.destdir}}/etc/clickhouse-server/config.xml ${{targets.contextdir}}/opt/bitnami/clickhouse/etc/config.xml
-
-          mkdir -p ${{targets.contextdir}}/var/log/
 
           # Disable some commands used in Bitnami scripts. These commands more likely fail in this since this image take non root approach
           # sed -i 's/owned_by "$dir" "$owner_user" "$owner_group"/continue/g' ${{targets.contextdir}}/opt/bitnami/scripts/libfs.sh
@@ -174,10 +175,13 @@ subpackages:
           # Use package path while unpacking
           find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.contextdir}}/opt/bitnami#g' -i {} \;
           find . -iname "*.sh" -exec sed -i '/chown/c\continue'  -i {} \;
-          find . -iname "*.sh" -exec sed 's#/BITNAMI_VOLUME_DIR="/bitnami"#BITNAMI_VOLUME_DIR="${{targets.contextdir}}/bitnami"#g' -i {} \;
+          find . -iname "*.sh" -exec sed 's#BITNAMI_VOLUME_DIR="/bitnami"#BITNAMI_VOLUME_DIR="${{targets.contextdir}}/bitnami"#g' -i {} \;
           find . -iname "*.sh" -exec sed 's#"/bitnami/clickhouse"#"${{targets.contextdir}}/bitnami/clickhouse"#g' -i {} \;
 
+          # Remove potentially conflicting symlinks from other subpkg builds that utilize postunpack.sh
+          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server
           ${{targets.contextdir}}/opt/bitnami/scripts/clickhouse/postunpack.sh
+
           # Restore path
           find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
 
@@ -196,10 +200,11 @@ subpackages:
               fi
           done
 
-          ln -s /dev/stdout ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse.log
-          ln -s /dev/stderr ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
-          mkdir -p ${{targets.contextdir}}/var/lib
-          ln -s /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+          # recreate symlinks from postunpack.sh with absolute target paths to ensure no contextdir prefixes
+          ln -sf /bitnami/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+          ln -sf /opt/bitnami/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
+          ln -sf /opt/bitnami/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
+          ln -sf /opt/bitnami/clickhouse/tmp ${{targets.contextdir}}/var/lib/clickhouse/tmp
     test:
       environment:
         contents:
@@ -238,25 +243,32 @@ subpackages:
           mkdir -p /opt/iamguarded/clickhouse/logs
           mkdir -p /opt/iamguarded/clickhouse/tmp
           mkdir -p /opt/iamguarded/clickhouse/licenses
-          mkdir -p ${{targets.contextdir}}/var/log/clickhouse-server
+          mkdir -p ${{targets.contextdir}}/var/lib
+          mkdir -p ${{targets.contextdir}}/var/log
+
           mkdir ${{targets.contextdir}}/docker-entrypoint-initdb.d
           mkdir ${{targets.contextdir}}/docker-entrypoint-startdb.d
+
           install -m755 ${{targets.destdir}}/etc/clickhouse-keeper/keeper_config.xml /opt/iamguarded/clickhouse/etc/keeper_config.xml
           install -m755 ${{targets.destdir}}/etc/clickhouse-server/users.xml /opt/iamguarded/clickhouse/etc/users.xml
           install -m755 ${{targets.destdir}}/etc/clickhouse-server/config.xml /opt/iamguarded/clickhouse/etc/config.xml
-          mkdir -p ${{targets.contextdir}}/var/log/
+
           # Disable some commands used in iamguarded scripts. These commands more likely fail in this since this image take non root approach
           # sed -i 's/owned_by "$dir" "$owner_user" "$owner_group"/continue/g' /opt/iamguarded/scripts/libfs.sh
           sed -i 's/ensure_user_exists/# ensure_user_exists/g' /opt/iamguarded/scripts/clickhouse/postunpack.sh
           # sed -i 's/am_i_root/# am_i_root/g' /opt/iamguarded/scripts/clickhouse/setup.sh
+
           # The `--userspec`` flag belongs to GNU's chroot, whereas we are use BusyBox's. As a workaround, use `su-exec` instead.
           sed -i 's|exec chroot --userspec="$userspec" /|exec chroot / su-exec "$userspec"|' /opt/iamguarded/scripts/libos.sh
           sed -i 's|chroot --userspec="$userspec" /|chroot / su-exec "$userspec"|' /opt/iamguarded/scripts/libos.sh
+
           # Use package path while unpacking
           find /opt/iamguarded/scripts -iname "*.sh" -exec sed -i '/chown/c\continue' -i {} \;
-          # Remove existing symlinks that might conflict
-          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server /var/lib/clickhouse/tmp
+
+          # Remove potentially conflicting symlinks from other subpkg builds that utilize postunpack.sh
+          rm -f /etc/clickhouse-server /var/lib/clickhouse /var/log/clickhouse-server
           /opt/iamguarded/scripts/clickhouse/postunpack.sh
+
           # Find all files in /usr/bin that are either named "clickhouse" or symlinks pointing to "clickhouse"
           for file in ${{targets.destdir}}/usr/bin/*; do
               if [ -f "$file" ] && [ "$(basename "$file")" = "clickhouse" ]; then
@@ -271,10 +283,12 @@ subpackages:
                   fi
               fi
           done
-          ln -s /dev/stdout ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse.log
-          ln -s /dev/stderr ${{targets.contextdir}}/var/log/clickhouse-server/clickhouse_error.log
-          mkdir -p ${{targets.contextdir}}/var/lib
-          ln -s /iamguarded/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+
+          # recreate symlinks from postunpack.sh with absolute target paths to ensure no contextdir prefixes
+          ln -sf /iamguarded/clickhouse/data ${{targets.contextdir}}/var/lib/clickhouse
+          ln -sf /opt/iamguarded/clickhouse/etc ${{targets.contextdir}}/etc/clickhouse-server
+          ln -sf /opt/iamguarded/clickhouse/logs ${{targets.contextdir}}/var/log/clickhouse-server
+          ln -sf /opt/iamguarded/clickhouse/tmp ${{targets.contextdir}}/var/lib/clickhouse/tmp
       - uses: iamguarded/finalize-compat
         with:
           package: clickhouse
@@ -343,7 +357,8 @@ subpackages:
 
           # Use package path while unpacking
           find /opt/iamguarded/scripts -iname "*.sh" -exec sed -i '/chown/c\continue' -i {} \;
-          # Remove existing symlinks that might conflict
+
+          # Remove potentially conflicting symlinks from other subpkg builds that utilize postunpack.sh
           rm -f /etc/clickhouse-keeper /var/lib/clickhouse /var/log/clickhouse-server
           /opt/iamguarded/scripts/clickhouse-keeper/postunpack.sh
 


### PR DESCRIPTION
Our compat subpackages are including links to build system paths. This was caused by our `targets.contextdir` being injected during parts of the build; that's necessary to do things like writing config files to the correct place, but it had unintended consequences when making final package symlinks.  For example:

```
lrwxrwxrwx 0/0               0 2025-07-31 21:26 tmp -> /home/build/melange-out/clickhouse-25.5-bitnami-compat/opt/bitnami/clickhouse/tmp
```

This PR fixes this by removing potentially errant symlinks during each compat build and recreating them with absolute target paths.

Drive by to speed up our builds by parallelizing git submodule fetches.