### PR TITLE
Add test/no-docs pipeline to batch 13 packages

### DIFF
--- a/iperf.yaml
+++ b/iperf.yaml
@@ -1,7 +1,7 @@
 package:
   name: iperf
   version: 2.2.1
-  epoch: 1
+  epoch: 2
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: NCSA
@@ -116,6 +116,7 @@ test:
         post: |
           # Test with bandwidth limit of 10Mbps
           iperf -c localhost -b 10M -t 2 -f m
+    - uses: test/no-docs
 
 subpackages:
   - name: iperf-doc

--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: "6.16.0"
-  epoch: 0
+  epoch: 1
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -138,3 +138,4 @@ test:
       runs: |
         cmd="ip link add dev myinterface type dummy"
         $cmd || $cmd 2>&1 | grep 'RTNETLINK answers: Operation not supported'
+    - uses: test/no-docs

--- a/ipset.yaml
+++ b/ipset.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipset
   version: "7.24"
-  epoch: 1
+  epoch: 2
   description: Manage Linux IP sets
   copyright:
     - license: GPL-2.0-only
@@ -88,3 +88,4 @@ test:
         ipset --help
         ipset-translate --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 26
+  epoch: 27
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -272,3 +272,4 @@ test:
         done
         no_other_commands "${{context.name}}" $iptables_cmds
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/ipvsadm.yaml
+++ b/ipvsadm.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipvsadm
   version: "1.31"
-  epoch: 42
+  epoch: 43
   description: The IP Virtual Server administration utility
   copyright:
     - license: GPL-2.0-or-later
@@ -56,3 +56,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 1398
+
+test:
+  pipeline:
+    - uses: test/no-docs

--- a/isa-l.yaml
+++ b/isa-l.yaml
@@ -1,7 +1,7 @@
 package:
   name: isa-l
   version: 2.31.1
-  epoch: 3
+  epoch: 4
   description: "Intelligent Storage Acceleration Library"
   copyright:
     - license: BSD-3-Clause
@@ -82,3 +82,4 @@ test:
     - name: Compare contents
       runs: |
         diff -q igzip gzip
+    - uses: test/no-docs

--- a/itstool.yaml
+++ b/itstool.yaml
@@ -1,7 +1,7 @@
 package:
   name: itstool
   version: 2.0.7
-  epoch: 4
+  epoch: 5
   description: ITS-based XML translation tool
   copyright:
     - license: GPL-3.0-or-later
@@ -82,3 +82,4 @@ test:
 
         cd tests
         python3 -m unittest run_tests.py
+    - uses: test/no-docs

--- a/ivykis.yaml
+++ b/ivykis.yaml
@@ -2,7 +2,7 @@
 package:
   name: ivykis
   version: "0.43.2"
-  epoch: 2
+  epoch: 3
   description: Library for asynchronous I/O readiness notification
   copyright:
     - license: LGPL-2.1-or-later
@@ -68,3 +68,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/jack.yaml
+++ b/jack.yaml
@@ -2,7 +2,7 @@
 package:
   name: jack
   version: 1.9.22
-  epoch: 2
+  epoch: 3
   description: The Jack Audio Connection Kit
   copyright:
     - license: GPL-2.0-or-later
@@ -89,3 +89,4 @@ test:
         jackd --version
         jackd --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/jasper.yaml
+++ b/jasper.yaml
@@ -1,7 +1,7 @@
 package:
   name: jasper
   version: "4.2.7"
-  epoch: 0
+  epoch: 1
   description: "Official Repository for the JasPer Image Coding Toolkit"
   copyright:
     - license: MIT
@@ -69,3 +69,4 @@ test:
         imgcmp --version | grep ${{package.version}}
         imginfo --version | grep ${{package.version}}
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
- iperf: Add test/no-docs pipeline, epoch 1→2
- iproute2: Add test/no-docs pipeline, epoch 0→1
- ipset: Add test/no-docs pipeline, epoch 1→2
- iptables: Add test/no-docs pipeline, epoch 26→27
- ipvsadm: Add test/no-docs pipeline, epoch 42→43
- isa-l: Add test/no-docs pipeline, epoch 3→4
- itstool: Add test/no-docs pipeline, epoch 4→5
- ivykis: Add test/no-docs pipeline, epoch 2→3
- jack: Add test/no-docs pipeline, epoch 2→3
- jasper: Add test/no-docs pipeline, epoch 0→1

🤖 Generated with [Claude Code](https://claude.ai/code)