### PR TITLE
Add test/no-docs pipeline to batch 14 packages

### DIFF
--- a/jbig2dec.yaml
+++ b/jbig2dec.yaml
@@ -2,7 +2,7 @@
 package:
   name: jbig2dec
   version: 0.20
-  epoch: 1
+  epoch: 2
   description: JBIG2 image compression format decoder
   copyright:
     - license: AGPL-3.0-or-later
@@ -77,3 +77,4 @@ test:
         jbig2dec --version
         jbig2dec --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/jemalloc.yaml
+++ b/jemalloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: jemalloc
   version: 5.3.0
-  epoch: 3
+  epoch: 4
   description: general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support
   copyright:
     - license: BSD-2-Clause
@@ -88,6 +88,7 @@ test:
         [ -d /sys/devices/system/cpu ] || exit 0
         LD_PRELOAD=/usr/lib/libjemalloc.so.2 stress-ng --vdso 1 -t 5 --metrics
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.521"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -206,3 +206,4 @@ test:
           echo "WAR file timestamp is zero"
           exit 1
         fi
+    - uses: test/no-docs

--- a/jenkins-docker.yaml
+++ b/jenkins-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-docker
   version: "2.522"
-  epoch: 0
+  epoch: 1
   description: Docker compatbility scripts and tooling for Jenkins
   copyright:
     - license: MIT
@@ -52,3 +52,4 @@ test:
     - runs: |
         jenkins-support --version
         jenkins-support --help
+    - uses: test/no-docs

--- a/jitterentropy-rngd.yaml
+++ b/jitterentropy-rngd.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitterentropy-rngd
   version: 1.2.8
-  epoch: 40
+  epoch: 41
   description: Jitterentropy RNGd
   copyright:
     - license: GPL-2.0-only
@@ -53,6 +53,7 @@ test:
   pipeline:
     - runs: |
         jitterentropy-rngd --version 2>&1 | grep ${{package.version}}
+    - uses: test/no-docs
 
 subpackages:
   - name: jitterentropy-rngd-doc

--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: "1.8.1"
-  epoch: 1
+  epoch: 2
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -87,3 +87,4 @@ test:
         [ "$output" = "true" ]
         output=$(echo '["NaN1"]' | jq -r '.[] | try (fromjson | isnan) catch .')
         [ "$output" = "Invalid numeric literal at EOF at line 1, column 4 (while parsing 'NaN1')" ]
+    - uses: test/no-docs

--- a/json-c.yaml
+++ b/json-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: json-c
   version: "0.18"
-  epoch: 3
+  epoch: 4
   description: A JSON implementation in C
   copyright:
     - license: MIT
@@ -99,3 +99,4 @@ test:
         gcc -Wall -Wextra test.c -ljson-c -o test_json
         ./test_json
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/jupyter-docker-stacks.yaml
+++ b/jupyter-docker-stacks.yaml
@@ -2,7 +2,7 @@
 package:
   name: jupyter-docker-stacks
   version: "0.0.0_git20250728"
-  epoch: 0
+  epoch: 1
   description: Ready-to-run images containing Jupyter applications
   copyright:
     - license: BSD-3-Clause
@@ -72,3 +72,4 @@ update:
 test:
   pipeline:
     - uses: test/emptypackage
+    - uses: test/no-docs

--- a/kakoune.yaml
+++ b/kakoune.yaml
@@ -1,7 +1,7 @@
 package:
   name: kakoune
   version: "2025.06.03"
-  epoch: 2
+  epoch: 3
   description: Code editor heavily inspired by Vim, but with less keystrokes
   copyright:
     - license: Unlicense
@@ -46,6 +46,7 @@ test:
   pipeline:
     - name: Verify kakoune installation
       runs: kak -version || exit 1
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/keyutils.yaml
+++ b/keyutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: keyutils
   version: 1.6.3
-  epoch: 36
+  epoch: 37
   description: Linux Key Management Utilities
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later
@@ -112,3 +112,4 @@ test:
         keyctl --version
         key.dns_resolver --version
         request-key --version
+    - uses: test/no-docs


### PR DESCRIPTION
- jbig2dec: Add test/no-docs pipeline, epoch 1→2
- jemalloc: Add test/no-docs pipeline, epoch 3→4
- jenkins-2: Add test/no-docs pipeline, epoch 0→1
- jenkins-docker: Add test/no-docs pipeline, epoch 0→1
- jitterentropy-rngd: Add test/no-docs pipeline, epoch 40→41
- jq: Add test/no-docs pipeline, epoch 1→2
- json-c: Add test/no-docs pipeline, epoch 3→4
- jupyter-docker-stacks: Add test/no-docs pipeline, epoch 0→1
- kakoune: Add test/no-docs pipeline, epoch 2→3
- keyutils: Add test/no-docs pipeline, epoch 36→37

🤖 Generated with [Claude Code](https://claude.ai/code)