### PR TITLE
Add test/no-docs pipeline to batch 16 packages

### DIFF
--- a/libasyncns.yaml
+++ b/libasyncns.yaml
@@ -2,7 +2,7 @@
 package:
   name: libasyncns
   version: "0.8"
-  epoch: 2
+  epoch: 3
   description: Asynchronous Name Service Library
   copyright:
     - license: LGPL-2.1
@@ -55,3 +55,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libatasmart.yaml
+++ b/libatasmart.yaml
@@ -1,7 +1,7 @@
 package:
   name: libatasmart
   version: "0.19"
-  epoch: 40
+  epoch: 41
   description: ATA S.M.A.R.T. Reading and Parsing Library
   copyright:
     - license: LGPL-2.1-or-later
@@ -76,3 +76,4 @@ test:
     - runs: |
         skdump --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libatomic_ops.yaml
+++ b/libatomic_ops.yaml
@@ -1,7 +1,7 @@
 package:
   name: libatomic_ops
   version: 7.8.2
-  epoch: 2
+  epoch: 3
   description: Semi-portable access to hardware provided atomic memory operations
   copyright:
     - license: GPL-2.0-or-later
@@ -63,3 +63,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libb64-1.2.yaml
+++ b/libb64-1.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libb64-1.2
   version: 1.2.1
-  epoch: 1
+  epoch: 2
   description: Fast Base64 encoding/decoding routines
   dependencies:
     provides:
@@ -59,3 +59,4 @@ test:
     - uses: test/tw/header-check
       with:
         configure-opts: "CPPFLAGS=-DBUFFERSIZE=123456"
+    - uses: test/no-docs

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbsd
   version: 0.12.2
-  epoch: 2
+  epoch: 3
   description: commonly-used BSD functions not implemented by all libcs
   copyright:
     - license: BSD-3-Clause
@@ -59,3 +59,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libburn.yaml
+++ b/libburn.yaml
@@ -2,7 +2,7 @@
 package:
   name: libburn
   version: 1.5.6
-  epoch: 3
+  epoch: 4
   description: Library for reading, mastering and writing optical discs
   copyright:
     - license: GPL-2.0-or-later
@@ -66,3 +66,4 @@ test:
         cdrskin --version
         cdrskin --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libcap-ng.yaml
+++ b/libcap-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap-ng
   version: 0.8.5
-  epoch: 2
+  epoch: 3
   description: POSIX capabilities library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -88,3 +88,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.76"
-  epoch: 5
+  epoch: 6
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only
@@ -99,3 +99,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libcmis.yaml
+++ b/libcmis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcmis
   version: 0.6.2
-  epoch: 4
+  epoch: 5
   description: C/C++ CMIS client library
   copyright:
     - license: GPL-2.0-or-later
@@ -74,3 +74,4 @@ test:
         cmis-client --help
         cmis-client version
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libdaemon.yaml
+++ b/libdaemon.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdaemon
   version: 0.14
-  epoch: 2
+  epoch: 3
   description: A lightweight C library which eases the writing of UNIX daemons
   copyright:
     - license: LGPL-2.1-or-later
@@ -55,3 +55,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
This batch adds the test/no-docs pipeline to packages 151-160:
- libasyncns: epoch 2→3
- libatasmart: epoch 40→41
- libatomic_ops: epoch 2→3
- libb64-1.2: epoch 1→2
- libbsd: epoch 2→3
- libburn: epoch 3→4
- libcap-ng: epoch 2→3
- libcap: epoch 5→6 (manual bump due to version-filter-contains field)
- libcmis: epoch 4→5
- libdaemon: epoch 2→3

🤖 Generated with [Claude Code](https://claude.ai/code)