### PR TITLE
Add test/no-docs pipeline to batch 17 packages

### DIFF
--- a/libdc1394.yaml
+++ b/libdc1394.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdc1394
   version: 2.2.7
-  epoch: 1
+  epoch: 2
   description: "High level programming interface to control IEEE 1394 based cameras"
   copyright:
     - license: LGPL-2.1-or-later
@@ -54,3 +54,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdwarf
   version: "2.1.0"
-  epoch: 0
+  epoch: 1
   description: Parsing library for DWARF2 and later debugging file format
   copyright:
     - license: LGPL-2.1-only
@@ -101,6 +101,7 @@ test:
   pipeline:
     - runs: stat /usr/lib/libdwarf.so.${{package.version}}
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 12
+  epoch: 13
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause
@@ -65,3 +65,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libev.yaml
+++ b/libev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libev
   version: 4.33
-  epoch: 8
+  epoch: 9
   description: "event dispatch library"
   copyright:
     - license: BSD-2-Clause OR GPL-2.0-or-later
@@ -69,3 +69,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libevdev.yaml
+++ b/libevdev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevdev
   version: "1.13.4"
-  epoch: 0
+  epoch: 1
   description: Kernel Evdev Device Wrapper Library
   copyright:
     - license: MIT
@@ -74,3 +74,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libexif.yaml
+++ b/libexif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libexif
   version: 0.6.25
-  epoch: 1
+  epoch: 2
   description: library to parse an EXIF file and read the data from those tags
   copyright:
     - license: LGPL-2.1
@@ -63,3 +63,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: "3.5.2"
-  epoch: 0
+  epoch: 1
   description: "portable foreign function interface library"
   copyright:
     - license: MIT
@@ -91,3 +91,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libfido2.yaml
+++ b/libfido2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfido2
   version: "1.16.0"
-  epoch: 51
+  epoch: 52
   description: library for FIDO 2.0 functionality
   copyright:
     - license: BSD-2-Clause
@@ -91,3 +91,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -59,7 +59,8 @@ subpackages:
   - name: libgcrypt-doc
     pipeline:
       - uses: split/manpages
-    description: libgcrypt manpages
+      - uses: split/infodir
+    description: libgcrypt documentation
     test:
       pipeline:
         - uses: test/docs

--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgcrypt
   version: "1.11.2"
-  epoch: 0
+  epoch: 1
   description: General purpose crypto library based on the code used in GnuPG
   copyright:
     - license: LGPL-2.1-or-later
@@ -85,3 +85,4 @@ test:
         mpicalc --version
         mpicalc --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libgeotiff.yaml
+++ b/libgeotiff.yaml
@@ -2,7 +2,7 @@
 package:
   name: libgeotiff
   version: "1.7.4"
-  epoch: 2
+  epoch: 3
   description: TIFF based interchange format for georeferenced raster imagery
   copyright:
     - license: MIT
@@ -71,3 +71,4 @@ test:
         makegeo --version
         makegeo --help
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
This batch adds the test/no-docs pipeline to packages 161-170:
- libdc1394: epoch 1→2
- libdwarf: epoch 0→1
- libedit: epoch 12→13
- libevdev: epoch 0→1
- libev: epoch 8→9
- libexif: epoch 1→2
- libffi: epoch 0→1
- libfido2: epoch 51→52
- libgcrypt: epoch 0→1
- libgeotiff: epoch 2→3

🤖 Generated with [Claude Code](https://claude.ai/code)