### PR TITLE
feat: add cloud-provider-gcp-cloud-controller-manager package

### DIFF
--- a/cloud-provider-gcp-cloud-controller-manager.yaml
+++ b/cloud-provider-gcp-cloud-controller-manager.yaml
@@ -1,0 +1,52 @@
+package:
+  name: cloud-provider-gcp-cloud-controller-manager
+  version: "33.1.1"
+  epoch: 0
+  description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/cloud-provider-gcp
+      tag: ccm/v${{package.version}}
+      expected-commit: 64bba5886a47ce757f4b6e9d5409a7ce58e13df1
+
+  - uses: go/build
+    with:
+      packages: ./cmd/cloud-controller-manager
+      output: cloud-controller-manager
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for cluster-api-gcp-controller"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s ./usr/bin/cloud-controller-manager ${{targets.subpkgdir}}/cloud-controller-manager
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: test/tw/symlink-check
+        - runs: |
+            /cloud-controller-manager --help
+
+# the repository has separate tags for the cloud-controller-manager, so
+# each binary has to be a separate package with separate update definition
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/cloud-provider-gcp
+    strip-prefix: ccm/v
+    tag-filter: ccm/v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        /usr/bin/cloud-controller-manager --help
+        /usr/bin/cloud-controller-manager --version


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
