### PR TITLE
tests for grafana-alloy

### DIFF
--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-alloy
   version: "1.10.0"
-  epoch: 1
+  epoch: 2
   description: OpenTelemetry Collector distribution with programmable pipelines
   copyright:
     - license: Apache-2.0
@@ -50,11 +50,37 @@ pipeline:
       install -m644 -D example-config.alloy ${{targets.contextdir}}/etc/alloy/config.alloy
 
 test:
+  environment:
+    contents:
+      packages:
+        - libsystemd
   pipeline:
     - runs: |
         /usr/bin/alloy --version
         alloy --version
         alloy --help
+    - uses: test/daemon-check-output
+      with:
+        setup: |
+          mkdir /var/log/journal
+          # Append journal config to the existing default config
+          cat >> /etc/alloy/config.alloy << 'EOF'
+
+          loki.source.journal "worker" {
+            path = "/var/log/journal"
+            forward_to = [loki.write.test.receiver]
+          }
+
+          loki.write "test" {
+            endpoint {
+              url = "http://localhost:3100/loki/api/v1/push"
+            }
+          }
+          EOF
+        start: "alloy run /etc/alloy/config.alloy"
+        timeout: 10
+        expected_output: |
+          finished node evaluation.*loki.source.journal.worker
 
 update:
   enabled: true

--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -6,6 +6,9 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
+    provides:
+      # REMOVE_POST_USRMERGE - https://github.com/orgs/wolfi-dev/discussions/40270
+      - ${{package.name}}-compat=${{package.full-version}}
     runtime:
       - libsystemd
 

--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -6,12 +6,8 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
-    provides:
-      # REMOVE_POST_USRMERGE - https://github.com/orgs/wolfi-dev/discussions/40270
-      - ${{package.name}}-compat=${{package.full-version}}
     runtime:
-      - merged-bin
-      - wolfi-baselayout
+      - libsystemd
 
 environment:
   contents:
@@ -50,10 +46,6 @@ pipeline:
       install -m644 -D example-config.alloy ${{targets.contextdir}}/etc/alloy/config.alloy
 
 test:
-  environment:
-    contents:
-      packages:
-        - libsystemd
   pipeline:
     - runs: |
         /usr/bin/alloy --version


### PR DESCRIPTION
Follow-up to this comment - https://github.com/chainguard-images/images-private/pull/13389#pullrequestreview-3090426648

Without libsystemd the tests will fail -
`Error: /etc/alloy/config.alloy:39:1: Failed to build component: building component: creating journal reader: unable to open a handle to the library`
