### PR TITLE
add wslay

### DIFF
--- a/wslay.yaml
+++ b/wslay.yaml
@@ -67,7 +67,6 @@ test:
     contents:
       packages:
         - wait-for-it
-        - busybox
   pipeline:
     - uses: test/tw/ldd-check
     - runs: |

--- a/wslay.yaml
+++ b/wslay.yaml
@@ -1,0 +1,86 @@
+package:
+  name: wslay
+  version: 1.1.1
+  epoch: 0
+  description: The WebSocket library in C
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - file
+      - libtool
+      - mtdev-dev
+      - nettle-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tatsuhiro-t/wslay
+      tag: release-${{package.version}}
+      expected-commit: c9a84aa6df8512584c77c8cd15be9536b89c35aa
+
+  - name: Disable docs
+    runs: |
+      # Upstream is not compatible with latest py3-sphinx, which build resulting
+      # with the error: "AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'"
+      # Let's disable docs for now until upstream fixes or someone asks for it.
+      sed -i 's/\bdoc\b//g' Makefile.am
+
+  - runs: autoreconf -i
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: wslay-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - wslay
+    description: wslay dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+        - uses: test/tw/header-check
+
+update:
+  enabled: true
+  github:
+    identifier: tatsuhiro-t/wslay
+    use-tag: true
+    strip-prefix: release-
+
+test:
+  environment:
+    contents:
+      packages:
+        - wait-for-it
+        - busybox
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        set -e
+        testclient --help 2>&1 | grep -q "Usage"
+    - name: "Test quick tunnel creation"
+      uses: test/daemon-check-output
+      with:
+        start: echoserv 9000
+        timeout: 10
+        expected_output: |
+          listening on
+        post: |
+          wait-for-it -t 3 --strict localhost:9000 -- echo "echoserv is up"
+          # Since its a WS server, it never closes the connection, so we need to kill it after a timeout.
+          timeout 5s bash -c 'printf "test\n" | testclient 127.0.0.1 9000 | tr -d "\r"'


### PR DESCRIPTION
Needed by dnsdist.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
