### PR TITLE
Ignore checks for packages with known setuidgid usage

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,10 +1,13 @@
 package:
   name: apache2
   version: "2.4.65"
-  epoch: 1
+  epoch: 2
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - ${{package.name}}-config

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,10 +3,13 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.68.3"
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - blkid

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -1,10 +1,13 @@
 package:
   name: fuse2
   version: 2.9.9
-  epoch: 51
+  epoch: 52
   description: A library that makes it possible to implement a filesystem in a userspace program.
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-bin

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,10 +1,13 @@
 package:
   name: fuse3
   version: "3.17.3"
-  epoch: 0
+  epoch: 1
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-usrsbin

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,10 +1,13 @@
 package:
   name: krb5
   version: "1.22"
-  epoch: 0
+  epoch: 1
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-usrsbin

--- a/libutempter.yaml
+++ b/libutempter.yaml
@@ -1,8 +1,11 @@
 package:
   name: libutempter
   version: 1.2.3
-  epoch: 3
+  epoch: 4
   description: Library interface to record user sessions in utmp/wtmp files
+  checks:
+    disabled:
+      - setuidgid
   copyright:
     - license: LGPL-2.1-or-later
 

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,10 +1,13 @@
 package:
   name: nfs-utils
   version: "2.8.3"
-  epoch: 3
+  epoch: 4
   description: kernel-mode NFS
   copyright:
     - license: GPL-2.0-only
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - busybox

--- a/opendoas.yaml
+++ b/opendoas.yaml
@@ -1,10 +1,13 @@
 package:
   name: opendoas
   version: 6.8.2
-  epoch: 4
+  epoch: 5
   description: A portable fork of the OpenBSD `doas` command
   copyright:
     - license: MIT
+  checks:
+    disabled:
+      - setuidgid
 
 environment:
   contents:

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,10 +1,13 @@
 package:
   name: openssh
   version: "10.0_p1"
-  epoch: 3
+  epoch: 4
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-usrsbin
@@ -223,7 +226,7 @@ subpackages:
       pipeline:
         - uses: test/verify-service
           with:
-            man: 'true'
+            man: "true"
 
   - name: "openssh-server-config"
     description: "OpenSSH server configuration"

--- a/polkit.yaml
+++ b/polkit.yaml
@@ -1,10 +1,13 @@
 package:
   name: polkit
   version: "126"
-  epoch: 3
+  epoch: 4
   description: "A toolkit for defining and handling authorizations."
   copyright:
     - license: LGPL-2.0-or-later
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - dbus

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.3"
-  epoch: 5
+  epoch: 6
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0
@@ -15,6 +15,9 @@ package:
       adduser -S -H -h /var/mail/domains -s /sbin/nologin -G postdrop -g vmail vmail 2>/dev/null
 
       exit 0
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-usrsbin

--- a/screen.yaml
+++ b/screen.yaml
@@ -2,10 +2,13 @@
 package:
   name: screen
   version: "5.0.1"
-  epoch: 2
+  epoch: 3
   description: Window manager that multiplexes a physical terminal
   copyright:
     - license: GPL-3.0-or-later
+  checks:
+    disabled:
+      - setuidgid
 
 environment:
   contents:

--- a/shadow.yaml
+++ b/shadow.yaml
@@ -2,10 +2,13 @@
 package:
   name: shadow
   version: "4.18.0"
-  epoch: 1
+  epoch: 2
   description: PAM login and passwd utilities
   copyright:
     - license: BSD-3-Clause
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-bin

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,11 +1,14 @@
 package:
   name: util-linux
   version: "2.41.1"
-  epoch: 3
+  epoch: 4
   description: Random collection of Linux utilities
   copyright:
     - license: |-
         GPL-3.0-or-later AND GPL-2.0-or-later AND GPL-2.0-only AND GPL-1.0-only AND LGPL-2.1-or-later AND BSD-1-Clause AND BSD-3-Clause AND BSD-4-Clause-UC AND MIT AND CC-PDDC
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - merged-bin

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,10 +1,13 @@
 package:
   name: xorg-server
   version: "21.1.18"
-  epoch: 1
+  epoch: 2
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
+  checks:
+    disabled:
+      - setuidgid
   dependencies:
     runtime:
       - dbus


### PR DESCRIPTION
This PR avoids linting packages with known setuid/setgid usage. We do this in a few spots but not consistently so it will be nice to have this addressed everywhere.