### PR TITLE
add missing deps in postfix package

### DIFF
--- a/postfix.yaml
+++ b/postfix.yaml
@@ -18,6 +18,9 @@ package:
   dependencies:
     runtime:
       - merged-usrsbin
+      - rspamd
+      - sasl-xoauth2
+      - supervisor
       - wolfi-baselayout
 
 environment:
@@ -39,6 +42,7 @@ environment:
       - pcre2-dev
       - perl
       - postgresql-dev
+      - sasl-xoauth2-dev
       - sqlite-dev
 
 data:


### PR DESCRIPTION
Add missing runtime deps, required for building postfix image with process management, auth, and mail filtering capabilities