### PR TITLE
fix(kserve-modelmesh): Do not bump Netty

### DIFF
--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -1,22 +1,28 @@
+# Do not bump Netty. It pulls in an incompatible version of gRPC
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 11
+  epoch: 12
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:
       - bash # entrypoint script uses bash
-      - openjdk-17-default-jvm
+      - openjdk-${{vars.java-version}}-default-jvm
   copyright:
     - license: Apache-2.0
+
+vars:
+  java-version: '17'
 
 environment:
   contents:
     packages:
       - build-base
       - busybox
-      - maven-3.9
-      - openjdk-17
+      - maven
+      - openjdk-${{vars.java-version}}
+  environment:
+    JAVA_HOME: "/usr/lib/jvm/java-${{vars.java-version}}-openjdk"
 
 pipeline:
   - uses: git-checkout
@@ -27,11 +33,8 @@ pipeline:
 
   - uses: auth/maven
 
-  - uses: maven/pombump
-
   - name: Compile
     runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
       mvn -B package -Dfile.encoding=UTF8 -DskipTests=true --file pom.xml
       mkdir -p ${{targets.destdir}}/opt/kserve/mmesh
       mv /home/build/target/dockerhome/* ${{targets.destdir}}/opt/kserve/mmesh/

--- a/kserve-modelmesh/pombump-properties.yaml
+++ b/kserve-modelmesh/pombump-properties.yaml
@@ -1,3 +1,0 @@
-properties:
-  - property: netty-version
-    value: 4.1.118.Final


### PR DESCRIPTION
This introduced a regression as Netty pulled in an incompatible version of gRPC that broke modelmesh