### PR TITLE
fix(kserve-modelmesh): Restore pombump

### DIFF
--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -2,7 +2,7 @@
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 12
+  epoch: 13
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:
@@ -32,6 +32,8 @@ pipeline:
       expected-commit: f8212c75fffba9af22c3f3831ea0a8caade518d2
 
   - uses: auth/maven
+
+  - uses: maven/pombump
 
   - name: Compile
     runs: |


### PR DESCRIPTION
I erroneously removed pombump entirely so following up to restore it for other dependencies that need to be bumped