### PR TITLE
add dnsdist

### DIFF
--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -17,7 +17,7 @@ package:
 
 vars:
   py-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
-  lua-version: 5.4 # keep in sync with remaining Wolfi stack
+  lua-version: 5.4 # Pinning latest lua version to pass cmake
 
 environment:
   contents:
@@ -69,7 +69,7 @@ pipeline:
             --enable-dnscrypt \
             --enable-dns-over-tls \
             --enable-dns-over-https \
-            # --enable-dns-over-quic \
+            --enable-dns-over-quic \
             --enable-unit-tests \
             --with-re2 \
             --with-libsodium \

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -28,9 +28,11 @@ environment:
       - cargo-auditable
       - cmake
       - fstrm-dev
+      - gnutls-dev
       - libbpf-dev # eBPF/XDP support
       - libcap-dev
       - libedit-dev
+      - libquiche
       - libsodium-dev
       - libtool
       - lmdb-dev
@@ -44,6 +46,7 @@ environment:
       - protobuf-dev
       - py3-yaml
       - python-3.12
+      - quiche
       - ragel-dev
       - re2-dev
       - systemd
@@ -70,12 +73,19 @@ pipeline:
             --enable-dns-over-tls \
             --enable-dns-over-https \
             --enable-dns-over-quic \
+            --enable-dns-over-http3 \
             --enable-unit-tests \
-            --with-re2 \
+            --enable-yaml \
+            --enable-systemd \
+            --enable-dnstap \
             --with-libsodium \
             --with-net-snmp \
             --with-lua=lua${{vars.lua-version}} \
-            --enable-yaml
+            --with-gnutls \
+            --with-h2o \
+            --with-libcap \
+            --with-nghttp2 \
+            --with-re2
       - uses: autoconf/make
       - uses: autoconf/make-install
       - runs: make check

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -1,0 +1,143 @@
+package:
+  name: dnsdist-1.9
+  version: "1.9.10"
+  epoch: 0
+  description: PowerDNS dnsdist — highly DNS-, DoS- and abuse-aware load-balancer
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    provides:
+      - dnsdist=${{package.full-version}}
+  scriptlets:
+    pre-install: |
+      #!/bin/sh
+      addgroup -S dnsdist 2>/dev/null
+      adduser  -S -D -H -h /var/empty -s /bin/false -G dnsdist -g dnsdist dnsdist 2>/dev/null
+      exit 0
+
+vars:
+  lua-version: 5.4 # keep in sync with remaining Wolfi stack
+
+environment:
+  contents:
+    packages:
+      - boost-dev
+      - build-base
+      - busybox
+      - cargo-auditable
+      - cmake
+      - fstrm-dev
+      - libbpf-dev # eBPF/XDP support
+      - libcap-dev
+      - libedit-dev
+      - libsodium-dev
+      - libtool
+      # - libxdp-dev
+      - lmdb-dev
+      - lua${{vars.lua-version}}-dev
+      - luajit-dev
+      - net-snmp-dev
+      - nghttp2-dev
+      - openssl-dev
+      - pkgconf-dev
+      - protobuf-dev
+      - py3-yaml
+      - python-3.12
+      - re2-dev
+      - systemd-dev
+      # - wslay-dev
+      - zlib-dev
+      - ragel-dev
+      - mtdev-dev
+      - systemd
+      - systemd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/PowerDNS/pdns
+      tag: dnsdist-${{package.version}}
+      expected-commit: a1ab4e4d0764d2f36eec35f169f81e30281a9b09
+
+  - working-directory: ./pdns/dnsdistdist
+    pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            --sysconfdir=/etc/dnsdist \
+            --sbindir=/usr/bin \
+            --enable-dnscrypt \
+            --enable-dns-over-tls \
+            --enable-dns-over-https \
+            # --enable-dns-over-quic \
+            --enable-unit-tests \
+            --with-re2 \
+            --with-libsodium \
+            --with-net-snmp \
+            --with-lua=lua${{vars.lua-version}} \
+            --enable-yaml
+      - uses: autoconf/make
+      - uses: autoconf/make-install
+      - runs: make check
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: dnsdist development files
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      provides:
+        - dnsdist-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}
+    test:
+      pipeline:
+        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-doc
+    description: dnsdist manual pages & docs
+    pipeline:
+      - uses: split/manpages
+    dependencies:
+      provides:
+        - dnsdist-doc=${{package.full-version}}
+    test:
+      pipeline:
+        - uses: test/docs
+
+test:
+  environment:
+    contents:
+      packages:
+        - wait-for-it
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        dnsdist --version
+        dnsdist --help
+    - name: "daemon smoke-test"
+      uses: test/daemon-check-output
+      with:
+        start: "/usr/bin/dnsdist --disable-syslog --local=127.0.0.1:5053 --console-address=127.0.0.1 --console-port=5199 --disable-syslog --uid=0"
+        timeout: 20
+        expected_output: |
+          Listening on 127.0.0.1:5053
+          DNS over TLS disabled
+          DNS over HTTPS enabled
+        post: |
+          wait-for-it -t 5 --strict 127.0.0.1:5053 -- echo "dnsdist is up"
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - -alpha
+    - -beta
+    - -rc
+  github:
+    identifier: PowerDNS/pdns
+    strip-prefix: dnsdist-
+    tag-filter: dnsdist-1.9.
+    use-tag: true

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -141,6 +141,7 @@ test:
       packages:
         - wait-for-it
         - ${{package.name}}-compat
+        - bind-tools
     accounts:
       groups:
         - groupname: pdns
@@ -159,7 +160,7 @@ test:
     - runs: |
         dnsdist --version
         dnsdist --help
-    - name: "daemon smoke-test"
+    - name: "daemon smoke-test for entrypoint"
       uses: test/daemon-check-output
       with:
         start: "/usr/bin/tini -- /usr/local/bin/dnsdist-startup"
@@ -168,6 +169,22 @@ test:
           Listening on
         post: |
           wait-for-it -t 5 --strict 127.0.0.1:53 -- echo "dnsdist is up"
+    - name: "daemon smoke-test for standalone"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          cat > test.toml <<EOF
+          setLocal("127.0.0.1:5300")
+          newServer("1.1.1.1")
+          EOF
+        start: "dnsdist --config test.toml --supervised"
+        timeout: 30
+        expected_output: |
+          Listening on
+          Marking downstream 1.1.1.1:53
+        post: |
+          wait-for-it -t 5 --strict 127.0.0.1:5300 -- echo "dnsdist is up"
+          dig @127.0.0.1 -p 5300 example.com A | grep -q "ANSWER"
 
 update:
   enabled: true

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -44,8 +44,8 @@ environment:
       - openssl-dev
       - pkgconf-dev
       - protobuf-dev
-      - py3-yaml
-      - python-3.12
+      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-pyyaml
       - quiche
       - ragel-dev
       - re2-dev

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -33,7 +33,6 @@ environment:
       - libedit-dev
       - libsodium-dev
       - libtool
-      # - libxdp-dev
       - lmdb-dev
       - lua${{vars.lua-version}}-dev
       - luajit-dev
@@ -49,7 +48,8 @@ environment:
       - re2-dev
       - systemd
       - systemd-dev
-      # - wslay-dev
+      - wslay-dev
+      - xdp-tools-dev
       - zlib-dev
 
 pipeline:

--- a/dnsdist-1.9.yaml
+++ b/dnsdist-1.9.yaml
@@ -16,6 +16,7 @@ package:
       exit 0
 
 vars:
+  py-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
   lua-version: 5.4 # keep in sync with remaining Wolfi stack
 
 environment:
@@ -36,6 +37,7 @@ environment:
       - lmdb-dev
       - lua${{vars.lua-version}}-dev
       - luajit-dev
+      - mtdev-dev
       - net-snmp-dev
       - nghttp2-dev
       - openssl-dev
@@ -43,14 +45,12 @@ environment:
       - protobuf-dev
       - py3-yaml
       - python-3.12
+      - ragel-dev
       - re2-dev
+      - systemd
       - systemd-dev
       # - wslay-dev
       - zlib-dev
-      - ragel-dev
-      - mtdev-dev
-      - systemd
-      - systemd-dev
 
 pipeline:
   - uses: git-checkout
@@ -83,19 +83,36 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-dev
-    description: dnsdist development files
-    pipeline:
-      - uses: split/dev
+  - name: ${{package.name}}-compat
+    description: Compatibility package for dnsdist
     dependencies:
       provides:
-        - dnsdist-dev=${{package.full-version}}
+        - dnsdist-compat=${{package.full-version}}
       runtime:
-        - ${{package.name}}
+        - python-${{vars.py-version}}
+        - py${{vars.py-version}}-jinja2
+        - tini
+        - libcap-utils
+        - coreutils # For env -S support
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - working-directory: ./dockerdata
+        pipeline:
+          - runs: |
+              # https://github.com/PowerDNS/pdns/blob/master/Dockerfile-dnsdist
+              mkdir -p ${{targets.contextdir}}/etc/dnsdist
+              mkdir -p ${{targets.contextdir}}/usr/local/bin/
+              mkdir -p ${{targets.contextdir}}/etc/dnsdist/conf.d
+              mkdir -p ${{targets.contextdir}}/etc/dnsdist/templates.d
+              install -Dm755 startup.py ${{targets.contextdir}}/usr/local/bin/dnsdist-startup
+              install -Dm755 dnsdist.conf ${{targets.contextdir}}/etc/dnsdist/dnsdist.conf
+              install -Dm644 dnsdist-resolver.lua ${{targets.contextdir}}/etc/dnsdist/dnsdist-resolver.lua
+              ln -sf /usr/bin/dnsdist ${{targets.contextdir}}/usr/local/bin/dnsdist
     test:
       pipeline:
-        - uses: test/pkgconf
-        - uses: test/tw/ldd-check
+        - runs: |
+            test "$(readlink /usr/local/bin/dnsdist)" = "/usr/bin/dnsdist"
 
   - name: ${{package.name}}-doc
     description: dnsdist manual pages & docs
@@ -113,6 +130,20 @@ test:
     contents:
       packages:
         - wait-for-it
+        - ${{package.name}}-compat
+    accounts:
+      groups:
+        - groupname: pdns
+          gid: 953
+      users:
+        - username: pdns
+          gid: 953
+          uid: 953
+      run-as: 0 # To bind :53 on the CI
+    environment:
+      TINI_SUBREAPER: 1
+      DEBUG_CONFIG: yes
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   pipeline:
     - uses: test/tw/ldd-check
     - runs: |
@@ -121,14 +152,12 @@ test:
     - name: "daemon smoke-test"
       uses: test/daemon-check-output
       with:
-        start: "/usr/bin/dnsdist --disable-syslog --local=127.0.0.1:5053 --console-address=127.0.0.1 --console-port=5199 --disable-syslog --uid=0"
-        timeout: 20
+        start: "/usr/bin/tini -- /usr/local/bin/dnsdist-startup"
+        timeout: 30
         expected_output: |
-          Listening on 127.0.0.1:5053
-          DNS over TLS disabled
-          DNS over HTTPS enabled
+          Listening on
         post: |
-          wait-for-it -t 5 --strict 127.0.0.1:5053 -- echo "dnsdist is up"
+          wait-for-it -t 5 --strict 127.0.0.1:53 -- echo "dnsdist is up"
 
 update:
   enabled: true

--- a/dnsdist-2.0.yaml
+++ b/dnsdist-2.0.yaml
@@ -1,6 +1,6 @@
 package:
-  name: dnsdist-1.9
-  version: "1.9.10"
+  name: dnsdist-2.0
+  version: "2.0.0"
   epoch: 0
   description: PowerDNS dnsdist — highly DNS-, DoS- and abuse-aware load-balancer
   copyright:
@@ -49,6 +49,7 @@ environment:
       - quiche
       - ragel-dev
       - re2-dev
+      - rust
       - systemd
       - systemd-dev
       - wslay-dev
@@ -60,7 +61,7 @@ pipeline:
     with:
       repository: https://github.com/PowerDNS/pdns
       tag: dnsdist-${{package.version}}
-      expected-commit: a1ab4e4d0764d2f36eec35f169f81e30281a9b09
+      expected-commit: 89747e81bc60d7950276d5fda3ca669fa81b7cf9
 
   - working-directory: ./pdns/dnsdistdist
     pipeline:
@@ -104,6 +105,7 @@ subpackages:
         - tini
         - libcap-utils
         - coreutils # For env -S support
+        - lua${{vars.lua-version}}
         - merged-usrsbin
         - wolfi-baselayout
     pipeline:
@@ -195,5 +197,5 @@ update:
   github:
     identifier: PowerDNS/pdns
     strip-prefix: dnsdist-
-    tag-filter: dnsdist-1.9.
+    tag-filter: dnsdist-2.0.
     use-tag: true

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -1,7 +1,7 @@
 package:
   name: quiche
   version: 0.24.4
-  epoch: 0
+  epoch: 1
   description: An implementation of the QUIC transport protocol and HTTP/2 as specified by the IETF
   copyright:
     - license: BSD-2-Clause
@@ -42,23 +42,25 @@ pipeline:
     runs: |
       mkdir -p ${{targets.destdir}}/usr/lib
       mkdir -p ${{targets.destdir}}/usr/lib/pkgconfig
-      mkdir -p ${{targets.destdir}}/usr/share/licenses/${{package.name}}
       install -Dm755 ./target/release/quiche-client ${{targets.destdir}}/usr/bin/quiche-client
-      install -Dm755 ./target/release/libquiche.so ${{targets.destdir}}/usr/lib
+      install -Dm755 ./target/release/libquiche.so ${{targets.destdir}}/usr/lib/libquiche.so
       install -Dm755 ./target/release/quiche.pc ${{targets.destdir}}/usr/lib/pkgconfig/quiche.pc
-      install -Dm644 quiche/include/quiche.h ${{targets.destdir}}/usr/include
+      install -Dm644 quiche/include/quiche.h ${{targets.destdir}}/usr/include/quiche.h
       install -Dm644 COPYING ${{targets.destdir}}/usr/share/licenses/${{package.name}}/COPYING
 
   - uses: strip
 
 subpackages:
   - name: libquiche
+    description: "Development headers, .pc files, and static libs for quiche"
     pipeline:
+      - uses: split/dev
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libquiche.so* ${{targets.subpkgdir}}/usr/lib/
     test:
       pipeline:
+        - uses: test/pkgconf
         - uses: test/tw/ldd-check
 
 update:

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/cloudflare/quiche
       tag: ${{package.version}}
-      expected-commit: 70d6d3e233568e906e66179a56c93cf9b0616899
+      expected-commit: 5ea8d8e3569c1ed34b895e2211e62791e77c29ab
 
   - name: Prepare
     runs: |

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -1,7 +1,7 @@
 package:
   name: quiche
-  version: 0.24.4
-  epoch: 1
+  version: 0.24.5
+  epoch: 0
   description: An implementation of the QUIC transport protocol and HTTP/2 as specified by the IETF
   copyright:
     - license: BSD-2-Clause
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/cloudflare/quiche
       tag: ${{package.version}}
-      expected-commit: 70d6d3e233568e906e66179a56c93cf9b0616899
+      expected-commit: 5ea8d8e3569c1ed34b895e2211e62791e77c29ab
 
   - name: Prepare
     runs: |

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -1,7 +1,7 @@
 package:
   name: quiche
   version: 0.24.5
-  epoch: 0
+  epoch: 1
   description: An implementation of the QUIC transport protocol and HTTP/2 as specified by the IETF
   copyright:
     - license: BSD-2-Clause
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/cloudflare/quiche
       tag: ${{package.version}}
-      expected-commit: 5ea8d8e3569c1ed34b895e2211e62791e77c29ab
+      expected-commit: 70d6d3e233568e906e66179a56c93cf9b0616899
 
   - name: Prepare
     runs: |

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -1,6 +1,6 @@
 package:
   name: quiche
-  version: 0.24.5
+  version: 0.24.4
   epoch: 1
   description: An implementation of the QUIC transport protocol and HTTP/2 as specified by the IETF
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/cloudflare/quiche
       tag: ${{package.version}}
-      expected-commit: 5ea8d8e3569c1ed34b895e2211e62791e77c29ab
+      expected-commit: 70d6d3e233568e906e66179a56c93cf9b0616899
 
   - name: Prepare
     runs: |


### PR DESCRIPTION
~Needs: https://github.com/wolfi-dev/os/pull/61786 and https://github.com/wolfi-dev/os/pull/61845~

Rework quiche package to make libquiche co-installable with quiche itself.

Quiche bump results build failure so we can ignore in this PR for now: https://github.com/wolfi-dev/os/pull/61929 (something is broken in the upstream I guess, couldn't able to compile with Rust)

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
