### PR TITLE
openssl: avoid potentially broken ARMV8_UNROLL12_EOR3

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,8 +1,7 @@
-#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
   version: "3.5.2"
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -45,7 +44,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch
+      patches: fix-jitter.patch 0001-openssl-clear-ARMV8_UNROLL12_EOR3-to-prevent-unalign.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl/0001-openssl-clear-ARMV8_UNROLL12_EOR3-to-prevent-unalign.patch
+++ b/openssl/0001-openssl-clear-ARMV8_UNROLL12_EOR3-to-prevent-unalign.patch
@@ -1,0 +1,59 @@
+From 933f2cb2aa8202e47cde777e9667fe74cee26cda Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Thu, 7 Aug 2025 12:03:30 +0100
+Subject: [PATCH] openssl: clear ARMV8_UNROLL12_EOR3 to prevent unaligned
+ access
+
+Clear ARMV8_UNROLL12_EOR3 to possibly prevent potential unaligned
+access without https://github.com/openssl/openssl/pull/27203.
+
+This might be useful to whoever is using fips providers without the
+above patch and are experiencing aes-gcm crashes.
+
+This is unlikely to be merged, as one cannot know if above pull
+request is already integrated in the fips provider or not.
+---
+ crypto/provider_conf.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/crypto/provider_conf.c b/crypto/provider_conf.c
+index 9649517dd2..8186d7d476 100644
+--- a/crypto/provider_conf.c
++++ b/crypto/provider_conf.c
+@@ -18,6 +18,11 @@
+ #include "provider_local.h"
+ #include "crypto/context.h"
+ 
++#if defined(__aarch64__)
++# include <stdlib.h>
++# include "crypto/arm_arch.h"
++#endif
++
+ DEFINE_STACK_OF(OSSL_PROVIDER)
+ 
+ /* PROVIDER config module */
+@@ -211,6 +216,21 @@ static int provider_conf_activate(OSSL_LIB_CTX *libctx, const char *name,
+         ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+         return -1;
+     }
++
++    /*
++     * Attempt to clear ARMV8_UNROLL12_EOR3 to possibly prevent
++     * potential unaligned access without
++     * https://github.com/openssl/openssl/pull/27203
++     */
++#if defined(__aarch64__)
++    if ((OPENSSL_armcap_P & ARMV8_UNROLL12_EOR3) && strncmp("fips", name, 4) == 0) {
++        OPENSSL_armcap_P -= ARMV8_UNROLL12_EOR3;
++        char new_armcap[10];
++        sprintf(new_armcap, "0x%x", OPENSSL_armcap_P);
++        setenv("OPENSSL_armcap", new_armcap, 1);
++    }
++#endif
++
+     if (!prov_already_activated(name, pcgbl->activated_providers)) {
+         /*
+         * There is an attempt to activate a provider, so we should disable
+-- 
+2.48.1
+


### PR DESCRIPTION
Fix potential unaligned access in providers on ARMv9 instances.

Actually not too sure if it is unaligned access, or just in general ARMV8_UNROLL12_EOR3 not working, or not working in some cases but not others.