### PR TITLE
xorg: provide lowercase xvfb and xnest

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: "21.1.18"
-  epoch: 2
+  epoch: 3
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -49,13 +49,6 @@ environment:
       - pixman-dev
       - systemd-dev
       - zlib-dev
-
-data:
-  - name: bins
-    items:
-      Xvfb: Virtual Framebuffer 'fake' X server
-      Xnest: A nested Xorg server
-      gtf: Generate mode timings using the GTF Timing Standard
 
 pipeline:
   - uses: fetch
@@ -109,15 +102,36 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
 
-  - range: bins
-    name: ${{range.key}}
-    description: ${{range.value}}
-    pipeline:
-      - runs: |
-          install -Dm755 "${{targets.destdir}}"/usr/bin/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
+  - name: Xvfb
+    description: Virtual Framebuffer 'fake' X server
     dependencies:
       runtime:
         - mesa-libgallium
+      provides:
+        - xvfb=${{package.full-version}}
+    pipeline:
+      - runs: |
+          install -Dm755 "${{targets.destdir}}"/usr/bin/Xvfb "${{targets.subpkgdir}}"/usr/bin/Xvfb
+
+  - name: Xnest
+    description: A nested Xorg server
+    dependencies:
+      runtime:
+        - mesa-libgallium
+      provides:
+        - xnest=${{package.full-version}}
+    pipeline:
+      - runs: |
+          install -Dm755 "${{targets.destdir}}"/usr/bin/Xnest "${{targets.subpkgdir}}"/usr/bin/Xnest
+
+  - name: gtf 
+    description: Generate mode timings using the GTF Timing Standard
+    dependencies:
+      runtime:
+        - mesa-libgallium
+    pipeline:
+      - runs: |
+          install -Dm755 "${{targets.destdir}}"/usr/bin/gtf "${{targets.subpkgdir}}"/usr/bin/gtf
 
   - name: xvfb-run
     description: imlib2 dev

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -124,7 +124,7 @@ subpackages:
       - runs: |
           install -Dm755 "${{targets.destdir}}"/usr/bin/Xnest "${{targets.subpkgdir}}"/usr/bin/Xnest
 
-  - name: gtf 
+  - name: gtf
     description: Generate mode timings using the GTF Timing Standard
     dependencies:
       runtime:


### PR DESCRIPTION
This unrolls a `range` so that we can make `Xvfb` also `provide: xvfb` (lowercase)

This seems to avoid a common confusing footgun, and should make it easier to install these things using `apk add`