### PR TITLE
Add test/no-docs pipeline to batch 18 packages

### DIFF
--- a/libxaw.yaml
+++ b/libxaw.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxaw
   version: 1.0.16
-  epoch: 1
+  epoch: 2
   description: X Athena Widget Set
   copyright:
     - license: MIT
@@ -70,6 +70,7 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: 1.17.0
-  epoch: 7
+  epoch: 8
   description: X11 client-side library
   copyright:
     - license: MIT
@@ -79,6 +79,7 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/libxcomposite.yaml
+++ b/libxcomposite.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcomposite
   version: 0.4.6
-  epoch: 5
+  epoch: 6
   description: X11 Composite extension library
   copyright:
     - license: MIT
@@ -67,6 +67,7 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: "4.4.38"
-  epoch: 3
+  epoch: 4
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -92,3 +92,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libxcursor.yaml
+++ b/libxcursor.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcursor
   version: 1.2.3
-  epoch: 1
+  epoch: 2
   description: X cursor management library
   copyright:
     - license: MIT
@@ -60,3 +60,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libxcvt.yaml
+++ b/libxcvt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcvt
   version: 0.1.3
-  epoch: 1
+  epoch: 2
   description: "VESA CVT standard timing modeline generation library & utility"
   copyright:
     - license: MIT
@@ -44,6 +44,7 @@ subpackages:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxdmcp
   version: 1.1.5
-  epoch: 8
+  epoch: 9
   description: X11 Display Manager Control Protocol library
   copyright:
     - license: MIT
@@ -72,3 +72,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libxext.yaml
+++ b/libxext.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxext
   version: 1.3.6
-  epoch: 6
+  epoch: 7
   description: X11 miscellaneous extensions library
   copyright:
     - license: MIT
@@ -70,3 +70,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libxfixes.yaml
+++ b/libxfixes.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxfixes
   version: 6.0.1
-  epoch: 2
+  epoch: 3
   description: X11 miscellaneous 'fixes' extension library
   copyright:
     - license: MIT
@@ -62,3 +62,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/no-docs

--- a/libxfont.yaml
+++ b/libxfont.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxfont
   version: 2.0.7
-  epoch: 1
+  epoch: 2
   description: "X font handling library for server & utilities"
   copyright:
     - license: BSD-4-Clause
@@ -79,3 +79,4 @@ test:
       runs: |
         ./test
     - uses: test/tw/ldd-check
+    - uses: test/no-docs


### PR DESCRIPTION
Add test/no-docs pipeline to 10 X11-related packages:
- libxaw: epoch 1→2
- libxcb: epoch 7→8
- libxcomposite: epoch 5→6
- libxcrypt: epoch 3→4
- libxcursor: epoch 1→2
- libxcvt: epoch 1→2
- libxdmcp: epoch 8→9
- libxext: epoch 6→7
- libxfixes: epoch 2→3
- libxfont: epoch 1→2

All packages tested individually and passed test/no-docs pipeline validation.

🤖 Generated with [Claude Code](https://claude.ai/code)