### PR TITLE
build xfsprogs with different python3 versions

### DIFF
--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -11,6 +11,14 @@ package:
       - wolfi-baselayout
       - xfsprogs-core
 
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
 environment:
   contents:
     packages:
@@ -160,13 +168,13 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/xfs_scrub* "${{targets.subpkgdir}}"/usr/bin/
 
-  - name: xfsprogs-extra
-    description: "extra xfsprogs"
-    options:
-      no-provides: true
+  - range: py-versions
+    name: xfsprogs-extra-${{range.key}}
+    description: python${{range.value}} version of xfsprogs-extra
     dependencies:
+      provider-priority: ${{range.value}}
       runtime:
-        - python3
+        - python-${{range.value}}
         - xfsprogs-core
     pipeline:
       - runs: |

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.15.0"
-  epoch: 2
+  epoch: 3
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -162,6 +162,8 @@ subpackages:
 
   - name: xfsprogs-extra
     description: "extra xfsprogs"
+    options:
+      no-provides: true
     dependencies:
       runtime:
         - python3


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: The `python3` runtime dependency in `xfsprogs-extra` causes conflict with other packages that have `python3` dependencies.  We're add `no-provides` to prevents `xfsprogs-extra` from providing `python3`.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
