### PR TITLE
melange/0.30.5 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
-  version: "0.30.4"
-  epoch: 0 # GHSA-x4rx-4gw3-53p4
+  version: "0.30.5"
+  epoch: 0
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: c625d0d0023ef28187bc103af79cfee36f5b120a
+      expected-commit: 17454714ad8089570bc870d102515f2d20b671f7
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
This PR bumps melange to `0.30.5` to pull in fixes for a few of our package-level linters.