### PR TITLE
squid: disable -march=native

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -1,8 +1,7 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/squid/APKBUILD
 package:
   name: squid
   version: "7.1"
-  epoch: 1
+  epoch: 2
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -56,6 +55,7 @@ pipeline:
       # Enable OpenSSL for SSL Bump functionality (caching https requests)
       # To run it as non-root, we set default user as squid
       opts: |
+        --disable-arch-native \
         --sbindir=/usr/bin \
         --without-mit-krb5 \
         --without-heimdal-krb5 \


### PR DESCRIPTION
The minimum required abi is encoded in our toolchains, and we must
stick to it for now.

Reported by: @jamonation
