### PR TITLE
backfill binutils

### DIFF
--- a/backfill-packages.txt
+++ b/backfill-packages.txt
@@ -9,3 +9,6 @@ libstdc++-13.2.0-r7
 openssl-3.3.1-r3
 openssl-provider-legacy-3.3.1-r3
 wolfi-baselayout-20230201-r12
+binutils-2.42-r1.apk
+binutils-dev-2.42-r1.apk
+binutils-gold-2.42-r1.apk

--- a/squid.yaml
+++ b/squid.yaml
@@ -1,8 +1,7 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/squid/APKBUILD
 package:
   name: squid
   version: "7.1"
-  epoch: 1
+  epoch: 2
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -56,6 +55,7 @@ pipeline:
       # Enable OpenSSL for SSL Bump functionality (caching https requests)
       # To run it as non-root, we set default user as squid
       opts: |
+        --disable-arch-native \
         --sbindir=/usr/bin \
         --without-mit-krb5 \
         --without-heimdal-krb5 \


### PR DESCRIPTION
- **squid: disable -march=native**
  The minimum required abi is encoded in our toolchains, and we must
  stick to it for now.
  
  Reported by: @jamonation
  

- **backfill-packages: backfill missing binutils**
  Backfill missing binutils, which should have been published to apk.cgr.dev/chainguard, but for unknown reasons hasn't.
  
  ```
  wolfictl apk ls  https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | grep 2.42-r1 | grep binutils >> backfill-packages.txt
  ```
  