### PR TITLE
backfill-packages: backfill missing binutils

### DIFF
--- a/backfill-packages.txt
+++ b/backfill-packages.txt
@@ -9,3 +9,6 @@ libstdc++-13.2.0-r7
 openssl-3.3.1-r3
 openssl-provider-legacy-3.3.1-r3
 wolfi-baselayout-20230201-r12
+binutils-2.42-r1.apk
+binutils-dev-2.42-r1.apk
+binutils-gold-2.42-r1.apk


### PR DESCRIPTION
Backfill missing binutils, which should have been published to apk.cgr.dev/chainguard, but for unknown reasons hasn't.

```
wolfictl apk ls  https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | grep 2.42-r1 | grep binutils >> backfill-packages.txt
```
