### PR TITLE
keycloak-config-cli: fix GHSA-9342-92gg-6v29 by updating angus-mail to 2.0.4

### DIFF
--- a/keycloak-config-cli.yaml
+++ b/keycloak-config-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-config-cli
   version: 6.4.0
-  epoch: 47
+  epoch: 48
   description: Import YAML/JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
   copyright:
     - license: Apache-2.0

--- a/keycloak-config-cli/pombump-deps.yaml
+++ b/keycloak-config-cli/pombump-deps.yaml
@@ -13,3 +13,6 @@ patches:
   - groupId: org.apache.commons
     artifactId: commons-lang3
     version: 3.18.0
+  - groupId: org.eclipse.angus
+    artifactId: angus-mail
+    version: 2.0.4


### PR DESCRIPTION
## Summary

Fixes GHSA-9342-92gg-6v29 (CVE-2025-7962) - Jakarta Mail SMTP Injection vulnerability in keycloak-config-cli by upgrading org.eclipse.angus:angus-mail from 2.0.3 to 2.0.4.

## CVE Details

**CVE**: CVE-2025-7962 / GHSA-9342-92gg-6v29  
**Component**: org.eclipse.angus:smtp @ 2.0.3  
**Severity**: MODERATE  
**Vulnerability**: Jakarta Mail SMTP Injection  
**Fixed Version**: 2.0.4  

## Root Cause Analysis

This is a **transitive dependency** vulnerability with the following dependency chain:
```
keycloak-config-cli
└── keycloak-admin-client 
    └── org.jboss.resteasy:resteasy-multipart-provider:7.0.0.Alpha2
        └── org.eclipse.angus:angus-mail:2.0.3 (VULNERABLE)
```

## Implementation

### 1. Pombump Override
Added `org.eclipse.angus:angus-mail:2.0.4` to `keycloak-config-cli/pombump-deps.yaml`:

```yaml
patches:
  # ... existing patches
  - groupId: org.eclipse.angus
    artifactId: angus-mail
    version: 2.0.4
```

### 2. Epoch Increment
Incremented epoch from `47` to `48` to force package rebuild with the updated dependency.

## Verification

The pombump mechanism will override the transitive dependency version during the Maven build process, ensuring that the vulnerable angus-mail 2.0.3 is replaced with the fixed version 2.0.4.

## Files Changed

- `keycloak-config-cli.yaml`: Incremented epoch 47 → 48
- `keycloak-config-cli/pombump-deps.yaml`: Added angus-mail 2.0.4 override

## Related Issues

This fix addresses the same SMTP injection vulnerability (GHSA-9342-92gg-6v29) that affects other Keycloak-related packages but uses the pombump override approach suitable for keycloak-config-cli's architecture as a separate upstream project consuming Keycloak dependencies.

## Testing

After build completion, verify the fix by scanning the resulting APK:
```bash
wolfictl scan packages/$(uname -m)/keycloak-config-cli-*.apk
```