### PR TITLE
Add test/no-docs pipeline to 10 packages without prior tests

### DIFF
--- a/perl-class-data-inheritable.yaml
+++ b/perl-class-data-inheritable.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-data-inheritable
   version: "0.10"
-  epoch: 1
+  epoch: 2
   description: Inheritable, overridable class data
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-class-inspector.yaml
+++ b/perl-class-inspector.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-inspector
   version: "1.36"
-  epoch: 4
+  epoch: 5
   description: Class::Inspector perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -46,6 +46,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-class-singleton.yaml
+++ b/perl-class-singleton.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-class-singleton
   version: "1.6"
-  epoch: 4
+  epoch: 5
   description: "Implementation of a Singleton class "
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-date-format.yaml
+++ b/perl-date-format.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-date-format
   version: "2.33"
-  epoch: 4
+  epoch: 5
   description: Perl - Date formating subroutines
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -41,6 +41,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-datetime-locale.yaml
+++ b/perl-datetime-locale.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-datetime-locale
   version: "1.45"
-  epoch: 1
+  epoch: 2
   description: Localization support for DateTime.pm
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -57,6 +57,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-datetime-timezone.yaml
+++ b/perl-datetime-timezone.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-datetime-timezone
   version: "2.65"
-  epoch: 1
+  epoch: 2
   description: Time zone object base class and factory
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -56,6 +56,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-eval-closure.yaml
+++ b/perl-eval-closure.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-eval-closure
   version: "0.14"
-  epoch: 4
+  epoch: 5
   description: safely and cleanly create closures via string eval
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -45,6 +45,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-exception-class.yaml
+++ b/perl-exception-class.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-exception-class
   version: "1.45"
-  epoch: 4
+  epoch: 5
   description: A module that allows you to declare real exception classes in Perl
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -48,6 +48,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-extutils-config.yaml
+++ b/perl-extutils-config.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-config
   version: "0.010"
-  epoch: 2
+  epoch: 3
   description: A wrapper for perl's configuration
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -42,6 +42,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-extutils-helpers.yaml
+++ b/perl-extutils-helpers.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-helpers
   version: "0.028"
-  epoch: 2
+  epoch: 3
   description: Various portability utilities for module builders
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -42,6 +42,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true


### PR DESCRIPTION
All packages had no existing test sections and now include test/no-docs validation:

- perl-class-data-inheritable: Added test/no-docs pipeline, epoch 1→2
- perl-class-inspector: Added test/no-docs pipeline, epoch 4→5
- perl-class-singleton: Added test/no-docs pipeline, epoch 4→5
- perl-date-format: Added test/no-docs pipeline, epoch 4→5
- perl-datetime-locale: Added test/no-docs pipeline, epoch 1→2
- perl-datetime-timezone: Added test/no-docs pipeline, epoch 1→2
- perl-eval-closure: Added test/no-docs pipeline, epoch 4→5
- perl-exception-class: Added test/no-docs pipeline, epoch 4→5
- perl-extutils-config: Added test/no-docs pipeline, epoch 2→3
- perl-extutils-helpers: Added test/no-docs pipeline, epoch 2→3

These packages now validate proper documentation separation between main and -doc subpackages. The -doc subpackages retain their existing test/docs pipelines.

🤖 Generated with [Claude Code](https://claude.ai/code)