### PR TITLE
Fix `test/compiler/asan` on GCC 14

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/pipelines/test/compiler/asan.yaml
+++ b/pipelines/test/compiler/asan.yaml
@@ -27,7 +27,14 @@ pipeline:
         return 0;
       }
       EOF
-      ${{inputs.cc}} noleak.c -o noleak -fsanitize=address -lasan
+      ver=$(echo "${{inputs.cc}}" | sed -n 's@[a-z0-9]\+-\([0-9]\+\)@\1@p')
+      cc="${{inputs.cc}}"
+      rpath=""
+      if [ -n "${ver}" ]; then
+        cc=$(echo "${{inputs.cc}}" | cut -d'-' -f1)
+        rpath="-Wl,-rpath,/usr/lib/${cc}/${{host.triplet.gnu}}/${ver}/"
+      fi
+      ${cc} noleak.c -o noleak -fsanitize=address -lasan ${rpath}
       [ "$(./noleak 2>&1 | grep -v 'Hello world!')" = "" ]
 
   - name: missing free
@@ -48,7 +55,14 @@ pipeline:
         return 0;
       }
       EOF
-      ${{inputs.cc}} leak.c -o leak -fsanitize=address -lasan
+      ver=$(echo "${{inputs.cc}}" | sed -n 's@[a-z0-9]\+-\([0-9]\+\)@\1@p')
+      cc="${{inputs.cc}}"
+      rpath=""
+      if [ -n "${ver}" ]; then
+        cc=$(echo "${{inputs.cc}}" | cut -d'-' -f1)
+        rpath="-Wl,-rpath,/usr/lib/${cc}/${{host.triplet.gnu}}/${ver}/"
+      fi
+      ${cc} leak.c -o leak -fsanitize=address -lasan ${rpath}
       ./leak 2>&1 | grep "detected memory leaks"
 
   - name: use after free
@@ -70,5 +84,12 @@ pipeline:
         return 0;
       }
       EOF
-      ${{inputs.cc}} uaf.c -o uaf -fsanitize=address -lasan
+      ver=$(echo "${{inputs.cc}}" | sed -n 's@[a-z0-9]\+-\([0-9]\+\)@\1@p')
+      cc="${{inputs.cc}}"
+      rpath=""
+      if [ -n "${ver}" ]; then
+        cc=$(echo "${{inputs.cc}}" | cut -d'-' -f1)
+        rpath="-Wl,-rpath,/usr/lib/${cc}/${{host.triplet.gnu}}/${ver}/"
+      fi
+      ${cc} uaf.c -o uaf -fsanitize=address -lasan ${rpath}
       ./uaf 2>&1 | grep "heap-use-after-free"


### PR DESCRIPTION
I don't know how this test ever passed.  libasan is installed in a non-standard path and can't be found without setting `LD_LIBRARY_PATH`, which leads to an error when executing the test programs.

I came up with this hack to automatically set `LD_LIBRARY_PATH` if a new parameter `version` is provided for the compiler.