### PR TITLE
quiche: provide versioned soname and 0.24.5 update

### DIFF
--- a/quiche.yaml
+++ b/quiche.yaml
@@ -68,7 +68,7 @@ subpackages:
         runs: |
           # Create a versioned symlink for the library, as most binaries linked against versioned libraries.
           # For example, /usr/local/bin/dnsdist needs libquiche.so.<VERSION>.
-          ln -sf /usr/lib/libquiche.so ${{targets.destdir}}/usr/lib/libquiche.so.${{vars.major-version}}
+          ln -sf /usr/lib/libquiche.so ${{targets.subpkgdir}}/usr/lib/libquiche.so.${{vars.major-version}}
     test:
       pipeline:
         - uses: test/pkgconf

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -1,7 +1,7 @@
 package:
   name: quiche
-  version: 0.24.4
-  epoch: 1
+  version: 0.24.5
+  epoch: 0
   description: An implementation of the QUIC transport protocol and HTTP/2 as specified by the IETF
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,7 @@ pipeline:
     with:
       repository: https://github.com/cloudflare/quiche
       tag: ${{package.version}}
-      expected-commit: 70d6d3e233568e906e66179a56c93cf9b0616899
+      expected-commit: 5ea8d8e3569c1ed34b895e2211e62791e77c29ab
 
   - name: Prepare
     runs: |
@@ -42,7 +42,7 @@ pipeline:
         --release \
         --frozen \
         --no-default-features \
-        --features ffi,pkg-config-meta,qlog,boringssl-boring-crate
+        --features ffi,pkg-config-meta,qlog,boringssl-boring-crate,sync
 
   - name: Install files
     runs: |

--- a/quiche.yaml
+++ b/quiche.yaml
@@ -6,6 +6,12 @@ package:
   copyright:
     - license: BSD-2-Clause
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
 environment:
   contents:
     packages:
@@ -58,10 +64,16 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libquiche.so* ${{targets.subpkgdir}}/usr/lib/
+      - name: Versioned SONAME
+        runs: |
+          # Create a versioned symlink for the library, as most binaries linked against versioned libraries.
+          # For example, /usr/local/bin/dnsdist needs libquiche.so.<VERSION>.
+          ln -sf /usr/lib/libquiche.so ${{targets.destdir}}/usr/lib/libquiche.so.${{vars.major-version}}
     test:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/libquiche.so.${{vars.major-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Fixes the following error:

```
/usr/local/bin/dnsdist: error while loading shared libraries: libquiche.so.0: cannot open shared object file: No such file or directory
```

```
tar tvf packages/aarch64/libquiche-0.24.5-r0.apk | grep .so
-rwxr-xr-x  0 root   root  3601544 Aug  9 21:28 usr/lib/libquiche.so
lrwxrwxrwx  0 root   root        0 Aug  9 21:28 usr/lib/libquiche.so.0 -> /usr/lib/libquiche.so
```

And bumps the version: https://github.com/wolfi-dev/os/pull/61929