### PR TITLE
add missing runtime dependency for headlamp-plugin-flux

### DIFF
--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -1,7 +1,7 @@
 package:
   name: headlamp-plugin-flux
   version: "0.4.0"
-  epoch: 0
+  epoch: 1
   description: Flux plugin for Headlamp that provides a way to visualize Flux resources.
   copyright:
     - license: Apache-2.0

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - nodejs
+      - busybox
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


Related: https://github.com/headlamp-k8s/plugins

Added `busybox` to runtime dependencies to provide `/bin/sh` and core utilities (mkdir, cp, chown) needed by the `initContainer` script that copies plugin files into Headlamp’s pluginsDir. Removed nodejs from runtime since the plugin ships as static assets and does not require node.js at execution time. This aligns the image behavior with upstream and prevents init step failures.

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

