### PR TITLE
Add test/no-docs pipeline to 12 Perl packages without prior tests

### DIFF
--- a/perl-appconfig.yaml
+++ b/perl-appconfig.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-appconfig
   version: "1.71"
-  epoch: 3
+  epoch: 4
   description: AppConfig is a bundle of Perl5 modules for reading configuration files and parsing command line arguments.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -35,6 +35,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-appconfig-doc

--- a/perl-b-hooks-endofscope.yaml
+++ b/perl-b-hooks-endofscope.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-b-hooks-endofscope
   version: "0.28"
-  epoch: 3
+  epoch: 4
   description: Execute code after a scope finished compilation
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -38,6 +38,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-b-hooks-endofscope-doc

--- a/perl-canary-stability.yaml
+++ b/perl-canary-stability.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-canary-stability
   version: "2013"
-  epoch: 5
+  epoch: 6
   description: CPAN/Canary-Stability - canary to check perl compatibility for schmorp's modules
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -32,6 +32,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-canary-stability-doc

--- a/perl-capture-tiny.yaml
+++ b/perl-capture-tiny.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-capture-tiny
   version: "0.50"
-  epoch: 1
+  epoch: 2
   description: Capture STDOUT and STDERR from Perl, XS or external programs
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: perl/cleanup
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-capture-tiny-doc

--- a/perl-devel-stacktrace.yaml
+++ b/perl-devel-stacktrace.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-devel-stacktrace
   version: "2.05"
-  epoch: 3
+  epoch: 4
   description: An object representing a stack trace
   copyright:
     - license: Artistic-2.0
@@ -36,6 +36,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-devel-stacktrace-doc

--- a/perl-devel-symdump.yaml
+++ b/perl-devel-symdump.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-devel-symdump
   version: "2.18"
-  epoch: 3
+  epoch: 4
   description: dump symbol names or the symbol table
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -36,6 +36,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-devel-symdump-doc

--- a/perl-dist-checkconflicts.yaml
+++ b/perl-dist-checkconflicts.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-dist-checkconflicts
   version: "0.11"
-  epoch: 4
+  epoch: 5
   description: declare version conflicts for your dist
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -38,6 +38,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-dist-checkconflicts-doc

--- a/perl-encode-locale.yaml
+++ b/perl-encode-locale.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-encode-locale
   version: "1.05"
-  epoch: 5
+  epoch: 6
   description: Perl module - Determine the locale encoding
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -33,6 +33,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-encode-locale-doc

--- a/perl-extutils-installpaths.yaml
+++ b/perl-extutils-installpaths.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-extutils-installpaths
   version: "0.014"
-  epoch: 2
+  epoch: 3
   description: Build.PL install path logic made easy
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -34,6 +34,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-extutils-installpaths-doc

--- a/perl-file-listing.yaml
+++ b/perl-file-listing.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-file-listing
   version: "6.16"
-  epoch: 4
+  epoch: 5
   description: Parse directory listing
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -35,6 +35,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-file-listing-doc

--- a/perl-file-next.yaml
+++ b/perl-file-next.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-next
   version: "1.18"
-  epoch: 3
+  epoch: 4
   description: Perl module for taint-safe file-finding
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -32,6 +32,10 @@ pipeline:
   - runs: find "${{targets.destdir}}" -name perllocal.pod -delete
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-file-next-doc

--- a/perl-file-remove.yaml
+++ b/perl-file-remove.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-remove
   version: "1.61"
-  epoch: 4
+  epoch: 5
   description: Remove files and directories
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -37,6 +37,10 @@ pipeline:
   - uses: perl/cleanup
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 subpackages:
   - name: perl-file-remove-doc


### PR DESCRIPTION
All packages had no existing test sections and now include test/no-docs validation:

- perl-appconfig: Added test/no-docs pipeline, epoch 3→4
- perl-b-hooks-endofscope: Added test/no-docs pipeline, epoch 3→4
- perl-canary-stability: Added test/no-docs pipeline, epoch 5→6
- perl-capture-tiny: Added test/no-docs pipeline, epoch 1→2
- perl-devel-stacktrace: Added test/no-docs pipeline, epoch 3→4
- perl-devel-symdump: Added test/no-docs pipeline, epoch 3→4
- perl-dist-checkconflicts: Added test/no-docs pipeline, epoch 4→5
- perl-encode-locale: Added test/no-docs pipeline, epoch 5→6
- perl-extutils-installpaths: Added test/no-docs pipeline, epoch 2→3
- perl-file-listing: Added test/no-docs pipeline, epoch 4→5
- perl-file-next: Added test/no-docs pipeline, epoch 3→4
- perl-file-remove: Added test/no-docs pipeline, epoch 4→5

These packages now validate proper documentation separation between main and -doc subpackages. All packages tested successfully before commit.

🤖 Generated with [Claude Code](https://claude.ai/code)