### PR TITLE
Add test/no-docs pipeline to batch 28 packages

### DIFF
--- a/perl-file-sharedir-install.yaml
+++ b/perl-file-sharedir-install.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-sharedir-install
   version: "0.14"
-  epoch: 4
+  epoch: 5
   description: Install shared files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -45,6 +45,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-file-sharedir.yaml
+++ b/perl-file-sharedir.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-file-sharedir
   version: "1.118"
-  epoch: 4
+  epoch: 5
   description: Locate per-dist and per-module shared files
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -50,6 +50,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-html-tagset.yaml
+++ b/perl-html-tagset.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-html-tagset
   version: "3.24"
-  epoch: 4
+  epoch: 5
   description: data tables useful in parsing HTML
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -42,6 +42,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-http-cookies.yaml
+++ b/perl-http-cookies.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-cookies
   version: "6.11"
-  epoch: 3
+  epoch: 4
   description: HTTP cookie jars
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -46,6 +46,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-http-date.yaml
+++ b/perl-http-date.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-date
   version: "6.06"
-  epoch: 5
+  epoch: 6
   description: Perl module date conversion routines
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -41,6 +41,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-http-message.yaml
+++ b/perl-http-message.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-message
   version: "7.00"
-  epoch: 2
+  epoch: 3
   description: HTTP style message
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -55,6 +55,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-http-negotiate.yaml
+++ b/perl-http-negotiate.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-http-negotiate
   version: "6.01"
-  epoch: 5
+  epoch: 6
   description: HTTP::Negotiate perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-importer.yaml
+++ b/perl-importer.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-importer
   version: "0.026"
-  epoch: 5
+  epoch: 6
   description: Alternative but compatible interface to modules that export symbols.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-inc-latest.yaml
+++ b/perl-inc-latest.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-inc-latest
   version: "0.500"
-  epoch: 4
+  epoch: 5
   description: use modules bundled in inc/ if they are newer than installed ones
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-io-html.yaml
+++ b/perl-io-html.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-io-html
   version: "1.004"
-  epoch: 4
+  epoch: 5
   description: Open an HTML file with automatic charset detection
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -40,6 +40,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-ipc-run3.yaml
+++ b/perl-ipc-run3.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-ipc-run3
   version: "0.049"
-  epoch: 4
+  epoch: 5
   description: IPC::Run3 perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0 OR Artistic-2.0 OR BSD-2-Clause
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-json-maybexs.yaml
+++ b/perl-json-maybexs.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-json-maybexs
   version: "1.004008"
-  epoch: 2
+  epoch: 3
   description: Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -45,6 +45,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-json.yaml
+++ b/perl-json.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-json
   version: "4.10"
-  epoch: 2
+  epoch: 3
   description: Perl module implementing a JSON encoder/decoder
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -38,6 +38,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-lwp-mediatypes.yaml
+++ b/perl-lwp-mediatypes.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-lwp-mediatypes
   version: "6.04"
-  epoch: 4
+  epoch: 5
   description: Perl module - guess media type for a file or a URL
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -40,6 +40,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-lwp-protocol-https.yaml
+++ b/perl-lwp-protocol-https.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-lwp-protocol-https
   version: "6.14"
-  epoch: 1
+  epoch: 2
   description: Perl extension to provide https support for LWP::UserAgent
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -41,6 +41,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true


### PR DESCRIPTION
Added test/no-docs pipeline to 15 high-priority Perl packages that had no existing test sections. This provides documentation split validation and ensures these packages have proper test coverage:

- perl-file-sharedir, perl-file-sharedir-install
- perl-html-tagset
- perl-http-cookies, perl-http-date, perl-http-message, perl-http-negotiate
- perl-importer, perl-inc-latest, perl-io-html, perl-ipc-run3
- perl-json, perl-json-maybexs, perl-lwp-mediatypes, perl-lwp-protocol-https

All packages tested successfully with test/no-docs pipeline and epochs bumped for CI compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)