### PR TITLE
aom: various fixes

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -19,8 +19,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      # gcc-14 hits ICE on arm64
-      - gcc~13
       - perl
       - samurai
       - tree

--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: "3.12.1"
-  epoch: 5
+  epoch: 6
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause

--- a/aom.yaml
+++ b/aom.yaml
@@ -33,6 +33,11 @@ pipeline:
       destination: aom
 
   - working-directory: aom
+    uses: patch
+    with:
+      patches: ../ftbfs-include-cmath.patch
+
+  - working-directory: aom
     uses: cmake/configure
     with:
       opts: |

--- a/aom.yaml
+++ b/aom.yaml
@@ -32,16 +32,21 @@ pipeline:
       expected-commit: 10aece4157eb79315da205f39e19bf6ab3ee30d0
       destination: aom
 
-  - runs: |
-      cd aom
-      cmake -B build -G Ninja \
+  - working-directory: aom
+    uses: cmake/configure
+    with:
+      opts: |
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DBUILD_SHARED_LIBS=True \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_TESTS="OFF"
-      ninja -C build
-      DESTDIR=${{targets.destdir}} ninja -C build install
+
+  - working-directory: aom
+    uses: cmake/build
+
+  - working-directory: aom
+    uses: cmake/install
 
   - uses: strip
 

--- a/aom/ftbfs-include-cmath.patch
+++ b/aom/ftbfs-include-cmath.patch
@@ -1,0 +1,39 @@
+From 2525b73c6d01ce0f6b36cfe71b7921290e4169bd Mon Sep 17 00:00:00 2001
+From: dann frazier <dann.frazier@chainguard.dev>
+Date: Mon, 11 Aug 2025 18:26:24 -0600
+Subject: [PATCH] examples: svc_encoder_rtc: Add missing include
+
+<cmath> must be included when using std::abs().
+
+Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
+---
+ examples/svc_encoder_rtc.cc | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/examples/svc_encoder_rtc.cc b/examples/svc_encoder_rtc.cc
+index 62ab44d297..335d018ffe 100644
+--- a/examples/svc_encoder_rtc.cc
++++ b/examples/svc_encoder_rtc.cc
+@@ -20,6 +20,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++#include <cmath>
+ #include <memory>
+ 
+ #include "config/aom_config.h"
+@@ -1496,6 +1497,11 @@ static void add_multilayer_metadata(
+         write_literal(&buffer, 0, 7);  // ai_reserved_7bits
+         write_literal(&buffer, !alpha_info.label_type_id.empty(), 1);
+         if (!alpha_info.label_type_id.empty()) {
++	  // This comment is here to break application of a patch when
++	  // it is no longer needed. The patch adds a #include <cmath>
++	  // for the `std::abs` definition. But this call has since been
++	  // removed upstream so - unless it was later re-added, that
++	  // include should no longer be needed.
+           const size_t num_values =
+               std::abs(alpha_info.alpha_transparent_value -
+                        alpha_info.alpha_opaque_value) +
+-- 
+2.48.1
+


### PR DESCRIPTION
- Remove a no-longer needed pin on gcc 13
- Fix a ftbfs w/ `oldglibc`
- Convert to using `cmake` pipelines