### PR TITLE
nginx: correct pid location

### DIFF
--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.13
   version: "2.13.2"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4 # CVE-2025-47907
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0
@@ -128,8 +128,6 @@ subpackages:
       pipeline:
         - runs: |
             useradd nginx
-            mkdir -p /var/lib/nginx/logs
-            mkdir -p /var/lib/nginx/tmp
             # The endpoint created by nginx is forbidden in CI
             nginx -g "daemon off;" & sleep 5; kill $! 2>&1
 

--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.13
   version: "1.13.0"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 5 # CVE-2025-47907
+  epoch: 6 # CVE-2025-47907
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -511,7 +511,7 @@ pipeline:
         --modules-path=/etc/nginx/modules \
         --http-log-path=/var/log/nginx/access.log \
         --error-log-path=/var/log/nginx/error.log \
-        --lock-path=/var/lock/nginx.lock \
+        --lock-path=/run/nginx.lock \
         --pid-path=/run/nginx.pid \
         --http-client-body-temp-path=/var/lib/nginx/body \
         --http-fastcgi-temp-path=/var/lib/nginx/fastcgi \

--- a/it-tools.yaml
+++ b/it-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: it-tools
   version: 2024.10.22
-  epoch: 2
+  epoch: 3
   description: Collection of handy online tools for developers, with great UX
   copyright:
     - license: GPL-3.0
@@ -94,7 +94,7 @@ test:
     # Using manual runs instead of test/daemon-check-output since nginx doesn't emit usable stdout on startup.
     - name: "Start and verify nginx manually"
       runs: |
-        mkdir -p /var/lib/nginx/tmp/client_body /var/log/nginx /var/run
+        mkdir -p /var/log/nginx
         nginx -g 'daemon off;' 2>&1 | tee /tmp/nginx.log &
         NGINX_PID=$!
         trap 'kill -9 $NGINX_PID' EXIT

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.0"
-  epoch: 4
+  epoch: 5
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -89,8 +89,8 @@ pipeline:
           --sbin-path=/usr/bin/nginx \
           --modules-path=/usr/lib/nginx/modules \
           --conf-path=/etc/nginx/nginx.conf \
-          --pid-path=/run/nginx/nginx.pid \
-          --lock-path=/run/nginx/nginx.lock \
+          --pid-path=/run/nginx.pid \
+          --lock-path=/run/nginx.lock \
           --http-client-body-temp-path=/var/lib/nginx/tmp/client_body \
           --http-proxy-temp-path=/var/lib/nginx/tmp/proxy \
           --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi \
@@ -303,7 +303,7 @@ test:
     - name: Create Nginx user and directories
       runs: |
         # Create necessary directories
-        mkdir -p /var/lib/nginx/tmp/client_body /var/lib/nginx/tmp/proxy /var/lib/nginx/tmp/fastcgi /var/lib/nginx/tmp/uwsgi /var/lib/nginx/tmp/scgi /run/nginx
+        mkdir -p /var/lib/nginx/tmp/client_body /var/lib/nginx/tmp/proxy /var/lib/nginx/tmp/fastcgi /var/lib/nginx/tmp/uwsgi /var/lib/nginx/tmp/scgi /run
     - name: Verify Nginx Version
       runs: |
         # Ensure Nginx is installed and shows the correct version
@@ -332,8 +332,8 @@ test:
         sleep 5  # Give some time for Nginx to start
         curl -I http://localhost  # Check if Nginx is serving a basic request
 
-        if [ -f /run/nginx/nginx.pid ]; then
-          kill $(cat /run/nginx/nginx.pid)
+        if [ -f /run/nginx.pid ]; then
+          kill $(cat /run/nginx.pid)
         fi
     - name: Check modules are installed/loadable
       runs: |

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -146,6 +146,8 @@ pipeline:
       # directory that I could find.
       mkdir pkg-config
       mv ${{targets.destdir}}/etc/nginx pkg-config/
+      # Create parent location for tmp files
+      mkdir -p ${{targets.destdir}}/var/lib/nginx/tmp
 
   - uses: strip
 
@@ -300,10 +302,6 @@ test:
         - ${{package.name}}-mod-stream
         - curl
   pipeline:
-    - name: Create Nginx user and directories
-      runs: |
-        # Create necessary directories
-        mkdir -p /var/lib/nginx/tmp/client_body /var/lib/nginx/tmp/proxy /var/lib/nginx/tmp/fastcgi /var/lib/nginx/tmp/uwsgi /var/lib/nginx/tmp/scgi /run
     - name: Verify Nginx Version
       runs: |
         # Ensure Nginx is installed and shows the correct version

--- a/nginx-mainline/nginx.conf
+++ b/nginx-mainline/nginx.conf
@@ -3,7 +3,7 @@ user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
+pid        /run/nginx.pid;
 
 
 events {

--- a/nginx-mainline/nginx.initd
+++ b/nginx-mainline/nginx.initd
@@ -5,7 +5,7 @@ extra_commands="checkconfig"
 extra_started_commands="reload reopen upgrade"
 
 cfgfile=${cfgfile:-/etc/nginx/nginx.conf}
-pidfile=/run/nginx/nginx.pid
+pidfile=/run/nginx.pid
 command=${command:-/usr/sbin/nginx}
 command_args="-c $cfgfile"
 required_files="$cfgfile"

--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-prometheus-exporter
   version: "1.4.2"
-  epoch: 6 # CVE-2025-47907
+  epoch: 7 # CVE-2025-47907
   description: NGINX Prometheus Exporter for NGINX and NGINX Plus
   copyright:
     - license: Apache-2.0
@@ -147,7 +147,6 @@ test:
         timeout: 60
         setup: |
           useradd nginx
-          mkdir -p /var/lib/nginx/logs
           nginx -g "daemon off;" > /dev/null 2>&1 &
         expected_output: |
           Listening on

--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-prometheus-exporter
   version: "1.4.2"
-  epoch: 5 # CVE-2025-47907
+  epoch: 6 # CVE-2025-47907
   description: NGINX Prometheus Exporter for NGINX and NGINX Plus
   copyright:
     - license: Apache-2.0
@@ -148,7 +148,6 @@ test:
         setup: |
           useradd nginx
           mkdir -p /var/lib/nginx/logs
-          mkdir -p /var/lib/nginx/tmp
           nginx -g "daemon off;" > /dev/null 2>&1 &
         expected_output: |
           Listening on

--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -121,7 +121,7 @@ subpackages:
           sed -i "/^server {/a \    listen       8080;" "${NGINX_DIRECTORY}/templates/default.conf.template"
           sed -i '/user  nginx;/d' "${NGINX_DIRECTORY}/nginx.conf"
           sed -i 's#http://127.0.0.1:80#http://127.0.0.1:8080#g' "${NGINX_DIRECTORY}/include/s3gateway.js"
-          sed -i 's,/run/nginx.pid,/tmp/nginx.pid,' "${NGINX_DIRECTORY}/nginx.conf"
+          sed -i 's,^pid .*nginx.pid;,pid /tmp/nginx.pid;,' "${NGINX_DIRECTORY}/nginx.conf"
           sed -i "/^http {/a \\
           proxy_temp_path /tmp/proxy_temp;\\
           client_body_temp_path /tmp/client_temp;\\

--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -2,7 +2,7 @@
 package:
   name: nginx-s3-gateway
   version: 0_git20250605
-  epoch: 4
+  epoch: 5
   description: NGINX S3 Gateway
   copyright:
     - license: Apache-2.0
@@ -121,7 +121,7 @@ subpackages:
           sed -i "/^server {/a \    listen       8080;" "${NGINX_DIRECTORY}/templates/default.conf.template"
           sed -i '/user  nginx;/d' "${NGINX_DIRECTORY}/nginx.conf"
           sed -i 's#http://127.0.0.1:80#http://127.0.0.1:8080#g' "${NGINX_DIRECTORY}/include/s3gateway.js"
-          sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' "${NGINX_DIRECTORY}/nginx.conf"
+          sed -i 's,/run/nginx.pid,/tmp/nginx.pid,' "${NGINX_DIRECTORY}/nginx.conf"
           sed -i "/^http {/a \\
           proxy_temp_path /tmp/proxy_temp;\\
           client_body_temp_path /tmp/client_temp;\\

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-stable
   # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
   version: "1.28.0"
-  epoch: 6
+  epoch: 7
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -88,8 +88,8 @@ pipeline:
           --sbin-path=/usr/bin/nginx \
           --modules-path=/usr/lib/nginx/modules \
           --conf-path=/etc/nginx/nginx.conf \
-          --pid-path=/run/nginx/nginx.pid \
-          --lock-path=/run/nginx/nginx.lock \
+          --pid-path=/run/nginx.pid \
+          --lock-path=/run/nginx.lock \
           --http-client-body-temp-path=/var/lib/nginx/tmp/client_body \
           --http-proxy-temp-path=/var/lib/nginx/tmp/proxy \
           --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi \

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -145,6 +145,8 @@ pipeline:
       # directory that I could find.
       mkdir pkg-config
       mv ${{targets.destdir}}/etc/nginx pkg-config/
+      # Create parent location for tmp files
+      mkdir -p ${{targets.destdir}}/var/lib/nginx/tmp
 
   - uses: strip
 

--- a/nginx-stable/nginx.conf
+++ b/nginx-stable/nginx.conf
@@ -3,7 +3,7 @@ user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
+pid        /run/nginx.pid;
 
 
 events {

--- a/openrc.yaml
+++ b/openrc.yaml
@@ -2,7 +2,7 @@
 package:
   name: openrc
   version: "0.62.6"
-  epoch: 0
+  epoch: 1
   description: OpenRC is a dependency-based init system that works with the system provided init program.
   copyright:
     - license: BSD-2-Clause
@@ -216,7 +216,6 @@ test:
     - name: Run nginx
       runs: |
         mkdir -p /var/lib/nginx/tmp
-        mkdir -p /run/nginx
         nginx -t
 
         touch /run/openrc/softlevel

--- a/openrc.yaml
+++ b/openrc.yaml
@@ -215,7 +215,6 @@ test:
         rc-status
     - name: Run nginx
       runs: |
-        mkdir -p /var/lib/nginx/tmp
         nginx -t
 
         touch /run/openrc/softlevel


### PR DESCRIPTION
Currently nginx was configured to store pidfiles in a location which
is not otherwise created by the package, in a location that is
inconsistent with neither Debian/Ubuntu, nor Fedora/RHEL, nor systemd,
nor containers guaranteed filesystem layout.

Furthermore it was inconsistent across our packages.

Update all nginx related pieces of software to use /run/nginx.pid
file, as such location is guaranteed to be available in all containers
and VMs out of the box. Which is also consistent with Debian/Ubuntu,
Fedora/RHEL, and existing ingress-nginx-controller packages.

Also move lockfile to /run, like it is done in
Fedora/Rhel. Debian/Ubuntu use legacy /var/lock/nginx.lock location,
which is a symlink to /run/lock which is also deprecated.

Note that previously nothing shipped /var/run/nginx, thus it is
difficult to provide backwards compat by shipping a symlink
`/run/nginx -> ../` somewhere, as it's not clear if it would help or
hinder. Given likely, existing integrations had to create
/var/run/nginx to make nginx work (or provide a custom pid location).

Similarly also ship the mandatory directory for the tmp directories destination. No consistency so far, some of our packages use it with /tmp/ subdir, some without, and there are similar differences between Fedora and Debian.