### PR TITLE
dnsdist: fix versioning

### DIFF
--- a/dnsdist-2.0.yaml
+++ b/dnsdist-2.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnsdist-2.0
   version: "2.0.0"
-  epoch: 0
+  epoch: 1
   description: PowerDNS dnsdist — highly DNS-, DoS- and abuse-aware load-balancer
   copyright:
     - license: GPL-2.0-only
@@ -65,6 +65,7 @@ pipeline:
 
   - working-directory: ./pdns/dnsdistdist
     pipeline:
+      - runs: BUILDER_VERSION=${{package.version}} BUILDER_MODULES=dnsdist autoreconf -vfi
       - uses: autoconf/configure
         with:
           opts: |
@@ -160,7 +161,7 @@ test:
   pipeline:
     - uses: test/tw/ldd-check
     - runs: |
-        dnsdist --version
+        dnsdist --version | grep -q "${{package.version}}"
         dnsdist --help
     - name: "daemon smoke-test for entrypoint"
       uses: test/daemon-check-output
@@ -184,6 +185,8 @@ test:
         expected_output: |
           Listening on
           Marking downstream 1.1.1.1:53
+          Polled security status
+          no known issues reported
         post: |
           wait-for-it -t 5 --strict 127.0.0.1:5300 -- echo "dnsdist is up"
           dig @127.0.0.1 -p 5300 example.com A | grep -q "ANSWER"


### PR DESCRIPTION
Fixes `0.0.0` versioning, stamp the version properly during build-time.