### PR TITLE
wolfi-baselayout - queue a change to create /tmp with expected perms.

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -51,6 +51,10 @@ pipeline:
         mkdir -p "${{targets.destdir}}"/${i}
       done
 
+      # be explicit here, and create tmp as 1777 (drwxrwxrwt) even though
+      # apko does this itself in its baseDirectories / initDB
+      chmod 1777 "${{targets.destdir}}/tmp"
+
       # usr-merge
       ln -sf usr/bin ${{targets.destdir}}/sbin
       ln -sf usr/bin ${{targets.destdir}}/bin


### PR DESCRIPTION
/tmp in the wolfi-baselayout package was being created with 0755
and we were relying on apko's initDB and 'baseDirectories' to set
the permissions correctly on /tmp to the typical values of 01755.

Better to correctly record the expected permissions here.

I did not bump the epoch so as to not force world rebuilds.

After https://github.com/chainguard-dev/apko/pull/1811
lands, then apko-built images will have an entry for tmp
in /lib/apk/db/installed/ like:

    F:tmp

And after this change lands we would then see an entry like:

    F:tmp
    M:0:0:1777

For reference, note that alpine-baselayout (3.7.0-r0) does
have tmp with 1777 permissions

    $ burl=https://dl-cdn.alpinelinux.org/alpine/edge/main/
    $ curl -sL $burl/x86_64/alpine-baselayout-3.7.0-r0.apk |
       tar -tvz tmp
    drwxrwxrwt root/root         0 2025-03-25 09:16 tmp/