### PR TITLE
systemd: fix for aarch64 systemd-detect logic

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -2,7 +2,7 @@ package:
   name: systemd
   # 35712.patch can be dropped when 258 releases
   version: "257.8"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -91,6 +91,15 @@ pipeline:
       repository: https://github.com/systemd/systemd
       tag: v${{package.version}}
       expected-commit: 5e38d199a623563698ab4a69acbbe3afa9135198
+
+  # systemd-detect is currently broken for aarch64 GCP VM's https://github.com/systemd/systemd/pull/38125
+  # https://github.com/chainguard-dev/internal-dev/issues/17776
+  - pipeline:
+      - if: ${{build.arch}} == 'aarch64'
+        uses: patch
+        with:
+          patches: |
+            revert-detect-virt.patch
 
   - uses: meson/configure
     with:

--- a/systemd/revert-detect-virt.patch
+++ b/systemd/revert-detect-virt.patch
@@ -1,0 +1,49 @@
+From 0f031fc95985661e5993cc9b42504c5f0491f461 Mon Sep 17 00:00:00 2001
+From: Zach <zach.marano@chainguard.dev>
+Date: Tue, 12 Aug 2025 10:28:47 -0700
+Subject: [PATCH] Revert "detect-virt: add bare-metal support for GCE"
+
+This reverts commit fb71571d3a4efddeb44f02939304be9007301974.
+---
+ src/basic/virt.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/basic/virt.c b/src/basic/virt.c
+index 226d0b53f8..68732e7636 100644
+--- a/src/basic/virt.c
++++ b/src/basic/virt.c
+@@ -475,7 +475,8 @@ Virtualization detect_vm(void) {
+                    VIRTUALIZATION_ORACLE,
+                    VIRTUALIZATION_XEN,
+                    VIRTUALIZATION_AMAZON,
+-                   VIRTUALIZATION_PARALLELS)) {
++                   VIRTUALIZATION_PARALLELS,
++                   VIRTUALIZATION_GOOGLE)) {
+                 v = dmi;
+                 goto finish;
+         }
+@@ -514,10 +515,6 @@ Virtualization detect_vm(void) {
+                 hyperv = true;
+         else if (v == VIRTUALIZATION_VM_OTHER)
+                 other = true;
+-        else if (v == VIRTUALIZATION_KVM && dmi == VIRTUALIZATION_GOOGLE)
+-                /* The DMI vendor tables in /sys/class/dmi/id don't help us distinguish between GCE
+-                 * virtual machines and bare-metal instances, so we need to look at hypervisor. */
+-                return VIRTUALIZATION_GOOGLE;
+         else if (v != VIRTUALIZATION_NONE)
+                 goto finish;
+ 
+@@ -530,9 +527,7 @@ Virtualization detect_vm(void) {
+                 return dmi;
+         if (dmi == VIRTUALIZATION_VM_OTHER)
+                 other = true;
+-        else if (!IN_SET(dmi, VIRTUALIZATION_NONE, VIRTUALIZATION_GOOGLE)) {
+-                /* At this point if GCE has been detected in dmi, do not report as a VM. It should
+-                 * be a bare-metal machine */
++        else if (dmi != VIRTUALIZATION_NONE) {
+                 v = dmi;
+                 goto finish;
+         }
+-- 
+2.48.1
+


### PR DESCRIPTION
In upstream there was a regression for aarch64 VM detection on GCP. Revert that commit for aarch64 builds until it is resolved.