### PR TITLE
add a compat subpackage for providing symlink for jmx_prometheus_javaagent.jar

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.47.0"
-  epoch: 1
+  epoch: 2
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -168,6 +168,7 @@ subpackages:
         - kafka
         - kafka_exporter
         - kafka_exporter-strimzi-compat
+        - prometheus-jmx-exporter-strimzi-compat
         - kafka-strimzi-compat
         - net-tools
         - nmap
@@ -206,6 +207,14 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/kafka-exporter
           # https://github.com/strimzi/strimzi-kafka-operator/blob/23c0fb0726e1f212c6182eb251ff23697e72a353/docker-images/kafka-based/kafka/Dockerfile#L33
           ln -sf /usr/bin/kafka_exporter ${{targets.contextdir}}/opt/kafka-exporter/kafka_exporter
+
+  - name: prometheus-jmx-exporter-strimzi-compat
+    description: "Compatibility package to create a symlink between folders for prometheus_jmx_exporter package which is expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/prometheus-jmx-exporter/
+          # https://github.com/strimzi/strimzi-kafka-operator/blob/3f657dfadf053933e27efdf45a662c3b35ea03d5/docker-images/kafka-based/kafka/Dockerfile#L83-L93
+          ln -sf /usr/lib/prometheus/jmx_prometheus_javaagent.jar ${{targets.contextdir}}/opt/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar
 
 update:
   enabled: true


### PR DESCRIPTION
…agent.jar

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Related: https://github.com/strimzi/strimzi-kafka-operator/blob/main/docker-images/kafka-based/kafka/Dockerfile#L83-L93

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
