### PR TITLE
fix: removing grpc-health-probe as a runtime dep as it is not require…

### DIFF
--- a/spicedb.yaml
+++ b/spicedb.yaml
@@ -1,13 +1,10 @@
 package:
   name: spicedb
   version: "1.45.1"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4
   description: Open Source, Google Zanzibar-inspired fine-grained permissions database
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - grpc-health-probe
 
 pipeline:
   - uses: git-checkout
@@ -28,20 +25,14 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
-        - grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -sf /usr/bin/spicedb ${{targets.subpkgdir}}/usr/local/bin/spicedb
-          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/usr/bin/grpc_health_probe
     test:
       pipeline:
         - runs: |
             test "$(readlink /usr/local/bin/spicedb)" = "/usr/bin/spicedb"
-            # Since /bin is a symlink to /usr/bin in Wolfi, both paths work
-            test "$(readlink /usr/bin/grpc_health_probe)" = "/usr/bin/grpc-health-probe"
-            stat /bin/grpc_health_probe
 
 update:
   enabled: true


### PR DESCRIPTION
fix: removing `grpc-health-probe` from spicedb manifest, and will add it on the image level.
