### PR TITLE
add missing builddtags to registry

### DIFF
--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-registry
   version: 3.0.0
-  epoch: 5 # CVE-2025-47907
+  epoch: 6 # CVE-2025-47907
   description: An open source trusted cloud native registry project that stores, signs, and scans content (registry)
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,7 @@ pipeline:
     with:
       packages: ./cmd/registry
       output: harbor-registry
+      tags: include_oss,include_gcs
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
We missed to add build tags to go build: https://github.com/goharbor/harbor/blob/e80b940942314b38be586d73bcfe108acc06a9df/make/photon/registry/Dockerfile.binary#L5