### PR TITLE
add missing builddtags to registryctl

### DIFF
--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.13
   version: "2.13.2"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5 # CVE-2025-47907
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0
@@ -161,6 +161,7 @@ subpackages:
           packages: ./registryctl
           output: harbor-registryctl
           modroot: ./src
+          tags: include_oss,include_gcs
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/registryctl
           mkdir -p ${{targets.subpkgdir}}/harbor


### PR DESCRIPTION
add missing tags to registrctl to fix the following error:

```bash
2025-08-13T12:40:11Z [ERROR] [/registryctl/config/config.go:63]: failed to load storage driver, err:StorageDriver not registered: gcs
2025-08-13T12:40:11Z [FATAL] [/registryctl/main.go:102]: Failed to load configurations with error: StorageDriver not registered: gcs
```