### PR TITLE
langfuse: 3.97.3 pkg update and arch filter fixes

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,6 +1,6 @@
 package:
   name: langfuse
-  version: "3.97.1"
+  version: "3.97.3"
   epoch: 0
   description: "Langfuse webapp"
   copyright:
@@ -53,7 +53,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: 25bdb1690b4b4c0db738e0001a9785ce17fe5bb1
+      expected-commit: daf4e2fe028f73c066ab4646d7f979c46d5e2a01
 
   - name: "Bump deps and install"
     runs: |

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -111,9 +111,14 @@ pipeline:
 
   - name: remove deps that cause compat issues
     runs: |
-      find "${{targets.contextdir}}"/app/node_modules -type f -exec file {} \; | \
-        grep ELF | grep -E '(musl|[^${{build.arch}}])' | \
-        cut -d: -f1 | xargs rm -f
+      # Remove all musl (since we're using glibc) and non build-arch binaries
+      find "${{targets.destdir}}"/app/node_modules -type f -exec file {} \; | grep ELF > elf.check
+      if [ "${{build.arch}}" = "aarch64" ]; then
+        grep -E 'musl|ELF.*32-bit|ELF.*x86' elf.check | cut -d: -f1 | xargs rm -f
+      else
+        grep -E 'musl|ELF.*ARM' elf.check | cut -d: -f1 | xargs rm -f
+      fi
+      rm -f elf.check
 
 test:
   environment:
@@ -223,9 +228,14 @@ subpackages:
           cp /usr/bin/esbuild $(find "${{targets.contextdir}}"/app/node_modules/.pnpm -path '*@esbuild+linux*bin/esbuild')
       - name: remove deps that cause compat issues
         runs: |
-          find "${{targets.contextdir}}"/app/node_modules -type f -exec file {} \; | \
-            grep ELF | grep -E '(musl|[^${{build.arch}}])' | \
-            cut -d: -f1 | xargs rm -f
+          # Remove all musl (since we're using glibc) and non build-arch binaries
+          find "${{targets.contextdir}}"/app/node_modules -type f -exec file {} \; | grep ELF > elf.check
+          if [ "${{build.arch}}" = "aarch64" ]; then
+            grep -E 'musl|ELF.*32-bit|ELF.*x86' elf.check | cut -d: -f1 | xargs rm -f
+          else
+            grep -E 'musl|ELF.*ARM' elf.check | cut -d: -f1 | xargs rm -f
+          fi
+          rm -f elf.check
       - name: remove unneeded packages and tests that may introduce CVE's
         runs: |
           # monorepo-symlink-test vulnerability


### PR DESCRIPTION
We filter out non build-arch node module bits so they don't cause arch-related loader issues at runtime.  We modified that filter [recently](https://github.com/wolfi-dev/os/pull/62174/files), but that match wasn't quite right and resulted in legit binaries missing from our subpackages.  Specifically, this was lost:

```
/home/build/melange-out/langfuse-worker/app/node_modules/.pnpm/prisma@6.10.1_typescript@5.4.5/node_modules/prisma/libquery_engine-debian-openssl-3.0.x.so.node: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=3a731c8293070e0cdd249f49353b42e629c31556, stripped
```

which resulted in failures in the langfuse image like this:

```
PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x".

This is likely caused by tooling that has not copied "libquery_engine-debian-openssl-3.0.x.so.node" to the deployment folder.
Ensure that you ran `prisma generate` and that "libquery_engine-debian-openssl-3.0.x.so.node" has been copied to "../node_modules/.pnpm/@prisma+client@6.10.1_prisma@6.10.1_typescript@5.4.5__typescript@5.4.5/node_modules/.prisma/client".
```

This PR tweaks the logic in our file filters to exclude musl + arm(ish) bits on amd64 builders and musl + x86(ish) bits on arm64 builders.

For reference, example ELFs that we want filtered look like this:

```
melange-out/langfuse-worker/app/node_modules/.pnpm/@datadog+native-metrics@3.1.0/node_modules/@datadog/native-metrics/prebuilds/linuxglibc-arm/node-napi.node: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=cba75452b7a0fd9ed156bbd37c94309ca04756fb, not stripped

melange-out/langfuse-worker/app/node_modules/.pnpm/@datadog+pprof@5.5.1/node_modules/@datadog/pprof/prebuilds/linuxmusl-arm64/node-93.node: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, with debug_info, not stripped

melange-out/langfuse-worker/app/node_modules/.pnpm/@next+swc-linux-x64-musl@14.2.30/node_modules/@next/swc-linux-x64-musl/next-swc.linux-x64-musl.node: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, stripped
```