### PR TITLE
Speed up pre-commit checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0 # required for --from-ref and --to-ref
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - run: |
           python -m pip install pre-commit
@@ -35,10 +37,10 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       # A cache miss means that the pre-commit config changed and we should check everything
       # Otherwise, we can just check modified files which will be much faster
+      - if: steps.cache.outputs.cache-hit == 'true'
+        run: pre-commit run --show-diff-on-failure --color=always --from-ref HEAD^^^ --to-ref HEAD
       - if: steps.cache.outputs.cache-hit != 'true'
         run: pre-commit run --show-diff-on-failure --color=always --all-files
-      - if: steps.cache.outputs.cache-hit == 'true'
-        run: pre-commit run --show-diff-on-failure --color=always
       # Install yam
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     branches:
-      - 'main'
+      - "main"
 
 permissions:
   contents: read
@@ -23,13 +23,20 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: pre-commit run --show-diff-on-failure --color=always --all-files
       # Install yam
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
       - run: go install github.com/chainguard-dev/yam@v0.2.26
       - run: ./lint.sh
       - run: git diff --exit-code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,10 +37,10 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       # A cache miss means that the pre-commit config changed and we should check everything
       # Otherwise, we can just check modified files which will be much faster
-      - if: steps.cache.outputs.cache-hit == 'true'
-        run: pre-commit run --show-diff-on-failure --color=always --from-ref HEAD^^^ --to-ref HEAD
       - if: steps.cache.outputs.cache-hit != 'true'
         run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - if: steps.cache.outputs.cache-hit == 'true'
+        run: pre-commit run --show-diff-on-failure --color=always --from-ref HEAD^^^ --to-ref HEAD
       # Install yam
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,10 +29,16 @@ jobs:
           python -m pip install pre-commit
           python -m pip freeze --local
       - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        id: cache
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - run: pre-commit run --show-diff-on-failure --color=always --all-files
+      # A cache miss means that the pre-commit config changed and we should check everything
+      # Otherwise, we can just check modified files which will be much faster
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - if: steps.cache.outputs.cache-hit == 'true'
+        run: pre-commit run --show-diff-on-failure --color=always
       # Install yam
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: "5.3"
-  epoch: 42
+  epoch: 41
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only

--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: "5.3"
-  epoch: 41
+  epoch: 42
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only


### PR DESCRIPTION
The current pre-commit Action doesn't reliably cache its configuration, so we spend cycles initializing the environment each time. Also, we can avoid running against all files unless the pre-commit configuration changes which is about 4-5 times faster per commit.