### PR TITLE
Run Lint Workflow in main to persist cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - "main" # required to create a usable cache for other PRs
   pull_request:
     branches:
       - "main"


### PR DESCRIPTION
This is likely why the original pre-commit caches never worked. Each only existed in the feature branch and new branches can't leverage these.

While this will spend a few minutes running each time a PR merges, we'll be able to save a lot of time where it counts.