### PR TITLE
add pull_requests read permission for epoch bot

### DIFF
--- a/.github/chainguard/epoch-bot.sts.yaml
+++ b/.github/chainguard/epoch-bot.sts.yaml
@@ -7,3 +7,4 @@ subject_pattern: "(101928776192101947682|109129704552956512299)"
 permissions:
   contents: read
   checks: write
+  pull_requests: read


### PR DESCRIPTION
need pull_requests read permission becuase it does a get raw Pull request api call the epoch bot