### PR TITLE
ruby*-net-http-persistent: convert to git update backend

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -42,8 +42,7 @@ vars:
 
 update:
   enabled: true
-  github:
-    identifier: drbrain/net-http-persistent
+  git:
     strip-prefix: v
 
 var-transforms:

--- a/ruby3.3-net-http-persistent.yaml
+++ b/ruby3.3-net-http-persistent.yaml
@@ -42,8 +42,7 @@ vars:
 
 update:
   enabled: true
-  github:
-    identifier: drbrain/net-http-persistent
+  git:
     strip-prefix: v
 
 var-transforms:

--- a/ruby3.4-net-http-persistent.yaml
+++ b/ruby3.4-net-http-persistent.yaml
@@ -42,8 +42,7 @@ vars:
 
 update:
   enabled: true
-  github:
-    identifier: drbrain/net-http-persistent
+  git:
     strip-prefix: v
 
 var-transforms:


### PR DESCRIPTION
Upstream stopped using GitHub Releases (before the version we currently have, confusingly).