### PR TITLE
py3-decorator: convert to git update backend

### DIFF
--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -74,6 +74,4 @@ subpackages:
 
 update:
   enabled: true
-  manual: false
-  github:
-    identifier: micheles/decorator
+  git: {}


### PR DESCRIPTION
Upstream haven't used GitHub Releases since before the version we currently have.