### PR TITLE
RFC: python-3.13: Add support for dist-packages

### DIFF
--- a/pipelines/py/pip-build-install-bootstrap.yaml
+++ b/pipelines/py/pip-build-install-bootstrap.yaml
@@ -20,6 +20,7 @@ pipeline:
   - name: "pip-bootstrap build"
     runs: |
       export SOURCE_DATE_EPOCH=315532800
+      export CHAINGUARD_PYTHON_INSTALL_LAYOUT="chainguard_system"
       py=${{inputs.python}}
       pipzip=/usr/share/pip-zipapp/pip-zipapp.pyz
       [ -e "$pipzip" ] || { echo "missing pip-zip - $pipzip does not exist"; exit 1; }

--- a/pipelines/py/pip-build-install.yaml
+++ b/pipelines/py/pip-build-install.yaml
@@ -23,6 +23,7 @@ pipeline:
   - name: "pip build"
     runs: |
       export SOURCE_DATE_EPOCH=315532800
+      export CHAINGUARD_PYTHON_INSTALL_LAYOUT="chainguard_system"
       py=${{inputs.python}}
       pyexe=${{inputs.needs-exe-named-python}}
       py3exe=${{inputs.needs-exe-named-python3}}

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setuptools
   version: "80.9.0"
-  epoch: 2
+  epoch: 3
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.7"
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -61,6 +61,10 @@ pipeline:
       rm -rf Modules/expat \
         Modules/_ctypes/darwin* \
         Modules/_ctypes/libffi*
+
+  - uses: patch
+    with:
+      patches: distutils-install-layout.diff sysconfig-chainguard-schemes.diff
 
   - uses: patch
     with:

--- a/python-3.13/distutils-install-layout.diff
+++ b/python-3.13/distutils-install-layout.diff
@@ -1,0 +1,110 @@
+From 0c845ae43c5dd86ad868db5886e6afbe74e50a73 Mon Sep 17 00:00:00 2001
+From: dann frazier <dann.frazier@chainguard.dev>
+Date: Thu, 14 Aug 2025 12:36:51 -0600
+Subject: [PATCH] Add a distutils option --install-layout=chainguard
+
+Based on Debian's distutils-install-layout.diff
+
+This option:
+  - installs into $prefix/dist-packages instead of $prefix/site-packages.
+  - doesn't encode the python version into the egg name.
+
+ We install modules into dist-packages to avoid entangling native OS
+ packages with pip-installed packages.
+ .
+ Customize site.py to import from Chainguard's dist-packages layout.
+
+Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
+---
+ Lib/pydoc.py          |  1 +
+ Lib/site.py           | 16 +++++++++++++++-
+ Lib/test/test_site.py | 10 +++++-----
+ 3 files changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/Lib/pydoc.py b/Lib/pydoc.py
+index d508fb70ea4..ff2603c7e35 100644
+--- a/Lib/pydoc.py
++++ b/Lib/pydoc.py
+@@ -577,6 +577,7 @@ def getdocloc(self, object, basedir=sysconfig.get_path('stdlib')):
+                                  'marshal', 'posix', 'signal', 'sys',
+                                  '_thread', 'zipimport') or
+              (file.startswith(basedir) and
++              not file.startswith(os.path.join(basedir, 'dist-packages')) and
+               not file.startswith(os.path.join(basedir, 'site-packages')))) and
+             object.__name__ not in ('xml.etree', 'test.test_pydoc.pydoc_mod')):
+             if docloc.startswith(("http://", "https://")):
+diff --git a/Lib/site.py b/Lib/site.py
+index f9327197159..02b04b122c2 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -7,12 +7,17 @@
+ This will append site-specific paths to the module search path.  On
+ Unix (including Mac OSX), it starts with sys.prefix and
+ sys.exec_prefix (if different) and appends
+-lib/python<version>/site-packages.
++lib/python<version>/dist-packages.
+ On other platforms (such as Windows), it tries each of the
+ prefixes directly, as well as with lib/site-packages appended.  The
+ resulting directories, if they exist, are appended to sys.path, and
+ also inspected for path configuration files.
+ 
++For Chainguard, this sys.path is augmented with directories
++for packages distributed within the distribution. Chainguard addons
++install into /usr/lib/python<version>/dist-packages.
++/usr/lib/python<version>/site-packages is not used.
++
+ If a file named "pyvenv.cfg" exists one directory above sys.executable,
+ sys.prefix and sys.exec_prefix are set to that directory and
+ it is also checked for site-packages (sys.base_prefix and
+@@ -394,6 +399,8 @@ def getsitepackages(prefixes=None):
+     if prefixes is None:
+         prefixes = PREFIXES
+ 
++    is_virtual_environment = sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")
++
+     for prefix in prefixes:
+         if not prefix or prefix in seen:
+             continue
+@@ -410,6 +417,13 @@ def getsitepackages(prefixes=None):
+             if sys.platlibdir != "lib":
+                 libdirs.append("lib")
+ 
++            if is_virtual_environment:
++                sitepackages.append(os.path.join(prefix, "lib",
++                                                 "python%d.%d" % sys.version_info[:2],
++                                                 "site-packages"))
++            sitepackages.append(os.path.join(prefix, "lib",
++                                             "python%d.%d" % sys.version_info[:2],
++                                             "dist-packages"))
+             for libdir in libdirs:
+                 path = os.path.join(prefix, libdir,
+                                     f"{implementation}{ver[0]}.{ver[1]}{abi_thread}",
+diff --git a/Lib/test/test_site.py b/Lib/test/test_site.py
+index d0e32942635..312bf39ac43 100644
+--- a/Lib/test/test_site.py
++++ b/Lib/test/test_site.py
+@@ -326,16 +326,16 @@ def test_getsitepackages(self):
+         if os.sep == '/':
+             # OS X, Linux, FreeBSD, etc
+             if sys.platlibdir != "lib":
+-                self.assertEqual(len(dirs), 2)
++                self.assertEqual(len(dirs), 3)
+                 wanted = os.path.join('xoxo', sys.platlibdir,
+-                                      f'python{sysconfig._get_python_version_abi()}',
+-                                      'site-packages')
++                                  f'python{sysconfig._get_python_version_abi()}',
++                                  'site-packages')
+                 self.assertEqual(dirs[0], wanted)
+             else:
+-                self.assertEqual(len(dirs), 1)
++                self.assertEqual(len(dirs), 3)
+             wanted = os.path.join('xoxo', 'lib',
+                                   f'python{sysconfig._get_python_version_abi()}',
+-                                  'site-packages')
++                                  'dist-packages')
+             self.assertEqual(dirs[-1], wanted)
+         else:
+             # other platforms
+-- 
+2.48.1
+

--- a/python-3.13/sysconfig-chainguard-schemes.diff
+++ b/python-3.13/sysconfig-chainguard-schemes.diff
@@ -1,0 +1,91 @@
+From 04721272ce0d5041580d0a38a0efcbd31ffa7155 Mon Sep 17 00:00:00 2001
+From: dann frazier <dann.frazier@chainguard.dev>
+Date: Thu, 14 Aug 2025 11:54:53 -0600
+Subject: [PATCH] Add a dist-packages scheme to sysconfig
+
+Based on Debian's sysconfig-debian-shemes.diff
+
+Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
+---
+ Lib/sysconfig/__init__.py  | 29 ++++++++++++++++++++++++++---
+ Lib/test/test_sysconfig.py |  2 +-
+ 2 files changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/Lib/sysconfig/__init__.py b/Lib/sysconfig/__init__.py
+index c583b74ce54..b5d9edc7f9e 100644
+--- a/Lib/sysconfig/__init__.py
++++ b/Lib/sysconfig/__init__.py
+@@ -38,6 +38,18 @@
+         'scripts': '{base}/bin',
+         'data': '{base}',
+         },
++    'chainguard_system': {
++        'stdlib': '{installed_base}/lib/python{py_version_short}',
++        'platstdlib': '{platbase}/lib/python{py_version_short}',
++        'purelib': '{base}/lib/python{py_version_short}/dist-packages',
++        'platlib': '{platbase}/lib/python{py_version_short}/dist-packages',
++        'include':
++            '{installed_base}/include/python{py_version_short}{abiflags}',
++        'platinclude':
++            '{installed_platbase}/include/python{py_version_short}{abiflags}',
++        'scripts': '{base}/bin',
++        'data': '{base}',
++        },
+     'posix_home': {
+         'stdlib': '{installed_base}/lib/{implementation_lower}',
+         'platstdlib': '{base}/lib/{implementation_lower}',
+@@ -228,7 +240,7 @@ def is_python_build():
+ _PYTHON_BUILD = is_python_build()
+ 
+ if _PYTHON_BUILD:
+-    for scheme in ('posix_prefix', 'posix_home'):
++    for scheme in ('posix_prefix', 'posix_home', 'chainguard_system'):
+         # On POSIX-y platforms, Python will:
+         # - Build from .h files in 'headers' (which is only added to the
+         #   scheme when building CPython)
+@@ -289,8 +301,19 @@ def _get_preferred_schemes():
+             'user': 'osx_framework_user',
+         }
+ 
++    if sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix"):
++        # virtual environments
++        prefix_scheme = 'posix_prefix'
++    else:
++        # default to /usr for package builds, /usr/local otherwise
++        deb_build = os.environ.get('CHAINGUARD_PYTHON_INSTALL_LAYOUT', 'posix_prefix')
++        if deb_build in ('chainguard', 'chainguard_system'):
++            prefix_scheme = 'chainguard_system'
++        else:
++            prefix_scheme = 'posix_prefix'
++
+     return {
+-        'prefix': 'posix_prefix',
++        'prefix': prefix_scheme,
+         'home': 'posix_home',
+         'user': 'posix_user',
+     }
+@@ -467,7 +490,7 @@ def get_config_h_filename():
+         else:
+             inc_dir = _PROJECT_BASE
+     else:
+-        inc_dir = get_path('platinclude')
++        inc_dir = get_path('platinclude', 'posix_prefix')
+     return os.path.join(inc_dir, 'pyconfig.h')
+ 
+ 
+diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
+index 4aaef5b1429..b29faffde34 100644
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -387,7 +387,7 @@ def test_get_config_h_filename(self):
+         self.assertTrue(os.path.isfile(config_h), config_h)
+ 
+     def test_get_scheme_names(self):
+-        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv']
++        wanted = ['chainguard_system', 'posix_local', 'nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv']
+         if HAS_USER_BASE:
+             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
+         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
+-- 
+2.48.1
+


### PR DESCRIPTION
Add support for a dist-packages directory that sits next to site-packages. Libraries installed as apks can live here, keeping them separate from the pip-installed libraries that will continue to install into site-packages by default.

This is an experiment based on [PEP-668](https://peps.python.org/pep-0668). The hope was that we could somehow "protect" the deps used by the system from stacks installed by tools like pip. But it turns out we don't really get much benefit from it, for reasons described here: https://peps.python.org/pep-0668/#create-separate-distro-and-local-directories.

TLDR; the "EXTERNALLY-MANAGED" setting is per python-install, not per directory. So while we can separate where thing get installed, this is not a mechanism to prevent them from interfering with one another. They are in the same namepace, an pip will just as happily remove an apk-installed package from under dist-packages as it would remove a pip-installed package from under site-packages. We *could* set the EXTERNALLY-MANAGED flag, but that would just result in users having to set a flag to override this.

The only benefit I see is with potential conflicts between filepaths between apk's containing individual libraries and apk's containing bundled pip-installations. But even then, we'd just be allowing an install of libraries that may actually conflict at runtime.
