### PR TITLE
CODEOWNERS: Future-proof by selecting `go-2.*` as well

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@ openssl.yaml                  @wolfi-dev/foundations-squad
 # New perl releases may require a transition. Until that's automated:
 perl.yaml                     @wolfi-dev/foundations-squad
 go-1.*.yaml                   @wolfi-dev/foundations-squad
+go-2.*.yaml                   @wolfi-dev/foundations-squad
 
 # Adding sustaining-team as codeowner of nats* packages blocking any 
 # non sustaining-team and automation from merging of nats* package changes. 


### PR DESCRIPTION
Thanks to @dannf for the suggestion.