### PR TITLE
openssl: add MD5 and SHA1 to the base provider

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: "3.5.2"
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch
+      patches: fix-jitter.patch 0001-baseprovider-add-MD5-and-SHA1.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl/0001-baseprovider-add-MD5-and-SHA1.patch
+++ b/openssl/0001-baseprovider-add-MD5-and-SHA1.patch
@@ -1,0 +1,51 @@
+From 8a752acde850f0dad7a3451cd22c6d0458bb72b5 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Fri, 15 Aug 2025 19:43:56 +0100
+Subject: [PATCH] baseprovider: add MD5 and SHA1
+
+Open up access to MD5 and SHA1 from the base provider, this allows
+access to MD5 for non-security purposes from higher level languages
+such as dotnet, python and others.
+
+Crutially, this does not allow fips provider to use them for
+cryptographically secure purposes such as calculating HMAC, DRBG,
+PRNG, Signatures, KDF, etc.
+---
+ providers/baseprov.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/providers/baseprov.c b/providers/baseprov.c
+index c7c72cbc8e..0944e574d6 100644
+--- a/providers/baseprov.c
++++ b/providers/baseprov.c
+@@ -68,6 +68,18 @@ static int base_get_params(void *provctx, OSSL_PARAM params[])
+     return 1;
+ }
+ 
++/*
++ * open up access to MD5 and SHA1 for digest/crc non-security
++ * purposes, does not allow to be used in HMAC/DRBG/PRNG/KEM/Signature
++ * by the fips provider, this allows us to completely remove SHA1 from
++ * the fips provider.
++ */
++static const OSSL_ALGORITHM base_digests[] = {
++    { PROV_NAMES_SHA1, "provider=base", ossl_sha1_functions },
++    { PROV_NAMES_MD5, "provider=base", ossl_md5_functions },
++    { NULL, NULL, NULL }
++};
++
+ static const OSSL_ALGORITHM base_encoder[] = {
+ #define ENCODER_PROVIDER "base"
+ #include "encoders.inc"
+@@ -108,6 +120,8 @@ static const OSSL_ALGORITHM *base_query(void *provctx, int operation_id,
+         return base_encoder;
+     case OSSL_OP_DECODER:
+         return base_decoder;
++    case OSSL_OP_DIGEST:
++        return base_digests;
+     case OSSL_OP_STORE:
+         return base_store;
+     case OSSL_OP_RAND:
+-- 
+2.48.1
+


### PR DESCRIPTION
This is for compatibility with upstream python and dotnet fetching of
digests with -fips property.
