### PR TITLE
Add test/no-docs pipeline to batch 30 packages

### DIFF
--- a/perl-net-telnet.yaml
+++ b/perl-net-telnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-telnet
   version: "3.05"
-  epoch: 5
+  epoch: 6
   description: Interact with TELNET port or other TCP ports
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -39,6 +39,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-params-validationcompiler.yaml
+++ b/perl-params-validationcompiler.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-params-validationcompiler
   version: "0.31"
-  epoch: 5
+  epoch: 6
   description: Params::ValidationCompiler perl module
   copyright:
     - license: Artistic-2.0
@@ -61,6 +61,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-pod-parser.yaml
+++ b/perl-pod-parser.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-pod-parser
   version: "1.67"
-  epoch: 3
+  epoch: 4
   description: Modules for parsing/translating POD format documents
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-readonly.yaml
+++ b/perl-readonly.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-readonly
   version: "2.05"
-  epoch: 6
+  epoch: 7
   description: Facility for creating read-only scalars, arrays, hashes
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later
@@ -55,6 +55,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-role-tiny.yaml
+++ b/perl-role-tiny.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-role-tiny
   version: "2.002004"
-  epoch: 4
+  epoch: 5
   description: "Roles: a nouvelle cuisine portion size slice of Moose"
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-scope-guard.yaml
+++ b/perl-scope-guard.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-scope-guard
   version: "0.21"
-  epoch: 5
+  epoch: 6
   description: Scope::Guard perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -44,6 +44,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-specio.yaml
+++ b/perl-specio.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-specio
   version: "0.52"
-  epoch: 0
+  epoch: 1
   description: Type constraints and coercions for Perl
   copyright:
     - license: Artistic-2.0
@@ -61,6 +61,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-sub-exporter-progressive.yaml
+++ b/perl-sub-exporter-progressive.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-exporter-progressive
   version: "0.001013"
-  epoch: 4
+  epoch: 5
   description: Only use Sub::Exporter if you need it
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -45,6 +45,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-sub-info.yaml
+++ b/perl-sub-info.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-info
   version: "0.002"
-  epoch: 4
+  epoch: 5
   description: Tool for inspecting subroutines.
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -47,6 +47,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-sub-quote.yaml
+++ b/perl-sub-quote.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-sub-quote
   version: "2.006008"
-  epoch: 4
+  epoch: 5
   description: Efficient generation of subroutines via string eval
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -45,6 +45,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-term-table.yaml
+++ b/perl-term-table.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-term-table
   version: "0.024"
-  epoch: 1
+  epoch: 2
   description: Format a header and rows into a table
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -47,6 +47,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-test-differences.yaml
+++ b/perl-test-differences.yaml
@@ -2,7 +2,7 @@
 package:
   name: perl-test-differences
   version: "0.72"
-  epoch: 0
+  epoch: 1
   description: Test strings and data structures and show differences if not ok
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -50,6 +50,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true

--- a/perl-test2-plugin-nowarnings.yaml
+++ b/perl-test2-plugin-nowarnings.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-test2-plugin-nowarnings
   version: "0.10"
-  epoch: 4
+  epoch: 5
   description: Test2::Plugin::NoWarnings perl module
   copyright:
     - license: Artistic-2.0
@@ -48,6 +48,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+test:
+  pipeline:
+    - uses: test/no-docs
 
 update:
   enabled: true


### PR DESCRIPTION
Added test/no-docs pipeline to 13 high-priority Perl packages that had no existing test sections. This provides documentation split validation and ensures these packages have proper test coverage:

- perl-net-telnet, perl-params-validationcompiler, perl-pod-parser
- perl-readonly, perl-role-tiny, perl-scope-guard, perl-specio
- perl-sub-exporter-progressive, perl-sub-info, perl-sub-quote
- perl-term-table, perl-test2-plugin-nowarnings, perl-test-differences

All packages have documentation subpackages with split/manpages pipelines and epochs bumped for CI compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)