### PR TITLE
Revert "juicefs-1.3/1.3.0-r2: cve remediation"

### DIFF
--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -63,7 +63,14 @@ subpackages:
           ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/usr/local/bin/juicefs
           ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/usr/bin/mount.juicefs
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
         - runs: |
             test "$(readlink /usr/local/bin/juicefs)" = "/usr/bin/juicefs"
             test "$(readlink /usr/bin/mount.juicefs)" = "/usr/bin/juicefs"

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.0"
-  epoch: 2
+  epoch: 4
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0
@@ -58,10 +58,10 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin
-          mkdir -p "${{targets.contextdir}}"/bin
+          mkdir -p "${{targets.contextdir}}"/usr/bin
           mkdir -p "${{targets.contextdir}}"/var/run/sshd
           ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/usr/local/bin/juicefs
-          ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/bin/mount.juicefs
+          ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/usr/bin/mount.juicefs
     test:
       pipeline:
         - runs: |

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -66,7 +66,7 @@ subpackages:
       pipeline:
         - runs: |
             test "$(readlink /usr/local/bin/juicefs)" = "/usr/bin/juicefs"
-            test "$(readlink /bin/mount.juicefs)" = "/usr/bin/juicefs"
+            test "$(readlink /usr/bin/mount.juicefs)" = "/usr/bin/juicefs"
 
 update:
   enabled: true

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.0"
-  epoch: 3 # CVE-2025-47907
+  epoch: 2
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0
@@ -58,12 +58,15 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          mkdir -p "${{targets.contextdir}}"/bin
           mkdir -p "${{targets.contextdir}}"/var/run/sshd
           ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/usr/local/bin/juicefs
+          ln -sf /usr/bin/juicefs "${{targets.contextdir}}"/bin/mount.juicefs
     test:
       pipeline:
         - runs: |
             test "$(readlink /usr/local/bin/juicefs)" = "/usr/bin/juicefs"
+            test "$(readlink /bin/mount.juicefs)" = "/usr/bin/juicefs"
 
 update:
   enabled: true


### PR DESCRIPTION
Reverts wolfi-dev/os#62407

Images based on this package rely on a `mount.juicefs` symlink.  Reinstate that and adjust the path to account for usrmerge.