### PR TITLE
libnvidia-container: unpin go

### DIFF
--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: "1.17.8"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4 # CVE-2025-47907
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ environment:
       - curl
       - gcc-14-default
       - glibc-dev
-      - go-1.23
+      - go
       - libcap-dev # for sys/capability.h
       - libseccomp
       - libseccomp-dev


### PR DESCRIPTION
This was pinned due to FTBFS in:
- ea589ee3e08fb9132d7351b86546cd08ff63cde7

This was fixed upstream in v1.17.6 release.

See:
- https://github.com/NVIDIA/libnvidia-container/commit/1c680195fdc85948d635286b72a6ad9f823b5987
