### PR TITLE
fix: wrong ldflags for gitlab agent casuing UI issues

### DIFF
--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -28,7 +28,7 @@ pipeline:
       output: kas
       ldflags: |
         -w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
-        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=v${{package.version}}
+        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=$(git rev-parse HEAD)
 
 subpackages:
   - name: gitlab-agent-${{vars.major-minor-version}}

--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -44,7 +44,7 @@ subpackages:
           ldflags: |
             -w
             -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=v${{package.version}}
+            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=$(git rev-parse HEAD)
     test:
       pipeline:
         - runs: agentk --version

--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-kas-18.2
   version: "18.2.4"
-  epoch: 2 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: GitLab KAS is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT

--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-kas-18.2
   version: "18.2.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: GitLab KAS is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT
@@ -27,9 +27,8 @@ pipeline:
       packages: ./cmd/kas
       output: kas
       ldflags: |
-        -w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.Version=v${{package.version}}
-        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.Commit=v${{package.version}}
-        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.BuildTime=$(date -d@${SOURCE_DATE_EPOCH} +%F-%T)
+        -w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
+        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=v${{package.version}}
 
 subpackages:
   - name: gitlab-agent-${{vars.major-minor-version}}
@@ -44,9 +43,8 @@ subpackages:
           output: agentk
           ldflags: |
             -w
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.Version=v${{package.version}}
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.Commit=v${{package.version}}
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v17/cmd.BuildTime=$(date -d@${SOURCE_DATE_EPOCH} +%F-%T)
+            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
+            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=v${{package.version}}
     test:
       pipeline:
         - runs: agentk --version

--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -54,10 +54,10 @@ subpackages:
         - name: "Test agentk version and help"
           runs: |
             set -euo pipefail
-            agentk --version | grep "${{package.version}}"
-            agentk --help | grep "GitLab Agent for Kubernetes"
             agentk --help | grep "kas-address"
+            agentk --version | grep "${{package.version}}"
             agentk --help | grep "token-file"
+            agentk --help | grep "GitLab Agent for Kubernetes"
 
 test:
   environment:

--- a/gitlab-kas-18.2.yaml
+++ b/gitlab-kas-18.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-kas-18.2
-  version: "18.2.2"
-  epoch: 1 # CVE-2025-47907
+  version: "18.2.4"
+  epoch: 2 # CVE-2025-47907
   description: GitLab KAS is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT
@@ -14,21 +14,25 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: major-version
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent
       tag: v${{package.version}}
-      expected-commit: 0efd39ba033590adf7d8326127cdef9220607e60
+      expected-commit: aa1b6f9f80359df0a30cfca92646227ee5acdf2e
 
   - uses: go/build
     with:
       packages: ./cmd/kas
       output: kas
       ldflags: |
-        -w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
-        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=$(git rev-parse HEAD)
+        -w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v${{vars.major-version}}/internal/cmd.Version=v${{package.version}}
+        -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v${{vars.major-version}}/internal/cmd.GitRef=$(git rev-parse HEAD)
 
 subpackages:
   - name: gitlab-agent-${{vars.major-minor-version}}
@@ -43,26 +47,89 @@ subpackages:
           output: agentk
           ldflags: |
             -w
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.Version=v${{package.version}}
-            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v18/internal/cmd.GitRef=$(git rev-parse HEAD)
+            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v${{vars.major-version}}/internal/cmd.Version=v${{package.version}}
+            -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v${{vars.major-version}}/internal/cmd.GitRef=$(git rev-parse HEAD)
     test:
       pipeline:
-        - runs: agentk --version
+        - name: "Test agentk version and help"
+          runs: |
+            set -euo pipefail
+            agentk --version | grep "${{package.version}}"
+            agentk --help | grep "GitLab Agent for Kubernetes"
+            agentk --help | grep "kas-address"
+            agentk --help | grep "token-file"
+
+test:
+  environment:
+    contents:
+      packages:
+        - wait-for-it
+        - curl
+        - valkey
+        - valkey-cli
+  pipeline:
+    - name: "Version and help tests for KAS and Agent"
+      runs: |
+        set -euo pipefail
+        kas --version | grep "${{package.version}}"
+        kas --help | grep "GitLab Kubernetes Agent Server"
+    - name: "Test KAS daemon with Valkey (Redis)"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          openssl rand -base64 32 > /tmp/auth_secret
+          openssl rand -base64 48 > /tmp/websocket_secret
+
+          valkey-server --port 6379 --daemonize yes --pidfile /tmp/valkey.pid --logfile /tmp/valkey.log
+
+          sleep 5
+
+          # Create KAS configuration with Redis
+          cat > /tmp/kas-config.yaml <<EOF
+          gitlab:
+            address: http://localhost:3000
+            authentication_secret_file: /tmp/auth_secret
+          redis:
+            server:
+              address: 127.0.0.1:6379
+          agent:
+            listen:
+              address: 127.0.0.1:8150
+              network: tcp
+            kubernetes_api:
+              listen:
+                address: 127.0.0.1:8154
+                network: tcp
+              websocket_token_secret_file: /tmp/websocket_secret
+          observability:
+            listen:
+              address: 127.0.0.1:8151
+              network: tcp
+          api:
+            listen:
+              address: 127.0.0.1:8153
+              network: tcp
+              authentication_secret_file: /tmp/auth_secret
+          private_api:
+            listen:
+              address: 127.0.0.1:8155
+              network: tcp
+              authentication_secret_file: /tmp/auth_secret
+          EOF
+        start: kas --configuration-file=/tmp/kas-config.yaml
+        timeout: 30
+        expected_output: |
+          Running KAS
+          endpoint is up
+        post: |
+          set -o pipefail
+          wait-for-it 127.0.0.1:8151 -t 10
+
+          curl -fsSL -o /dev/null -w "%{http_code}" http://127.0.0.1:8151/liveness | grep -F "200"
+          curl -fsSL -o /dev/null -w "%{http_code}" http://127.0.0.1:8151/readiness | grep -F "200"
 
 update:
   enabled: true
   git:
     strip-prefix: v
     tag-filter-prefix: v18.2
-
-test:
-  environment:
-    contents:
-      packages:
-        - gitlab-kas-${{vars.major-minor-version}}
-        - gitlab-agent-${{vars.major-minor-version}}
-  pipeline:
-    - runs: |
-        kas --version
-        agentk --version
-        kas --help


### PR DESCRIPTION
Fix GitLab agent showing incorrect/default version as `ldflags` are set incorrectly
Without fix

737ce1c69c00:/usr/bin# agentk --version
agentk version v0.0.0, git ref: 0000000000000000000000000000000000000000
737ce1c69c00:/usr/bin#

with fix:

6eaf78fed830:/usr/bin# agentk --version
agentk version v18.2.2, git ref: v18.2.2
6eaf78fed830:/usr/bin#

check correct ldflags [here](https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/blob/18-2-stable/cmd/agentk/main.go?ref_type=heads)