### PR TITLE
refactor(linkerd2): merge 'policy-controller' into the 'controller' subpkg

### DIFF
--- a/linkerd2.yaml
+++ b/linkerd2.yaml
@@ -5,6 +5,10 @@ package:
   description: "meta linkerd package"
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - merged-bin
+      - wolfi-baselayout
 
 environment:
   contents:

--- a/linkerd2.yaml
+++ b/linkerd2.yaml
@@ -1,17 +1,10 @@
 package:
   name: linkerd2
   version: "25.8.3"
-  epoch: 0 # GHSA-qx2v-8332-m4fv
+  epoch: 1 # GHSA-qx2v-8332-m4fv
   description: "meta linkerd package"
   copyright:
     - license: Apache-2.0
-  dependencies:
-    # REMOVE_POST_USRMERGE - https://github.com/orgs/wolfi-dev/discussions/40270
-    provides:
-      - ${{package.name}}-policy-controller-compat=${{package.full-version}}
-    runtime:
-      - merged-bin
-      - wolfi-baselayout
 
 environment:
   contents:
@@ -96,6 +89,7 @@ subpackages:
         - merged-bin
         - wolfi-baselayout
 
+  # included policy-controller which was merged in https://github.com/linkerd/linkerd2/pull/14348
   - name: ${{package.name}}-controller
     pipeline:
       - uses: go/build
@@ -103,30 +97,6 @@ subpackages:
           packages: ./controller/cmd/main.go
           tags: prod
           output: controller
-    test:
-      pipeline:
-        - name: check presence of required files
-          runs: |
-            # executable doesn't have help or version flag.
-            stat /usr/bin/controller
-    dependencies:
-      runtime:
-        - merged-bin
-        - wolfi-baselayout
-
-  - name: ${{package.name}}-controller-compat
-    description: "upstream image have executable placed at /"
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          ln -sf /usr/bin/controller ${{targets.contextdir}}/controller
-    dependencies:
-      runtime:
-        - merged-bin
-        - wolfi-baselayout
-
-  - name: ${{package.name}}-policy-controller
-    pipeline:
       - runs: |
           export RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable"
           cargo auditable build --release --package=linkerd-policy-controller
@@ -138,7 +108,20 @@ subpackages:
         - name: check presence of required files
           runs: |
             # executable doesn't have help or version flag.
+            stat /usr/bin/controller
             stat /usr/bin/linkerd-policy-controller
+    dependencies:
+      runtime:
+        - merged-bin
+        - wolfi-baselayout
+
+  - name: ${{package.name}}-controller-compat
+    description: "upstream image has executable placed at /"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/controller ${{targets.contextdir}}/controller
+          ln -sf /usr/bin/linkerd-policy-controller ${{targets.contextdir}}/linkerd-policy-controller
     dependencies:
       runtime:
         - merged-bin


### PR DESCRIPTION
Upstream has merged policy-controller into controller
https://github.com/linkerd/linkerd2/pull/14348
Updating to sync with upstream.

This pr will be needed before https://github.com/chainguard-images/images-private/pull/14725 can be merged.