### PR TITLE
Grant CVE detection jobs read access

### DIFF
--- a/.github/chainguard/lifecycle-cve-detection.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-detection.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://accounts.google.com
+
+# Have more than one service account
+# - cve-detection-sa@prod-images-c6e5.iam.gserviceaccount.com 107176869706106619885
+# - cve-detection-sa@staging-images-183e.iam.gserviceaccount.com 108595486951512447790
+subject_pattern: "(107176869706106619885|108595486951512447790)"
+
+# Allow CVE detection automation to use Melange package information.
+permissions:
+  contents: read

--- a/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://accounts.google.com
+
+# Have more than one service account
+# - cve-eol-sa@prod-images-c6e5.iam.gserviceaccount.com 117413894424617998846
+# - cve-eol-sa@staging-images-183e.iam.gserviceaccount.com 105584575053184700385
+subject_pattern: "(117413894424617998846|105584575053184700385)"
+
+# Allow CVE EOL automation to use Melange package information.
+permissions:
+  contents: read

--- a/.github/chainguard/lifecycle-cve-fixed.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-fixed.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://accounts.google.com
+
+# Have more than one service account
+# - cve-fix-sa@prod-images-c6e5.iam.gserviceaccount.com: 116759360681829295530
+# - cve-fix-sa@staging-images-183e.iam.gserviceaccount.com: 110841568661625776456
+subject_pattern: "(116759360681829295530|110841568661625776456)"
+
+# Allow CVE fix automation to use Melange package information.
+permissions:
+  contents: read


### PR DESCRIPTION
Detection jobs need Melange package files to detect properly. Not strictly sure if this is necessary, given wolfi/os is world readable.

Related: chainguard-dev/internal-dev#12705

https://github.com/chainguard-dev/infra-images/pull/2723 will make use of this.
