### PR TITLE
openjdk-8: Fix FTBFS with glibc 2.42

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.452.09 # this corresponds to same release as jdk8u452-ga / jdk8u452-b09
-  epoch: 6
+  epoch: 7
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -86,6 +86,41 @@ pipeline:
           uri: https://icedtea.classpath.org/download/drops/icedtea8/hotspot.tar.xz
           expected-sha512: 5c8e839d2d74b0308f468d8763a69ab06920f43b92659bbac76f53b48d83ce8d7070a091ca36df99629364fc8d05b8272e7c12d04609b969d5e8db6ace6908df
           extract: false
+      - runs: |
+          # Here be dragons.
+          #
+          # We need to patch the contents of openjdk-git.tar.xz in
+          # order to make it buildable with glibc 2.42.
+          # Unfortunately, we cannot patch it directly because
+          # icedtea's Makefile (correctly) checks if the tarball's
+          # sha256sum is what it expects.  This means that we will
+          # need to do the patching in stages:
+          #
+          # - First, perform the sha256sum verification ourselves.
+          old_sha256sum=$(grep '^OPENJDK_SHA256SUM = ' ../Makefile.am | cut -d ' ' -f3)
+          if [ -z "${old_sha256sum}" ]; then
+            echo "Error: Empty sha256sum for openjdk-git.tar.xz.  Please check the YAML file."
+            exit 1
+          fi
+          if ! echo "${old_sha256sum}  openjdk-git.tar.xz" | sha256sum --check; then
+            echo "Error: sha256sum mismatch for openjdk-git.tar.xz."
+            exit 1
+          fi
+
+          # - Second, unpack, patch the contents and re-tar it.
+          tar xf openjdk-git.tar.xz
+          dir=$(tar tf openjdk-git.tar.xz | head -n1 | cut -d/ -f1)
+          cd "$dir"
+          find . -type f | xargs grep -Fl 'uabs(' | xargs sed -i 's@uabs(@g_uabs(@g'
+          cd ..
+          tar cf openjdk-git.tar.xz "${dir}"
+          rm -rf "${dir}"
+
+          # - Third, calculate the new sha256sum of the tarball.
+          new_sha256sum=$(sha256sum openjdk-git.tar.xz | cut -d' '  -f1)
+
+          # - Fourth, patch icedtea's Makefile to expect the new sha256sum.
+          sed -i "s@^OPENJDK_SHA256SUM = .*@OPENJDK_SHA256SUM = ${new_sha256sum}@" ../Makefile*
 
   - runs: |
       ./autogen.sh


### PR DESCRIPTION
Unfortunately we cannot patch openjdk-8 in the same trivial manner as we did for all other openjdk's.  This happens because openjdk-8 builds from icedtea's sources, and as such it requires some "external" tarballs to be present and checks their sha256sum.  One of these tarballs is exactly what we need to patch.

To overcome this limitation, I'm performing the patching by hand during build time by exploding the tarball, patching its contents, repacking it, and adjusting the expected sha256sum accordingly.  As a way to ensure that we're using the correct tarball, a sha256sum is still manually performed before anything else.