### PR TITLE
poppler: properly split poppler-glib and poppler-utils subpackages

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,7 +1,7 @@
 package:
   name: poppler
   version: "25.08.0"
-  epoch: 0
+  epoch: 1
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later
@@ -90,11 +90,39 @@ subpackages:
 
   - name: poppler-glib
     pipeline:
-      - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libpoppler-glib.* ${{targets.subpkgdir}}/usr/lib/
+    test:
+      pipeline:
+        - runs: |
+            ls -la /usr/lib
+            find /usr/lib -name 'libpoppler-glib.*' | grep '^'
 
   - name: poppler-utils
     pipeline:
-      - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/* ${{targets.subpkgdir}}/usr/bin/
+    dependencies:
+      runtime:
+        - libnss
+    test:
+      pipeline:
+        - runs: |
+            /usr/bin/pdfattach -v 2>&1 | grep 'version'
+            /usr/bin/pdfdetach -v 2>&1 | grep 'version'
+            /usr/bin/pdffonts -v 2>&1 | grep 'version'
+            /usr/bin/pdfimages -v 2>&1 | grep 'version'
+            /usr/bin/pdfinfo -v 2>&1 | grep 'version'
+            /usr/bin/pdfseparate -v 2>&1 | grep 'version'
+            /usr/bin/pdfsig -v 2>&1 | grep 'version'
+            /usr/bin/pdftocairo -v 2>&1 | grep 'version'
+            /usr/bin/pdftohtml -v 2>&1 | grep 'version'
+            /usr/bin/pdftoppm -v 2>&1 | grep 'version'
+            /usr/bin/pdftops -v 2>&1 | grep 'version'
+            /usr/bin/pdftotext -v 2>&1 | grep 'version'
+            /usr/bin/pdfunite -v 2>&1 | grep 'version'
 
 test:
   environment:


### PR DESCRIPTION
All of the utilities were in the `poppler` package vs. `poppler-utils` where they are expected