### PR TITLE
grpc-*: Unvendor deps, fix env to work around melange bug

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 13
+  epoch: 14
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -54,6 +54,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: 1
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: 1
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: 1
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: 1
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: 1
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: 1
 
 pipeline:
   - uses: git-checkout
@@ -63,35 +70,24 @@ pipeline:
       expected-commit: f686ffe7e703fb1440dabea419579e566a8becc3
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
-      GRPC_PYTHON_CFLAGS="-std=c++17" \
-      GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_CARES=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_RE2=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_ABSL=1 \
       python3 setup.py build
 
       # grpcio-tools

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67 # On update, please check if -fdelete-null-pointer-checks is still required
   version: 1.67.1
-  epoch: 13
+  epoch: 14
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,14 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34075
     CMAKE_CXX_FLAGS: -fdelete-null-pointer-checks
+    # Same as they above but so it can modify the python comp
+    GRPC_PYTHON_CFLAGS: "-std=c++17 -fdelete-null-pointer-checks"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,27 +83,23 @@ pipeline:
       expected-commit: d3286610f703a339149c3f9be69f0d7d0abb130a
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -118,14 +122,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.68.yaml
+++ b/grpc-1.68.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.68
   version: 1.68.2
-  epoch: 11
+  epoch: 12
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17 -fdelete-null-pointer-checks"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: 859bc5216ba3955fb8925326bdec391fd93c8730
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.69.yaml
+++ b/grpc-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.69
   version: 1.69.0
-  epoch: 11
+  epoch: 12
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17 -fdelete-null-pointer-checks"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: b4ef7c141d960be62e0008601261bb22cecb5d40
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.70.yaml
+++ b/grpc-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.70
   version: "1.70.2"
-  epoch: 6
+  epoch: 7
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: c5805f42dbdf4f09bc6b9b5c49ebdb2f48e0efa7
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.71.yaml
+++ b/grpc-1.71.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.71
   version: "1.71.2"
-  epoch: 4
+  epoch: 5
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: c65cf153238102c16f5f11573767384ef112d17a
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.72.yaml
+++ b/grpc-1.72.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.72
   version: "1.72.2"
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: d6b42b2fd3e522a60318c7e2f2021219c6b5c470
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.73.yaml
+++ b/grpc-1.73.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.73
   version: "1.73.1"
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,13 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_CYTHON: "True"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +82,22 @@ pipeline:
       expected-commit: 6eae42baf0dc7950a8c25d227575a0d24c9aa286
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=True \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
         -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_ABSL_PROVIDER=package \
         -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+        -DgRPC_BENCHMARK_PROVIDER=package \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
   - runs: |
@@ -117,14 +120,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/grpc-1.74.yaml
+++ b/grpc-1.74.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.74
   version: "1.74.1"
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,14 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117739
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_CYTHON: "True"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +83,23 @@ pipeline:
       expected-commit: 893bdadd56dbb75fb156175afdaa2b0d47e1c15b
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
-        -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
-        -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+          -DCMAKE_BUILD_TYPE=None \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DBUILD_SHARED_LIBS=ON \
+          -DgRPC_INSTALL=ON \
+          -DgRPC_CARES_PROVIDER=package \
+          -DgRPC_SSL_PROVIDER=package \
+          -DgRPC_ZLIB_PROVIDER=package \
+          -DgRPC_PROTOBUF_PROVIDER=package \
+          -DgRPC_ABSL_PROVIDER=package \
+          -DgRPC_RE2_PROVIDER=package \
+          -DgRPC_BENCHMARK_PROVIDER=package \
+          -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+          -DgRPC_BUILD_TESTS=OFF \
+          -DgRPC_BUILD_CODEGEN=ON
       cmake --build _build
 
   - runs: |
@@ -117,14 +122,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip


### PR DESCRIPTION
In general we shouldn't be using submodules to vendor in software.

In this case it was working with a melange bug that didn't apply environment variables that were being set on uses pipelines. For now just set them for all the builds. We also need to add a workaround for the abseil compiler issues since it shows up in the development headers as well once you use it instead of the vendored version.

See this melange issue for more details.

https://github.com/chainguard-dev/internal-dev/issues/19342

