### PR TITLE
gitness: remediate CVE-2025-54410

### DIFF
--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
   version: "3.2.0"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5 # CVE-2025-54410
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,7 @@ pipeline:
         golang.org/x/net@v0.38.0
         github.com/cloudflare/circl@v1.6.1
         github.com/go-chi/chi/v5@v5.2.2
+        github.com/docker/docker@28.0.0
 
   - runs: |
       cd web

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -43,7 +43,7 @@ pipeline:
         golang.org/x/net@v0.38.0
         github.com/cloudflare/circl@v1.6.1
         github.com/go-chi/chi/v5@v5.2.2
-        github.com/docker/docker@28.0.0
+        github.com/docker/docker@v28.0.0
 
   - runs: |
       cd web


### PR DESCRIPTION
Bump dependency on docker to remediate CVE-2025-54410

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
