### PR TITLE
feat(k8sgpt): bump dep to remediate GHSA-9h84-qmv7-982p and GHSA-f9f8-9pmf-xv68

### DIFF
--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: "0.4.23"
-  epoch: 0
+  epoch: 1
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
         github.com/containerd/containerd@v1.7.27
+        helm.sh/helm/v3@v3.18.5
 
   - runs: |
       make tidy


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump deps to remediate GHSA-9h84-qmv7-982p and GHSA-f9f8-9pmf-xv68
