### PR TITLE
CODEOWNERS: hand over .github/chainguard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@ CODEOWNERS @wolfi-dev/foundations-squad
 
 # Important CI and Repo configuration
 .github/                @wolfi-dev/foundations-squad
-.github/chainguard/     @wolfi-dev/foundations-squad @wolfi-dev/acceleration
+.github/chainguard/     @wolfi-dev/platform-team-write
 .pre-commit-config.yaml @wolfi-dev/foundations-squad
 
 # Makefile and pipeline changes require approval of the Foundations squad.


### PR DESCRIPTION
Relieve foundations from reviewing .github/chainguard and hand it over
to the platform team. The changes there are obscure and are mostly
related to the access controls to wolfi-dev/os, rather than what it
contains.

Remove acceleration, as it is not a valid public reference, github says codeowners has issues.