### PR TITLE
harbor-scanner-trivy: remediate CVE-2025-54410

### DIFF
--- a/harbor-scanner-trivy.yaml
+++ b/harbor-scanner-trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-scanner-trivy
   version: "0.33.2"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-54410
   description: Use Trivy as a plug-in vulnerability scanner in the Harbor registry
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ pipeline:
     with:
       deps: |-
         github.com/redis/go-redis/v9@v9.6.3
+        github.com/docker/docker@v28.0.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Remediate CVE-2025-54410.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
