### PR TITLE
fix(llvm-20): correct cmake packaging for dev subpackages

### DIFF
--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-20
   version: "20.1.8"
-  epoch: 1
+  epoch: 2
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -628,7 +628,7 @@ subpackages:
           for d in mlir mlir-c; do
             move_to_subpkg "/usr/lib/llvm-${{vars.major-version}}/include/${d}"
           done
-          move_to_subpkg "/usr/lib/llvm-${{vars.major-version}}/lib/cmake"
+          move_to_subpkg "/usr/lib/llvm-${{vars.major-version}}/lib/cmake/mlir"
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
The `libmlir-20-dev` subpackage was incorrectly moving the entire `/usr/lib/llvm-20/lib/cmake` directory. This resulted in essential files like `LLVMConfig.cmake` being removed from the main `llvm-20-dev` package, breaking its usability.

This commit refines the packaging logic to only move the mlir-specific subdirectory. The `epoch` has also been bumped to 2.

```
<!--ci-cve-scan:fail-any-->
```


