### PR TITLE
once-off re-build of py3-pydantic-core v2.33.2

### DIFF
--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/pydantic-core/
 package:
   name: py3-pydantic-core
-  version: "2.39.0"
-  epoch: 0
+  version: "2.33.2"
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:
@@ -41,7 +41,7 @@ data:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e0bc980764ec5d5f59c7d451948df937b5a1921f
+      expected-commit: 74fc28b9f9a3c8f4f5e4ede21058bc560f727606
       repository: https://github.com/pydantic/pydantic-core
       tag: v${{package.version}}
 


### PR DESCRIPTION
Temporarily downgrades to v2.33.2 for a once-off re-build of this package version. Automation will run later and bump it back to the most recent version.