### PR TITLE
rspamd: add config for postfix integration

### DIFF
--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -48,21 +48,14 @@ pipeline:
         -DENABLE_PCRE2=ON \
         -DENABLE_LUAJIT=ON \
         -DINSTALL_WEBUI=OFF \
-        -DINSTALL_EXAMPLES=OFF
+        -DINSTALL_EXAMPLES=OFF \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc
 
   - uses: cmake/build
 
   - uses: cmake/install
 
   - runs: |
-      mkdir -p "${{targets.destdir}}"/etc/rspamd
-
-      # Copy config files from /usr/etc/rspamd to /etc/rspamd as upstream
-      if [ -d "${{targets.destdir}}"/usr/etc/rspamd ]; then
-          cp -r "${{targets.destdir}}"/usr/etc/rspamd/* "${{targets.destdir}}"/etc/rspamd/
-          rm -rf "${{targets.destdir}}"/usr/etc/rspamd
-      fi
-
       # Create required runtime directories
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd
       install -d -m 755 "${{targets.destdir}}"/var/log/rspamd
@@ -71,6 +64,16 @@ pipeline:
       install -d -m 700 "${{targets.destdir}}"/var/lib/rspamd/dkim
       install -d -m 755 "${{targets.destdir}}"/etc/rspamd/local.d
       install -d -m 755 "${{targets.destdir}}"/etc/rspamd/override.d
+
+      # Copy config files from /usr/etc/rspamd to /etc/rspamd as upstream
+      if [ -d "${{targets.destdir}}"/usr/etc/rspamd ]; then
+          cp -r "${{targets.destdir}}"/usr/etc/rspamd/* "${{targets.destdir}}"/etc/rspamd/
+          rm -rf "${{targets.destdir}}"/usr/etc/rspamd
+      fi
+
+      # Create symlink for binary compatibility (hardcoded paths)
+      install -d -m 755 "${{targets.destdir}}"/usr/etc
+      ln -sf /etc/rspamd "${{targets.destdir}}"/usr/etc/rspamd
 
   - uses: strip
 

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -57,9 +57,11 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/rspamd
 
-      # Copy instead of symlink to avoid build vs runtime path issues
-      # symlinks may point to non-existent build paths and fail checks
-      cp "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/
+      # Copy config files from /usr/etc/rspamd to /etc/rspamd as upstream
+      if [ -d "${{targets.destdir}}"/usr/etc/rspamd ]; then
+          cp -r "${{targets.destdir}}"/usr/etc/rspamd/* "${{targets.destdir}}"/etc/rspamd/
+          rm -rf "${{targets.destdir}}"/usr/etc/rspamd
+      fi
 
       # Create required runtime directories
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - curl
       - glib
       - libarchive
       - libevent
@@ -17,6 +18,7 @@ package:
       - luajit
       - openssl
       - pcre2
+      - redis
       - sqlite-libs
       - zlib
 
@@ -67,6 +69,10 @@ pipeline:
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd
       install -d -m 755 "${{targets.destdir}}"/var/log/rspamd
       install -d -m 755 "${{targets.destdir}}"/run/rspamd
+
+      install -d -m 700 "${{targets.destdir}}"/var/lib/rspamd/dkim
+      install -d -m 755 "${{targets.destdir}}"/etc/rspamd/local.d
+      install -d -m 755 "${{targets.destdir}}"/etc/rspamd/override.d
 
   - uses: strip
 

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -1,7 +1,7 @@
 package:
   name: rspamd
   version: "3.12.1"
-  epoch: 0
+  epoch: 1
   description: "Rapid spam filtering system"
   copyright:
     - license: Apache-2.0
@@ -54,14 +54,21 @@ pipeline:
 
   - uses: cmake/install
 
-  - uses: strip
-
   - runs: |
-      # Create required directories with proper permissions
-      install -d -m 755 "${{targets.destdir}}"/etc/rspamd
+      mkdir -p "${{targets.destdir}}"/etc/rspamd
+
+      # Copy main rspamd.conf to /etc/rspamd/
+      cp "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/
+
+      # Set proper permissions
+      chmod 644 "${{targets.destdir}}"/etc/rspamd/rspamd.conf
+
+      # Create required runtime directories
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd
       install -d -m 755 "${{targets.destdir}}"/var/log/rspamd
       install -d -m 755 "${{targets.destdir}}"/run/rspamd
+
+  - uses: strip
 
 update:
   enabled: true

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - ca-certificates-bundle
-      - curl
       - glib
       - libarchive
       - libevent
@@ -18,7 +17,6 @@ package:
       - luajit
       - openssl
       - pcre2
-      - redis
       - sqlite-libs
       - zlib
 

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -57,8 +57,8 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/rspamd
 
-      # Copy main rspamd.conf to /etc/rspamd/
-      cp "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/
+      # Create symlink to main rspamd.conf in /etc/rspamd/
+      ln -sf "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/rspamd.conf
 
       # Set proper permissions
       chmod 644 "${{targets.destdir}}"/etc/rspamd/rspamd.conf

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -75,10 +75,10 @@ pipeline:
       install -d -m 755 "${{targets.destdir}}"/usr/etc
       ln -sf /etc/rspamd "${{targets.destdir}}"/usr/etc/rspamd
 
-      # Create symlinks for unversioned binary
-      ln -sf rspamadm-3.12.1 "${{targets.destdir}}"/usr/bin/rspamadm
-      ln -sf rspamc-3.12.1 "${{targets.destdir}}"/usr/bin/rspamc
-      ln -sf rspamd-3.12.1 "${{targets.destdir}}"/usr/bin/rspamd
+      # Create symlinks for unversioned binary names (upstream standard)
+      ln -sf rspamadm-${{package.version}} "${{targets.destdir}}"/usr/bin/rspamadm
+      ln -sf rspamc-${{package.version}} "${{targets.destdir}}"/usr/bin/rspamc
+      ln -sf rspamd-${{package.version}} "${{targets.destdir}}"/usr/bin/rspamd
 
   - uses: strip
 

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -75,6 +75,11 @@ pipeline:
       install -d -m 755 "${{targets.destdir}}"/usr/etc
       ln -sf /etc/rspamd "${{targets.destdir}}"/usr/etc/rspamd
 
+      # Create symlinks for unversioned binary
+      ln -sf rspamadm-3.12.1 "${{targets.destdir}}"/usr/bin/rspamadm
+      ln -sf rspamc-3.12.1 "${{targets.destdir}}"/usr/bin/rspamc
+      ln -sf rspamd-3.12.1 "${{targets.destdir}}"/usr/bin/rspamd
+
   - uses: strip
 
 update:

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -59,11 +59,9 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/rspamd
 
-      # Create symlink to main rspamd.conf in /etc/rspamd/
-      ln -sf "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/rspamd.conf
-
-      # Set proper permissions
-      chmod 644 "${{targets.destdir}}"/etc/rspamd/rspamd.conf
+      # Copy instead of symlink to avoid build vs runtime path issues
+      # symlinks may point to non-existent build paths and fail checks
+      cp "${{targets.destdir}}"/usr/etc/rspamd/rspamd.conf "${{targets.destdir}}"/etc/rspamd/
 
       # Create required runtime directories
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd


### PR DESCRIPTION
rspamd is being used as a DKIM signer with postfix over the mail filter protocol, and the default `rspamd.conf` is needed here for it to start in postfix. for DKIM, we will be using the `var/lib/rspamd/dkim/` directory to store private keys for email signing in postfix, and `local.d/` and `override.d/` provide config overrides to place custom settings without modifying the base rspamd config

more context could be found: https://github.com/chainguard-dev/image-requests/issues/5962

We copy `rspamd.conf` instead of symlinking it because it would point to build time paths. The target path `/usr/etc/rspamd/rspamd.conf` only exists after installation, not during build