### PR TITLE
ingress-nginx-controller-1.13: bump to version 1.13.1

### DIFF
--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -1,9 +1,9 @@
 #nolint:valid-pipeline-fetch-digest,valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: ingress-nginx-controller-1.13
-  version: "1.13.0"
+  version: "1.13.1"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 6 # CVE-2025-47907
+  epoch: 0 # CVE-2025-47907
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -182,7 +182,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/ingress-nginx
       tag: controller-v${{package.version}}
-      expected-commit: 9dc73d17c76e2289408ebff2f3446b8b13c3e72e
+      expected-commit: 3bb5d0c12e6146dac70cc0c4d70740cf2f1d010e
 
   - name: Verify all the vars are up to date with the upstream
     runs: |


### PR DESCRIPTION
<!--ci-cve-scan:fail-any-->