### PR TITLE
add py3 versions to xfsprogs

### DIFF
--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -11,6 +11,14 @@ package:
       - wolfi-baselayout
       - xfsprogs-core
 
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
+
 environment:
   contents:
     packages:
@@ -160,13 +168,13 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/xfs_scrub* "${{targets.subpkgdir}}"/usr/bin/
 
-  - name: xfsprogs-extra
-    description: "extra xfsprogs"
-    options:
-      no-provides: true
+  - range: py-versions
+    name: xfsprogs-extra-${{range.key}}
+    description: python${{range.value}} version of xfsprogs-extra
     dependencies:
+      provider-priority: ${{range.value}}
       runtime:
-        - python3
+        - python-${{range.value}}
         - xfsprogs-core
     pipeline:
       - runs: |

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -221,11 +221,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
-          for file in xfs_copy xfs_freeze xfs_info xfs_mdrestore xfs_ncheck \
-            xfs_quota xfs_admin xfs_db xfs_fsr xfs_io xfs_metadump xfs_property \
-            xfs_rtcp xfs_bmap xfs_estimate xfs_growfs xfs_logprint xfs_mkfile xfs_spaceman; do
-               mv "${{targets.destdir}}/usr/bin/$file" "${{targets.subpkgdir}}/usr/bin/"
-          done
+          # removing xfs_protofile to keep it contained to its subpackage
+          rm "${{targets.destdir}}/usr/bin/xfs_protofile"
+          mv ${{targets.destdir}}/usr/bin/* "${{targets.subpkgdir}}/usr/bin/"
     test:
       environment:
         contents:
@@ -276,6 +274,55 @@ subpackages:
             mkfs.xfs xfs.img
             xfs_admin -L "TestXFS" xfs.img
             xfs_admin -l xfs.img | grep 'TestXFS'
+        - name: "Test xfs reproducibility"
+          runs: |
+            dd if=/dev/zero of=xfs1.img bs=1M count=300
+            dd if=/dev/zero of=xfs2.img bs=1M count=300
+            SOURCE_DATE_EPOCH=1744654025
+            FAKE_TIME="$(date -d @"$SOURCE_DATE_EPOCH" +'%Y-%m-%d %H:%M:%S')"
+            export LD_PRELOAD="/usr/lib/faketime/libfaketime.so.1"
+            export FAKERANDOM_SEED="0x12345678DEADBEEF"
+            export FAKETIME="$FAKE_TIME"
+            export NO_FAKE_STAT=1
+            mkfs.xfs \
+              -b size=4096 \
+              -d agcount=4 \
+              -d noalign \
+              -i attr=2 \
+              -i projid32bit=1 \
+              -i size=512 \
+              -l size=67108864 \
+              -l su=4096 \
+              -l version=2 \
+              -m crc=1 \
+              -m finobt=1 \
+              -m uuid=44444444-4444-4444-4444-444444444444 \
+              -n size=16384 \
+              -n version=2 \
+              -p file=/usr \
+              xfs1.img
+
+            sleep 5
+
+            mkfs.xfs \
+              -b size=4096 \
+              -d agcount=4 \
+              -d noalign \
+              -i attr=2 \
+              -i projid32bit=1 \
+              -i size=512 \
+              -l size=67108864 \
+              -l su=4096 \
+              -l version=2 \
+              -m crc=1 \
+              -m finobt=1 \
+              -m uuid=44444444-4444-4444-4444-444444444444 \
+              -n size=16384 \
+              -n version=2 \
+              -p file=/usr \
+              xfs2.img
+
+              cmp xfs1.img xfs2.img
 
 update:
   enabled: true

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -211,11 +211,9 @@ subpackages:
         #     xfs_db -c "sb 0" -c "p" proto.img | grep -q "magicnum" || exit 1
 
   - name: xfsprogs-extra
-    description: xfsprogs-extra tools
+    description: "extra xfsprogs"
     dependencies:
       runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
         - xfsprogs-core
         - xfs-protofile
     pipeline:

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -173,7 +173,7 @@ subpackages:
     description: python-${{range.key}} version of xfs_protofile
     dependencies:
       provider-priority: ${{range.value}}
-      provides: 
+      provides:
         - xfs-protofile
       runtime:
         - python-${{range.key}}
@@ -188,7 +188,6 @@ subpackages:
             - busybox
             - python-${{range.key}}
       pipeline:
-        - uses: test/tw/ldd-check
         - name: "Check xfs_protofile version"
           runs: |
             xfs_protofile -V

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.15.0"
-  epoch: 6 #correct epoch is 3
+  epoch: 3
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -192,23 +192,28 @@ subpackages:
         - name: "Check xfs_protofile version"
           runs: |
             xfs_protofile -V
-        # - name: "Test xfs_protofile functionality"
-        #   runs: |
-        # AI generated, needs to be tested.
-        #     # Create a test prototype file
-        #     cat > test.proto << EOF
-        #     d /usr 755
-        #     d /usr/bin 755
-        #     f /usr/bin/test 755 echo "Hello World"
-        #     EOF
+        - name: "Test xfs_protofile functionality"
+          runs: |
+            TMP_DIR=$(mktemp -d)
+            trap 'rm -rf "$TMP_DIR"' EXIT
 
-        #     # Create a test image with xfs_protofile
-        #     dd if=/dev/zero of=proto.img bs=1M count=300
-        #     mkfs.xfs proto.img
-        #     xfs_protofile -f test.proto proto.img
+            # create a test directory
+            mkdir -p "$TMP_DIR/dir1/subdir1"
+            touch "$TMP_DIR/dir1/file1" "$TMP_DIR/dir1/file2"
 
-        #     # Verify the image was created successfully
-        #     xfs_db -c "sb 0" -c "p" proto.img | grep -q "magicnum" || exit 1
+            # generate protofile for dir1
+            OUTPUT=$(xfs_protofile "$TMP_DIR/dir1")
+
+            if echo "$OUTPUT" | grep -q "dir1" && \
+              echo "$OUTPUT" | grep -q "dir1/file1" && \
+              echo "$OUTPUT" | grep -q "dir1/file2" && \
+              echo "$OUTPUT" | grep -q "subdir1"; then
+                echo "Test passed! All entries present in the protofile"
+            else
+                echo "Test Failed! One or more entries were not found."
+                echo "GOT: $OUTPUT"
+                exit 1
+            fi
 
   - name: xfsprogs-extra
     description: "extra xfsprogs"
@@ -283,6 +288,10 @@ subpackages:
             mkfs.xfs xfs.img
             xfs_admin -L "TestXFS" xfs.img
             xfs_admin -l xfs.img | grep 'TestXFS'
+        - name: "Test xfs_mkfile"
+          runs: |
+            xfs_mkfile 20m testfile.img
+            du -h testfile.img | grep 20.0M
         - name: "Test xfs reproducibility"
           runs: |
             dd if=/dev/zero of=xfs1.img bs=1M count=300

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -169,12 +169,12 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/xfs_scrub* "${{targets.subpkgdir}}"/usr/bin/
 
   - range: py-versions
-    name: xfs-protofile-py-${{range.key}}
+    name: xfsprogs-protofile-py-${{range.key}}
     description: python-${{range.key}} version of xfs_protofile
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - xfs-protofile
+        - xfsprogs-protofile
       runtime:
         - python-${{range.key}}
     pipeline:
@@ -219,7 +219,7 @@ subpackages:
     dependencies:
       runtime:
         - xfsprogs-core
-        - xfs-protofile
+        - xfsprogs-protofile
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.15.0"
-  epoch: 3
+  epoch: 6 #correct epoch is 3
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -169,17 +169,63 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/xfs_scrub* "${{targets.subpkgdir}}"/usr/bin/
 
   - range: py-versions
-    name: xfsprogs-extra-${{range.key}}
-    description: python${{range.value}} version of xfsprogs-extra
+    name: xfs-protofile-py-${{range.key}}
+    description: python-${{range.key}} version of xfs_protofile
     dependencies:
       provider-priority: ${{range.value}}
+      provides: 
+        - xfs-protofile
       runtime:
-        - python-${{range.value}}
-        - xfsprogs-core
+        - python-${{range.key}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
-          mv ${{targets.destdir}}/usr/bin/* ${{targets.subpkgdir}}/usr/bin
+          cp "${{targets.destdir}}/usr/bin/xfs_protofile" "${{targets.subpkgdir}}/usr/bin/"
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+            - python-${{range.key}}
+      pipeline:
+        - uses: test/tw/ldd-check
+        - name: "Check xfs_protofile version"
+          runs: |
+            xfs_protofile -V
+        # - name: "Test xfs_protofile functionality"
+        #   runs: |
+        # AI generated, needs to be tested.
+        #     # Create a test prototype file
+        #     cat > test.proto << EOF
+        #     d /usr 755
+        #     d /usr/bin 755
+        #     f /usr/bin/test 755 echo "Hello World"
+        #     EOF
+
+        #     # Create a test image with xfs_protofile
+        #     dd if=/dev/zero of=proto.img bs=1M count=300
+        #     mkfs.xfs proto.img
+        #     xfs_protofile -f test.proto proto.img
+
+        #     # Verify the image was created successfully
+        #     xfs_db -c "sb 0" -c "p" proto.img | grep -q "magicnum" || exit 1
+
+  - name: xfsprogs-extra
+    description: xfsprogs-extra tools
+    dependencies:
+      runtime:
+        - merged-usrsbin
+        - wolfi-baselayout
+        - xfsprogs-core
+        - xfs-protofile
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          for file in xfs_copy xfs_freeze xfs_info xfs_mdrestore xfs_ncheck \
+            xfs_quota xfs_admin xfs_db xfs_fsr xfs_io xfs_metadump xfs_property \
+            xfs_rtcp xfs_bmap xfs_estimate xfs_growfs xfs_logprint xfs_mkfile xfs_spaceman; do
+               mv "${{targets.destdir}}/usr/bin/$file" "${{targets.subpkgdir}}/usr/bin/"
+          done
     test:
       environment:
         contents:
@@ -230,55 +276,6 @@ subpackages:
             mkfs.xfs xfs.img
             xfs_admin -L "TestXFS" xfs.img
             xfs_admin -l xfs.img | grep 'TestXFS'
-        - name: "Test xfs reproducibility"
-          runs: |
-            dd if=/dev/zero of=xfs1.img bs=1M count=300
-            dd if=/dev/zero of=xfs2.img bs=1M count=300
-            SOURCE_DATE_EPOCH=1744654025
-            FAKE_TIME="$(date -d @"$SOURCE_DATE_EPOCH" +'%Y-%m-%d %H:%M:%S')"
-            export LD_PRELOAD="/usr/lib/faketime/libfaketime.so.1"
-            export FAKERANDOM_SEED="0x12345678DEADBEEF"
-            export FAKETIME="$FAKE_TIME"
-            export NO_FAKE_STAT=1
-            mkfs.xfs \
-              -b size=4096 \
-              -d agcount=4 \
-              -d noalign \
-              -i attr=2 \
-              -i projid32bit=1 \
-              -i size=512 \
-              -l size=67108864 \
-              -l su=4096 \
-              -l version=2 \
-              -m crc=1 \
-              -m finobt=1 \
-              -m uuid=44444444-4444-4444-4444-444444444444 \
-              -n size=16384 \
-              -n version=2 \
-              -p file=/usr \
-              xfs1.img
-
-            sleep 5
-
-            mkfs.xfs \
-              -b size=4096 \
-              -d agcount=4 \
-              -d noalign \
-              -i attr=2 \
-              -i projid32bit=1 \
-              -i size=512 \
-              -l size=67108864 \
-              -l su=4096 \
-              -l version=2 \
-              -m crc=1 \
-              -m finobt=1 \
-              -m uuid=44444444-4444-4444-4444-444444444444 \
-              -n size=16384 \
-              -n version=2 \
-              -p file=/usr \
-              xfs2.img
-
-              cmp xfs1.img xfs2.img
 
 update:
   enabled: true

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -244,11 +244,22 @@ subpackages:
 
             vercheck xfs_admin
             vercheck xfs_bmap
+            vercheck xfs_copy
+            vercheck xfs_db
             vercheck xfs_estimate
+            vercheck xfs_freeze
             vercheck xfs_fsr
+            vercheck xfs_growfs
+            vercheck xfs_info
+            vercheck xfs_io
+            vercheck xfs_logprint
+            vercheck xfs_mdrestore
+            vercheck xfs_metadump
             vercheck xfs_mkfile
-            vercheck xfs_quota
+            vercheck xfs_ncheck
             vercheck xfs_property
+            vercheck xfs_quota
+            vercheck xfs_rtcp
             vercheck xfs_spaceman
         - name: "Test basic xfs_db functionality"
           runs: |

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: "6.15.0"
-  epoch: 2
+  epoch: 3
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -162,6 +162,8 @@ subpackages:
 
   - name: xfsprogs-extra
     description: "extra xfsprogs"
+    options:
+      no-provides: true
     dependencies:
       runtime:
         - python3


### PR DESCRIPTION
Adding multiple py3 versions to xfs_protofile to fix dependency issues with cephcsi.

Context:
`cephcsi` has two runtime dependencies:
* `ceph` → requires Python 3.11 specifically
* `xfsprogs-extra` → built against `python3` which currently resolves to Python 3.13.

This leads to a conflict when building the cephcsi image:
```
solving "ceph" constraint: resolving "ceph-19.2.3-r3.apk" deps:
solving "python-3.11" constraint:
  python-3.11-3.11.1-r5.apk disqualified because python-3.13-3.13.6-r0.apk already provides python3
```

To fix this, I extracted `xfs-protofile` from `xfsprogs-extra`, because it is the only component in that package that actually requires Python. I bundled `xfs-protofile` separately for multiple Python versions. This means that:
- `xfsprogs-extra` itself no longer depends on a specific Python version.
- I can choose the required  `xfs-protofile` dependency for `cephcsi` (e.g., `xfs-protofile-py-3.11`) without causing conflicts with `ceph`’s Python 3.11 requirement.
-  By default, `xfs-protofile` still resolves to Python 3.13, so other packages that depend on it are unaffected.
