### PR TITLE
libdrm: a few cleanups

### DIFF
--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -2,7 +2,7 @@
 package:
   name: libdrm
   version: "2.4.125"
-  epoch: 2
+  epoch: 3
   description: Userspace interface to kernel DRM services
   copyright:
     - license: MIT
@@ -14,12 +14,13 @@ environment:
       - automake
       - build-base
       - busybox
-      - ca-certificates-bundle
       - libpciaccess-dev
       - linux-headers
       - meson
       - systemd-dev
       - xmlto
+  environment:
+    CFLAGS: "-O2"
 
 pipeline:
   - uses: fetch
@@ -28,7 +29,7 @@ pipeline:
       uri: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{package.version}}/drm-libdrm-${{package.version}}.tar.gz
 
   - runs: |
-      CFLAGS="$CFLAGS -O2" CPPFLAGS="$CPPFLAGS -O2" CXXFLAGS="$CXXFLAGS -O2" meson \
+      meson \
         -Db_lto=true \
         -Dfreedreno=enabled \
         -Dtegra=enabled \
@@ -41,7 +42,7 @@ pipeline:
         -Dtests=true \
         --prefix=/usr \
         . output
-      meson compile -C output
+      meson compile --verbose -C output
       DESTDIR="${{targets.destdir}}" meson install --no-rebuild -C output
 
   - uses: strip


### PR DESCRIPTION
- Drop unnecessary build-dep on `ca-certificates-bundle`
- Stop setting `-O2` in `CPPFLAGS` and `CXXFLAGS` (it's not a valid cpp argument, and this package doesn't contain C++ code)
- Set CFLAGS declaratively
- Enable verbose debug output
