### PR TITLE
harbor-2.13: unpin swagger

### DIFF
--- a/harbor-2.13.yaml
+++ b/harbor-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.13
   version: "2.13.2"
-  epoch: 6 # GHSA-f9f8-9pmf-xv68
+  epoch: 7 # GHSA-f9f8-9pmf-xv68
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ environment:
       - npm
       - py3-setuptools
       - python3
-      - swagger~0.30.5
+      - swagger
   environment:
     CGO_ENABLED: "0"
 


### PR DESCRIPTION
We've had `swagger` pinned for over a year now. Unfortunately, I couldn't find a record of what the exact problem was so we just seem to have been cargo-culting it.

The package builds/tests fine today with the pin removed, and our `harbor` images test/build fine against it.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
