### PR TITLE
llvm-20: Cleanup collateral changes from enabling MLIR

### DIFF
--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -111,6 +111,13 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/usr/lib/cmake
       ln -s ${{vars.llvm-prefix}}/lib/cmake/llvm ${{targets.contextdir}}/usr/lib/cmake/llvm
 
+  - name: Cleanup installed MLIR .o files
+    runs: |
+      objdir="${{targets.contextdir}}/usr/lib/llvm-${{vars.major-version}}/lib/objects-Release"
+      # Abort if/when this step is no longer needed so we can remove it
+      test -d "$objdir"
+      rm -rf "$objdir"
+
   - uses: strip
 
 subpackages:

--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -653,6 +653,10 @@ subpackages:
       - runs: |
           bindir="/usr/lib/llvm-${{vars.major-version}}/bin"
           mkdir -p "${{targets.contextdir}}${bindir}"
+          for cmd in tblgen-lsp-server tblgen-to-irdl; do
+            mv "${{targets.destdir}}${bindir}/$cmd" \
+              "${{targets.contextdir}}${bindir}"
+          done
           mv "${{targets.destdir}}${bindir}"/mlir-* \
             "${{targets.contextdir}}${bindir}"
     test:

--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-20
   version: "20.1.8"
-  epoch: 2
+  epoch: 3
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Spurred by https://github.com/wolfi-dev/os/pull/63612, I wrote [a script](https://gist.github.com/dannf/555bf5c01a0209bb55f58ebffa462d04) to compare the last pre-MLIR build manifests with the current ones and found a couple additional issues:

[diff-current.txt](https://github.com/user-attachments/files/21920807/diff-current.txt)

Here's a `diff` for the build in this PR (again, vs the last pre-MLIR build) showing that manifest differences are restricted to the new packages:
[diff-this-pr.txt](https://github.com/user-attachments/files/21920808/diff-this-pr.txt)

```bash
$ diffstat diff-this-pr.txt 
 aarch64/libmlir-20-dev.lst | 2028 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 aarch64/libmlir-20.lst     |  353 ++++++++++
 aarch64/mlir-20-tools.lst  |   23 
 x86_64/libmlir-20-dev.lst  | 2028 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 x86_64/libmlir-20.lst      |  353 ++++++++++
 x86_64/mlir-20-tools.lst   |   23 
 6 files changed, 4808 insertions(+)
```
