### PR TITLE
php-8.3: add php-8.3-pear

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.24"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -20,6 +20,9 @@ var-transforms:
     match: ^php-(\d\.\d+)
     replace: $1
     to: phpMM
+
+vars:
+  datadir: /usr/share/php
 
 environment:
   contents:
@@ -71,6 +74,10 @@ pipeline:
       tag: php-${{package.version}}
       expected-commit: 4d0d45170203aaaed5ce2bf69699fce92afbeab9
 
+  - uses: patch
+    with:
+      patches: install-pear.patch
+
   - name: Configure
     runs: |
       ./buildconf --force
@@ -78,7 +85,7 @@ pipeline:
         --prefix=/usr \
         --libdir=/usr/lib/php \
         --sbindir=/usr/bin \
-        --datadir=/usr/share/php \
+        --datadir=${{vars.datadir}} \
         --sysconfdir=/etc/php \
         --localstatedir=/var \
         --with-layout=GNU \
@@ -212,6 +219,32 @@ data:
       sysvshm: System V Shared Memory
 
 subpackages:
+  - name: ${{package.name}}-pear
+    dependencies:
+      provides:
+        - php-pear=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-xml
+    pipeline:
+      - runs: |
+          mkdir -p \
+            ${{targets.subpkgdir}}/usr/bin \
+            ${{targets.subpkgdir}}${{vars.datadir}} \
+            ${{targets.subpkgdir}}/etc/php
+          mv ${{targets.destdir}}/usr/bin/pear ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/peardev ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pecl ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}${{vars.datadir}}/pear ${{targets.subpkgdir}}${{vars.datadir}}/
+          mv ${{targets.destdir}}/etc/php/pear.conf ${{targets.subpkgdir}}/etc/php/pear.conf
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - runs: |
+            pear version
+
   - name: ${{package.name}}-config
     dependencies:
       provides:

--- a/php-8.3/install-pear.patch
+++ b/php-8.3/install-pear.patch
@@ -1,0 +1,15 @@
+diff --git a/pear/Makefile.frag b/pear/Makefile.frag
+index 9408757a..53f98762 100644
+--- a/pear/Makefile.frag
++++ b/pear/Makefile.frag
+@@ -1,7 +1,8 @@
+ peardir=$(PEAR_INSTALLDIR)
+
+ # Skip all php.ini files altogether
+-PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0
++PEAR_INSTALL_XML_FLAGS = -d extension="$(top_builddir)/modules/xml.so" -d extension="$(top_builddir)/modules/phar.so"
++PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0 $(PEAR_INSTALL_XML_FLAGS)
+
+ WGET = `which wget 2>/dev/null`
+ FETCH = `which fetch 2>/dev/null`
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
