### PR TITLE
fix: add coreutils for init container compatibility

### DIFF
--- a/flannel.yaml
+++ b/flannel.yaml
@@ -7,8 +7,8 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - coreutil
       - ca-certificates
+      - coreutil
       - ip6tables
       - iproute2
       - iptables

--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,12 +1,13 @@
 package:
   name: flannel
   version: "0.27.2"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - coreutil
       - ca-certificates
       - ip6tables
       - iproute2

--- a/flannel.yaml
+++ b/flannel.yaml
@@ -8,7 +8,7 @@ package:
   dependencies:
     runtime:
       - ca-certificates
-      - coreutil
+      - coreutils
       - ip6tables
       - iproute2
       - iptables


### PR DESCRIPTION
Flannel Helm chart's init containers require POSIX utilities (cp, mv, etc.) to copy CNI binaries and configuration files to the host filesystem. Without these utilities, pods fail with `exec: cp: executable file not found in $PATH`
check here https://github.com/flannel-io/flannel/blob/v0.27.2/chart/kube-flannel/templates/daemonset.yaml