### PR TITLE
sqlite: Enable TCL extension

### DIFF
--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlite
   version: "3.50.4"
-  epoch: 0
+  epoch: 1
   description: "C library which implements an SQL database engine"
   copyright:
     - license: blessing
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - readline-dev
+      - tcl-dev
 
 # ref: https://www.sqlite.org/download.html
 # For version 3.X.Y the filename encoding is 3XX0Y00.
@@ -28,8 +29,14 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.sqlite.org/2025/sqlite-autoconf-${{vars.sqlite-download-version}}.tar.gz
-      expected-sha256: a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18
+      uri: https://www.sqlite.org/2025/sqlite-src-${{vars.sqlite-download-version}}.zip
+      expected-sha256: b7b4dc060f36053902fb65b344bbbed592e64b2291a26ac06fe77eec097850e9
+      extract: false
+
+  - name: Extract ZIP & move it to the normal place
+    runs: |
+      unzip sqlite-src-${{vars.sqlite-download-version}}.zip -d ../
+      mv ../sqlite-src-${{vars.sqlite-download-version}}/* .
 
   - name: Configure
     runs: |
@@ -58,6 +65,7 @@ pipeline:
          --enable-fts3
 
       make "-j$(nproc)" V=1
+      make tclextension-install
 
   - uses: autoconf/make-install
 
@@ -100,6 +108,10 @@ update:
     identifier: 4877
 
 test:
+  environment:
+    contents:
+      packages:
+        - tcl
   pipeline:
     - name: "version check"
       runs: |
@@ -118,3 +130,22 @@ test:
         sqlite3 /tmp/test.db "SELECT * FROM test WHERE id > 50 LIMIT 5;"
         sqlite3 /tmp/test.db ".schema"
         sqlite3 /tmp/test.db "SELECT COUNT(*) FROM test;"
+    - name: "Jamon's Test"
+      runs: |
+        cat << EOF | tclsh
+        puts [info tclversion]
+        package require sqlite3
+
+        # Open sqlite.db file
+        sqlite3 db sqlite.db
+
+        # Create users table
+        db eval {CREATE TABLE IF NOT EXISTS users (firstname TEXT, lastname TEXT);}
+
+        # Show schema
+        puts "Database schema:"
+        puts [db eval {SELECT sql FROM sqlite_master WHERE type='table';}]
+
+        # Close database
+        db close
+        EOF


### PR DESCRIPTION
In this commit I enable the compilation of the TCL extension for SQLite.

I had to change to a different source archive as the TCL extension
library was not included in the autoconf tarball.