### PR TITLE
apk-tools: future proof CRC algorithms access

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 7
+  epoch: 8
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -33,7 +33,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: 292.patch usrmerge-lib.patch
+      patches: 292.patch usrmerge-lib.patch 0001-Work-without-fips-sha1.patch
 
   - runs: |
       sed -i -e 's:-Werror::' Make.rules

--- a/apk-tools/0001-Work-without-fips-sha1.patch
+++ b/apk-tools/0001-Work-without-fips-sha1.patch
@@ -1,0 +1,26 @@
+From e80d57e7756aa119ca161487cad255462ae559c8 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+Date: Thu, 21 Aug 2025 12:46:43 +0100
+Subject: [PATCH] Work without fips sha1
+
+---
+ src/apk.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/apk.c b/src/apk.c
+index 3b4ce40..c9f9202 100644
+--- a/src/apk.c
++++ b/src/apk.c
+@@ -432,6 +432,9 @@ static void fini_openssl(void)
+ 
+ static void init_openssl(void)
+ {
++	// Preffer, but do not require FIPS algorithms, CRC usage of
++	// SHA1 is needed
++	EVP_set_default_properties(NULL, "?fips=yes");
+ 	atexit(fini_openssl);
+ 	OpenSSL_add_all_algorithms();
+ #ifndef OPENSSL_NO_ENGINE
+-- 
+2.48.1
+


### PR DESCRIPTION
In some cases apk-tools needs access to MD5 and SHA1 for CRC
purposes. Future proof this access by preffering fips algorithms, but
not requiring them. This results in FIPS usage for RSA256 signature
validation, and yet allows to parse all existing SHA1 manifest CRC
digests as well even when SHA1 is removed.
