### PR TITLE
libspatialindex: No-change rebuild for 2.28 toolchain

### DIFF
--- a/libspatialindex.yaml
+++ b/libspatialindex.yaml
@@ -1,7 +1,7 @@
 package:
   name: libspatialindex
   version: 2.1.0
-  epoch: 2
+  epoch: 3
   description: "C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API"
   copyright:
     - license: MIT


### PR DESCRIPTION
Needed for some Python libraries (e.g. rtree).