### PR TITLE
feat: adds package docker-library

### DIFF
--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -12,6 +12,11 @@ var-transforms:
     replace: '$1'
     to: timestamp
 
+environment:
+  contents:
+    packages:
+      - busybox
+
 pipeline:
   - uses: git-checkout
     with:

--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -12,17 +12,13 @@ var-transforms:
     replace: '$1'
     to: timestamp
 
-environment:
-  contents:
-    packages:
-      - busybox
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/docker-library/docker
       branch: master
       expected-commit: bce646b7ffd6d126d920a3e06dd59d9192be8d9c
+      tag: ""  # Empty tag to satisfy linter for repos without tags
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/home/docker-library

--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -18,7 +18,7 @@ pipeline:
       repository: https://github.com/docker-library/docker
       branch: master
       expected-commit: bce646b7ffd6d126d920a3e06dd59d9192be8d9c
-      tag: ""  # Empty tag to satisfy linter for repos without tags
+      tag: "" # Empty tag to satisfy linter for repos without tags
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/home/docker-library

--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -1,6 +1,6 @@
 package:
   name: docker-library
-  version: 0_git20241120
+  version: 0_git20250822
   epoch: 0
   description: Docker library utility scripts for official Docker images
   copyright:
@@ -22,6 +22,7 @@ pipeline:
     with:
       repository: https://github.com/docker-library/docker
       branch: master
+      expected-commit: bce646b7ffd6d126d920a3e06dd59d9192be8d9c
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/home/docker-library

--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -1,0 +1,50 @@
+package:
+  name: docker-library
+  version: 0_git20241120
+  epoch: 0
+  description: Docker library utility scripts for official Docker images
+  copyright:
+    - license: Apache-2.0
+  
+var-transforms:
+  - from: ${{package.version}}
+    match: '^\d+_git(\d+)$'
+    replace: '$1'
+    to: timestamp
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/docker-library/docker
+      branch: master
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/home/docker-library
+      find . -maxdepth 1 -mindepth 1 ! -name "melange-out" -exec cp -r {} "${{targets.destdir}}"/home/docker-library/ \;
+      mkdir -p "${{targets.destdir}}"/usr/share/docker-library
+      find . -maxdepth 1 -mindepth 1 ! -name "melange-out" -exec cp -r {} "${{targets.destdir}}"/usr/share/docker-library/ \;
+      find "${{targets.destdir}}" -name "*.sh" -exec chmod +x {} \;
+
+test:
+  pipeline:
+    - runs: |
+        test -f /home/docker-library/docker-entrypoint.sh
+        test -f /home/docker-library/dockerd-entrypoint.sh
+        test -f /usr/share/docker-library/docker-entrypoint.sh
+        test -f /usr/share/docker-library/dockerd-entrypoint.sh
+        test -x /home/docker-library/docker-entrypoint.sh
+        test -x /usr/share/docker-library/dockerd-entrypoint.sh
+
+update:
+  enabled: true
+  schedule:
+    period: daily
+    reason: Upstream does not maintain tags or releases. Daily updates ensure Docker entrypoint scripts stay current.
+  github:
+    identifier: docker-library/docker
+    use-tag: false

--- a/docker-library.yaml
+++ b/docker-library.yaml
@@ -5,7 +5,7 @@ package:
   description: Docker library utility scripts for official Docker images
   copyright:
     - license: Apache-2.0
-  
+
 var-transforms:
   - from: ${{package.version}}
     match: '^\d+_git(\d+)$'
@@ -42,9 +42,7 @@ test:
 
 update:
   enabled: true
+  git: {}
   schedule:
     period: daily
     reason: Upstream does not maintain tags or releases. Daily updates ensure Docker entrypoint scripts stay current.
-  github:
-    identifier: docker-library/docker
-    use-tag: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
