### PR TITLE
hardening-check: ignore .git versions

### DIFF
--- a/hardening-check.yaml
+++ b/hardening-check.yaml
@@ -27,6 +27,8 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - .git$
   release-monitor:
     identifier: 5419
 


### PR DESCRIPTION
These appear to be due to an additional source artifact upstream, rather than indicating a different release.