### PR TITLE
kube-arangodb/cve remediation

### DIFF
--- a/kube-arangodb.yaml
+++ b/kube-arangodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-arangodb
   version: "1.3.0"
-  epoch: 2 # GHSA-f9f8-9pmf-xv68
+  epoch: 3
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
fix: epoch bump was missed previously