### PR TITLE
cluster-api-provider-vsphere: omit version stream

### DIFF
--- a/cluster-api-provider-vsphere.yaml
+++ b/cluster-api-provider-vsphere.yaml
@@ -1,13 +1,10 @@
 package:
-  name: cluster-api-provider-vsphere-1.13
+  name: cluster-api-provider-vsphere
   version: "1.13.1"
-  epoch: 0
+  epoch: 1
   description: Kubernetes-native declarative infrastructure for vSphere.
   copyright:
     - license: Apache-2.0
-  dependencies:
-    provides:
-      - cluster-api-provider-vsphere=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout
@@ -44,9 +41,6 @@ subpackages:
         - uses: test/tw/symlink-check
         - runs: |
             /manager --help 2>&1 | grep "Usage of /manager"
-    dependencies:
-      provides:
-        - cluster-api-provider-vsphere-compat=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Upstream doesn't manage multiple versions so lets omit the version suffix: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere