### PR TITLE
systemd - add systemd-measure package

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -359,6 +359,30 @@ subpackages:
             kernel-install --version
             kernel-install --help
 
+  - name: systemd-measure
+    description: "Pre-calculate and sign expected TPM2 PCR 11 values for booted unified kernel images"
+    dependencies:
+      runtime:
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd
+          mv ${{targets.destdir}}/usr/lib/systemd/systemd-measure ${{targets.subpkgdir}}/usr/lib/systemd/systemd-measure
+    test:
+      pipeline:
+        - runs: |
+            fail() { echo FAIL: "$@"; exit 1; }
+
+            /usr/lib/systemd/systemd-measure --version | grep -F "${{package.version}}" &&
+              echo "PASS: /usr/lib/systemd/systemd-measure --version contained ${{package.version}}" ||
+              fail "/usr/lib/systemd/systemd-measure --version did not contain '${{package.version}}'"
+
+            /usr/lib/systemd/systemd-measure --help && echo "PASS: /usr/lib/systemd/systemd-measure --help exited 0" ||
+              fail "/usr/lib/systemd/systemd-measure --help exited $?"
+
   - name: systemd-container
     description: "systemd container tools"
     dependencies:


### PR DESCRIPTION
Follow up to: #64040 

A follow up to the systemd-ukify package added by @smoser.
systemd-measure can be used in conjunction with systemd-ukify to pre-compute PCMs for use with unified kernel images.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
