### PR TITLE
chore: update symlink-check in few packages

### DIFF
--- a/cluster-api-provider-vsphere.yaml
+++ b/cluster-api-provider-vsphere.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-provider-vsphere
   version: "1.13.1"
-  epoch: 1
+  epoch: 2
   description: Kubernetes-native declarative infrastructure for vSphere.
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"
-          ln -sf /usr/bin/manager "${{targets.contextdir}}/manager"
+          ln -sf ./usr/bin/manager "${{targets.contextdir}}/manager"
     test:
       environment:
         contents:

--- a/datadog-operator.yaml
+++ b/datadog-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-operator
   version: "1.17.0"
-  epoch: 0
+  epoch: 1
   description: Kubernetes Operator for Datadog Resources
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,10 @@ subpackages:
           ln -s /usr/bin/manager "${{targets.contextdir}}/manager"
           ln -s /usr/bin/helpers "${{targets.contextdir}}/helpers"
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - uses: test/tw/symlink-check
         - runs: |

--- a/kubernetes-csi-external-health-monitor.yaml
+++ b/kubernetes-csi-external-health-monitor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-health-monitor
   version: "0.15.0"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: CSI external health monitor controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,8 +26,12 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"
-          ln -sf /usr/bin/csi-external-health-monitor-controller ${{targets.subpkgdir}}/
+          ln -sf ./usr/bin/csi-external-health-monitor-controller ${{targets.subpkgdir}}/csi-external-health-monitor-controller
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
       pipeline:
         - name: "Verify the symlink"
           uses: test/tw/symlink-check


### PR DESCRIPTION
this commit updates symlink-check tests in following packages:
cluster-api-provider-vsphere.yaml
datadog-operator.yaml
kubernetes-csi-external-health-monitor.yaml

the changes are following:
- we want to use relative symlinks so changed package config to use
relative symlinks
- we want to create a full fs while testing so added main package to
test dependencies.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
