### PR TITLE
feat(neo4j-2025.07): bump dep to remediate GHSA-mmxm-8w33-wc4h

### DIFF
--- a/neo4j-2025.07.yaml
+++ b/neo4j-2025.07.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-2025.07
   version: "2025.07.1"
-  epoch: 1 # GHSA-prj3-ccx8-p6x4
+  epoch: 2
   description:
   copyright:
     - license: GPL-3.0-or-later

--- a/neo4j-2025.07/pombump-properties.yaml
+++ b/neo4j-2025.07/pombump-properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - property: jetty.version
-    value: 12.0.17
+    value: 12.0.25


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-mmxm-8w33-wc4h

<!--ci-cve-scan:fail-any-->

