### PR TITLE
feat(argo-events): bump dep to remediate GHSA-2464-8j7c-4cjm

### DIFF
--- a/argo-events.yaml
+++ b/argo-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-events
   version: "1.9.7"
-  epoch: 2 # CVE-2025-47907
+  epoch: 3
   description: Event-driven Automation Framework for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,8 @@ pipeline:
 
   - uses: go/bump
     with:
+      deps: |-
+        github.com/go-viper/mapstructure/v2@v2.4.0
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v1.0.2
 
   - uses: go/build


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update dep for remediate GHSA-2464-8j7c-4cjm

<!--ci-cve-scan:fail-any-->
