### PR TITLE
Fix `go/bump` FTBFSes with newer golangs

### DIFF
--- a/jitsucom-bulker.yaml
+++ b/jitsucom-bulker.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-bulker
   version: "2.11.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Service for bulk-loading data to databases with automatic schema management (Redshift, Snowflake, BigQuery, ClickHouse, Postgres, MySQL)
   copyright:
     - license: MIT
@@ -25,6 +25,7 @@ pipeline:
       deps: |-
         github.com/go-viper/mapstructure/v2@v2.3.0
       modroot: bulkerapp
+      go-version: "1.24"
 
   - uses: go/bump
     with:
@@ -32,6 +33,7 @@ pipeline:
         github.com/snowflakedb/gosnowflake@v1.13.3
         github.com/go-viper/mapstructure/v2@v2.3.0
       modroot: bulkerlib
+      go-version: "1.24"
 
 data:
   - name: commands

--- a/kubernetes-dashboard-api.yaml
+++ b/kubernetes-dashboard-api.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-api
   version: "1.13.0"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5
   description: Go module handling authentication to the Kubernetes API
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
       modroot: ./modules/api
+      go-version: "1.23.0"
 
   - uses: go/build
     with:

--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-auth
   version: "1.3.0"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5
   description: Stateless Go module, which could be referred to as a Kubernetes API extension
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
       modroot: ./modules/auth
+      go-version: "1.23.0"
 
   - uses: go/build
     with:

--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-metrics-scraper
   version: "1.2.2"
-  epoch: 11 # CVE-2025-47907
+  epoch: 12
   description: Go module used to scrape and store a small window of metrics fetched from the Kubernetes Metrics Server.
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,7 @@ pipeline:
         golang.org/x/oauth2@v0.27.0
         golang.org/x/net@v0.38.0
       modroot: ./modules/metrics-scraper
+      go-version: "1.23.0"
 
   - uses: go/build
     with:

--- a/kubernetes-dashboard-web.yaml
+++ b/kubernetes-dashboard-web.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-web
   version: "1.7.0"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5
   description: General-purpose web UI for Kubernetes clusters with enhanced authentication features
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
       modroot: ./modules/web
+      go-version: "1.23.0"
 
   - uses: go/build
     with:

--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard
   version: "7.13.0"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,7 @@ pipeline:
       deps: |-
         golang.org/x/oauth2@v0.27.0
       modroot: modules/web
+      go-version: "1.23.0"
 
   - working-directory: modules/web
     runs: |


### PR DESCRIPTION
Some of our golang packages are FTBFSing because they required older golang versions than the one being used.  Let's pin these packages to specific golang versions to fix the failures.

Fixes: #64186