### PR TITLE
Fix FTBFSes due to missing `AM_ICONV`

### DIFF
--- a/dosfstools.yaml
+++ b/dosfstools.yaml
@@ -2,7 +2,7 @@
 package:
   name: dosfstools
   version: "4.2"
-  epoch: 42
+  epoch: 43
   description: DOS filesystem utilities
   copyright:
     - license: GPL-3.0-or-later
@@ -33,8 +33,7 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
-      touch config.rpath
-      autoreconf -fiv
+      ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluxbox
   version: 1.3.7
-  epoch: 4
+  epoch: 5
   description: Fluxbox Window Manager
   copyright:
     - license: GPL-2.0-or-later
@@ -39,6 +39,7 @@ pipeline:
       expected-sha256: 6bcd91faac07066e5c9c952625500219774ff1dc7d5960264d0ae005fb562a97
 
   - runs: |
+      autopoint --force
       ./autogen.sh
 
   - name: "Configure binutils"

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetds
   version: "1.5.4"
-  epoch: 1
+  epoch: 2
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
     - license: GPL-2.0-or-later
@@ -38,6 +38,7 @@ pipeline:
 
   - working-directory: ${{package.name}}
     pipeline:
+      - runs: autopoint --force
       - uses: autoconf/configure
         with:
           opts: |

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse2
   version: 2.9.9
-  epoch: 52
+  epoch: 53
   description: A library that makes it possible to implement a filesystem in a userspace program.
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only
@@ -43,6 +43,7 @@ pipeline:
       patches: fuse-closefrom.patch
 
   - runs: |
+      autopoint --force
       ./makeconf.sh
 
   - runs: |


### PR DESCRIPTION
These packages are all FTBFSing because autotools changed the way to copy gettext-related autoconf files. `autoreconf` is not the recommended way anymore, and packages should invoke `autopoint` instead.  This is what most of the commits do.