### PR TITLE
feat(boring-registry): bump dep to remediate GHSA-2464-8j7c-4cjm

### DIFF
--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: "0.16.4"
-  epoch: 4 # CVE-2025-47907
+  epoch: 5
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
-        github.com/go-viper/mapstructure/v2@v2.3.0
+        github.com/go-viper/mapstructure/v2@v2.4.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-2464-8j7c-4cjm

<!--ci-cve-scan:fail-any-->

