### PR TITLE
feat(ratify): bump dep to remediate GHSA-2464-8j7c-4cjm

### DIFF
--- a/ratify.yaml
+++ b/ratify.yaml
@@ -1,7 +1,7 @@
 package:
   name: ratify
   version: "1.4.0"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4
   description: Artifact Ratification Framework (CNCF Sandbox)
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
         github.com/golang-jwt/jwt/v5@v5.2.2
         github.com/cloudflare/circl@v1.6.1
         github.com/open-policy-agent/opa@v1.4.0
-        github.com/go-viper/mapstructure/v2@v2.3.0
+        github.com/go-viper/mapstructure/v2@v2.4.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-2464-8j7c-4cjm

<!--ci-cve-scan:fail-any-->

