### PR TITLE
feat(kyverno-notation-aws): bump dep to remediate GHSA-2464-8j7c-4cjm

### DIFF
--- a/kyverno-notation-aws.yaml
+++ b/kyverno-notation-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-notation-aws
   version: 1.1
-  epoch: 20
+  epoch: 21
   description: Kyverno extension service for Notation and the AWS signer
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
         golang.org/x/net@v0.38.0
         github.com/open-policy-agent/opa@v1.4.0
         github.com/cloudflare/circl@v1.6.1
-        github.com/go-viper/mapstructure/v2@v2.3.0
+        github.com/go-viper/mapstructure/v2@v2.4.0
         github.com/kyverno/kyverno@v1.14.2
       replaces: github.com/docker/docker=github.com/docker/docker@v26.1.5+incompatible
 


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update dep to remediate GHSA-2464-8j7c-4cjm

<!--ci-cve-scan:fail-any-->

