### PR TITLE
rancher-charts-2.12: add new version stream manually

### DIFF
--- a/rancher-charts-2.12.yaml
+++ b/rancher-charts-2.12.yaml
@@ -1,0 +1,56 @@
+#nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
+package:
+  name: rancher-charts-2.12
+  version: "0_git20250826"
+  epoch: 0
+  description: Complete container management platform - charts
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - rancher-charts=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - perl-utils
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/charts
+      branch: release-v2.12
+      expected-commit: 8535acc7f3fa2f76b3c89fe5deb131b88738e381
+      destination: ./charts
+      depth: -1
+
+  - working-directory: ./charts
+    runs: |
+      shasum256=$(echo -n "https://git.rancher.io/charts" |shasum -a 256 | awk '{ print $1 }')
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256
+      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256
+
+      git checkout master
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/library
+      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/library
+
+test:
+  environment:
+    contents:
+      packages:
+        - perl-utils
+  pipeline:
+    - runs: |
+        shasum256=$(echo -n "https://git.rancher.io/charts" |shasum -a 256 | awk '{ print $1 }')
+        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256/`
+        test -f /var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256/README.md
+        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/library/`
+        test -f /var/lib/rancher-data/local-catalogs/library/README.md
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Commit at head of branch moves frequently


### PR DESCRIPTION
Per `rancher-charts-2.10`'s creation commit, the `git` update backend is not supported by the version stream automation: we also did this for 2.11 in f23047ab3a.

<!--ci-cve-scan:fail-any-->