### PR TITLE
rancher-kontainer-driver-metadata-2.12: add new version stream manually

### DIFF
--- a/rancher-kontainer-driver-metadata-2.12.yaml
+++ b/rancher-kontainer-driver-metadata-2.12.yaml
@@ -1,0 +1,40 @@
+#nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
+package:
+  name: rancher-kontainer-driver-metadata-2.12
+  version: "0_git20250826"
+  epoch: 0
+  description: Complete container management platform - kontainer driver metadata
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - rancher-kontainer-driver-metadata=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/kontainer-driver-metadata
+      branch: release-v2.12
+      expected-commit: aee930f9f9777b72d96ca22184849e024e66d49e
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata
+      install -Dm755 data/data.json  ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata/data.json
+
+test:
+  pipeline:
+    - runs: |
+        # check the expected files are available at the expected location at `/var/lib/rancher-data/driver-metadata/`
+        test -f /var/lib/rancher-data/driver-metadata/data.json
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Commit at head of branch moves frequently


### PR DESCRIPTION
Per `rancher-charts-2.10`'s creation commit, the `git` update backend is not supported by the version stream automation.  We did this for 2.11 in dd6415980c.

<!--ci-cve-scan:fail-any-->