### PR TITLE
curl: Remove `no-vendored-cross-package-deps` stanza

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,13 +1,10 @@
 package:
   name: curl
   version: "8.15.0"
-  epoch: 4
+  epoch: 5
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
-  options:
-    # Avoid a hard dependency on libcurl-openssl
-    no-vendored-cross-package-deps: true
   dependencies:
     runtime:
       # Allow only libcurl libraries built from the same upstream


### PR DESCRIPTION
This isn't needed anymore because the melange change has since been reverted.  It's effectively a no-op now.