### PR TITLE
test run for falco grpc bump

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20250127.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 4
+  epoch: 5
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: "0.41.3"
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -39,7 +39,7 @@ environment:
       - git
       # <= 0.39.1 is incompatible with grpc 1.67 due to a removal of deprecated symbols falco was relying on.
       # We should remove this pinning once falco is updated to use the new abseil API.
-      - grpc-1.66-dev
+      - grpc-1.74-dev
       - icu-dev
       - jq-dev
       - jsoncpp-dev
@@ -82,7 +82,7 @@ pipeline:
   - uses: patch
     with:
       # to prevent usage of vendored tbb
-      patches: tbb.patch libcurl-include.patch
+      patches: tbb.patch libcurl-include.patch remove-deprecated-grpc-log.patch
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/falco

--- a/falco/remove-deprecated-grpc-log.patch
+++ b/falco/remove-deprecated-grpc-log.patch
@@ -1,0 +1,165 @@
+From 390aa7f8bd5bf13c32912fa861382e84b7f6061c Mon Sep 17 00:00:00 2001
+From: Azimjon Ulmasov <azimjon.ulmasov@chainguard.dev>
+Date: Tue, 26 Aug 2025 18:30:02 -0400
+Subject: [PATCH] grpc_server: replace deprecated gpr_* logging with Abseil LogSink (gRPC 1.74 compat)
+
+gRPC 1.74 removed the legacy gpr logging APIs, which caused build errors in Falco. This change migrates our
+gRPC logging integration to Abseil’s logging stack.
+
+What changed
+- Drop the old dispatcher and hooks:
+  - Removed gpr_log_dispatcher_func()
+  - Removed calls to gpr_set_log_verbosity(), gpr_log_verbosity_init(), gpr_set_log_function()
+- Introduce an Abseil LogSink bridge:
+  - Add falcoGrpcLogSink (absl::LogSink) that forwards gRPC’s Abseil logs into Falco’s logger
+  - Preserve message formatting: prefix with "grpc: " and end with '\n'
+  - Map severities: ERROR→ERR, WARNING→WARNING, default→INFO
+- Initialize and register the sink:
+  - Call absl::InitializeLog() during server init
+  - Register the sink via absl::AddLogSink(falcoGrpcLogSink::instance())
+
+---
+ userspace/falco/grpc_server.cpp | 43 +++--------------------
+ userspace/falco/grpc_server.h   | 61 +++++++++++++++++++++++++++++++++
+ 2 files changed, 66 insertions(+), 38 deletions(-)
+
+diff --git a/userspace/falco/grpc_server.cpp b/userspace/falco/grpc_server.cpp
+index d8578e13..5a33fb06 100644
+--- a/userspace/falco/grpc_server.cpp
++++ b/userspace/falco/grpc_server.cpp
+@@ -54,26 +54,6 @@ limitations under the License.
+ 		c.start(this);                                                    \
+ 	}
+ 
+-static void gpr_log_dispatcher_func(gpr_log_func_args* args) {
+-	falco_logger::level priority;
+-	switch(args->severity) {
+-	case GPR_LOG_SEVERITY_ERROR:
+-		priority = falco_logger::level::ERR;
+-		break;
+-	case GPR_LOG_SEVERITY_DEBUG:
+-		priority = falco_logger::level::DEBUG;
+-		break;
+-	default:
+-		priority = falco_logger::level::INFO;
+-		break;
+-	}
+-
+-	std::string copy = "grpc: ";
+-	copy.append(args->message);
+-	copy.push_back('\n');
+-	falco_logger::log(priority, std::move(copy));
+-}
+-
+ void falco::grpc::server::thread_process(int thread_index) {
+ 	void* tag = nullptr;
+ 	bool event_read_success = false;
+@@ -134,24 +114,11 @@ void falco::grpc::server::init(const std::string& server_addr,
+ 	m_cert_chain = cert_chain;
+ 	m_root_certs = root_certs;
+ 
+-	// Set the verbosity level of gpr logger
+-	falco::schema::priority logging_level = falco::schema::INFORMATIONAL;
+-	falco::schema::priority_Parse(log_level, &logging_level);
+-	switch(logging_level) {
+-	case falco::schema::ERROR:
+-		gpr_set_log_verbosity(GPR_LOG_SEVERITY_ERROR);
+-		break;
+-	case falco::schema::DEBUG:
+-		gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
+-		break;
+-	case falco::schema::INFORMATIONAL:
+-	default:
+-		// note > info will always enter here since it is != from "informational"
+-		gpr_set_log_verbosity(GPR_LOG_SEVERITY_INFO);
+-		break;
+-	}
+-	gpr_log_verbosity_init();
+-	gpr_set_log_function(gpr_log_dispatcher_func);
++	// Initialize Abseil logging (required for gRPC 1.74+)
++	absl::InitializeLog();
++	
++	// Set up gRPC log forwarding to Falco's logging system
++	absl::AddLogSink(&falcoGrpcLogSink::instance());
+ 
+ 	if(falco::utils::network::is_unix_scheme(m_server_addr)) {
+ 		init_unix_server_builder();
+diff --git a/userspace/falco/grpc_server.h b/userspace/falco/grpc_server.h
+index 5c28206a..ba25f9d6 100644
+--- a/userspace/falco/grpc_server.h
++++ b/userspace/falco/grpc_server.h
+@@ -24,6 +24,13 @@ limitations under the License.
+ #include "outputs.grpc.pb.h"
+ #include "version.grpc.pb.h"
+ #include "grpc_context.h"
++#include "logger.h"
++
++#include "absl/log/globals.h"
++#include "absl/log/initialize.h"
++#include "absl/log/log_sink_registry.h"
++#include "absl/log/log_sink.h" 
++#include "absl/log/log_entry.h"
+ 
+ namespace falco {
+ namespace grpc {
+@@ -75,5 +82,59 @@ private:
+ 	std::atomic<bool> m_stop{false};
+ };
+ 
++/* 		FalcoGrpcLogSink - gRPC 1.74 Compatibility Bridge
++	This singleton class replaces the deprecated gpr_log integration that was removed in recent gRPC.
++	It implements absl::LogSink to capture gRPC's internal Abseil logs and forwards them to Falco's 
++	unified logging system, maintaining the same "grpc: " prefixed format as the original implementation.
++
++	Changes made for gRPC 1.74 compatibility:
++	- Replaced gpr_log_dispatcher_func() with absl::LogSink::Send() override
++	- Removed 
++		gpr_set_log_verbosity(), 
++		gpr_log_verbosity_init(), 
++		gpr_set_log_function() 	calls
++	- Added absl::InitializeLog() and absl::AddLogSink() integration
++	- Preserved original severity mapping: ERROR->ERR, WARNING->WARNING, default->INFO
++	- Maintained identical message formatting with "grpc: " prefix and newline termination
++ */
++class falcoGrpcLogSink : public absl::LogSink {
++public:
++	static falcoGrpcLogSink& instance() {
++		static falcoGrpcLogSink instance_;
++		return instance_;
++	}
++
++	void Send(const absl::LogEntry& entry) override {
++		falco_logger::level m_priority;
++		switch(entry.log_severity()) {
++		case absl::LogSeverity::kError:
++			m_priority = falco_logger::level::ERR;
++			break;
++		case absl::LogSeverity::kWarning:
++			m_priority = falco_logger::level::WARNING;
++			break;
++		default:
++			m_priority = falco_logger::level::INFO;
++			break;
++		}
++
++		std::string msg = "grpc: ";
++		msg.append(entry.text_message());
++		msg.push_back('\n');
++		falco_logger::log(m_priority, std::move(msg));
++	}
++
++private:
++	falcoGrpcLogSink() = default;
++	 
++	~falcoGrpcLogSink() override = default;
++
++	// Non-copyable, non-movable
++	falcoGrpcLogSink(const falcoGrpcLogSink&) = delete;
++	falcoGrpcLogSink& operator=(const falcoGrpcLogSink&) = delete;
++	falcoGrpcLogSink(falcoGrpcLogSink&&) = delete;
++	falcoGrpcLogSink& operator=(falcoGrpcLogSink&&) = delete;
++};
++
+ }  // namespace grpc
+ }  // namespace falco
+

--- a/grpc-1.74.yaml
+++ b/grpc-1.74.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.74
   version: "1.74.1"
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -66,6 +66,14 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: no-hardening.spec
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117739
+    GRPC_PYTHON_CFLAGS: "-std=c++17"
+    GRPC_PYTHON_BUILD_SYSTEM_CARES: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_RE2: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_ABSL: "True"
+    GRPC_PYTHON_BUILD_SYSTEM_CYTHON: "True"
 
 pipeline:
   - uses: git-checkout
@@ -75,26 +83,23 @@ pipeline:
       expected-commit: 893bdadd56dbb75fb156175afdaa2b0d47e1c15b
 
   - runs: |
-      cd third_party
-      git submodule update --init --recursive
-
-  - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DCMAKE_CXX_STANDARD=17 \
-      	-DBUILD_SHARED_LIBS=True \
-      	-DgRPC_INSTALL=ON \
-      	-DgRPC_CARES_PROVIDER=package \
-      	-DgRPC_SSL_PROVIDER=package \
-      	-DgRPC_ZLIB_PROVIDER=package \
-        -DgRPC_PROTOBUF_PROVIDER=package \
-      	-DgRPC_ABSL_PROVIDER=package \
-        -DgRPC_RE2_PROVIDER=package \
-      	-DgRPC_BENCHMARK_PROVIDER=package \
-      	-DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
-      	-DgRPC_BUILD_TESTS=OFF
+          -DCMAKE_BUILD_TYPE=None \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DBUILD_SHARED_LIBS=ON \
+          -DgRPC_INSTALL=ON \
+          -DgRPC_CARES_PROVIDER=package \
+          -DgRPC_SSL_PROVIDER=package \
+          -DgRPC_ZLIB_PROVIDER=package \
+          -DgRPC_PROTOBUF_PROVIDER=package \
+          -DgRPC_ABSL_PROVIDER=package \
+          -DgRPC_RE2_PROVIDER=package \
+          -DgRPC_BENCHMARK_PROVIDER=package \
+          -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+          -DgRPC_BUILD_TESTS=OFF \
+          -DgRPC_BUILD_CODEGEN=ON
       cmake --build _build
 
   - runs: |
@@ -117,14 +122,6 @@ subpackages:
         - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
-        environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
-          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
-          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
         with:
           python: python${{range.key}}
       - uses: strip

--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: "1.5.2" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 3
+  epoch: 4
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,18 +1,10 @@
 package:
   name: protobuf
-  version: "3.29.5" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 2
+  version: "31.1" # On update, please check if -fdelete-null-pointer-checks is still required
+  epoch: 0
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
-
-var-transforms:
-  # 3.26.1 -> 26.1
-  # TODO: Figure out how to make this 26.1.0
-  - from: ${{package.version}}
-    match: \d+\.(\d+\.\d+)
-    replace: $1
-    to: mangled-package-version
 
 environment:
   contents:
@@ -37,13 +29,9 @@ pipeline:
     with:
       repository: https://github.com/protocolbuffers/protobuf
       tag: v${{package.version}}
-      expected-commit: f5de0a0495faa63b4186fc767324f8b9a7bf4fc4
+      expected-commit: 74211c0dfc2777318ab53c2cd2c317a2ef9012de
       cherry-picks: |
         main/ced605d0e6a7ad20985375b596b2ca6720e07737: utf8_range: add version marker to library
-
-  - runs: |
-      cd third_party
-      git submodule update --init --recursive
 
   - runs: |
       cmake -B build -G Ninja \
@@ -54,7 +42,8 @@ pipeline:
         -DCMAKE_BUILD_TYPE=Release \
         -Dprotobuf_ABSL_PROVIDER=package \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -Dprotobuf_BUILD_LIBUPB=OFF
+        -Dprotobuf_BUILD_LIBUPB=ON \
+        -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON
       ninja -C build
       DESTDIR=${{targets.destdir}} ninja -C build install
 
@@ -84,15 +73,15 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv ${{targets.destdir}}/usr/bin/protoc-${{vars.mangled-package-version}}.0 ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/protoc-${{package.version}}.0 ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/protoc ${{targets.subpkgdir}}/usr/bin/protoc
     test:
       pipeline:
         - name: Verify protoc installation
           runs: |
             protoc --version || exit 1
-            protoc-${{vars.mangled-package-version}}.0 --version
-            protoc-${{vars.mangled-package-version}}.0 --help
+            protoc-${{package.version}}.0 --version
+            protoc-${{package.version}}.0 --help
         - name: Compile sample proto file
           runs: |
             echo 'syntax = "proto3"; message Test { string name = 1; }' > test.proto
@@ -135,7 +124,6 @@ update:
     identifier: protocolbuffers/protobuf
     strip-prefix: v
     use-tag: true
-    tag-filter: "v3."
 
 test:
   environment:


### PR DESCRIPTION
As part of our `protobuf` bump to `31.1`, I attempted to build the `falco` package against a newer gRPC that’s compatible with `protobuf 31.1`. Recent gRPC releases have removed the legacy `gpr_*` logging APIs in favor of `abseil` logging, while the latest `falco` release still relies on the older (`gRPC-1.66`) symbols. This PR is a proof of concept to move `falco` toward newer gRPC by replacing the deprecated `gpr_*` logging integration with an `abseil` `LogSink` bridge (context: https://github.com/grpc/proposal/blob/master/L117-core-replace-gpr-logging-with-abseil-logging.md?utm_source=chatgpt.com).

Local builds and smoke tests succeeded. Functionally, runtime behavior seems to be unchanged, aside from the logging path. Below are representative logs from current (`current-grpc-1.66`) vs. modified (`patched-grpc-1.74`) builds. Note that both fail to start the `TLS` server in this environment due to an invalid cert chain; that’s unrelated to this change and serves just to show the logging differences:

`current-grpc-1.66`:
```
46afbde596d9:/work# ./ss.sh 
Falco PID: 56, waiting for startup...
Tue Aug 26 23:25:29 2025: Falco version: 0.41.3 (x86_64)
Tue Aug 26 23:25:29 2025: Falco initialized with configuration files:
Tue Aug 26 23:25:29 2025:    fix-all-complete.yaml | schema validation: ok
Tue Aug 26 23:25:29 2025: System info: Linux version 6.15.4-r0-gcp-generic (noreply@chainguard.dev) (gcc (Wolfi 15.1.0-r1) 15.1.0, GNU ld (GNU Binutils) 2.44) #Chainguard SMP PREEMPT_DYNAMIC Fri Jun 27 18:26:44 UTC 2025
Tue Aug 26 23:25:29 2025: Loading plugin 'container' from file /usr/share/falco/plugins/libcontainer.so
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'podman' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/podman/podman.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'docker' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/var/run/docker.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'cri' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/containerd/containerd.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/crio/crio.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/k3s/containerd/containerd.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/host-containerd/containerd.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'containerd' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: * enabled container runtime socket at '/run/host-containerd/containerd.sock'
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'lxc' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'libvirt_lxc' container engine.
Tue Aug 26 23:25:29 2025: [libs]: container: Enabled 'bpm' container engine.
Tue Aug 26 23:25:29 2025: Loading rules from:
Tue Aug 26 23:25:29 2025:    /etc/falco/falco_rules.yaml | schema validation: ok
Tue Aug 26 23:25:29 2025:    /etc/falco/falco_rules.local.yaml | schema validation: none
Tue Aug 26 23:25:29 2025: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Tue Aug 26 23:25:29 2025: gRPC server threadiness equals to 4
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1756250729.242943      59 log.cc:102] This will not be set. Please set this via absl log level settings.
E0000 00:00:1756250729.243101      59 log.cc:145] This function is deprecated. This function will be deleted in the next gRPC release. You may create a new absl LogSink with similar functionality. gRFC: https://github.com/grpc/proposal/pull/425 
Tue Aug 26 23:25:29 2025: Starting health webserver with threadiness 88, listening on 0.0.0.0:8765
Tue Aug 26 23:25:29 2025: Loaded event sources: syscall
Tue Aug 26 23:25:29 2025: Enabled event sources: syscall
Tue Aug 26 23:25:29 2025: Opening 'syscall' source with Kernel module
Tue Aug 26 23:25:29 2025: [libs]: Trying to open the right engine!
Tue Aug 26 23:25:29 2025: Trying to inject the Kernel module and opening the capture again...
Tue Aug 26 23:25:29 2025: Unable to load the driver
Tue Aug 26 23:25:29 2025: [libs]: Trying to open the right engine!
Tue Aug 26 23:25:29 2025: An error occurred in an event source, forcing termination...
E0000 00:00:1756250729.250379      79 ssl_transport_security.cc:794] Invalid cert chain file.
E0000 00:00:1756250729.250450      79 ssl_security_connector.cc:238] Handshaker factory creation failed with TSI_INVALID_ARGUMENT
E0000 00:00:1756250729.250599      79 chttp2_server.cc:1118] UNKNOWN:Unable to create secure server with credentials of type Ssl {file:"/home/build/src/core/ext/transport/chttp2/server/chttp2_server.cc", file_line:1105, created_time:"2025-08-26T23:25:29.250557634+00:00"}
Tue Aug 26 23:25:29 2025: Error starting gRPC server
```

`patched-grpc-1.74`:
```
ea35d7e29d7c:/work# ./ss.sh 
Falco PID: 612, waiting for startup...
Tue Aug 26 23:08:34 2025: Falco version: 0.41.3 (x86_64)
Tue Aug 26 23:08:34 2025: Falco initialized with configuration files:
Tue Aug 26 23:08:34 2025:    fix-all-complete.yaml | schema validation: ok
Tue Aug 26 23:08:34 2025: System info: Linux version 6.16.1-r0-gcp-generic (noreply@chainguard.dev) (gcc (Wolfi 15.2.0-r0) 15.2.0, GNU ld (GNU Binutils) 2.45) #Chainguard SMP PREEMPT_DYNAMIC Fri Aug 15 18:46:28 UTC 2025
Tue Aug 26 23:08:34 2025: Loading plugin 'container' from file /usr/share/falco/plugins/libcontainer.so
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'podman' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/podman/podman.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'docker' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/var/run/docker.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'cri' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/containerd/containerd.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/crio/crio.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/k3s/containerd/containerd.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/host-containerd/containerd.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'containerd' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: * enabled container runtime socket at '/run/host-containerd/containerd.sock'
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'lxc' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'libvirt_lxc' container engine.
Tue Aug 26 23:08:34 2025: [libs]: container: Enabled 'bpm' container engine.
Tue Aug 26 23:08:34 2025: Loading rules from:
Tue Aug 26 23:08:34 2025:    /etc/falco/falco_rules.yaml | schema validation: ok
Tue Aug 26 23:08:34 2025:    /etc/falco/falco_rules.local.yaml | schema validation: none
Tue Aug 26 23:08:34 2025: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Tue Aug 26 23:08:34 2025: gRPC server threadiness equals to 4
Tue Aug 26 23:08:34 2025: Starting health webserver with threadiness 88, listening on 0.0.0.0:8765
Tue Aug 26 23:08:34 2025: Loaded event sources: syscall
Tue Aug 26 23:08:34 2025: Enabled event sources: syscall
Tue Aug 26 23:08:34 2025: Opening 'syscall' source with Kernel module
Tue Aug 26 23:08:34 2025: [libs]: Trying to open the right engine!
Tue Aug 26 23:08:34 2025: Trying to inject the Kernel module and opening the capture again...
Tue Aug 26 23:08:34 2025: Unable to load the driver
Tue Aug 26 23:08:34 2025: [libs]: Trying to open the right engine!
Tue Aug 26 23:08:34 2025: An error occurred in an event source, forcing termination...
E0826 23:08:34.659222     634 ssl_transport_security.cc:917] Invalid cert chain file.
Tue Aug 26 23:08:34 2025: grpc: Invalid cert chain file.
E0826 23:08:34.659324     634 ssl_security_connector.cc:263] Handshaker factory creation failed with TSI_INVALID_ARGUMENT
Tue Aug 26 23:08:34 2025: grpc: Handshaker factory creation failed with TSI_INVALID_ARGUMENT
E0826 23:08:34.659370     634 add_port.cc:56] Unable to create secure server with credentials of type 
Tue Aug 26 23:08:34 2025: grpc: Unable to create secure server with credentials of type 
Tue Aug 26 23:08:34 2025: Error starting gRPC server
```

The main difference is in this portion:
`old`:
```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 ... log.cc:145] This function is deprecated. This function will be deleted in the next gRPC release. ...
...
E0000 ... ssl_transport_security.cc:794] Invalid cert chain file.
E0000 ... ssl_security_connector.cc:238] Handshaker factory creation failed with TSI_INVALID_ARGUMENT
E0000 ... chttp2_server.cc:1118] UNKNOWN:Unable to create secure server with credentials of type Ssl {...}
Falco: Error starting gRPC server
```

`new`:
```
E0826 ... ssl_transport_security.cc:917] Invalid cert chain file.
Falco: grpc: Invalid cert chain file.
E0826 ... ssl_security_connector.cc:263] Handshaker factory creation failed with TSI_INVALID_ARGUMENT
Falco: grpc: Handshaker factory creation failed with TSI_INVALID_ARGUMENT
E0826 ... add_port.cc:56] Unable to create secure server with credentials of type
Falco: grpc: Unable to create secure server with credentials of type
Falco: Error starting gRPC server
```