### PR TITLE
withdraw plugin-barman-cloud packages from Os

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -7,3 +7,9 @@ redpanda-25.1-25.2.1-r1.apk
 redpanda-25.1-dev-25.2.1-r2.apk
 redpanda-25.1-compat-25.2.1-r2.apk
 redpanda-25.1-25.2.1-r2.apk
+plugin-barman-cloud-0.5.0-r0.apk
+plugin-barman-cloud-0.6.0-r0.apk
+plugin-barman-cloud-0.6.0-r1.apk
+plugin-barman-cloud-compat-0.5.0-r0.apk
+plugin-barman-cloud-compat-0.6.0-r0.apk
+plugin-barman-cloud-compat-0.6.0-r1.apk


### PR DESCRIPTION
The package is only added in the first week on this month, and there are no other packages dependent upon and only 1 image which uses this package.Please Check [here](https://github.com/search?q=repo%3Awolfi-dev%2Fos%20plugin-barman-cloud&type=code) for usage in OS.
Names of the packages that we need to withdraw.

➜  images-private git:(plugin-barman-cloud-sidecar/-fips) ✗ curl -L -u "user:$(chainctl auth token --audience ```

> apk.cgr.dev)" \
>   https://apk.cgr.dev/chainguard/aarch64/APKINDEX.tar.gz | 
>   tar -Oxz APKINDEX |
>   awk -v RS='' '
>     {
>       pkg=""; ver="";
>       for (i=1; i<=NF; i++) {
>         if ($i ~ /^P:/) { sub(/^P:[[:space:]]*/,"",$i); pkg=$i }
>         if ($i ~ /^V:/) { sub(/^V:[[:space:]]*/,"",$i); ver=$i }
>       }
>       if (pkg ~ /^plugin-barman-cloud/ && pkg && ver) {
>         print "/" pkg "-" ver ".apk"
>       }
>     }
>   ' | sort -u
>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
>                                  Dload  Upload   Total   Spent    Left  Speed
> 100 10.8M  100 10.8M    0     0  2757k      0  0:00:04  0:00:04 --:--:-- 2758k
> /plugin-barman-cloud-0.5.0-r0.apk
> /plugin-barman-cloud-0.6.0-r0.apk
> /plugin-barman-cloud-0.6.0-r1.apk
> /plugin-barman-cloud-compat-0.5.0-r0.apk
> /plugin-barman-cloud-compat-0.6.0-r0.apk
> /plugin-barman-cloud-compat-0.6.0-r1.apk

```