### PR TITLE
gke-gcloud-auth-plugin: remove runtime dependency on gcloud and kubectl CLIs

### DIFF
--- a/gke-gcloud-auth-plugin.yaml
+++ b/gke-gcloud-auth-plugin.yaml
@@ -1,14 +1,10 @@
 package:
   name: gke-gcloud-auth-plugin
   version: "0.1.0"
-  epoch: 9 # CVE-2025-47907
+  epoch: 10
   description: "kubectl plugin for GKE authentication"
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - google-cloud-sdk
-      - kubectl
 
 environment:
   contents:


### PR DESCRIPTION
Currently this package "requires" the entire `gcloud` CLI/SDK and the `kubectl` CLI command at runtime.

While it's true that [the default behavior](https://github.com/kubernetes/cloud-provider-gcp/blob/6ff0ef70d4fbc3b5678fa9d5fb114d486662e201/cmd/gke-gcloud-auth-plugin/cred.go#L135-L141) of `gke-gcloud-auth-plugin` shells out to the `gcloud` CLI to get an authentication token by default, you can also provide the `--use_application_default_credentials` flag or set the `CLOUDSDK_AUTH_ACCESS_TOKEN` environment variable instead. In-fact, this usage pattern is much more likely to be used inside an OCI/Docker image where the authenticated principal is a service account not a human authenticated via SSO (`gcloud auth login`).

Similarly, the `kubectl` CLI is not actually a dependency of this package. It's true the `kubectl` will use this package if it's configured as the authentication plugin in `KUBECONFIG`, but the plugin itself does not require `kubectl`.