### PR TITLE
fix: add symlink to cilium image to match upstream

### DIFF
--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -129,6 +129,14 @@ subpackages:
             test -x $(readlink -f /install-plugin.sh)
             test -x $(readlink -f /cni-uninstall.sh)
 
+  - name: ${{package.name}}-compat
+    description: Compat to make our image compatible with upstream
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/run
+          mkdir -p ${{targets.subpkgdir}}/var
+          ln -sf /run ${{targets.subpkgdir}}/var/run
+
   - name: ${{package.name}}-iptables
     description: iptables compatibility package for cilium
     dependencies:

--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.18
   version: "1.18.1"
-  epoch: 1 # GHSA-2464-8j7c-4cjm
+  epoch: 2 # GHSA-2464-8j7c-4cjm
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -131,6 +131,11 @@ subpackages:
 
   - name: ${{package.name}}-compat
     description: Compat to make our image compatible with upstream
+    dependencies:
+      runtime:
+        - wolfi-baselayout
+      provides:
+        - cilium-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/run


### PR DESCRIPTION
Fix https://github.com/chainguard-dev/customer-issues/issues/2417 with symlink compat package.