### PR TITLE
nginx-mainline - move from pcre to pcre2

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.1"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -34,7 +34,7 @@ environment:
       - libxslt-dev
       - luajit-dev
       - openssl-dev
-      - pcre-dev
+      - pcre2-dev
       - perl-dev
       - pkgconf
       - zeromq-dev
@@ -102,8 +102,6 @@ pipeline:
           --group=nginx \
           --with-threads \
           --with-file-aio \
-          \
-          --without-pcre2 \
           \
           --with-compat \
           \


### PR DESCRIPTION
We were using pcre for nginx builds.  That almost certainly came from a 'melange convert' from alpine.

Alpine recently moved to pcre2 at [1] with the message

> The lua module added support for PCRE2, so we can finally switch to it.

--
[1] https://github.com/alpinelinux/aports/commit/8490019abbd20ca77ebda9d0b9540ff4ffe330e5
