### PR TITLE
harbor-registry: fix ldflags, enable auto-updates, improve tests

### DIFF
--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -34,7 +34,7 @@ pipeline:
       packages: ./cmd/registry
       output: harbor-registry
       tags: include_oss,include_gcs
-      ldflags: -X github.com/distribution/distribution/v3/version.Version=${{package.version}}
+      ldflags: -X github.com/distribution/distribution/v3/version.version=${{package.version}}
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -55,13 +55,13 @@ test:
   pipeline:
     - runs: |
         # Basic version and help validation
-        harbor-registry --version
-        harbor-registry --help
+        harbor-registry --version | grep ${{package.version}}
+        harbor-registry --help | grep "Available Commands"
 
         # Test compatibility symlink
         [ "$(readlink -f /usr/bin/registry_DO_NOT_USE_GC)" = "/usr/bin/harbor-registry" ]
-        registry_DO_NOT_USE_GC --version
-        registry_DO_NOT_USE_GC --help
+        registry_DO_NOT_USE_GC --version | grep ${{package.version}}
+        registry_DO_NOT_USE_GC --help | grep "Available Commands"
     - uses: test/daemon-check-output
       with:
         start: "harbor-registry serve /etc/registry/config.yml"

--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-registry
   version: 3.0.0
-  epoch: 6 # CVE-2025-47907
+  epoch: 7 # CVE-2025-47907
   description: An open source trusted cloud native registry project that stores, signs, and scans content (registry)
   copyright:
     - license: Apache-2.0
@@ -34,12 +34,13 @@ pipeline:
       packages: ./cmd/registry
       output: harbor-registry
       tags: include_oss,include_gcs
+      ldflags: -X github.com/distribution/distribution/v3/version.Version=${{package.version}}
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/etc/registry
 
-      # Symlink to expected binary path
+      # Create compatibility symlink for legacy registry binary name
       ln -sf /usr/bin/harbor-registry ${{targets.destdir}}/usr/bin/registry_DO_NOT_USE_GC
       # Use example config as registry config
       cp ./cmd/registry/config-example.yml ${{targets.destdir}}/etc/registry/config.yml
@@ -49,18 +50,35 @@ test:
     contents:
       packages:
         - curl
+        - procps
+        - wait-for-it
   pipeline:
     - runs: |
-        # The registry should start and begin listening before it's killed
+        # Basic version and help validation
         harbor-registry --version
-        registry_DO_NOT_USE_GC serve /etc/registry/config.yml > /dev/null 2>&1 &
-        sleep 5
-        test $(curl -LI localhost:5000 -o /dev/null -w '%{http_code}\n' -s) == "200"
         harbor-registry --help
+
+        # Test compatibility symlink
+        [ "$(readlink -f /usr/bin/registry_DO_NOT_USE_GC)" = "/usr/bin/harbor-registry" ]
         registry_DO_NOT_USE_GC --version
         registry_DO_NOT_USE_GC --help
+    - uses: test/daemon-check-output
+      with:
+        start: "harbor-registry serve /etc/registry/config.yml"
+        expected_output: |
+          level=info
+          service=registry
+        post: |
+          wait-for-it localhost:5000 -t 10
+          curl -fsSL -I localhost:5000 | grep "HTTP/1.1 200"
 
 update:
+  enabled: true
   github:
     identifier: distribution/distribution
     strip-prefix: v
+    tag-filter: v3
+  ignore-regex-patterns:
+    - ".*alpha.*"
+    - ".*beta.*"
+    - ".*rc.*"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
