### PR TITLE
fix(dotnet-8/9): Always use latest .NET host by default

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.119"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -125,7 +125,7 @@ subpackages:
       provides:
         - dotnet-runtime=${{package.full-version}}
       runtime:
-        - dotnet-${{vars.major-version}}=${{package.full-version}}
+        - dotnet
     test:
       pipeline:
         - uses: test/tw/ldd-check

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.109"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -116,7 +116,7 @@ subpackages:
       provides:
         - dotnet-runtime=${{package.full-version}}
       runtime:
-        - dotnet-${{vars.major-version}}=${{package.full-version}}
+        - dotnet
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
The only thing that seems to be preventing co-installation of .NET 8 and .NET 9 is the strict dependency on host versions. Loosen this dependency so that the latest version of the .NET host is always installed unless the user explicitly requests an older version of the host