### PR TITLE
Unpin `gcc-14-default` from packages that build with GCC 15 -- part 1

### DIFF
--- a/apache-kvrocks.yaml
+++ b/apache-kvrocks.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-kvrocks
   version: "2.13.0"
-  epoch: 0
+  epoch: 1
   description: Apache Kvrocks is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol.
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,6 @@ environment:
       - busybox
       - cmake
       - coreutils
-      - gcc-14-default
       - libtool
       - lld
       - openssl-dev

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.45"
-  epoch: 0
+  epoch: 1
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0
@@ -18,7 +18,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - flex
-      - gcc-14-default
       - isl
       - posix-libc-utils
       - texinfo

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.83"
-  epoch: 2
+  epoch: 3
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0 AND LGPL-2.1 AND BSD-2-Clause AND MIT
@@ -18,7 +18,6 @@ environment:
       - dbus
       - dbus-dev
       - ell-dev
-      - gcc-14-default
       - glib-dev
       - icu-dev
       - json-c-dev

--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: cifs-utils
   version: "7.4"
-  epoch: 4
+  epoch: 5
   description: CIFS filesystem user-space tools
   copyright:
     - license: GPL-3.0-or-later
@@ -18,7 +18,6 @@ environment:
       - automake
       - build-base
       - busybox
-      - gcc-14-default
       - keyutils-dev
       - krb5-dev
       - libcap-dev

--- a/difftastic.yaml
+++ b/difftastic.yaml
@@ -1,7 +1,7 @@
 package:
   name: difftastic
   version: "0.64.0"
-  epoch: 1
+  epoch: 2
   description: "a structural diff that understands syntax"
   copyright:
     - license: MIT
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - gcc-14-default
       - rust
 
 pipeline:

--- a/envoy-gateway.yaml
+++ b/envoy-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy-gateway
   version: "1.5.0"
-  epoch: 1 # GHSA-f9f8-9pmf-xv68
+  epoch: 2
   description: Manages Envoy Proxy as a Standalone or Kubernetes-based Application Gateway
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,6 @@ environment:
   contents:
     packages:
       - btrfs-progs-dev
-      - gcc-14-default
 
 pipeline:
   - uses: git-checkout

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
   version: "3.3.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - go~1.24
       - nodejs
       - protobuf

--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-alloy
   version: "1.10.2"
-  epoch: 1 # GHSA-2464-8j7c-4cjm
+  epoch: 2
   description: OpenTelemetry Collector distribution with programmable pipelines
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,6 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - go
       - nodejs-18
       - systemd-dev

--- a/imath.yaml
+++ b/imath.yaml
@@ -1,7 +1,7 @@
 package:
   name: imath
   version: "3.2.1"
-  epoch: 1
+  epoch: 2
   description: C++ and python library of 2D and 3D vector, matrix, and math operations for computer graphics
   copyright:
     - license: BSD-3-Clause
@@ -16,7 +16,6 @@ environment:
       - ca-certificates-bundle
       - cmake-3
       - doxygen
-      - gcc-14-default
       - py3-supported-numpy~1.26
       - python3-dev
       - samurai

--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: "1.8.1"
-  epoch: 2
+  epoch: 3
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -13,7 +13,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - libtool
       - oniguruma-dev
       - wolfi-base

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: "1.22.1"
-  epoch: 0
+  epoch: 1
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
@@ -24,7 +24,6 @@ environment:
       - ca-certificates-bundle
       - e2fsprogs-dev
       - flex
-      - gcc-14-default
       - keyutils-dev
       - krb5-conf
       - libverto-dev

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.14.0"
-  epoch: 1 # GHSA-2464-8j7c-4cjm
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -17,7 +17,6 @@ environment:
     packages:
       - argo-cd
       - eslint
-      - gcc-14-default
       - go-licenses
       - jq
       - kubectl


### PR DESCRIPTION
A number of our packages got updated since GCC 15 was uploaded, and now we can unpin `gcc-14-default` so that they build with the latest compiler.

Part 2: #64510 
Part 3: #64511 

Fixes #54851
Fixes #54856
Fixes #54857
Fixes #54858
Fixes #54868
Fixes #54882
Fixes #54884