### PR TITLE
Make cpio and gnutar co-installable.

### DIFF
--- a/cpio.yaml
+++ b/cpio.yaml
@@ -1,10 +1,16 @@
 package:
   name: cpio
   version: "2.15"
-  epoch: 4
+  epoch: 5
   description: tool to copy files into or out of a cpio or tar archive
   copyright:
     - license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+      - gnutar-rmt
+
+vars:
+  rmt-path: /usr/libexec/rmt
 
 environment:
   contents:
@@ -27,6 +33,9 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+  - runs: |
+      rm ${{targets.destdir}}/${{vars.rmt-path}}
 
 subpackages:
   - name: cpio-doc
@@ -54,4 +63,8 @@ test:
       runs: cpio --version | grep ${{package.version}}
     - runs: |
         find /usr/local -print -depth | cpio -ov > foo.cpio
+    - runs: |
+        p=${{vars.rmt-path}}
+        [ -x "$p" ] && [ -f "$p" ] && echo "PASS: $p is an executable file" ||
+          { echo "FAIL: $p is an executable file"; exit 1; }
     - uses: test/no-docs

--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -1,10 +1,13 @@
 package:
   name: gnutar
   version: "1.35"
-  epoch: 5
+  epoch: 6
   description: "The GNU Tar program"
   copyright:
     - license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+      - gnutar-rmt
 
 environment:
   contents:
@@ -37,6 +40,21 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+
+  - name: gnutar-rmt
+    description: remote magnetic tape server
+    pipeline:
+      - runs: |
+          src=${{targets.destdir}}/usr/libexec
+          dest=${{targets.subpkgdir}}/usr/libexec
+          mkdir -p $dest
+          mv "$src/rmt" "$dest/rmt"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: |
+            /usr/libexec/rmt --help
+            /usr/libexec/rmt --version | grep -F "${{package.version}}"
 
 update:
   enabled: true


### PR DESCRIPTION
cpio and tar both ship /usr/lib/rmt (remote magnetic tape).

It probably would have been sufficient to just remove /usr/lib/rmt from cpio and no one would notice - I do not think too many people are using remote tape drives at this point, but might as well keep it working.
