### PR TITLE
Unpin `gcc-14-default` from packages that build with GCC 15 -- part 2

### DIFF
--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgdiplus
   version: 6.2
-  epoch: 1
+  epoch: 2
   description: "Open Source Implementation of the GDI+ API"
   copyright:
     - license: MIT
@@ -18,7 +18,6 @@ environment:
       - cmake
       - expat-dev
       - fribidi-dev
-      - gcc-14-default
       - giflib-dev
       - glib-dev
       - glib-static

--- a/libical.yaml
+++ b/libical.yaml
@@ -2,7 +2,7 @@
 package:
   name: libical
   version: 3.0.20
-  epoch: 2
+  epoch: 3
   description: Reference implementation of the iCalendar format
   copyright:
     - license: LGPL-2.1-only OR MPL-2.0
@@ -16,7 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      - gcc-14-default
       - glib-dev
       - glib-gir
       - gobject-introspection-dev

--- a/libtirpc.yaml
+++ b/libtirpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtirpc
   version: "1.3.7"
-  epoch: 0
+  epoch: 1
   description: Transport Independent RPC library (SunRPC replacement)
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - krb5-dev
       - libtool
 

--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,7 +1,7 @@
 package:
   name: malcontent
   version: "1.15.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: enumerate file capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,6 @@ package:
 environment:
   contents:
     packages:
-      - gcc-14-default
       - openssl-dev
       - yara-x
 

--- a/mariadb-12.0.yaml
+++ b/mariadb-12.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-12.0
   version: "12.0.2"
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -22,7 +22,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      - gcc-14-default
       - libaio-dev
       - libevent-dev
       - linux-pam-dev

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: "3.4.7"
-  epoch: 0
+  epoch: 1
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later
@@ -15,7 +15,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      - gcc-14-default
       - openssl-dev
       - samurai
       - zlib-dev

--- a/mysql-connector-cpp.yaml
+++ b/mysql-connector-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-connector-cpp
   version: "9.4.0"
-  epoch: 0
+  epoch: 1
   description: MySQL Connector/C++ is a MySQL database connector for C++
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake-3
-      - gcc-14-default
       - lz4-dev
       - openssl-dev
       - protobuf-dev

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.1"
-  epoch: 1
+  epoch: 2
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -26,7 +26,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - gd-dev
       - geoip-dev
       - libmaxminddb-dev

--- a/ninja-build.yaml
+++ b/ninja-build.yaml
@@ -9,7 +9,7 @@
 package:
   name: ninja-build
   version: "1.13.1"
-  epoch: 1
+  epoch: 2
   description: "Ninja is a small build system with a focus on speed."
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - wolfi-base
 
 pipeline:

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,7 +1,7 @@
 package:
   name: ollama
   version: "0.11.7"
-  epoch: 0
+  epoch: 1
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT
@@ -9,7 +9,6 @@ package:
 environment:
   contents:
     packages:
-      - gcc-14-default
 
 pipeline:
   - uses: git-checkout

--- a/pstack.yaml
+++ b/pstack.yaml
@@ -1,7 +1,7 @@
 package:
   name: pstack
   version: "2.14"
-  epoch: 0
+  epoch: 1
   description: "Print stack traces from running processes, or core files."
   copyright:
     - license: BSD-2-Clause
@@ -11,7 +11,6 @@ environment:
     packages:
       - build-base
       - cmake
-      - gcc-14-default
       - python-3.12
       - wolfi-base
       - xz-dev

--- a/py3-sentencepiece.yaml
+++ b/py3-sentencepiece.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sentencepiece
   version: "0.2.1"
-  epoch: 0
+  epoch: 1
   description: SentencePiece is an unsupervised text tokenizer and detokenizer
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ environment:
       - build-base
       - busybox
       - cmake
-      - gcc-14-default
       - py3-supported-pip
       - py3-supported-python-dev
 

--- a/py3-tensorflow-data-validation.yaml
+++ b/py3-tensorflow-data-validation.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tensorflow-data-validation
   version: "1.17.0"
-  epoch: 1
+  epoch: 2
   description: Library for exploring and validating machine learning data
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - numpy
       - openjdk-11
       - patch

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: "3.10.18"
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -20,7 +20,6 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
-      - gcc-14-default
       - gdbm-dev
       - libffi-dev
       - linux-headers


### PR DESCRIPTION
A number of our packages got updated since GCC 15 was uploaded, and now we can unpin gcc-14-default so that they build with the latest compiler.

Part 1: #64501 
Part 3: #64511 

Fixes #54888
Fixes #54889
Fixes #54895
Fixes #54905
Fixes #54906
Fixes #54909
Fixes #54931
Fixes #54933