### PR TITLE
Unpin `gcc-14-default` from packages that build with GCC 15 -- part 3

### DIFF
--- a/sasl-xoauth2.yaml
+++ b/sasl-xoauth2.yaml
@@ -1,7 +1,7 @@
 package:
   name: sasl-xoauth2
   version: "0.27"
-  epoch: 0
+  epoch: 1
   description: "SASL plugin for XOAUTH2"
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,6 @@ environment:
       - cmake-3
       - curl-dev
       - cyrus-sasl-dev
-      - gcc-14-default
       - jsoncpp-dev
       - openssl-dev
       - pkgconf

--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: splunk-otel-collector
   version: "0.132.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Splunk OpenTelemetry Collector is a distribution of the OpenTelemetry Collector. It provides a unified way to receive, process, and export metric, trace, and log data for Splunk Observability Cloud
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,6 @@ package:
 environment:
   contents:
     packages:
-      - gcc-14-default
 
 pipeline:
   - uses: git-checkout

--- a/strongswan.yaml
+++ b/strongswan.yaml
@@ -1,7 +1,7 @@
 package:
   name: strongswan
   version: "6.0.2"
-  epoch: 2
+  epoch: 3
   description: IPsec-based VPN solution focused on security and ease of use, supporting IKEv1/IKEv2 and MOBIKE
   copyright:
     # GPL-2.0-or-later WITH OpenSSL-Exception
@@ -42,7 +42,6 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - flex
-      - gcc-14-default
       - gettext-dev
       - gmp-dev
       - gperf

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: "9.2.11"
-  epoch: 1
+  epoch: 2
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0
@@ -14,7 +14,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - libtool
       - linux-headers
       - openssl-dev

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmedge
   version: "0.15.0"
-  epoch: 0
+  epoch: 1
   description: WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications.
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,6 @@ environment:
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
       - cmake
-      - gcc-14-default
       - libLLVM-${{vars.llvm-vers}}
       - libxml2-dev
       - llvm-${{vars.llvm-vers}}

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.25.0
-  epoch: 4
+  epoch: 5
   description: "GNU wget"
   copyright:
     - license: GPL-3.0
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       # somehow openssl-config-fipshardened-3.4.0 fails on ARMv9 with gcc-15
-      - gcc-14-default
       - openssl-dev
 
 pipeline:

--- a/yaml-cpp.yaml
+++ b/yaml-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: yaml-cpp
   version: 0.8.0
-  epoch: 9
+  epoch: 10
   description: "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec."
   copyright:
     - license: MIT
@@ -13,7 +13,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake-3
-      - gcc-14-default
       - wolfi-base
 
 pipeline:

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "1.5.0"
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,6 @@ environment:
       - build-base
       - ca-certificates-bundle
       - cargo-c
-      - gcc-14-default
       - openssl-dev
       - perl
       - rust
@@ -54,7 +53,6 @@ test:
   environment:
     contents:
       packages:
-        - gcc-14-default
         - git
         - glibc-dev
         - go


### PR DESCRIPTION
A number of our packages got updated since GCC 15 was uploaded, and now we can unpin gcc-14-default so that they build with the latest compiler.

Part 1: #64501
Part 2: #64510 

Fixes #54956
Fixes #54958
Fixes #54965