### PR TITLE
zookeeper-3.9: add missing runtime deps

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.2"
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -78,6 +78,8 @@ subpackages:
         - merged-usrsbin
         - netcat-openbsd
         - wolfi-baselayout
+        - openssl
+        - wait-for-port
     pipeline:
       - uses: bitnami/compat
         with:
@@ -117,6 +119,8 @@ subpackages:
         - merged-usrsbin
         - netcat-openbsd
         - wolfi-baselayout
+        - openssl
+        - wait-for-port
     pipeline:
       - uses: iamguarded/build-compat
         with:


### PR DESCRIPTION
Adds missing required runtime dependencies: https://github.com/bitnami/containers/blob/a873fc56a06af42c75599415195fa32856e27aa6/bitnami/zookeeper/3.9/debian-12/rootfs/opt/bitnami/scripts/libzookeeper.sh#L595