### PR TITLE
fix(python-3.11): remediate CVE-2025-8194

### DIFF
--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: "3.11.13"
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -48,6 +48,8 @@ pipeline:
       expected-commit: 498b971ea3673012a1d4b21860b229d55fc6e575
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.11/b4ec17488eedec36d3c05fec127df71c0071f6cb: Remediate CVE-2025-8194
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
This PR cherry picks https://github.com/python/cpython/pull/137172 to remediate CVE-2025-8194