### PR TITLE
Bump kubernetes to remediate CVE-2025-5187|GHSA-4x4m-3c2p-qppc

### DIFF
--- a/yunikorn-k8shim.yaml
+++ b/yunikorn-k8shim.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-k8shim
   version: "1.7.0"
-  epoch: 2 # CVE-2025-47907
+  epoch: 3 # CVE-2025-5187|GHSA-4x4m-3c2p-qppc
   description: Apache YuniKorn K8shim
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
-        k8s.io/kubernetes@v1.32.6
+        k8s.io/kubernetes@v1.32.8
         golang.org/x/net@v0.38.0
       modroot: .
 


### PR DESCRIPTION
Fixes: [CVE-2025-5187|GHSA-4x4m-3c2p-qppc](https://github.com/chainguard-dev/CVE-Dashboard/issues/29688)

Related: https://github.com/wolfi-dev/advisories/pull/23063

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories/pull/23063) repo


<!--ci-cve-scan:fail-any-->
<!--ci-cve-scan:must-fix: CVE-2025-5187-->
