### PR TITLE
fix(nfs-subdir-external-provisioner): bump yaml.v3 to remediate CVE-2022-28948|GHSA-hp87-p4gw-j4gq

### DIFF
--- a/nfs-subdir-external-provisioner.yaml
+++ b/nfs-subdir-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-subdir-external-provisioner
   version: 4.0.18
-  epoch: 24 # CVE-2025-47907
+  epoch: 25 # CVE-2022-28948|GHSA-hp87-p4gw-j4gq
   description: Dynamic sub-dir volume provisioner on a remote NFS server.
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
     with:
       deps: |-
         golang.org/x/text@v0.9.0
-        gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+        gopkg.in/yaml.v3@v3.0.1
         google.golang.org/protobuf@v1.33.0
         github.com/prometheus/client_golang@v1.11.1
         github.com/golang/glog@v1.2.4


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/CVE-Dashboard/issues/29717

Related: https://github.com/wolfi-dev/advisories/pull/23064


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories/pull/23064) repo

<!--ci-cve-scan:must-fix: CVE-2022-28948-->
<!--ci-cve-scan:fail-any-->
