### PR TITLE
fix(kubernetes-dns-node-cache): track tags instead of releases

### DIFF
--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -40,6 +40,7 @@ update:
   github:
     identifier: kubernetes/dns
     strip-prefix: v
+    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
Upstream use an unusual approach to tracking releases: Github releases are only created for new minor versions, with patch versions only being tracked by tags.

Switch to tracking tags to ensure that we pick up on new versions
