### PR TITLE
openssl: allow sha1 usage for non-security purposes

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: "3.5.2"
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,10 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch 0001-baseprovider-add-MD5-and-SHA1.patch
+      patches: |
+        fix-jitter.patch
+        0001-baseprovider-add-MD5-and-SHA1.patch
+        0001-fips-support-oscp-and-x509-unapproved-SHA1-usage.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl/0001-fips-support-oscp-and-x509-unapproved-SHA1-usage.patch
+++ b/openssl/0001-fips-support-oscp-and-x509-unapproved-SHA1-usage.patch
@@ -1,0 +1,72 @@
+From af4299e210e9c5995608abe8428fb00d832d0d9c Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Fri, 29 Aug 2025 12:39:56 +0100
+Subject: [PATCH] fips: support oscp and x509 unapproved SHA1 usage
+
+OSCP and X509 currently must use SHA1 for non-security sensitive
+purposes of hashish key subjects.
+
+Prefer, but allow using unapproved SHA1 implementation when computing
+these fields.
+
+Currently there is no path forward away from SHA1 for OSCP.
+
+For x509 however, most other implementations are switching to SHA-256/160. See:
+- https://github.com/openssl/openssl/issues/28381
+---
+ crypto/ocsp/ocsp_srv.c | 4 ++--
+ crypto/x509/v3_skid.c  | 2 +-
+ crypto/x509/x509_cmp.c | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/ocsp/ocsp_srv.c b/crypto/ocsp/ocsp_srv.c
+index dbb6e760b2..1fcd1deaf4 100644
+--- a/crypto/ocsp/ocsp_srv.c
++++ b/crypto/ocsp/ocsp_srv.c
+@@ -248,7 +248,7 @@ int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
+ {
+     ASN1_OCTET_STRING *byKey = NULL;
+     unsigned char md[SHA_DIGEST_LENGTH];
+-    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
++    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
+     int ret = 0;
+ 
+     if (sha1 == NULL)
+@@ -292,7 +292,7 @@ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
+     if (respid->type == V_OCSP_RESPID_KEY) {
+         unsigned char md[SHA_DIGEST_LENGTH];
+ 
+-        sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
++        sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
+         if (sha1 == NULL)
+             goto err;
+ 
+diff --git a/crypto/x509/v3_skid.c b/crypto/x509/v3_skid.c
+index 8657f4cdf2..e34f211990 100644
+--- a/crypto/x509/v3_skid.c
++++ b/crypto/x509/v3_skid.c
+@@ -69,7 +69,7 @@ ASN1_OCTET_STRING *ossl_x509_pubkey_hash(X509_PUBKEY *pubkey)
+     }
+     if (!ossl_x509_PUBKEY_get0_libctx(&libctx, &propq, pubkey))
+         return NULL;
+-    if ((md = EVP_MD_fetch(libctx, SN_sha1, propq)) == NULL)
++    if ((md = EVP_MD_fetch(libctx, SN_sha1, "?fips=yes")) == NULL)
+         return NULL;
+     if ((oct = ASN1_OCTET_STRING_new()) == NULL) {
+         EVP_MD_free(md);
+diff --git a/crypto/x509/x509_cmp.c b/crypto/x509/x509_cmp.c
+index de34fa5cc2..ceed2abfc4 100644
+--- a/crypto/x509/x509_cmp.c
++++ b/crypto/x509/x509_cmp.c
+@@ -295,7 +295,7 @@ unsigned long X509_NAME_hash_ex(const X509_NAME *x, OSSL_LIB_CTX *libctx,
+ {
+     unsigned long ret = 0;
+     unsigned char md[SHA_DIGEST_LENGTH];
+-    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
++    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
+     int i2d_ret;
+ 
+     /* Make sure X509_NAME structure contains valid cached encoding */
+-- 
+2.48.1
+


### PR DESCRIPTION
Various RFCs specify SHA1 as the digest used to hash various subject
and key identifier names. These are not used for security purposes.

Note that SHA1 is deprecated and already is not in use anywhere for SECURITY_LEVEL 2 or in FIPS.

Specifically SHA1 is used to generate hash of key identifier in x509 certificates, which is not certificate signature nor key fingerprint - those use SHA256.

Similarly OSCP uses SHA1 for certificate identification but that too is not security sensitive.
