### PR TITLE
sudo: encode upstream patch level into our versioning

### DIFF
--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
-  version: 1.9.17
-  epoch: 3
+  version: 1.9.17_p2
+  epoch: 0
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: BSD-2-Clause AND BSD-2-Clause-NetBSD AND Zlib AND BSD-3-Clause AND BSD-2-Clause AND ISC
@@ -13,10 +13,11 @@ package:
       - merged-usrsbin
       - wolfi-baselayout
 
-vars:
-  # Manually maintained for now, the auto-update mechanism doesn't seemt to support this
-  # versioning scheme with a string 'pN' to capture patch level
-  upstream-patch-level: p2
+var-transforms:
+  - from: ${{package.version}}
+    match: _p
+    replace: p
+    to: mangled-package-version
 
 environment:
   contents:
@@ -31,7 +32,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sudo-project/sudo.git
-      tag: v${{package.version}}${{vars.upstream-patch-level}}
+      tag: v${{vars.mangled-package-version}}
       expected-commit: d1b48c651cec19fe37d1f0d3299d2283fb0f88e4
 
   - uses: autoconf/configure
@@ -134,8 +135,14 @@ test:
 
 update:
   enabled: true
+  version-transform:
+    # Convert upstream's X.Y.ZpN to X.Y.Z_pN
+    - match: p
+      replace: _p
+    # Convert upstream's X.Y.Z to X.Y.Z_p0 to ensure consistent sort behaviour
+    - match: '(\.\d+)$'
+      replace: $1_p0
   github:
     identifier: sudo-project/sudo
     tag-filter-prefix: v
     strip-prefix: v
-  manual: true


### PR DESCRIPTION
This makes it clear which upstream artifact we've built from, and should enable automation to correctly identify new versions (allowing us to enable automated updates).

<!--ci-cve-scan:fail-any-->