### PR TITLE
Revert "wget: Unpin gcc-14-default"

### DIFF
--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.25.0
-  epoch: 5
+  epoch: 6
   description: "GNU wget"
   copyright:
     - license: GPL-3.0
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       # somehow openssl-config-fipshardened-3.4.0 fails on ARMv9 with gcc-15
+      - gcc-14-default
       - openssl-dev
 
 pipeline:


### PR DESCRIPTION
This reverts commit 0d64b87ea7f9d68314e49525e325a51493a4fba4.

Still broken for fips. Please see:
- https://github.com/chainguard-dev/internal-dev/issues/17777
