### PR TITLE
py3-supported-numpy: transition to version stream

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -48,7 +48,7 @@ environment:
       - protoc
       - py3-supported-build-base-dev
       - py3-supported-cython
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - rapidjson-dev
       - re2-dev
       - snappy-dev

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -77,7 +77,7 @@ environment:
       - postgresql-17-dev
       - postgresql-dev
       - proj-dev
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-python
       - py3-supported-python-dev
       - py3-supported-setuptools

--- a/py3-faiss-cpu.yaml
+++ b/py3-faiss-cpu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-faiss-cpu
   version: "1.12.0"
-  epoch: 0
+  epoch: 1
   description: Community-maintained faiss wheel builder
   annotations:
     cgr.dev/ecosystem: python
@@ -17,7 +17,6 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -31,7 +30,7 @@ environment:
       - gfortran
       - openblas-dev
       - py3-supported-build-base-dev
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - swig
 
 pipeline:
@@ -61,7 +60,7 @@ subpackages:
     dependencies:
       runtime:
         - faiss-cpu
-        - py${{range.key}}-numpy
+        - py${{range.key}}-numpy-2.3
         - py${{range.key}}-packaging
         - py${{range.key}}-setuptools
     pipeline:
@@ -70,10 +69,6 @@ subpackages:
           python: python${{range.key}}
       - uses: strip
     test:
-      environment:
-        contents:
-          packages:
-            - py${{range.key}}-numpy
       pipeline:
         - uses: python/import
           with:

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-graph-tool
   version: "2.98"
-  epoch: 0
+  epoch: 1
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
@@ -45,7 +45,7 @@ environment:
       - py3-supported-cairo
       - py3-supported-gobject3
       - py3-supported-libboost
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-scipy
       - sparsehash-dev
       - zlib-dev

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: "3.10.6"
-  epoch: 0
+  epoch: 1
   description: Python plotting package
   copyright:
     - license: PSF-2.0
@@ -30,7 +30,7 @@ environment:
       - py3-supported-fonttools
       - py3-supported-kiwisolver
       - py3-supported-meson-python
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-pillow
       - py3-supported-pybind11
       - py3-supported-pyparsing

--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: "2.3.2"
-  epoch: 0
+  epoch: 1
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: BSD-3-Clause
@@ -30,7 +30,7 @@ environment:
       - numpy
       - py3-supported-cython
       - py3-supported-meson-python
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-pip
       - py3-supported-python-dev
       - py3-supported-versioneer

--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: "1.7.2"
-  epoch: 0
+  epoch: 1
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause
@@ -30,7 +30,7 @@ environment:
       - py3-supported-cython
       - py3-supported-joblib
       - py3-supported-meson-python
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-python-dev

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scipy
   version: "1.16.1"
-  epoch: 0
+  epoch: 1
   description: Fundamental algorithms for scientific computing in Python
   copyright:
     - license: BSD-3-Clause
@@ -35,7 +35,7 @@ environment:
       - openblas-dev
       - py3-pythran-bin
       - py3-supported-meson-python
-      - py3-supported-numpy
+      - py3-supported-numpy-2.3
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-pybind11


### PR DESCRIPTION
The package 'py3-supported-numpy' is not provided by any numpy version.

Use a version-streamed variant instead.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
