### PR TITLE
Newer pcre version for njs

### DIFF
--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: "0.9.1"
-  epoch: 2
+  epoch: 3
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause
@@ -21,7 +21,7 @@ environment:
       # Must bump this when nginx-mainline is upgraded
       - nginx-src-main
       - openssl-dev
-      - pcre-dev
+      - pcre2-dev
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
getting `undefined symbol: pcre_free` in nginx-s3-gateway with older version

https://github.com/chainguard-dev/image-release-stats/issues/6720