### PR TITLE
opensearch-dashboards-3: fix CVE-2025-9287 and CVE-2025-9288

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.1.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 2
+  epoch: 3
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -83,6 +83,14 @@ pipeline:
 
       # fix CVE-2023-28155
       devDependencies='{"cypress": "^13.5.1"}'
+      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
+
+      # fix CVE-2025-9288
+      devDependencies='{"sha.js": "^2.4.12"}'
+      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
+
+      # fix CVE-2025-9287
+      devDependencies='{"cipher-base": "^1.0.5"}'
       jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
 
       yarn osd bootstrap --allow-root


### PR DESCRIPTION
Remediate two CVEs:
 * CVE-2025-9288
 * CVE-2025-9287

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
