### PR TITLE
fix(keycloak-operator): unpin Netty

### DIFF
--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-operator
   version: "26.3.3"
-  epoch: 0 # GHSA-4cx2-fc23-5wg6
+  epoch: 1 # GHSA-4cx2-fc23-5wg6
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0

--- a/keycloak-operator/pombump-deps.yaml
+++ b/keycloak-operator/pombump-deps.yaml
@@ -1,8 +1,4 @@
 patches:
-  - groupId: io.netty
-    artifactId: netty-codec-http
-    version: 4.1.108.Final
-    scope: import
   - groupId: org.bouncycastle
     artifactId: bcprov-jdk18on
     version: "1.78"
@@ -13,12 +9,3 @@ patches:
     version: "1.79"
     scope: import
     type: jar
-  - groupId: io.netty
-    artifactId: netty-common
-    version: 4.1.118.Final
-  - groupId: io.netty
-    artifactId: netty-handler
-    version: 4.1.118.Final
-  - groupId: io.netty
-    artifactId: netty-codec-http2
-    version: 4.1.124.Final


### PR DESCRIPTION
The latest version of keycloak operator uses 4.1.124 which is more recent than our previous pin.

