### PR TITLE
fix: revert kubernetes-1.33: make kubelet-1.33 subpackage provide kubelet

### DIFF
--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.33
   version: "1.33.4"
-  epoch: 1 # CVE-2025-4674 GHSA-j5pm-7495-qmr3
+  epoch: 2 # CVE-2025-4674 GHSA-j5pm-7495-qmr3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -181,8 +181,6 @@ subpackages:
   - name: kubelet-${{vars.kubernetes-version}}
     description: An agent that runs on each node in a Kubernetes cluster making sure that containers are running in a Pod
     dependencies:
-      provides:
-        - kubelet=${{package.full-version}}
       runtime:
         - ip6tables
     pipeline:


### PR DESCRIPTION
## Changes

Reverts: https://github.com/wolfi-dev/os/commit/919c79d2d1fba183cad08d294799872f5571ea3f

`apk add kubelet-1.33-default` is not working properly since this change.
```
/ # apk add -s kubelet-1.33-default
(1/2) Installing kubelet-1.33 (1.33.1-r3)
(2/2) Installing kubelet-1.33-default (1.33.4-r1)
OK: 5750 MiB in 376 packages
```

Other packages without this `provides` work fine
```
/ # apk add -s kubectl-1.33-default
(1/2) Installing kubectl-1.33 (1.33.4-r1)
(2/2) Installing kubectl-1.33-default (1.33.4-r1)
```

That provides is redundant as kubelet is already being provided here: https://github.com/wolfi-dev/os/blob/3348022d9df25ebcae1c8e34ca49f32edd761726/kubernetes-1.33.yaml#L315

What's happening when we install `kubelet-1.33-default`:
- `kubelet-1.33-default` provides kubelet and depends on `kubelet-1.33`
- After that commit, `kubelet-1.33` also provided `kubelet`

The dependency `kubelet-1.33` also provides `kubelet`, and our package `kubelet-1.33-default` also provides it. 
This created a conflict in dependency resolution, and since `1.33.1-r3` is the last package version that does not have this conflict, it is picked. Since the minor version is the same `1.33`, it satisfies the condition