### PR TITLE
kubernetes-1.33: extend subpackage test coverage

### DIFF
--- a/kubernetes-1.33.yaml
+++ b/kubernetes-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.33
   version: "1.33.4"
-  epoch: 2 # CVE-2025-4674 GHSA-j5pm-7495-qmr3
+  epoch: 3 # CVE-2025-4674 GHSA-j5pm-7495-qmr3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -317,6 +317,25 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -s ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+    test:
+      pipeline:
+        - name: "Check symlink /usr/bin/${{range.key}} points to the expected binary /usr/bin/${{range.key}}-${{vars.kubernetes-version}}"
+          runs: |
+            readlink="$(readlink -f /usr/bin/${{range.key}})"
+            expected="/usr/bin/${{range.key}}-${{vars.kubernetes-version}}"
+            if ! echo "$readlink" | grep -q "$expected" ; then
+                echo "FAIL: unexpected link. Expected: [$expected] but got:" >&2
+                echo "$readlink" >&2
+                exit 1
+            fi
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: "${{range.key}}-default"
+            real-pkg-name: "${{subpkg.name}}"
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: "${{range.key}}"
+            real-pkg-name: "${{subpkg.name}}"
 
   - name: kube-proxy-${{vars.kubernetes-version}}-default-compat
     description: kube-proxy-default compatibility package
@@ -329,7 +348,7 @@ subpackages:
         - runs: stat /usr/local/bin/kube-proxy
 
   - name: kubernetes-${{vars.kubernetes-version}}-default
-    description: "Compatibility package to set ${{vars.kubernetes-version}} as the default kubernetes, and add packages to their shortened path"
+    description: "Compatibility meta package to set ${{vars.kubernetes-version}} as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
         - kubectl-${{vars.kubernetes-version}}-default
@@ -343,6 +362,9 @@ subpackages:
     checks:
       disabled:
         - empty
+    test:
+      pipeline:
+        - uses: test/metapackage
 
 data:
   - name: components


### PR DESCRIPTION
Introduce additional subpackage tests.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
