### PR TITLE
fix(jitsucom-jitsu): Bump Next.js to 15.4.7 to remediate vulns

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 0
+  epoch: 1 # GHSA-xv57-4mr9-wg8v|GHSA-g5qg-72qw-gw5v|GHSA-4342-x723-ch2f
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/consolidated-cve-remedation.patch
+++ b/jitsucom-jitsu/consolidated-cve-remedation.patch
@@ -3,6 +3,7 @@ From: Kyle Steere <kyle.steere@chainguard.dev>
 Date: Thu, 5 Jun 2025 20:29:20 -0500
 Subject: [PATCH] consolidated cve remedation patches: CVE-2025-48387
  CVE-2025-22150 CVE-2025-27152 CVE-2025-27789 CVE-2024-53382 GHSA-fjxv-7rqg-78g4
+ GHSA-xv57-4mr9-wg8v GHSA-g5qg-72qw-gw5v GHSA-4342-x723-ch2f
 
 Signed-off-by: Kyle Steere <kyle.steere@chainguard.dev>
 ---
@@ -13,7 +14,7 @@ diff --git a/package.json b/package.json
 index a63735238..f631cd555 100644
 --- a/package.json
 +++ b/package.json
-@@ -66,5 +66,13 @@
+@@ -66,5 +66,14 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -25,7 +26,8 @@ index a63735238..f631cd555 100644
 +    "@babel/runtime": "^7.26.10",
 +    "tar-fs": "^2.1.3",
 +    "prismjs": "^1.30.0",
-+    "form-data": "^4.0.4"
++    "form-data": "^4.0.4",
++    "next": "^15.4.7"
 +  }
  }
 --


### PR DESCRIPTION
Remediates GHSA-xv57-4mr9-wg8v, GHSA-g5qg-72qw-gw5v and GHSA-4342-x723-ch2f.
The vulnerabilities are present in the `jitsucom-jitsu-console` subpackage.
Dependency bumps for this package are managed through the `jitsucom-jitsu/consolidated-cve-remedation.patch` patch, so the bump was introduced in the patch.


<!--ci-cve-scan:fail-any-->
<!--ci-cve-scan:must-fix: GHSA-xv57-4mr9-wg8v-->
<!--ci-cve-scan:must-fix: GHSA-g5qg-72qw-gw5v-->
<!--ci-cve-scan:must-fix: GHSA-4342-x723-ch2f-->

