### PR TITLE
py3-protobuf: disable aarch64 ASM optimization

### DIFF
--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: "6.32.0"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -40,6 +40,18 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
     pipeline:
+      # The upstream code enables aarch64-specific optimizations, which later will segfault in our tests
+      # because illegal CPU instructions are being used. I guess this is because different arm64 instructions extensions are
+      # embedded in the code compared to what most arm64 CPU could run.
+      # Disable the arm64-optimized ASM, and hope the non-optimized version can run just fine and not cause other problems.
+      # Before this change, functions call would be:
+      #   encode_varint() --> encode_longvarint_arm64()
+      # After this change, it would be:
+      #   encode_varint() --> encode_longvarint()
+      - if: ${{build.arch}} == "aarch64"
+        name: Disable aarch64 ASM optimizations
+        runs: |
+          find . -type f -name "*.c" -o -name "*.h" | xargs sed -i 's/#ifdef UPB_ARM64_ASM/#if 0/g'
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}


### PR DESCRIPTION
It results in illegal instruction in our aarch64 CPUs.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
