### PR TITLE
feat(ingress-nginx-controller): bump to 1.13.2; prune runtime reqs

### DIFF
--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -1,9 +1,9 @@
 #nolint:valid-pipeline-fetch-digest,valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: ingress-nginx-controller-1.13
-  version: "1.13.1"
+  version: "1.13.2"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 0 # CVE-2025-47907
+  epoch: 0
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,6 @@ package:
       - brotli
       - ca-certificates
       - ca-certificates-bundle
-      - curl
       - dumb-init-privileged-netbindservice
       - gd
       - libcrypt1
@@ -43,7 +42,6 @@ package:
       - mimalloc
       - modsecurity
       - msgpack
-      - openssh-client
       - openssl
       - openssl-dev
       - pcre
@@ -182,7 +180,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/ingress-nginx
       tag: controller-v${{package.version}}
-      expected-commit: 3bb5d0c12e6146dac70cc0c4d70740cf2f1d010e
+      expected-commit: 8f39a704d8a9b76a7167f2892d684ec3eb656c01
 
   - name: Verify all the vars are up to date with the upstream
     runs: |


### PR DESCRIPTION
The ingress-nginx-controller package doesn't need curl nor openssh-client at runtime. Remove those from our runtime reqs to limit our vuln exposure.

This PR also bumps to the latest pkg version (1.13.2).