### PR TITLE
opensearch-dashboards-3/GHSA-95m3-7q98-8xr5 fix

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.1.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 3
+  epoch: 4
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -61,6 +61,10 @@ pipeline:
       repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
       tag: ${{package.version}}
       expected-commit: 1feb86934e7f2d5fae58baebf1b98c5c0825bc3f
+
+  - uses: patch
+    with:
+      patches: CVE-2025-9287-fix.patch
 
   - runs: |
       # Workaround for "OpenSearch Dashboards should not be run as root.  Use --allow-root to continue."

--- a/opensearch-dashboards-3/CVE-2025-9287-fix.patch
+++ b/opensearch-dashboards-3/CVE-2025-9287-fix.patch
@@ -1,0 +1,35 @@
+From 492f1709325acba7ae076f68cfbbf28ccfe754dd Mon Sep 17 00:00:00 2001
+From: Suchit Sahoo <38322563+LDrago27@users.noreply.github.com>
+Date: Fri, 22 Aug 2025 17:31:38 -0700
+Subject: [PATCH] Fix GHSA-cpq7-6gpm-g9rc by bumping cipher-base,sha.js
+ (#10442)
+
+---
+ changelogs/fragments/10442.yml |  2 ++
+ package.json                   |  2 ++
+ yarn.lock                      | 22 +++++++---------------
+ 3 files changed, 11 insertions(+), 15 deletions(-)
+ create mode 100644 changelogs/fragments/10442.yml
+
+diff --git a/changelogs/fragments/10442.yml b/changelogs/fragments/10442.yml
+new file mode 100644
+index 00000000000..2c07b362a0a
+--- /dev/null
++++ b/changelogs/fragments/10442.yml
+@@ -0,0 +1,2 @@
++security:
++- Fix GHSA-cpq7-6gpm-g9rc by bumping cipher-base,sha.js ([#10442](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10442))
+\ No newline at end of file
+diff --git a/package.json b/package.json
+index 04fcc18e33a..f0d61143a6b 100644
+--- a/package.json
++++ b/package.json
+@@ -127,6 +127,8 @@
+     "**/@babel/runtime-corejs3": "^7.27.0",
+     "**/@babel/traverse": "^7.27.0",
+     "**/@cypress/request": "^3.0.0",
++    "**/cipher-base": "^1.0.5",
++    "**/sha.js": "^2.4.12",
+     "**/@types/node": "~20.10.5",
+     "**/ansi-regex": "^5.0.1",
+     "**/async": "^3.2.3",


### PR DESCRIPTION
Adding patch from [upstream commit](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10442/files) that sets package.lock versions to fix versions for cipher-base and sha.js.