### PR TITLE
cassandra-reaper: cherry-pick JWT secret length extension feature

### DIFF
--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: "3.8.0"
-  epoch: 9
+  epoch: 10
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,11 @@ pipeline:
       repository: https://github.com/thelastpickle/cassandra-reaper
       tag: ${{package.version}}
       expected-commit: 6547a9872bb10030c03382df03fa37f97262a5ca
+
+  - uses: patch
+    with:
+      patches: |
+        0001-Ensure-JWT-secret-is-at-least-32-bytes.patch
 
   - uses: maven/pombump
     working-directory: src/server

--- a/cassandra-reaper/0001-Ensure-JWT-secret-is-at-least-32-bytes.patch
+++ b/cassandra-reaper/0001-Ensure-JWT-secret-is-at-least-32-bytes.patch
@@ -1,0 +1,51 @@
+From 15ffb622f463e980d0f92bbcce088d85d60e5a15 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 3 Sep 2025 11:28:42 +0100
+Subject: [PATCH] Ensure JWT secret is at least 32 bytes
+
+Perform JWT secret length extensions, if the specified key is less
+than 32 bytes.
+
+Cherrypicked from:
+- https://github.com/thelastpickle/cassandra-reaper/blame/7104a81364eb6faeee2828a5b536a7d596a58ba8/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java#L80
+---
+ .../resources/auth/ShiroJwtProvider.java         | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
+index 842a1a9c..b490a12a 100644
+--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
++++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
+@@ -24,6 +24,9 @@ import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
+ import java.io.IOException;
+ import java.nio.charset.StandardCharsets;
+ import java.security.Key;
++import java.security.MessageDigest;
++import java.security.NoSuchAlgorithmException;
++import java.security.Security;
+ import java.util.Base64;
+ import javax.crypto.spec.SecretKeySpec;
+ import javax.servlet.http.HttpServletRequest;
+@@ -78,6 +81,19 @@ public final class ShiroJwtProvider {
+       key = Base64.getDecoder().decode(txt);
+     }
+ 
++    Boolean approvedOnly = "true".equals(Security.getProperty("org.bouncycastle.fips.approved_only"));
++
++    // Ensure the key is at least 256 bits (32 bytes) for HS256
++    if (approvedOnly && key.length < 32) {
++      try {
++        // Use SHA-256 to derive a proper 256-bit key
++        MessageDigest digest = MessageDigest.getInstance("SHA-256");
++        key = digest.digest(key);
++      } catch (NoSuchAlgorithmException e) {
++        throw new RuntimeException("SHA-256 algorithm not available", e);
++      }
++    }
++
+     return new SecretKeySpec(key, SIG_ALG.getJcaName());
+   }
+ }
+-- 
+2.48.1
+


### PR DESCRIPTION
Cherry-pick JWT secret length extension feature from 4.0-beta2, and
make it conditional for java implementations that need it.
