### PR TITLE
kube-arangodb: use releases instead of tags

### DIFF
--- a/kube-arangodb.yaml
+++ b/kube-arangodb.yaml
@@ -103,6 +103,5 @@ update:
   github:
     identifier: arangodb/kube-arangodb
     strip-prefix: v
-    use-tag: true
   ignore-regex-patterns:
     - "-preview"

--- a/kube-arangodb.yaml
+++ b/kube-arangodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-arangodb
   version: "1.3.0"
-  epoch: 3
+  epoch: 4
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Modify kube-arangodb config to use Github Releases instead of tags, bump epoch

Related: N/A

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
