### PR TITLE
Add jpegoptim package

### DIFF
--- a/jpegoptim.yaml
+++ b/jpegoptim.yaml
@@ -1,0 +1,42 @@
+package:
+  name: jpegoptim
+  version: 1.5.5
+  epoch: 0
+  description: jpegoptim - utility to optimize/compress JPEG files
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - gcc
+      - libjpeg-turbo-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tjko/jpegoptim
+      tag: v${{package.version}}
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: tjko/jpegoptim
+    use-tag: true
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Run basic jpegoptim tests
+      runs: |
+        jpegoptim --version | grep v${{package.version}}
+        jpegoptim --help


### PR DESCRIPTION
Adds jpegoptim package, which is used by spatie/laravel-medialibrary

Fixes: #53845

### Pre-review Checklist

#### For new package PRs only

- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)