### PR TITLE
Add optipng package

### DIFF
--- a/optipng.yaml
+++ b/optipng.yaml
@@ -1,0 +1,48 @@
+package:
+  name: optipng
+  version: 7.9.1
+  epoch: 0
+  description: OptiPNG is a PNG optimizer that recompresses image files to a smaller size, without losing any information.
+  copyright:
+    - license: Zlib
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - gcc
+      - libpng-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://git.code.sf.net/p/optipng/code
+      branch: tmp/main
+      expected-commit: ad856fa9d40561cca1078ec621b433e5a15d0282
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DOPTIPNG_USE_SYSTEM_LIBS=ON
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - name: Make binary executable
+    runs: |
+      chmod +x /home/build/melange-out/optipng/usr/bin/optipng
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2571
+
+test:
+  pipeline:
+    - name: Run basic optipng tests
+      runs: |
+        optipng --version | grep ${{package.version}}
+        optipng --help


### PR DESCRIPTION
Adds optipng package, which is used by spatie/laravel-medialibrary

Fixes: #53847

### Pre-review Checklist

#### For new package PRs only

- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)