### PR TITLE
fix(rancher-2.12): Bump jwt from v3 to v4 to remediate GHSA-mh63-6h87-95cp

### DIFF
--- a/rancher-2.12.yaml
+++ b/rancher-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.12
   version: "2.12.1"
-  epoch: 0
+  epoch: 1 # GHSA-mh63-6h87-95cp
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -112,11 +112,19 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/opt/jail
       mkdir -p /var/tmp
 
+  # According to upstream documentation v4 is a drop-in replacement for v3
+  # See https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md#migration-guide-v400
+  - name: Migrate jwt v3 to v4
+    runs: |
+      grep -rl "\"github.com/golang-jwt/jwt\"" . | grep "\.go" | xargs sed -i "s|\"github.com/golang-jwt/jwt\"|\"github.com/golang-jwt/jwt/v4\"|"
+      sed -i "\|github.com/golang-jwt/jwt v3.2.1+incompatible|d" go.mod
+
   - uses: go/bump
     with:
       deps: |-
         github.com/docker/docker@v28.0.0
         github.com/go-jose/go-jose/v3@v3.0.4
+        github.com/golang-jwt/jwt/v4@v4.5.2
 
   - uses: go/build
     with:


### PR DESCRIPTION
There's no 3.x.x patched version for GHSA-mh63-6h87-95cp. To address the CVE, bump jwt from v3 to v4.
v4 is a drop-in replacement for v3, according to [upstream documentation.](https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md#migration-guide-v400)

- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories/blob/3137ab8574d8446cc3d6ca3d93bd823e64265075/rancher-2.12.advisories.yaml#L29) repo

<!--ci-cve-scan:fail-any-->
