### PR TITLE
lint.sh - do stuff faster with multiple processes

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -2,43 +2,108 @@
 
 set -euo pipefail
 
-# If arguments are passed to the command, only lint the files listed.
-if [ "$#" == 0 ]; then
-  list="*.yaml"
-else
-  list=$*
-fi
+shellquote() {
+    command -v python3 >/dev/null ||
+        { echo "$*"; return 0; }
+    python3 -c 'import sys, shlex; print(shlex.join(sys.argv[1:]))' "$@"
+}
 
-for fn in $list; do
-  case $fn in *.yaml) ;; *) echo "--- $fn not a yaml file, skipping"; continue ;; esac
+stderr() {
+    echo "$@" 1>&2
+}
 
-  p=$(yq -r '.package.name' ${fn})
-  echo "--- package" $p
+yqrun() {
+    local rc="" out=""
+    yq "$@" && return 0
+    rc=$?
+    out=$(shellquote "$@")
+    stderr "FAIL${fn:+ [$fn]}" "cmd failed $rc:" "$out"
+    return $rc
+}
+
+ylint() {
+  local fn="$1" out=""
+  case "$fn" in
+      *.yaml) ;;
+      *) echo "--- $fn not a yaml file, skipping"
+         return 0
+  esac
+
+  p=$(yqrun -r '.package.name' "${fn}") || return
+  [ -n "$p" ] || { stderr "FAIL [$fn]: empty package name"; return 1; }
+  echo "--- package" "$p"
 
   # Don't specify repositories or keyring for os packages
-  if grep -q packages.wolfi.dev/os ${fn}; then
-    yq -i 'del(.environment.contents.repositories)' ${fn}
-    yq -i 'del(.environment.contents.keyring)' ${fn}
+  if grep -q packages.wolfi.dev/os "${fn}"; then
+    yqrun -i 'del(.environment.contents.repositories)' "${fn}" || return
+    yqrun -i 'del(.environment.contents.keyring)' "${fn}" || return
   fi
 
   # Don't specify wolfi-base or any of its packages, or the main package, for test pipelines.
-  for pkg in wolfi-base busybox apk-tools wolfi-keys ${p}; do
-    yq -i 'del(.test.environment.contents.packages[] | select(. == "'${pkg}'"))' ${fn}
+  for pkg in wolfi-base busybox apk-tools wolfi-keys "${p}"; do
+    yqrun -i 'del(.test.environment.contents.packages[] | select(. == "'"${pkg}"'"))' "${fn}" ||
+        return
   done
 
   # If .test.environment.contents.packages is empty, remove it all.
-  if [ "$(yq -r '.test.environment.contents.packages | length' ${fn})" == "0" ]; then
-    yq -i 'del(.test.environment.contents)' ${fn}
+  out=$(yqrun -r '.test.environment.contents.packages | length' "${fn}") ||
+      return
+  if [ "$out" = "0" ]; then
+    yqrun -i 'del(.test.environment.contents)' "${fn}" || return
   fi
 
-  yam ${fn}
+  yam "${fn}" || {
+      stderr "FAIL [$fn]: cmd failed $?: yam $fn"
+      return 1
+  }
+  return 0
+}
+
+if [ "${1:-x}" = "_ylint" ]; then
+    ylint "$2"
+    exit
+fi
+
+# If arguments are passed to the command, only lint the files listed.
+args=true
+if [ "$#" == "0" ]; then
+  set -- *.yaml
+  args=false
+fi
+
+yamls=()
+for fn in "$@"; do
+  case "$fn" in
+      *.yaml) ;;
+      *) echo "--- $fn not a yaml file, skipping"
+         continue ;;
+  esac
+  yamls+=( "$fn" )
 done
 
-# New section to check for .sts.yaml files under ./.github/chainguard/
-echo "Checking for .sts.yaml files in ./.github/chainguard/..."
-for file in $(find .github/chainguard -type f); do
-  if [[ ! $file =~ \.sts\.yaml$ ]]; then
-    echo "ERROR: File $file does not have the required '.sts.yaml' suffix"
+if [ "${#yamls[@]}" = "0" ]; then
+    stderr "no yaml files provided"
     exit 1
-  fi
-done
+fi
+
+nprocs=${NPROCS:-""}
+if [ -z "$nprocs" ]; then
+    nprocs=$(nproc 2>/dev/null) || nprocs=8
+fi
+
+printf "%s\0" "${yamls[@]}" |
+    xargs -0 --max-args=1 --max-procs="$nprocs" -- "$0" _ylint ||
+    exit
+
+if [ "$args" != "true" ]; then
+    # New section to check for .sts.yaml files under ./.github/chainguard/
+    echo "Checking for .sts.yaml files in ./.github/chainguard/..."
+    find .github/chainguard -type f ! -name "*.sts.yaml"
+    # shellcheck disable=SC2044
+    for file in $(find .github/chainguard -type f); do
+      if [[ ! $file =~ \.sts\.yaml$ ]]; then
+        echo "ERROR: File $file does not have the required '.sts.yaml' suffix"
+        exit 1
+      fi
+    done
+fi


### PR DESCRIPTION
Primarily this is a speedup.  lint.sh was painfully slow on all the .yaml files in this repository (3500+).

There are also many shellcheck fixes, basically amounting to using more quotes.

before:

    $ ./lint.sh
    ...
    real    2m17.449s
    user    1m17.135s
    sys     0m59.816s

after:

    $ ./lint.sh
    real    0m9.470s
    user    2m4.078s
    sys     1m49.249s

limiting to 8 processes rather than 32 (from nproc):

    $ NPROCS=8 ./lint.sh
    real    0m 22.26s
    user    1m 37.81s
    sys     1m 16.96s
