### PR TITLE
spark-4.0/hadoop-3.4.2 upgrade, fixes multiple CVEs 

### DIFF
--- a/spark-4.0.yaml
+++ b/spark-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-4.0
   version: "4.0.0"
-  epoch: 3 # GHSA-prj3-ccx8-p6x4
+  epoch: 4
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -88,7 +88,7 @@ subpackages:
       - uses: maven/pombump
       - uses: patch
         with:
-          patches: mvn.patch
+          patches: mvn.patch hadoop.patch
       - runs: |
           ./dev/change-scala-version.sh ${{vars.scala-version}}
       - runs: |

--- a/spark-4.0/hadoop.patch
+++ b/spark-4.0/hadoop.patch
@@ -1,0 +1,43 @@
+diff --git a/dev/deps/spark-deps-hadoop-3-hive-2.3 b/dev/deps/spark-deps-hadoop-3-hive-2.3
+index d5a0cea66ca..2d677354b0e 100644
+--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
++++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
+@@ -71,15 +71,15 @@ gcs-connector/hadoop3-2.2.26/shaded/gcs-connector-hadoop3-2.2.26-shaded.jar
+ gmetric4j/1.0.10//gmetric4j-1.0.10.jar
+ gson/2.11.0//gson-2.11.0.jar
+ guava/33.4.0-jre//guava-33.4.0-jre.jar
+-hadoop-aliyun/3.4.1//hadoop-aliyun-3.4.1.jar
+-hadoop-annotations/3.4.1//hadoop-annotations-3.4.1.jar
+-hadoop-aws/3.4.1//hadoop-aws-3.4.1.jar
+-hadoop-azure-datalake/3.4.1//hadoop-azure-datalake-3.4.1.jar
+-hadoop-azure/3.4.1//hadoop-azure-3.4.1.jar
+-hadoop-client-api/3.4.1//hadoop-client-api-3.4.1.jar
+-hadoop-client-runtime/3.4.1//hadoop-client-runtime-3.4.1.jar
+-hadoop-cloud-storage/3.4.1//hadoop-cloud-storage-3.4.1.jar
+-hadoop-huaweicloud/3.4.1//hadoop-huaweicloud-3.4.1.jar
++hadoop-aliyun/3.4.2//hadoop-aliyun-3.4.2.jar
++hadoop-annotations/3.4.2//hadoop-annotations-3.4.2.jar
++hadoop-aws/3.4.2//hadoop-aws-3.4.2.jar
++hadoop-azure-datalake/3.4.2//hadoop-azure-datalake-3.4.2.jar
++hadoop-azure/3.4.2//hadoop-azure-3.4.2.jar
++hadoop-client-api/3.4.2//hadoop-client-api-3.4.2.jar
++hadoop-client-runtime/3.4.2//hadoop-client-runtime-3.4.2.jar
++hadoop-cloud-storage/3.4.2//hadoop-cloud-storage-3.4.2.jar
++hadoop-huaweicloud/3.4.2//hadoop-huaweicloud-3.4.2.jar
+ hadoop-shaded-guava/1.3.0//hadoop-shaded-guava-1.3.0.jar
+ hive-beeline/2.3.10//hive-beeline-2.3.10.jar
+ hive-cli/2.3.10//hive-cli-2.3.10.jar
+diff --git a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+index 482983e698a..9fbee7065ee 100644
+--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
++++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+@@ -66,7 +66,7 @@ private[hive] object IsolatedClientLoader extends Logging {
+           case e: RuntimeException if e.getMessage.contains("hadoop") =>
+             // If the error message contains hadoop, it is probably because the hadoop
+             // version cannot be resolved.
+-            val fallbackVersion = "3.4.1"
++            val fallbackVersion = "3.4.2"
+             logWarning(log"Failed to resolve Hadoop artifacts for the version " +
+               log"${MDC(HADOOP_VERSION, hadoopVersion)}. We will change the hadoop version from " +
+               log"${MDC(HADOOP_VERSION, hadoopVersion)} to " +
+

--- a/spark-4.0/pombump-deps.yaml
+++ b/spark-4.0/pombump-deps.yaml
@@ -7,4 +7,4 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final

--- a/spark-4.0/pombump-properties.yaml
+++ b/spark-4.0/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "3.18.0"
   - property: hadoop.version
     value: "3.4.2"
+  - property: netty.version
+    value: "4.1.125.Final"

--- a/spark-4.0/pombump-properties.yaml
+++ b/spark-4.0/pombump-properties.yaml
@@ -1,3 +1,5 @@
 properties:
   - property: commons-lang3.version
     value: "3.18.0"
+  - property: hadoop.version
+    value: "3.4.2"


### PR DESCRIPTION
 Summary

  Fixes  GHSA-r7pg-v2c8-mfg3 and GHSA-rhrv-645h-fjfh by upgrading Hadoop dependencies from 3.4.1 to
  3.4.2 in Apache Spark 4.0.

  Changes

  - Package: Incremented epoch from 3 to 4 to force rebuild with updated
  dependencies
  - Pombump: 
      * Added hadoop.version: 3.4.2 property to override default Hadoop version which fixes GHSA-r7pg-v2c8-mfg3/GHSA-rhrv-645h-fjfh
      * Added netty.version to fix GHSA-3p8m-j85q-pgmj cves.
      * Updated netty-http-codec to fix GHSA-3p8m-j85q-pgmj 
  - Patch: Created hadoop.patch to update hardcoded Hadoop 3.4.1 references
  to 3.4.2 in:
    - dev/deps/spark-deps-hadoop-3-hive-2.3 (dependency list file)
    - sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClien
  tLoader.scala (fallback version)

  Verification

  This change is validated by the upstream Apache Spark commit https://githu
  b.com/apache/spark/commit/59b34dcb08a6f945c03f3eb4da8990f3de99bc5c which
  shows the identical pattern of updating Hadoop references from 3.4.1 to
  3.4.2 throughout the codebase.

  The fix addresses the vulnerability by ensuring all Hadoop components are
  upgraded to the patched 3.4.2 version, eliminating the security issue
  present in 3.4.1