### PR TITLE
istio-1.26/istio-1.27: fix Go module versioning

### DIFF
--- a/istio-1.26.yaml
+++ b/istio-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-1.26
   version: "1.26.4"
-  epoch: 0 # GHSA-f9f8-9pmf-xv68
+  epoch: 1 # GHSA-f9f8-9pmf-xv68
   description: Istio is an open source service mesh that layers transparently onto existing distributed applications.
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,12 @@ subpackages:
         with:
           packages: ./cni/cmd/istio-cni
           output: istio-cni
+          ldflags: |
+            -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+            -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+            -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+            -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - uses: strip
     dependencies:
       provides:
@@ -57,6 +63,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
     dependencies:
       provides:
         - istioctl=${{package.full-version}}
@@ -117,6 +124,12 @@ subpackages:
         with:
           packages: ./cni/cmd/install-cni
           output: install-cni
+          ldflags: |
+            -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+            -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+            -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+            -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - uses: strip
     dependencies:
       provides:
@@ -157,6 +170,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/istio/envoy
           cp ./tools/packaging/common/envoy_bootstrap.json \
@@ -192,6 +206,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/istio/envoy
           cp ./tools/packaging/common/envoy_bootstrap.json \

--- a/istio-1.27.yaml
+++ b/istio-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-1.27
   version: "1.27.1"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: Istio is an open source service mesh that layers transparently onto existing distributed applications.
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,12 @@ subpackages:
         with:
           packages: ./cni/cmd/istio-cni
           output: istio-cni
+          ldflags: |
+            -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+            -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+            -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+            -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - uses: strip
     dependencies:
       provides:
@@ -62,6 +68,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
     dependencies:
       provides:
         - istioctl=${{package.full-version}}
@@ -122,6 +129,12 @@ subpackages:
         with:
           packages: ./cni/cmd/install-cni
           output: install-cni
+          ldflags: |
+            -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+            -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+            -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+            -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - uses: strip
     dependencies:
       provides:
@@ -162,6 +175,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/istio/envoy
           cp ./tools/packaging/common/envoy_bootstrap.json \
@@ -197,6 +211,7 @@ subpackages:
             -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
             -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
             -X istio.io/istio/pkg/version.buildStatus="Clean"
+          extra-args: "-buildvcs=false"
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/istio/envoy
           cp ./tools/packaging/common/envoy_bootstrap.json \


### PR DESCRIPTION
Added extra-args: "-buildvcs=false" to go/build steps to prevent Go from
embedding VCS information that was causing pseudo-versions instead of
proper version tags.
Added version ldflags to istio-cni and install-cni components to ensure
consistent version reporting across all Istio binaries.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
