### PR TITLE
chore(skopeo): include containers-common as runtime dep

### DIFF
--- a/skopeo.yaml
+++ b/skopeo.yaml
@@ -1,13 +1,14 @@
 package:
   name: skopeo
   version: "1.20.0"
-  epoch: 2 # GHSA-jc7w-c686-c4v9
+  epoch: 3 # GHSA-jc7w-c686-c4v9
   description: Work with remote images registries - retrieving information, images, signing content
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - containers-common
 
 pipeline:
   - uses: git-checkout
@@ -27,8 +28,6 @@ pipeline:
       output: skopeo
       vendor: true
       tags: exclude_graphdriver_devicemapper,exclude_graphdriver_btrfs,containers_image_openpgp
-
-  - runs: install -Dm644 ./default-policy.json "${{targets.destdir}}"/etc/containers/policy.json
 
   - uses: strip
 


### PR DESCRIPTION
we previously didn't had containers-common package but we do have it now
this commit adds containers-common as runtime dependency of skopeo.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
