### PR TITLE
py3-pyyaml: re-instate py3-yaml provides

### DIFF
--- a/py3-pyyaml.yaml
+++ b/py3-pyyaml.yaml
@@ -1,12 +1,14 @@
 package:
   name: py3-pyyaml
   version: 6.0.2
-  epoch: 5
+  epoch: 6
   description: Python3 bindings for YAML
   copyright:
     - license: MIT
   dependencies:
     provider-priority: 0
+    provides:
+      - py3-yaml
 
 vars:
   pypi-package: pyyaml


### PR DESCRIPTION
Although we don't have in archive reverse dependencies on py3-yaml,
elemetry indicates that a number of external users are still actively
using py3-yaml.

We want to remove the most recent py3-yaml*.apk from the package
indexes, so add a provides to the renamed package so that we don't
create issues for existing external users.
