### PR TITLE
feat(dotnet-8/9): Make co-installable

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -14,6 +14,13 @@ package:
     provides:
       - dotnet=${{package.full-version}}
 
+vars:
+  # This is the major.minor version of the .NET Standard
+  # targeting pack. We validate this version is correct
+  # below, but as the version progresses, this will need
+  # to be manually bumped.
+  netstandard-version: '2.1'
+
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+)\.\d+\.\d+$
@@ -150,16 +157,50 @@ subpackages:
             virtual-pkg-name: aspnet-runtime
             real-pkg-name: ${{subpkg.name}}
 
+  # We separate the .NET Standard targeting pack to allow for
+  # co-installation of .NET versions. Different .NET versions
+  # may depend on the same version of this targeting pack.
+  - name: netstandard-${{vars.major-version}}-targeting-pack
+    description: "The .NET ${{vars.major-version}} Standard targeting pack"
+    dependencies:
+      provides:
+        - netstandard-targeting-pack-${{vars.netstandard-version}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # This is just the .NET Standard major minor version we specify above
+          expected_version="${{vars.netstandard-version}}"
+
+          # We retrieve the full .NET Standard version by listing the contents of
+          # the directory that contains the .NET Standard targeting pack
+          full_version="$(ls ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.Ref/)"
+
+          # And we manipulate the full version to derive the major minor version
+          found_version="${full_version%.*}"
+
+          if [ $expected_version != $found_version ]; then
+            echo ".NET Standard expected version does not match found version!"
+            echo "Expected: $expected_version"
+            echo "Found: $found_version"
+            echo "Please update the .NET Standard targeting pack version."
+            exit 1
+          fi
+
+          # Install .NET Standard targeting pack
+          mkdir -p ${{targets.contextdir}}/usr/share/dotnet
+          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* \
+             ${{targets.contextdir}}/usr/share/dotnet/packs/
+
   - name: dotnet-${{vars.major-version}}-targeting-pack
     description: "The .NET ${{vars.major-version}} Core targeting pack"
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
-          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* ${{targets.contextdir}}/usr/share/dotnet/packs/
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.NETCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
       provides:
         - dotnet-targeting-pack=${{package.full-version}}
+      runtime:
+        - netstandard-targeting-pack-${{vars.netstandard-version}}
     test:
       pipeline:
         - uses: test/virtualpackage

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.121"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -125,7 +125,7 @@ subpackages:
       provides:
         - dotnet-runtime=${{package.full-version}}
       runtime:
-        - dotnet-${{vars.major-version}}=${{package.full-version}}
+        - dotnet
     test:
       pipeline:
         - uses: test/tw/ldd-check

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.111"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -14,6 +14,13 @@ package:
     provides:
       - dotnet=${{package.full-version}}
 
+vars:
+  # This is the major.minor version of the .NET Standard
+  # targeting pack. We validate this version is correct
+  # below, but as the version progresses, this will need
+  # to be manually bumped.
+  netstandard-version: '2.1'
+
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+)\.\d+\.\d+$
@@ -141,16 +148,50 @@ subpackages:
             virtual-pkg-name: aspnet-runtime
             real-pkg-name: ${{subpkg.name}}
 
+  # We separate the .NET Standard targeting pack to allow for
+  # co-installation of .NET versions. Different .NET versions
+  # may depend on the same version of this targeting pack.
+  - name: netstandard-${{vars.major-version}}-targeting-pack
+    description: "The .NET ${{vars.major-version}} Standard targeting pack"
+    dependencies:
+      provides:
+        - netstandard-targeting-pack-${{vars.netstandard-version}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # This is just the .NET Standard major minor version we specify above
+          expected_version="${{vars.netstandard-version}}"
+
+          # We retrieve the full .NET Standard version by listing the contents of
+          # the directory that contains the .NET Standard targeting pack
+          full_version="$(ls ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.Ref/)"
+
+          # And we manipulate the full version to derive the major minor version
+          found_version="${full_version%.*}"
+
+          if [ $expected_version != $found_version ]; then
+            echo ".NET Standard expected version does not match found version!"
+            echo "Expected: $expected_version"
+            echo "Found: $found_version"
+            echo "Please update the .NET Standard targeting pack version."
+            exit 1
+          fi
+
+          # Install .NET Standard targeting pack
+          mkdir -p ${{targets.contextdir}}/usr/share/dotnet
+          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* \
+             ${{targets.contextdir}}/usr/share/dotnet/packs/
+
   - name: dotnet-${{vars.major-version}}-targeting-pack
     description: "The .NET ${{vars.major-version}} Core targeting pack"
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
-          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* ${{targets.contextdir}}/usr/share/dotnet/packs/
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.NETCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
       provides:
         - dotnet-targeting-pack=${{package.full-version}}
+      runtime:
+        - netstandard-targeting-pack-${{vars.netstandard-version}}
     test:
       pipeline:
         - uses: test/virtualpackage

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -116,7 +116,7 @@ subpackages:
       provides:
         - dotnet-runtime=${{package.full-version}}
       runtime:
-        - dotnet-${{vars.major-version}}=${{package.full-version}}
+        - dotnet
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
.NET SDKs and runtimes work with the latest version of the .NET host so always use the latest version. This previously prevented us from co-installing different versions of .NET as they strictly depended on the version of the host built alongside the current .NET SDK and runtime. This does not prevent installing older .NET host versions if desired (though maybe we should figure out how to not allow that without adding a replaces for every host package and prior .NET version...)

This also splits the .NET Standard targeting pack into separate subpackages. Both 8 and 9 install 2.1.0 causing conflicts when attempting to install both versions. Because the targeting pack is the same between both versions, we can safely split it away and install the targeting pack provided by the latest .NET Standard package. If the major.minor version ever changes, this will require the version be bumped, but I've added a check when building the subpackage that will pick up on that