### PR TITLE
CA certificates bundle needed for Amazon ECS exec

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -2,7 +2,7 @@ package:
   name: ca-certificates
   # manual: update java-cacerts
   version: "20250619"
-  epoch: 5
+  epoch: 6
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -107,6 +107,31 @@ subpackages:
               echo "file exists and contains contents."
             else
               echo "ca-bundle.crt file does not exist or is empty"
+              exit 1
+            fi
+
+  - name: "ca-certificates-bundle-ecs"
+    description: "CA certificates bundle needed for Amazon ECS exec"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/var/lib/ecs/deps/execute-command/certs
+          cp ${{targets.outdir}}/ca-certificates-bundle/etc/ssl/certs/ca-certificates.crt "${{targets.subpkgdir}}"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem
+    test:
+      pipeline:
+        - name: test for certs directory
+          runs: |
+            if [ -d "/var/lib/ecs/deps/execute-command/certs" ]; then
+              echo "certs directory exists"
+            else
+              echo "certs directory does not exist"
+              exit 1
+            fi
+        - name: test for tls-ca-bundle.pem file
+          runs: |
+            if [ -s "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem" ]; then
+              echo "file exists and contains contents."
+            else
+              echo "tls-ca-bundle.pem file does not exist or is empty"
               exit 1
             fi
 


### PR DESCRIPTION
Amazon's ECS Exec functionality has requirements for a copy of the TLS cert bundle in a specific directory used by a copy of the SSM agent that lives in the ecs-agent container. See https://github.com/chainguard-dev/internal-dev/issues/19944#issuecomment-3259167520
