### PR TITLE
Fix GHSA-3p8m-j85q-pgmj netty vulnerability - Cassandra family

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.26.0
-  epoch: 1
+  epoch: 2
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: patch
     with:
-      # includes patches for GHSA-pr98-23f8-jwxv, GHSA-6v67-2wr5-gvf4, GHSA-4g8c-wm8x-jfhw, GHSA-4g8c-wm8x-jfhw, GHSA-pq2g-wx69-c263, CVE-2025-48734, GHSA-j288-q9x7-2f5v and GHSA-xwmg-2g98-w7v9
+      # includes patches for GHSA-pr98-23f8-jwxv, GHSA-6v67-2wr5-gvf4, GHSA-4g8c-wm8x-jfhw, GHSA-4g8c-wm8x-jfhw, GHSA-pq2g-wx69-c263, CVE-2025-48734, GHSA-j288-q9x7-2f5v, GHSA-xwmg-2g98-w7v9 and GHSA-3p8m-j85q-pgmj
       patches: |
         cves-20250714.patch
 

--- a/akhq/cves-20250714.patch
+++ b/akhq/cves-20250714.patch
@@ -58,7 +58,7 @@ index ae531b3b..362fbd59 100644
 +logbackVersion=1.5.16
 +commonsCompressVersion=1.26.0
 +vertxVersion=4.4.8
-+nettyVersion=4.1.118.Final
++nettyVersion=4.1.125.Final
 +jettyHttpVersion=12.0.12
 +beansVersion=1.11.0
 \ No newline at end of file

--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.42.0"
-  epoch: 7 # GHSA-3p8m-j85q-pgmj
+  epoch: 8 # GHSA-3p8m-j85q-pgmj
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0

--- a/apache-activemq-artemis/pombump-deps.yaml
+++ b/apache-activemq-artemis/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: commons-beanutils
     artifactId: commons-beanutils
     version: 1.11.0

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.5"
-  epoch: 4 # GHSA-3p8m-j85q-pgmj
+  epoch: 5 # GHSA-3p8m-j85q-pgmj
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/cassandra-5.0/pombump-deps.yaml
+++ b/cassandra-5.0/pombump-deps.yaml
@@ -1,10 +1,10 @@
 patches:
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-all
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: com.fasterxml.jackson.core
     artifactId: jackson-databind
     version: 2.15.3

--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: "3.8.0"
-  epoch: 11 # GHSA-3p8m-j85q-pgmj
+  epoch: 12
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/cassandra-reaper/src/server/pombump-deps.yaml
+++ b/cassandra-reaper/src/server/pombump-deps.yaml
@@ -4,7 +4,7 @@ patches:
     version: "1.33"
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: org.eclipse.jetty
     artifactId: jetty-server
     version: 9.4.57.v20241219

--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.5
   version: 0.5.4
-  epoch: 6
+  epoch: 8 # Fix GHSA-prj3-ccx8-p6x4, GHSA-3p8m-j85q-pgmj by updating netty-all
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0
@@ -49,7 +49,9 @@ pipeline:
 
   - uses: patch
     with:
-      patches: commons-lang3-3.18.0.patch
+      patches: |
+        commons-lang3-3.18.0.patch
+        remove-maven-extension.patch
 
   - name: Build / install Celeborn
     runs: |

--- a/celeborn-0.5/pombump-deps.yaml
+++ b/celeborn-0.5/pombump-deps.yaml
@@ -5,3 +5,6 @@ patches:
   - groupId: com.fasterxml.jackson.core
     artifactId: jackson-core
     version: 2.13.0
+  - groupId: io.netty
+    artifactId: netty-all
+    version: 4.1.125.Final

--- a/celeborn-0.5/remove-maven-extension.patch
+++ b/celeborn-0.5/remove-maven-extension.patch
@@ -1,0 +1,16 @@
+--- a/.mvn/extensions.xml
++++ b/.mvn/extensions.xml
+@@ -15,10 +15,5 @@
+   ~ See the License for the specific language governing permissions and
+   ~ limitations under the License.
+   -->
+-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+-            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+-    <extension>
+-        <groupId>fish.payara.maven.extensions</groupId>
+-        <artifactId>regex-profile-activator</artifactId>
+-        <version>0.5</version>
+-    </extension>
+-</extensions>
++<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0">
++</extensions>

--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: 0.16.0 # Check if the version bump in the mvn command is still needed next time this package is updated
-  epoch: 7 # GHSA-3p8m-j85q-pgmj
+  epoch: 8 # GHSA-3p8m-j85q-pgmj
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0

--- a/cloudwatch-exporter/pombump-deps.yaml
+++ b/cloudwatch-exporter/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
   - groupId: io.netty
     artifactId: netty-codec-http
-    version: 4.1.108.Final
+    version: 4.1.125.Final
     scope: import
   - groupId: org.eclipse.jetty
     artifactId: jetty-servlet
@@ -9,13 +9,13 @@ patches:
     scope: import
   - groupId: io.netty
     artifactId: netty-common
-    version: 4.1.115.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec
     version: 4.1.125.Final

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.35.0.20250808"
-  epoch: 1
+  epoch: 2
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -110,7 +110,7 @@ subpackages:
               # Do not change these. Docker Selenium is sensitive to the versions used
               OPENTELEMETRY_VERSION=$(cat ./Dockerfile | grep "^ARG OPENTELEMETRY_VERSION" | sed "s/.*=//")
               GRPC_VERSION=$(cat ./Dockerfile | grep "^ARG GRPC_VERSION" | sed "s/.*=//")
-              NETTY_VERSION="4.1.118.Final"
+              NETTY_VERSION="4.1.125.Final"
 
               mkdir -p ${{targets.contextdir}}/external_jars
               curl -sSLfO https://github.com/coursier/launchers/raw/master/coursier

--- a/keycloak-26.3.yaml
+++ b/keycloak-26.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.3
   version: "26.3.3"
-  epoch: 5 # GHSA-3p8m-j85q-pgmj
+  epoch: 6 # GHSA-3p8m-j85q-pgmj
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak-26.3/pombump-deps.yaml
+++ b/keycloak-26.3/pombump-deps.yaml
@@ -1,12 +1,12 @@
 patches:
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
     scope: import
     type: pom
   - groupId: io.netty
     artifactId: netty-common
-    version: 4.1.118.Final
+    version: 4.1.125.Final
     scope: import
     type: pom
   - groupId: io.quarkus.http
@@ -24,7 +24,7 @@ patches:
     version: 42.7.7
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec
     version: 4.1.125.Final

--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -2,7 +2,7 @@
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 15 # GHSA-4cx2-fc23-5wg6
+  epoch: 16 # GHSA-4cx2-fc23-5wg6, GHSA-3p8m-j85q-pgmj
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:

--- a/kserve-modelmesh/pombump-deps.yaml
+++ b/kserve-modelmesh/pombump-deps.yaml
@@ -16,4 +16,4 @@ patches:
     version: "1.79"
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final

--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
   version: "0.1.107"
-  epoch: 1 # GHSA-prj3-ccx8-p6x4
+  epoch: 2 # GHSA-3p8m-j85q-pgmj netty fix
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
+++ b/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
@@ -7,7 +7,7 @@ index 63f9330..e6ed710 100644
    <properties>
      <cassandra5.version>5.0.3</cassandra5.version>
 -    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
-+    <netty.http.codec.version>4.1.124.Final</netty.http.codec.version>
++    <netty.http.codec.version>4.1.125.Final</netty.http.codec.version>
    </properties>
    <dependencies>
      <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -46,6 +46,6 @@ index dd3d9e8..fa544ca 100644
 -    <logback.version>1.5.13</logback.version>
 +    <slf4j.version>2.0.16</slf4j.version>
 +    <logback.version>1.5.16</logback.version>
-     <netty.version>4.1.124.Final</netty.version>
+     <netty.version>4.1.125.Final</netty.version>
      <mockito.version>3.5.13</mockito.version>
      <prometheus.version>0.16.0</prometheus.version>

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.2.0"
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -87,6 +87,10 @@ pipeline:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
       expected-commit: 6adc0bf476e1624190564d7fbe4aba00ccf49ad8
+
+  - uses: patch
+    with:
+      patches: GHSA-3p8m-j85q-pgmj-netty-fix.patch
 
   - uses: auth/gradle
 

--- a/opensearch-3/GHSA-3p8m-j85q-pgmj-netty-fix.patch
+++ b/opensearch-3/GHSA-3p8m-j85q-pgmj-netty-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
+index 24f128885f4..f48f9a737e1 100644
+--- a/gradle/libs.versions.toml
++++ b/gradle/libs.versions.toml
+@@ -33,7 +33,7 @@ json_smart        = "2.5.2"
+ # when updating the JNA version, also update the version in buildSrc/build.gradle
+ jna               = "5.16.0"
+ 
+-netty             = "4.1.121.Final"
++netty             = "4.1.125.Final"
+ joda              = "2.12.7"
+ roaringbitmap     = "1.3.0"
+ 

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,7 +1,7 @@
 package:
   name: selenium
   version: "4.35.0"
-  epoch: 0
+  epoch: 1
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: ignore-root-user-error.patch
+      patches: ignore-root-user-error.patch netty-version-update.patch
 
   - runs: |
       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/usr/lib

--- a/selenium/netty-version-update.patch
+++ b/selenium/netty-version-update.patch
@@ -1,0 +1,25 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 9a98a3348b..4644abd07c 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -182,13 +182,13 @@ maven.install(
+         "dev.failsafe:failsafe:3.3.2",
+         "io.grpc:grpc-context:1.68.1",
+         "io.lettuce:lettuce-core:6.5.0.RELEASE",
+-        "io.netty:netty-buffer:4.1.115.Final",
+-        "io.netty:netty-codec-http:4.1.115.Final",
+-        "io.netty:netty-codec-http2:4.1.115.Final",
+-        "io.netty:netty-common:4.1.115.Final",
+-        "io.netty:netty-handler:4.1.115.Final",
+-        "io.netty:netty-handler-proxy:4.1.115.Final",
+-        "io.netty:netty-transport:4.1.115.Final",
++        "io.netty:netty-buffer:4.1.125.Final",
++        "io.netty:netty-codec-http:4.1.125.Final",
++        "io.netty:netty-codec-http2:4.1.125.Final",
++        "io.netty:netty-common:4.1.125.Final",
++        "io.netty:netty-handler:4.1.125.Final",
++        "io.netty:netty-handler-proxy:4.1.125.Final",
++        "io.netty:netty-transport:4.1.125.Final",
+         "io.opentelemetry:opentelemetry-api:1.44.1",
+         "io.opentelemetry:opentelemetry-context:1.44.1",
+         "io.opentelemetry:opentelemetry-exporter-logging:1.44.1",

--- a/solr.yaml
+++ b/solr.yaml
@@ -1,7 +1,7 @@
 package:
   name: solr
   version: "9.9.0"
-  epoch: 1
+  epoch: 2 # GHSA-3p8m-j85q-pgmj
   description: Apache Solr open-source search software
   copyright:
     - license: Apache-2.0

--- a/solr/pombump-deps.yaml
+++ b/solr/pombump-deps.yaml
@@ -1,0 +1,4 @@
+patches:
+  - groupId: io.netty
+    artifactId: netty-codec
+    version: 4.1.125.Final

--- a/spark-4.0.yaml
+++ b/spark-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-4.0
   version: "4.0.0"
-  epoch: 3 # GHSA-prj3-ccx8-p6x4
+  epoch: 4 # GHSA-prj3-ccx8-p6x4, GHSA-3p8m-j85q-pgmj
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-4.0/pombump-deps.yaml
+++ b/spark-4.0/pombump-deps.yaml
@@ -7,4 +7,4 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.47.0"
-  epoch: 6 # GHSA-3p8m-j85q-pgmj
+  epoch: 7 # GHSA-3p8m-j85q-pgmj
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/strimzi-kafka-operator/pombump-deps-cc.yaml
+++ b/strimzi-kafka-operator/pombump-deps-cc.yaml
@@ -4,10 +4,10 @@ patches:
     version: 1.11.0
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final
   - groupId: org.apache.kafka
     artifactId: kafka-clients
     version: 3.9.1

--- a/strimzi-kafka-operator/pombump-deps.yaml
+++ b/strimzi-kafka-operator/pombump-deps.yaml
@@ -7,7 +7,7 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec
     version: 4.1.125.Final

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "476"
-  epoch: 6 # GHSA-mmxm-8w33-wc4h
+  epoch: 7 # GHSA-mmxm-8w33-wc4h, GHSA-3p8m-j85q-pgmj
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
   - groupId: io.netty
     artifactId: netty-common
-    version: 4.1.116.Final
+    version: 4.1.125.Final
   - groupId: ch.qos.logback
     artifactId: logback-core
     version: 1.5.15
@@ -9,7 +9,7 @@ patches:
     type: jar
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: org.apache.ignite
     artifactId: ignite-core
     version: 2.17.0
@@ -24,7 +24,7 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.2.4.Final
+    version: 4.1.125.Final
   - groupId: org.eclipse.jetty.http2
     artifactId: jetty-http2-common
     version: 12.0.25

--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -1,7 +1,7 @@
 package:
   name: zipkin
   version: "3.5.1"
-  epoch: 4
+  epoch: 5
   description: Zipkin distributed tracing system
   copyright:
     - license: Apache-2.0

--- a/zipkin/pombump-deps.yaml
+++ b/zipkin/pombump-deps.yaml
@@ -2,3 +2,6 @@ patches:
   - groupId: org.apache.kafka
     artifactId: kafka-clients
     version: 3.9.1
+  - groupId: io.netty
+    artifactId: netty-codec
+    version: 4.1.125.Final

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.2"
-  epoch: 1
+  epoch: 2 # GHSA-3p8m-j85q-pgmj netty fix
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -53,7 +53,7 @@ pipeline:
       # -Dnetty.version=4.1.108.Final
       # Patch commons-io version GHSA-78wr-2p64-hpwj/CVE-2024-47554
       # -Dcommons-io.version=2.14.0 moved from 2.11.0 https://github.com/apache/zookeeper/blob/release-3.9.2/pom.xml#L574C5-L574C52
-      mvn install -DskipTests -Dnetty.version=4.1.118.Final -Dcommons-io.version=2.14.0
+      mvn install -DskipTests -Dnetty.version=4.1.125.Final -Dcommons-io.version=2.14.0
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       # Cleanup Windows files


### PR DESCRIPTION
## Summary

Fixes GHSA-3p8m-j85q-pgmj netty DoS vulnerability in Cassandra family packages by updating netty dependencies to version 4.1.125.Final.

## Packages Updated

- **cassandra-5.0**: Update netty-handler, netty-all → 4.1.125.Final (epoch 4→5)
- **cassandra-reaper**: Update netty-handler → 4.1.125.Final (epoch 11→12)  
- **management-api-for-apache-cassandra-5.0**: Update consolidated patch file netty versions (epoch 0→1)

## Test Plan

- [ ] Build packages: `make package/cassandra-5.0`, `make package/cassandra-reaper`, `make package/management-api-for-apache-cassandra-5.0`
- [ ] Verify netty version 4.1.125.Final in built artifacts
- [ ] Run vulnerability scan: `wolfictl scan packages/$(uname -m)/<package>-*.apk`