### PR TITLE
Fix GHSA-3p8m-j85q-pgmj netty vulnerability - Cassandra family in os

### DIFF
--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.5"
-  epoch: 4 # GHSA-3p8m-j85q-pgmj
+  epoch: 5 # GHSA-3p8m-j85q-pgmj
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/cassandra-5.0/pombump-deps.yaml
+++ b/cassandra-5.0/pombump-deps.yaml
@@ -1,10 +1,10 @@
 patches:
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-all
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: com.fasterxml.jackson.core
     artifactId: jackson-databind
     version: 2.15.3

--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: "3.8.0"
-  epoch: 11 # GHSA-3p8m-j85q-pgmj
+  epoch: 12
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/cassandra-reaper/src/server/pombump-deps.yaml
+++ b/cassandra-reaper/src/server/pombump-deps.yaml
@@ -4,7 +4,7 @@ patches:
     version: "1.33"
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: org.eclipse.jetty
     artifactId: jetty-server
     version: 9.4.57.v20241219

--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
   version: "0.1.107"
-  epoch: 1 # GHSA-prj3-ccx8-p6x4
+  epoch: 2 # GHSA-3p8m-j85q-pgmj netty fix
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
+++ b/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
@@ -7,7 +7,7 @@ index 63f9330..e6ed710 100644
    <properties>
      <cassandra5.version>5.0.3</cassandra5.version>
 -    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
-+    <netty.http.codec.version>4.1.124.Final</netty.http.codec.version>
++    <netty.http.codec.version>4.1.125.Final</netty.http.codec.version>
    </properties>
    <dependencies>
      <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -46,6 +46,6 @@ index dd3d9e8..fa544ca 100644
 -    <logback.version>1.5.13</logback.version>
 +    <slf4j.version>2.0.16</slf4j.version>
 +    <logback.version>1.5.16</logback.version>
-     <netty.version>4.1.124.Final</netty.version>
+     <netty.version>4.1.125.Final</netty.version>
      <mockito.version>3.5.13</mockito.version>
      <prometheus.version>0.16.0</prometheus.version>

--- a/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
+++ b/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
@@ -46,6 +46,7 @@ index dd3d9e8..fa544ca 100644
 -    <logback.version>1.5.13</logback.version>
 +    <slf4j.version>2.0.16</slf4j.version>
 +    <logback.version>1.5.16</logback.version>
-     <netty.version>4.1.125.Final</netty.version>
+-    <netty.version>4.1.124.Final</netty.version>
++    <netty.version>4.1.125.Final</netty.version>
      <mockito.version>3.5.13</mockito.version>
      <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
## Summary

Fixes GHSA-3p8m-j85q-pgmj netty DoS vulnerability across the Cassandra ecosystem by updating netty dependencies to version 4.1.125.Final.

## Packages Updated

- **cassandra-5.0**: Update netty-handler and netty-all via pombump-deps, increment epoch to 5
- **cassandra-reaper**: Update netty-handler via pombump-deps, increment epoch to 12  
- **management-api-for-apache-cassandra-5.0**: Update netty.version and netty.http.codec.version via patch file, increment epoch to 2

## Fix Details

All packages now use netty version 4.1.125.Final which resolves the DoS vulnerability. Epoch increments force package rebuilds to incorporate the security fix.