### PR TITLE
opensearch-3/GHSA-3p8m-j85q-pgmj netty vulnerability fixes

### DIFF
--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.2.0"
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -87,6 +87,10 @@ pipeline:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
       expected-commit: 6adc0bf476e1624190564d7fbe4aba00ccf49ad8
+
+  - uses: patch
+    with:
+      patches: GHSA-3p8m-j85q-pgmj-netty-fix.patch
 
   - uses: auth/gradle
 

--- a/opensearch-3/GHSA-3p8m-j85q-pgmj-netty-fix.patch
+++ b/opensearch-3/GHSA-3p8m-j85q-pgmj-netty-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
+index 24f128885f4..f48f9a737e1 100644
+--- a/gradle/libs.versions.toml
++++ b/gradle/libs.versions.toml
+@@ -33,7 +33,7 @@ json_smart        = "2.5.2"
+ # when updating the JNA version, also update the version in buildSrc/build.gradle
+ jna               = "5.16.0"
+ 
+-netty             = "4.1.121.Final"
++netty             = "4.1.125.Final"
+ joda              = "2.12.7"
+ roaringbitmap     = "1.3.0"
+ 


### PR DESCRIPTION
## Summary

Fixes GHSA-3p8m-j85q-pgmj netty DoS vulnerability in the OpenSearch ecosystem by updating netty dependencies to version 4.1.125.Final.

## Package Updated

- **opensearch-3**: Update netty version from 4.1.121.Final to 4.1.125.Final via gradle patch, increment epoch to 1

## Fix Details

The package now uses netty version 4.1.125.Final which resolves the DoS vulnerability. Epoch increment forces package rebuild to incorporate the security fix.