### PR TITLE
apache-activemq-artemis/GHSA-3p8m-j85q-pgmj netty vulnerability fix

### DIFF
--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.42.0"
-  epoch: 7 # GHSA-3p8m-j85q-pgmj
+  epoch: 8 # GHSA-3p8m-j85q-pgmj
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0

--- a/apache-activemq-artemis/pombump-deps.yaml
+++ b/apache-activemq-artemis/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
   - groupId: io.netty
     artifactId: netty-handler
-    version: 4.1.118.Final
+    version: 4.1.125.Final
   - groupId: commons-beanutils
     artifactId: commons-beanutils
     version: 1.11.0

--- a/apache-activemq-artemis/pombump-properties.yaml
+++ b/apache-activemq-artemis/pombump-properties.yaml
@@ -2,6 +2,6 @@ properties:
   - property: commons.beanutils.version
     value: "1.11.0"
   - property: netty.version
-    value: "4.1.118.Final"
+    value: "4.1.125.Final"
   - property: commons.lang.version
     value: "3.18.0"


### PR DESCRIPTION
## Summary

Fixes GHSA-3p8m-j85q-pgmj netty DoS vulnerability in the Apache ecosystem by updating netty dependencies to version 4.1.125.Final.

## Package Updated

- **apache-activemq-artemis**: Update netty-handler and netty-codec via pombump-deps, increment epoch to 8

## Fix Details

The package now uses netty version 4.1.125.Final which resolves the DoS vulnerability. Epoch increment forces package rebuild to incorporate the security fix.