### PR TITLE
Kubernetes latest is now 1.34

### DIFF
--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-latest
   version: 0
-  epoch: 10
+  epoch: 11
   description: "Compatibility infrastructure for Kubernetes components"
   copyright:
     - license: GPL-2.0-or-later
@@ -13,7 +13,7 @@ environment:
 
 vars:
   components: "kubectl kubeadm kubelet kube-scheduler kube-proxy kube-controller-manager kube-apiserver"
-  kubernetes-version: 1.33
+  kubernetes-version: 1.34
 
 pipeline:
   - runs: |


### PR DESCRIPTION
Should fix
```
panic: error creating image.tar: failed to build layer image: installing apk packages:
installing packages: installing kubectl-latest (ver:0-r10 arch:aarch64):
unable to install files for pkg kubectl-latest: writing header for "usr/bin/kubectl":
packages map[kubectl-1.34-default:kubernetes-1.34 kubectl-latest:kubernetes-latest] has conflicting file: "usr/bin/kubectl"
```

Due to https://github.com/wolfi-dev/os/pull/64708