### PR TITLE
Fix GHSA-3p8m-j85q-pgmj netty vulnerability - Spark family

### DIFF
--- a/spark-4.0.yaml
+++ b/spark-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-4.0
   version: "4.0.0"
-  epoch: 3 # GHSA-prj3-ccx8-p6x4
+  epoch: 4 # GHSA-prj3-ccx8-p6x4, GHSA-3p8m-j85q-pgmj
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-4.0/pombump-deps.yaml
+++ b/spark-4.0/pombump-deps.yaml
@@ -7,4 +7,4 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.124.Final
+    version: 4.1.125.Final


### PR DESCRIPTION
## Summary

Fixes GHSA-3p8m-j85q-pgmj netty DoS vulnerability in the Spark ecosystem by updating netty dependencies to version 4.1.125.Final.

## Package Updated

- **spark-4.0**: Update netty-codec-http2 via pombump-deps, increment epoch to 4

## Fix Details

The package now uses netty version 4.1.125.Final which resolves the DoS vulnerability. Epoch increment forces package rebuild to incorporate the security fix.