### PR TITLE
zookeeper-3.9 fix GHSA-3p8m-j85q-pgmj by updating netty to 4.1.125.Final

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.2"
-  epoch: 1
+  epoch: 2
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -53,7 +53,7 @@ pipeline:
       # -Dnetty.version=4.1.108.Final
       # Patch commons-io version GHSA-78wr-2p64-hpwj/CVE-2024-47554
       # -Dcommons-io.version=2.14.0 moved from 2.11.0 https://github.com/apache/zookeeper/blob/release-3.9.2/pom.xml#L574C5-L574C52
-      mvn install -DskipTests -Dnetty.version=4.1.118.Final -Dcommons-io.version=2.14.0
+      mvn install -DskipTests -Dnetty.version=4.1.125.Final -Dcommons-io.version=2.14.0
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       # Cleanup Windows files


### PR DESCRIPTION
## Summary

Updates netty version to 4.1.125.Final to fix GHSA-3p8m-j85q-pgmj (Netty DoS vulnerability) in ZooKeeper family packages.

## Changes

**zookeeper-3.9**:
- Updated Maven command line parameter  to 
- Incremented epoch from 1 to 2

## Vulnerability Details

- **GHSA-3p8m-j85q-pgmj**: Netty DoS vulnerability
- **Fix version**: 4.1.125.Final
- **Previous version**: 4.1.118.Final

This completes the systematic remediation of GHSA-3p8m-j85q-pgmj across all affected Wolfi packages.