### PR TITLE
withdrawn-packages: don't remove APK's from GCS

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -75,15 +75,6 @@ jobs:
             # This is a bit of a hack until we drop this APKINDEX entirely.
             gcloud storage cp --if-generation-match="${GEN}" --cache-control="no-store" $arch/APKINDEX.tar.gz gs://wolfi-production-registry-destination/os/$arch/APKINDEX.tar.gz
           done
-      - name: Delete withdrawn packages
-        run: |
-          set -euo pipefail
-          for arch in x86_64 aarch64; do
-            for pkg in $(grep -v '\#' withdrawn-packages.txt); do
-              echo "=> $pkg"
-              gsutil -m rm -f gs://wolfi-production-registry-destination/os/$arch/$pkg || true
-            done
-          done
       - name: Upload full withdrawn packages list
         run: |
           set -euxo pipefail


### PR DESCRIPTION
We have a large number of APK's that are part of packages.wolfi.dev but
are not present in apk.cgr.dev/chainguard; as such we can't use the
preferred restore process (which relies on the package having been
present in apk.cgr.dev).

The restore process for these older APK's will be to upload to
apk.cgr.dev using the APK from the GCS bucket.

Stop removing them as part of withdrawal to support this contingency.

We can still remove the SBOM as this would be re-generated as part of
the restore process.
