### PR TITLE
Enable auto-update checks for a number of packages

### DIFF
--- a/inotify-tools.yaml
+++ b/inotify-tools.yaml
@@ -88,5 +88,6 @@ test:
     - uses: test/no-docs
 
 update:
+  enabled: true
   github:
     identifier: inotify-tools/inotify-tools

--- a/inotify-tools.yaml
+++ b/inotify-tools.yaml
@@ -2,7 +2,7 @@
 package:
   name: inotify-tools
   version: 4.23.9.0
-  epoch: 4
+  epoch: 5
   description: C library and CLI tools providing a simple interface to inotify
   copyright:
     - license: GPL-2.0-only

--- a/jack.yaml
+++ b/jack.yaml
@@ -79,8 +79,10 @@ subpackages:
             jackdbus --help
 
 update:
+  enabled: true
+  # https://release-monitoring.org/project/21358
   release-monitor:
-    identifier: 16338
+    identifier: 21358
 
 test:
   pipeline:

--- a/jack.yaml
+++ b/jack.yaml
@@ -2,7 +2,7 @@
 package:
   name: jack
   version: 1.9.22
-  epoch: 3
+  epoch: 4
   description: The Jack Audio Connection Kit
   copyright:
     - license: GPL-2.0-or-later

--- a/jvmkill.yaml
+++ b/jvmkill.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: jvmkill
-  version: 0.0.1
-  epoch: 1
+  version: 0.0.2
+  epoch: 0
   description: Terminate the JVM when resources are exhausted
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,11 @@ pipeline:
       mv libjvmkill.so ${{targets.destdir}}/usr/lib/
 
 update:
-  enabled: false
+  enabled: true
+  git: {}
+  schedule:
+    period: monthly
+    reason: This project doesn't push changes frequently and doesn't cut tags.
 
 test:
   pipeline:


### PR DESCRIPTION
Auto-updates were disabled for these packages. Whilst some are seldom updated, ensuring we're polling for changes ensures no manual work required in future.