### PR TITLE
openjdk-{8,11}: improve backwards compatibility

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -143,7 +143,7 @@ subpackages:
         - libxtst
         - ttf-dejavu
       provides:
-        - ${{package.name}}-jre-headless
+        - ${{package.name}}-jre-headless=${{package.full-version}}
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-11-openjdk"

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: "11.0.28" # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -142,6 +142,8 @@ subpackages:
         - libxrender
         - libxtst
         - ttf-dejavu
+      provides:
+        - ${{package.name}}-jre-headless
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-11-openjdk"

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.452.09 # this corresponds to same release as jdk8u452-ga / jdk8u452-b09
-  epoch: 8
+  epoch: 9
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -192,6 +192,8 @@ subpackages:
       runtime:
         - java-common
         - java-cacerts
+      provides:
+        - openjdk-8-jre-base
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -193,7 +193,7 @@ subpackages:
         - java-common
         - java-cacerts
       provides:
-        - openjdk-8-jre-base
+        - openjdk-8-jre-base=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/


### PR DESCRIPTION
Sometime in the history of these packages we published -base or
-headless versions of the jre subpackage; we've seen a few customers
using these package names from our extensive APK history, and as such
they would not be getting updates.

Provide provides for these old package names to ensure that updates to
the latest version of the package occur for these customers when they
rebuild their images.
