### PR TITLE
gcc: configure glibc 2.42

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: "15.2.0"
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -87,7 +87,7 @@ pipeline:
         --disable-nls \
         --disable-werror \
         --with-pkgversion='Wolfi ${{package.full-version}}' \
-        --with-glibc-version=2.41 \
+        --with-glibc-version=2.42 \
         --enable-initfini-array \
         --disable-nls \
         --disable-multilib \


### PR DESCRIPTION
We're now using GLIBC 2.42, we should configure gcc accordingly