### PR TITLE
bdftopcf: improve backwards compatibility

### DIFF
--- a/bdftopcf.yaml
+++ b/bdftopcf.yaml
@@ -1,10 +1,13 @@
 package:
   name: bdftopcf
   version: 1.1.2
-  epoch: 2
+  epoch: 3
   description: X.org font bdftopcf
   copyright:
     - license: MIT-open-group
+  dependencies:
+    provides:
+      - font-bdftopcf-dev=${{package.full-version}}
 
 environment:
   contents:
@@ -52,3 +55,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/docs
+    dependencies:
+      provides:
+        - font-bdftopcf-doc=${{package.full-version}}


### PR DESCRIPTION
Somewhere in the history of this package font-{package-name}-{dev,doc}
was published which at least one customer is using by name; add
versioned provides for the equivalent new package names to ensure that
updates are presented correctly.
