### PR TITLE
chore(gdal): bump to pick up latest openexr so dep

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.3"
-  epoch: 5
+  epoch: 6
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT


### PR DESCRIPTION
Rebuild to pick up latest `openexr` to resolve:

```
│ error:
│ resolving apk packages: for arch "amd64": solving "imagemagick" constraint: resolving "imagemagick-7-7.1.2.3-r1.apk" deps:
│ solving "so:libheif.so.1" constraint: resolving "libheif-1.20.2-r2.apk" deps:
│ solving "so:libopenjph.so.0.22" constraint: resolving "openexr-3.4.0-r0.apk" deps:
│ solving "so:libIex-3_4.so.33" constraint: resolving "openexr-libiex-3.4.0-r0.apk" deps:
│ selecting package openexr-libiex-3.4.0-r0.apk conflicts with openexr-libiex-3.3.5-r1.apk on "openexr-libiex"
```
 which affects anyone that needs the latest gdal + openexr:
```
# apk add -l gdal-py3.13 openexr-libiex
ERROR: unable to select packages:
  openexr-libiex-3.4.0-r0:
    conflicts: openexr-libiex-3.3.5-r1
    satisfies: world[openexr-libiex] openexr-libopenexr-3.4.0-r0[so:libIex-3_4.so.33] openexr-libilmthread-3.4.0-r0[so:libIex-3_4.so.33]
```