### PR TITLE
fix(datadog-agent): add embedded python home path for bugfix-2473

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -2,7 +2,7 @@ package:
   name: datadog-agent
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
-  version: "7.70.0"
+  version: "7.70.1"
   epoch: 1 # GHSA-jc7w-c686-c4v9
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
@@ -104,7 +104,7 @@ pipeline:
     with:
       repository: https://github.com/DataDog/datadog-agent
       tag: ${{package.version}}
-      expected-commit: 952ac8155cb871b72207bf78e570273168331d77
+      expected-commit: 432517c0f835823e7e6b137a91431ab27d1844a8
 
   - runs: |
       sed -i'' 's/v1\.3\.7/v1.6.1/g' go.mod

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.70.0"
-  epoch: 0 # GHSA-jc7w-c686-c4v9
+  epoch: 1 # GHSA-jc7w-c686-c4v9
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -133,6 +133,7 @@ pipeline:
 
   - uses: go/bump
     with:
+      go-version: "1.24.7" # package built w/ go-1.24 - keeps tidy at 1.24.7, otherwise go mod tidy fails
       replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
       show-diff: true
       deps: |-
@@ -242,6 +243,7 @@ pipeline:
         --bundle security-agent \
         --exclude-rtloader \
         --no-development \
+        --python-home-3=/opt/datadog-agent/embedded \
         --embedded-path /usr/lib
         #--bundle-ebpf \ # Same as above for the system-probe.build Invoke task.
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
- adds `--python-home-3=/opt/datadog-agent/embedded` build option during agent build

Related:
- https://github.com/chainguard-dev/customer-issues/issues/2473

Notes:
local and CI build was failing during `go/bump` stage with the following: 
```
Error: failed to run 'go mod tidy': exit status 2 with output: invalid value "1.25.0" for flag -go: maximum supported Go version is 1.24.7
```

Added the following line to `go/bump` section
```
go-version: "1.24.7" # package built w/ go-1.24 - keeps tidy at 1.24.7, otherwise go mod tidy fails
```
