### PR TITLE
pin incompatible packages to the protobuf 3.29

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: "0.41.3"
-  epoch: 3
+  epoch: 4
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ vars:
 environment:
   contents:
     packages:
-      - abseil-cpp-dev
+      - abseil-cpp-dev=20250127.1-r4
       - autoconf
       - bash
       - bpftool
@@ -44,7 +44,9 @@ environment:
       - nlohmann-json
       - openssl-dev
       - pkgconf
-      - protobuf-dev
+      - protobuf-dev=3.29.5
+      - protobuf=3.29.5
+      - protoc=3.29.5
       - systemd-dev
       - yaml-cpp-dev
       - zlib-dev

--- a/falco.yaml
+++ b/falco.yaml
@@ -12,7 +12,7 @@ package:
   resources:
     # https://go/wolfi-rsc/falco
     cpu: 20
-    memory: 40Gi
+    memory: 54Gi
 
 vars:
   llvm-vers: 19

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: "0.41.3"
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ vars:
 environment:
   contents:
     packages:
-      - abseil-cpp-dev
+      - abseil-cpp-dev=20250127.1-r4
       - autoconf
       - automake
       - bash
@@ -58,7 +58,9 @@ environment:
       - openssl-dev
       - patch
       - perl
-      - protobuf-dev
+      - protobuf-dev=3.29.5
+      - protobuf=3.29.5
+      - protoc=3.29.5
       - re2-dev
       - systemd-dev
       # TODO: Believe these are needed for 'make sinsp' to succeed.

--- a/falco.yaml
+++ b/falco.yaml
@@ -12,7 +12,7 @@ package:
   resources:
     # https://go/wolfi-rsc/falco
     cpu: 20
-    memory: 54Gi
+    memory: 40Gi
 
 vars:
   llvm-vers: 19
@@ -151,7 +151,9 @@ subpackages:
       environment:
         contents:
           packages:
-            - protobuf-dev
+            - protobuf-dev=3.29.5
+            - protobuf=3.29.5
+            - protoc=3.29.5
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: "3.7.2"
-  epoch: 1
+  epoch: 2
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,7 @@ package:
 environment:
   contents:
     packages:
-      - abseil-cpp-dev
+      - abseil-cpp-dev=20250127.1-r4
       - autoconf
       - automake
       - boost-dev<1.87
@@ -22,7 +22,9 @@ environment:
       - gmock
       - gtest-dev
       - openssl-dev
-      - protobuf-dev
+      - protobuf-dev=3.29.5
+      - protobuf=3.29.5
+      - protoc=3.29.5
       - python3
       - samurai
 


### PR DESCRIPTION
Pin the `falco` and `libpulsar` packages to the compatible `protobuf` version to prevent FTBFS