### PR TITLE
withdraw: a really old APK

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,14 +1,1 @@
-py3.10-onnx-1.18.0-r4.apk
-py3.11-onnx-1.18.0-r4.apk
-py3.10-onnx-bin-1.18.0-r4.apk
-py3.13-onnx-1.18.0-r4.apk
-py3.11-onnx-bin-1.18.0-r4.apk
-py3.12-onnx-1.18.0-r4.apk
-py3.13-onnx-bin-1.18.0-r4.apk
-py3-supported-onnx-1.18.0-r4.apk
-py3.12-onnx-bin-1.18.0-r4.apk
-py3-onnx-1.18.0-r4.apk
-crossplane-provider-gcp-family-2.0.0-r0.apk
-crossplane-provider-gcp-pubsub-2.0.0-r0.apk
-crossplane-provider-gcp-storage-2.0.0-r0.apk
-crossplane-provider-gcp-2.0.0-r0.apk
+7zip-doc-2501-r0.apk


### PR DESCRIPTION
This APK forms parts of the planned garbage collection on 10th September
2025; withdraw package to test a) downstream caching and b) restore
process once removed in production services (already done in staging).
