### PR TITLE
feat(logstash-9.1): bump dep to remediate GHSA-3p8m-j85q-pgmj and GHSA-fghv-69vj-qj49

### DIFF
--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.1
   version: "9.1.3"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -91,6 +91,10 @@ pipeline:
       repository: https://github.com/elastic/logstash
       tag: v${{package.version}}
       expected-commit: a5d8847b9867f9055516593052324db2256e0f7d
+
+  - uses: patch
+    with:
+      patches: GHSA-3p8m-j85q-pgmj.patch
 
   - name: Patch sources
     runs: |

--- a/logstash-9.1/GHSA-3p8m-j85q-pgmj.patch
+++ b/logstash-9.1/GHSA-3p8m-j85q-pgmj.patch
@@ -1,0 +1,12 @@
+diff --git a/logstash-core/build.gradle b/logstash-core/build.gradle
+index 14dd90e81..f41d2be77 100644
+--- a/logstash-core/build.gradle
++++ b/logstash-core/build.gradle
+@@ -245,6 +245,7 @@ dependencies {
+         exclude group: 'com.google.guava', module: 'guava'
+     }
+     implementation 'org.javassist:javassist:3.30.2-GA'
++    implementation 'io.netty:netty-codec:4.1.125.Final'
+     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}:tests"
+     testImplementation 'org.hamcrest:hamcrest:2.2'
+     testImplementation 'org.hamcrest:hamcrest-library:2.2'


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump deps to remediate GHSA-3p8m-j85q-pgmj and GHSA-fghv-69vj-qj49
<!--ci-cve-scan:fail-any-->

