### PR TITLE
docker: include /usr/lib/docker plugins directory with dockerd

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.4.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -134,6 +134,7 @@ subpackages:
           install -Dm755 bundles/dynbinary-daemon/docker-proxy ${{targets.destdir}}/usr/bin/docker-proxy
           install -Dm755 bundles/dynbinary-daemon/dockerd ${{targets.destdir}}/usr/bin/dockerd
           ln -sf /sbin/tini-static ${{targets.destdir}}/usr/bin/docker-init
+          mkdir -p ${{targets.destdir}}/usr/lib/docker/plugins
 
   - name: docker-oci-entrypoint
     description: "docker OCI entrypoint"


### PR DESCRIPTION
Some packages expect this to exist. I am not sure what the best subpackage for this is, but dockerd seems appropriate, I assume that's what is using the plugins.