### PR TITLE
erlang-26: improve backwards compatibility

### DIFF
--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -12,10 +12,22 @@ package:
     provides:
       - erlang=${{package.full-version}}
       # Backwards compatible provides based on observed usage of this package.
-      - ${{package.name}}-crypto=${{package.full-version}}
-      - ${{package.name}}-parsetools=${{package.full-version}}
-      - ${{package.name}}-public_key=${{package.full-version}}
+      - ${{package.name}}-xmerl=${{package.full-version}}
+      - ${{package.name}}-tools=${{package.full-version}}
+      - ${{package.name}}-tftp=${{package.full-version}}
+      - ${{package.name}}-syntax_tools=${{package.full-version}}
       - ${{package.name}}-ssl=${{package.full-version}}
+      - ${{package.name}}-snmp=${{package.full-version}}
+      - ${{package.name}}-runtime_tools=${{package.full-version}}
+      - ${{package.name}}-public_key=${{package.full-version}}
+      - ${{package.name}}-parsetools=${{package.full-version}}
+      - ${{package.name}}-os_mon=${{package.full-version}}
+      - ${{package.name}}-mnesia=${{package.full-version}}
+      - ${{package.name}}-inets=${{package.full-version}}
+      - ${{package.name}}-ftp=${{package.full-version}}
+      - ${{package.name}}-eldap=${{package.full-version}}
+      - ${{package.name}}-crypto=${{package.full-version}}
+      - ${{package.name}}-asn1=${{package.full-version}}
 
 environment:
   contents:

--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-26
   version: "26.2.5.14"
-  epoch: 1
+  epoch: 2
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,11 @@ package:
       - ca-certificates-bundle
     provides:
       - erlang=${{package.full-version}}
+      # Backwards compatible provides based on observed usage of this package.
+      - ${{package.name}}-crypto=${{package.full-version}}
+      - ${{package.name}}-parsetools=${{package.full-version}}
+      - ${{package.name}}-public_key=${{package.full-version}}
+      - ${{package.name}}-ssl=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
We've seen some usage of subpackages that where removed at 26.1-r1 in
the wild; provide backwards compatible provides to cover those seen and
ensure users actually get updates - they are currently pinned to 26.1
which very out of date.
