### PR TITLE
boost: enable system module

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: "1.89.0"
-  epoch: 0
+  epoch: 1
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"
@@ -53,6 +53,7 @@ data:
       random: random
       regex: regex
       serialization: serialization
+      system: system
       thread: thread
       unit_test_framework: unit_test_framework
       wave: wave


### PR DESCRIPTION
Enable system module for use in orthanc packages.
