### PR TITLE
numpy: make version stream dependency explicit

### DIFF
--- a/modelmesh-runtime-adapter.yaml
+++ b/modelmesh-runtime-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: modelmesh-runtime-adapter
   version: 0.12.0
-  epoch: 16
+  epoch: 17
   description: Unified runtime-adapter package of the sidecar containers which run in the modelmesh pods
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - py3-google-auth
       - py3-google-auth-oauthlib
       - py3-importlib-metadata
-      - py3-numpy
+      - py3-numpy-2.1
       - py3-oauthlib
       - py3-requests-oauthlib
       - py3-rsa

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: "2.19.0"
-  epoch: 4
+  epoch: 5
   copyright:
     - license: Apache-2.0
   resources:
@@ -157,7 +157,7 @@ subpackages:
         - py${{range.key}}-google-pasta # needed by tf_upgrade_v2
         - py${{range.key}}-keras # needed by toco, tflite_convert
         - py${{range.key}}-ml-dtypes
-        - py${{range.key}}-numpy
+        - py${{range.key}}-numpy-2.1
         - py${{range.key}}-opt-einsum
         - py${{range.key}}-pip
         - py${{range.key}}-protobuf


### PR DESCRIPTION
To depend on a named version stream.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
