### PR TITLE
Withdraw the temporary-package

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,14 +1,1 @@
-py3.10-onnx-1.18.0-r4.apk
-py3.11-onnx-1.18.0-r4.apk
-py3.10-onnx-bin-1.18.0-r4.apk
-py3.13-onnx-1.18.0-r4.apk
-py3.11-onnx-bin-1.18.0-r4.apk
-py3.12-onnx-1.18.0-r4.apk
-py3.13-onnx-bin-1.18.0-r4.apk
-py3-supported-onnx-1.18.0-r4.apk
-py3.12-onnx-bin-1.18.0-r4.apk
-py3-onnx-1.18.0-r4.apk
-crossplane-provider-gcp-family-2.0.0-r0.apk
-crossplane-provider-gcp-pubsub-2.0.0-r0.apk
-crossplane-provider-gcp-storage-2.0.0-r0.apk
-crossplane-provider-gcp-2.0.0-r0.apk
+temporary-package-1.0-r0.apk


### PR DESCRIPTION
Once https://github.com/wolfi-dev/os/pull/65767 is released, let's withdraw the package for testing purposes. We will restore it afterwards. This withdrawal should now use the bulk withdraw API.