### PR TITLE
Restore the recently withdrawn temporary-package, for testing

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -1,0 +1,1 @@
+temporary-package-1.0-r0.apk


### PR DESCRIPTION
Once https://github.com/wolfi-dev/os/pull/65767 is released and then withdrawn by https://github.com/wolfi-dev/os/pull/65768 , let's see if we can restore it.