### PR TITLE
fix[thingsboard]: correct bumping of Netty

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.2"
-  epoch: 4 # GHSA-fghv-69vj-qj49
+  epoch: 5 # GHSA-fghv-69vj-qj49
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -2,9 +2,3 @@ patches:
   - groupId: com.squareup.wire
     artifactId: wire-schema-jvm
     version: 4.9.9
-  - groupId: io.netty
-    artifactId: netty-codec
-    version: 4.1.125.Final
-  - groupId: io.netty
-    artifactId: netty-codec-http
-    version: 4.1.125.Final

--- a/thingsboard/pombump-properties.yaml
+++ b/thingsboard/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "7.2.1.202505142326-r"
   - property: spring-boot.version
     value: "3.4.9"
+  - property: netty.version
+    value: "4.1.125.Final"


### PR DESCRIPTION
Thingsboard is very sensitive about how dependencies are bumped and maven won't fail the build if it's done correctly.

This removes the original bumps and bumps the over-arching `netty.version` property instead

<!--ci-cve-scan:must-fix: CVE-2025-58056-->
