### PR TITLE
microvm-init: mount defaultshare read-only, do not chmod mountpoint

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 12
+  epoch: 13
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,7 @@ package:
       - kmod
       - mount
       - openssh-server
+      - umount
       - util-linux-misc
       - xfsprogs
 

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -93,10 +93,8 @@ mount -t 9p \
 	-o security_model=mapped-xattr \
 	-o posixacl=on \
 	-o msize=104857600 \
+	-o ro \
 	defaultshare /mount/mnt/
-
-# Allow the user we are running as to copy things to the shared dir
-chmod 0777 /mount/mnt
 
 mount --rbind /dev /mount/dev
 mount --rbind /proc /mount/proc


### PR DESCRIPTION
Change the mount of the defaultshare export from the host at `/mount/mnt` (`/mnt` in the build chroot) to read-only, and drop chmod'ing the directory after the mount occurs; melange copies the contents of `/mount/mnt` into the `/home/build/` directory in preparation for the build, and uses tar over ssh instead of the mounted filesystem to extract any artifacts out of the QEMU guest, so there's no need for the ability to write to the share.

The purpose of doing this is to reduce the ability of processes inside the guest being able to write outside of the guest.

None of the package yamls across the wolfi/chainguard repos reference `/mnt`, so nothing should be broken by this change. There is a followup change to melange (https://github.com/chainguard-dev/melange/pull/2155) to make the virtfs 9p exports to the guest be read-only as well, for the same purpose, but this change needs to land first to remove the chmod, as otherwise the QEMU runner guest will fail to boot if the chmod is attempted on a read-only share.

This change was tested locally with package builds that use the injected chainguard libraries tokens, as well as per-package subdirectories containing contents used in the build, the latter of which is what the `/mount/mnt` defaultshare makes available in the guest.

v2: add the `umount` package to the initramfs runtime, so that melange can unmount the defaultshare filesystem at `/mount/mnt` after copying the contents into the guest's build environment.