### PR TITLE
Enable virtual provides for numpy version streams

### DIFF
--- a/py3-numpy-2.3.yaml
+++ b/py3-numpy-2.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-2.3
   version: "2.3.3"
-  epoch: 0
+  epoch: 1
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause
@@ -58,10 +58,9 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-pygments
-      # Intentionally disabled for now to ensure a smooth migration
-      #provides:
-      #  - py${{range.key}}-${{vars.pypi-package}}
-      #  - numpy
+      provides:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - numpy
       provider-priority: ${{range.value}}
     test:
       pipeline:
@@ -132,6 +131,8 @@ subpackages:
         - py3.11-${{vars.pypi-package}}-${{vars.major-minor-version}}
         - py3.12-${{vars.pypi-package}}-${{vars.major-minor-version}}
         - py3.13-${{vars.pypi-package}}-${{vars.major-minor-version}}
+      provides:
+        - py3-supported-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-numpy-2.3.yaml
+++ b/py3-numpy-2.3.yaml
@@ -69,6 +69,14 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import numpy
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: py${{range.key}}-${{vars.pypi-package}}
+            real-pkg-name: ${{subpkg.name}}
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: numpy
+            real-pkg-name: ${{subpkg.name}}
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}-bin
@@ -97,6 +105,10 @@ subpackages:
             - python-${{range.key}}-dev
             - gfortran
       pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: f2py
+            real-pkg-name: ${{subpkg.name}}
         - name: "Downgrade Setuptools for Python < 3.12"
           runs: |
             # Reference: https://numpy.org/devdocs/reference/distutils_status_migration.html
@@ -139,6 +151,11 @@ subpackages:
           with:
             python: python3.13
             import: ${{vars.pypi-package}}
+        - uses: test/metapackage
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: py3-supported-${{vars.pypi-package}}
+            real-pkg-name: ${{subpkg.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
In an attempt to improve and solve the numpy versioning situation, I've now enabled virtual packages on the newer numpys, and then we can migrate everything forwards slowly and safely. 

This should not be merged before the other numpy PRs from me today. 

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

