### PR TITLE
chore(neo4j): bump io.netty bom vs individual components

### DIFF
--- a/neo4j-2025.07.yaml
+++ b/neo4j-2025.07.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-2025.07
   version: "2025.07.1"
-  epoch: 5 # GHSA-fghv-69vj-qj49
+  epoch: 6 # GHSA-fghv-69vj-qj49
   description:
   copyright:
     - license: GPL-3.0-or-later

--- a/neo4j-2025.07/pombump-deps.yaml
+++ b/neo4j-2025.07/pombump-deps.yaml
@@ -3,11 +3,5 @@ patches:
     artifactId: commons-lang3
     version: 3.18.0
   - groupId: io.netty
-    artifactId: netty-codec-http2
-    version: 4.2.4.Final
-  - groupId: io.netty
-    artifactId: netty-codec-compression
-    version: 4.2.5.Final
-  - groupId: io.netty
-    artifactId: netty-codec-http
+    artifactId: netty-bom
     version: 4.2.5.Final


### PR DESCRIPTION
Mismatched netty bumps lead to (annoyingly quiet) build issues and runtime failures like this:
```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: io/netty/handler/codec/http/HttpServerCodec [in thread "neo4j.BoltNetworkIO-3"]
	at org.neo4j.bolt.protocol.common.handler.TransportSelectionHandler.<clinit>(TransportSelectionHandler.java:57) ~[neo4j-bolt-2025.07.0.jar:2025.07.0]
```

Bump all the nettys via netty-bom with a pom import scope.