### PR TITLE
wolfi-baselayout: correct shadow permissions

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 23
+  epoch: 24
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -68,7 +68,7 @@ pipeline:
         install -m644 vendor/${i} "${{targets.destdir}}"/${i}
       done
 
-      install -m600 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
+      install -m000 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
 
       ln -s /etc/crontabs "${{targets.destdir}}"/var/spool/cron/crontabs
       ln -s /proc/mounts "${{targets.destdir}}"/etc/mtab
@@ -87,6 +87,7 @@ test:
       runs: |
         test -f /etc/passwd
         test -f /etc/shadow
+        [ "$(stat -c %a /etc/shadow)" = "0" ]
         test -f /etc/os-release
         test -f /etc/host.conf
         test -d /var/empty


### PR DESCRIPTION
Note shadow file can be 0000 which many security hardened operating
systems use. In practice it is modified by setuid / priviledged
processes or an external hypervisor, and thus its permissions are
largely irrelevant.

Tested VMs and docker, but possibly this change needs to be tested in
other container implementations too (podman, k8s).

Note fedora containers ship shadow with 0000 permissions by default.