### PR TITLE
openssh: change /etc/ssh/sshd_config permission to 600

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "10.0_p1"
-  epoch: 4
+  epoch: 5
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -236,6 +236,7 @@ subpackages:
           mv "${{targets.destdir}}"/etc/ssh "${{targets.subpkgdir}}"/etc/
           mkdir -p "${{targets.subpkgdir}}"/etc/ssh/sshd_config.d
           sed -i 's|\(^#Port\)|Include /etc/ssh/sshd_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/sshd_config
+          chmod 600 "${{targets.subpkgdir}}"/etc/ssh/sshd_config
     test:
       environment:
         contents:


### PR DESCRIPTION
Change /etc/ssh/sshd_config permission to 600, this matches
Fedora-like permissions.
