### PR TITLE
boost: switch to shared library naming policy

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -226,10 +226,17 @@ subpackages:
     description: "Development files for Boost"
     dependencies:
       runtime:
-        - boost
+        - boost-tools
         - boost-static
     pipeline:
       - uses: split/dev
+
+  - name: boost-tools
+    description: "Boost development tools"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/* "${{targets.contextdir}}"/usr/bin
 
 update:
   enabled: true

--- a/boost.yaml
+++ b/boost.yaml
@@ -37,6 +37,7 @@ data:
   - name: libs
     items:
       atomic: atomic
+      charconv: charconv
       chrono: chrono
       container: container
       context: context
@@ -47,14 +48,23 @@ data:
       filesystem: filesystem
       graph: graph
       iostreams: iostreams
+      json: json
       math: math
+      nowide: nowide
       prg_exec_monitor: prg_exec_monitor
+      process: process
       program_options: program_options
       random: random
       regex: regex
+      locale: locale
+      log: log
       serialization: serialization
+      stacktrace: stacktrace
+      timer: timer
       thread: thread
+      type_erasure: type_erasure
       unit_test_framework: unit_test_framework
+      url: url
       wave: wave
       wserialization: wserialization
 

--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: "1.89.0"
-  epoch: 0
+  epoch: 1
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"
@@ -64,6 +64,10 @@ var-transforms:
     match: \.
     replace: _
     to: mangled-package-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*$
+    replace: "$1"
+    to: major-minor-version
 
 pipeline:
   - uses: fetch
@@ -186,8 +190,11 @@ subpackages:
         - uses: test/metapackage
 
   - range: libs
-    name: libboost-${{range.key}}
+    name: libboost${{vars.major-minor-version}}-${{range.key}}
     description: "Boost ${{range.key}} library"
+    dependencies:
+      provides:
+        - libboost-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib

--- a/boost.yaml
+++ b/boost.yaml
@@ -207,6 +207,10 @@ subpackages:
     description: "Boost documentation"
     pipeline:
       - uses: split/manpages
+      - runs: |
+          # NOTE: ship license in -docs package so we can keep the main boost package empty
+          mkdir -p "${{targets.contextdir}}"/usr/share/licenses/${{package.name}}
+          mv "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE_1_0.txt "${{targets.contextdir}}"/usr/share/licenses/${{package.name}}
 
   - name: boost-static
     description: "Boost static libraries"
@@ -239,6 +243,8 @@ test:
         - boost-dev
         - gcc
   pipeline:
+    # NOTE: boost main package should always be empty otherwise we break upgrades due to new libraries appearing.
+    - uses: test/emptypackage
     - name: "Verify core tools installation"
       runs: |
         b2 -v

--- a/boost.yaml
+++ b/boost.yaml
@@ -74,10 +74,6 @@ var-transforms:
     match: \.
     replace: _
     to: mangled-package-version
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+).*$
-    replace: "$1"
-    to: major-minor-version
 
 pipeline:
   - uses: fetch
@@ -200,7 +196,7 @@ subpackages:
         - uses: test/metapackage
 
   - range: libs
-    name: libboost${{vars.major-minor-version}}-${{range.key}}
+    name: libboost-${{range.key}}${{package.version}}
     description: "Boost ${{range.key}} library"
     dependencies:
       provides:


### PR DESCRIPTION
Rename libboost-* packages to include soversion so that we can deal with
boost version updates as transitions, improving the general stability of the archive.

Move new shared libraries out of boost and into libboost subpackages.

Move binaries from boost to boost-tools.

These changes ensure co-install-ability between library versions.
