### PR TITLE
langfuse: remediate cves

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse
   version: "3.107.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -70,7 +70,7 @@ pipeline:
         "pnpm.overrides.path-to-regexp=^6.3.0" \
         "pnpm.overrides.prismjs=^1.30.0" \
         "pnpm.overrides.undici=^6.21.2" \
-        "pnpm.overrides.vite=^5.4.19" \
+        "pnpm.overrides.vite=^5.4.20" \
         "pnpm.overrides.vitest=^2.1.9" \
         "pnpm.overrides.ws=^8.17.1" \
         "pnpm.overrides.brace-expansion=^4.0.1" \


### PR DESCRIPTION
Remediate CVE-2025-58751 and CVE-2025-58752
bump vite to 5.4.20

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
