### PR TITLE
Bump malcontent to 1.16.0; try out greenteagc

### DIFF
--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,7 +1,7 @@
 package:
   name: malcontent
-  version: "1.15.1"
-  epoch: 2 # GHSA-jc7w-c686-c4v9
+  version: "1.16.0"
+  epoch: 0
   description: enumerate file capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0
@@ -21,17 +21,13 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/malcontent
       tag: v${{package.version}}
-      expected-commit: dee5201e21d7a3b2ee784d6ec46af0cada5325d0
-
-  - uses: go/bump
-    with:
-      deps: |-
-        github.com/ulikunitz/xz@v0.5.14
+      expected-commit: 81a9d06549aa8d9a55b7208dd0ae8deae9af366a
 
   - uses: go/build
     with:
       packages: ./cmd/mal
       output: mal
+      experiments: greenteagc # leverage the experimental Green Tea GC; easily removable if no improvement
 
 test:
   environment:


### PR DESCRIPTION
This PR bumps malcontent to the latest release and builds the binary using the new Green Tea garbage collector since we're using Go1.25. 

If the new GC doesn't pan out, it's trivial to revert.