### PR TITLE
chisel: switch tests from redis to valkey

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,7 +1,7 @@
 package:
   name: chisel
   version: "1.10.1"
-  epoch: 0
+  epoch: 1
   description: Chisel is a fast TCP/UDP tunnel over HTTP
   copyright:
     - license: MIT
@@ -61,8 +61,8 @@ test:
     contents:
       packages:
         - curl
-        - redis
-        - redis-cli
+        - valkey
+        - valkey-cli
         - wait-for-port
   pipeline:
     - runs: |


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
