### PR TITLE
envoy-ratelimit: switch tests from redis to valkey

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -3,7 +3,7 @@ package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
   version: "0.0.0_git20250908"
-  epoch: 0
+  epoch: 1
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
@@ -37,7 +37,7 @@ test:
   environment:
     contents:
       packages:
-        - redis
+        - valkey
   pipeline:
     - runs: |
         mkdir -p /var/run/nutcracker


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
