### PR TITLE
juicefs-1.3: switch tests from redis to valkey

### DIFF
--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.0"
-  epoch: 5 # GHSA-93mf-426m-g6x9
+  epoch: 6 # GHSA-93mf-426m-g6x9
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0
@@ -99,7 +99,7 @@ test:
       WEBDAV_PASSWORD: minioadmin
     contents:
       packages:
-        - redis
+        - valkey
         - minio
         - mc
         - wait-for-it


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
