### PR TITLE
kayenta-2.46: switch tests from redis to valkey

### DIFF
--- a/kayenta-2.46.yaml
+++ b/kayenta-2.46.yaml
@@ -1,7 +1,7 @@
 package:
   name: kayenta-2.46
   version: "2.46.0"
-  epoch: 0
+  epoch: 1
   description: Automated Canary Service
   copyright:
     - license: Apache-2.0
@@ -50,7 +50,7 @@ test:
     contents:
       packages:
         - jq
-        - redis
+        - valkey
         - curl
     environment:
       JAVA_HOME: /usr/lib/jvm/java-${{vars.java-version}}-openjdk


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
