### PR TITLE
nextcloud-server-31: switch tests from redis to valkey

### DIFF
--- a/nextcloud-server-31.yaml
+++ b/nextcloud-server-31.yaml
@@ -2,7 +2,7 @@
 package:
   name: nextcloud-server-31
   version: "31.0.8"
-  epoch: 0
+  epoch: 1
   description: "Nextcloud server, a safe home for all your data"
   copyright:
     - license: AGPL-3.0-or-later
@@ -67,11 +67,11 @@ package:
       - php-${{vars.php-version}}-xmlwriter
       - php-${{vars.php-version}}-zip
       - procps
-      - redis
       - rsync
       - rsync
       - sed
       - su-exec
+      - valkey
     provides:
       - nextcloud-server=${{package.full-version}}
   scriptlets:


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
