### PR TITLE
redka: switch tests from redis to valkey

### DIFF
--- a/redka.yaml
+++ b/redka.yaml
@@ -45,6 +45,6 @@ test:
     - runs: |
         redka&
         sleep 2
-        redis-cli ping
+        valkey-cli ping
         killall redka
         redka --help

--- a/redka.yaml
+++ b/redka.yaml
@@ -1,7 +1,7 @@
 package:
   name: redka
   version: "0.6.0"
-  epoch: 2 # CVE-2025-47907
+  epoch: 3 # CVE-2025-47907
   description: Redis re-implemented with SQLite
   copyright:
     - license: BSD-3-Clause
@@ -40,7 +40,7 @@ test:
   environment:
     contents:
       packages:
-        - redis-cli
+        - valkey-cli
   pipeline:
     - runs: |
         redka&


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
