### PR TITLE
Fix CMake FTBFSes (and convert recipes to use `git-checkout` instead of `fetch`)

### DIFF
--- a/cmake-3.yaml
+++ b/cmake-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-3
   version: 3.31.8
-  epoch: 1
+  epoch: 2
   description: "CMake 3.x is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provides:
@@ -31,10 +31,13 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.cmake.org/files/v3.31/cmake-${{package.version}}.tar.gz
-      expected-sha256: e3cde3ca83dc2d3212105326b8f1b565116be808394384007e7ef1c253af6caa
+      expected-commit: dbe9d4593f4b7a2b1eb87826949f09af0268240a
+      repository: https://gitlab.kitware.com/cmake/cmake
+      tag: v${{package.version}}
+      cherry-picks: |
+        master/c8143074cf3954b1e169904eb9d843cfbe14acc3: cmCTestCurl: Avoid using undocumented type for CURLOPT_PROXYTYPE values
 
   # Depending on system libraries for everything we have, as if any of
   # them use cmake they are built with cmake-bootstrap instead. Apart
@@ -61,9 +64,9 @@ pipeline:
 update:
   enabled: true
   manual: true # be careful upgrading cmake as it is a core package
-  release-monitor:
-    identifier: 306
-    version-filter-prefix: "3."
+  git:
+    strip-prefix: v
+    tag-filter-contains: v3.
 
 test:
   environment:

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 4.1.1
-  epoch: 0
+  epoch: 1
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10
@@ -30,10 +30,13 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/Kitware/CMake/releases/download/v${{package.version}}/cmake-${{package.version}}.tar.gz
-      expected-sha256: b29f6f19733aa224b7763507a108a427ed48c688e1faf22b29c44e1c30549282
+      expected-commit: ba8c4a15f10e2636405106ff0dc92b79d94a616c
+      repository: https://gitlab.kitware.com/cmake/cmake
+      tag: v${{package.version}}
+      cherry-picks: |
+        master/c8143074cf3954b1e169904eb9d843cfbe14acc3: cmCTestCurl: Avoid using undocumented type for CURLOPT_PROXYTYPE values
 
   # Depending on system libraries for everything we have, as if any of
   # them use cmake they are built with cmake-bootstrap instead. Apart
@@ -60,8 +63,9 @@ pipeline:
 update:
   enabled: true
   manual: true # be careful upgrading cmake as it is a core package
-  release-monitor:
-    identifier: 306
+  git:
+    strip-prefix: v
+    tag-filter-contains: v4.
 
 test:
   environment:


### PR DESCRIPTION
curl's commit https://github.com/curl/curl/commit/1a12663d06d9c42fd40a8655d5247f7afeeb8e1e changed the size of the "CURLPROXY_*" macros from "int" to "long". CMake needs to be patched to build with this.

Fixes: #65932 
Fixes: #65931 