### PR TITLE
WIP fix(tiff): Patch package for CVE-2024-13978, CVE-2025-8176, CVE-2025-9165 and CVE-2025-8961

### DIFF
--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.7.0
-  epoch: 5
+  epoch: 6
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff
@@ -23,12 +23,22 @@ environment:
       - zlib-dev
       - zstd-dev
 
+# Failed to apply the following patches
+# e8c9d6c616b19438695fd829e58ae4fde5bfbc22: CVE-2025-8177 bad object
+# 8a7a48d7a645992ca83062b3a1873c951661e2b3: CVE-2025-8851 merge conflict
 pipeline:
   - uses: git-checkout
     with:
       expected-commit: 9dff73bebc5661f2dace6f16e14cf9e857172f4e
       repository: https://gitlab.com/libtiff/libtiff.git
       tag: v${{package.version}}
+      cherry-picks: |
+        master/2ebfffb0e8836bfb1cd7d85c059cd285c59761a4: CVE-2024-13978
+        master/3994cf3b3bc6b54c32f240ca5a412cffa11633fa: CVE-2025-8176
+        master/ce46f002eca4148497363f80fab33f9396bcbeda: CVE-2025-8176
+        master/ecc4ddbf1f0fed7957d1e20361e37f01907898e0: CVE-2025-8176
+        master/ed141286a37f6e5ddafb5069347ff5d587e7a4e0: CVE-2025-9165
+        master/0ac97aa7a5bffddd88f7cdbe517264e9db3f5bd5: CVE-2025-8961
 
   - runs: |
       autoreconf -fiv


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2024-13978-->
<!--ci-cve-scan:must-fix: CVE-2025-8176-->
<!--ci-cve-scan:must-fix: CVE-2025-9165-->
<!--ci-cve-scan:must-fix: CVE-2025-8961-->

