### PR TITLE
restore: kubectl-1.29

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -1,1 +1,3 @@
-temporary-package-1.0-r0.apk
+kubectl-1.29-1.29.5-r0.apk
+kubectl-1.29-default-1.29.5-r0.apk
+kubectl-bash-completion-1.29-1.29.5-r0.apk


### PR DESCRIPTION
Restore kubectl-1.29 and related subpackages at most recent version
published prior to GC in Wolfi.
