### PR TITLE
backfill: zig-0.10.1-r0

### DIFF
--- a/backfill-packages.txt
+++ b/backfill-packages.txt
@@ -1,14 +1,1 @@
-ca-certificates-bundle-20240315-r4
-glibc-2.39-r6
-glibc-locale-posix-2.39-r6
-ld-linux-2.39-r6
-libcrypto3-3.3.1-r3
-libgcc-13.2.0-r7
-libssl3-3.3.1-r3
-libstdc++-13.2.0-r7
-openssl-3.3.1-r3
-openssl-provider-legacy-3.3.1-r3
-wolfi-baselayout-20230201-r12
-binutils-2.42-r1.apk
-binutils-dev-2.42-r1.apk
-binutils-gold-2.42-r1.apk
+zig-0.10.1-r0.apk


### PR DESCRIPTION
zig-0.10.x got recently garbage collected, but as it seemed to be in use, we want to restore it back. But for restoration to work, we first need to backfill it back to apk.cgr.dev as it was a very old package.