### PR TITLE
feat(tiff): patches for several CVEs

### DIFF
--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.7.0
-  epoch: 5
+  epoch: 6
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff
@@ -29,6 +29,22 @@ pipeline:
       expected-commit: 9dff73bebc5661f2dace6f16e14cf9e857172f4e
       repository: https://gitlab.com/libtiff/libtiff.git
       tag: v${{package.version}}
+
+  # CVE-2024-13978.patch https://gitlab.com/libtiff/libtiff/-/commit/2ebfffb0e8836bfb1cd7d85c059cd285c59761a4
+  # CVE-2025-8176.patch: https://gitlab.com/libtiff/libtiff/-/commit/fe10872e53efba9cc36c66ac4ab3b41a839d5172
+  # CVE-2025-8177.patch: https://gitlab.com/libtiff/libtiff/-/commit/e8c9d6c616b19438695fd829e58ae4fde5bfbc22
+  # CVE-2025-8961.patch: https://gitlab.com/libtiff/libtiff/-/merge_requests/753
+  # CVE-2025-9165.patch: https://gitlab.com/libtiff/libtiff/-/commit/ed141286a37f6e5ddafb5069347ff5d587e7a4e0
+  # CVE-2025-8851: fixed present since version 4.7.0 (https://gitlab.com/libtiff/libtiff/-/releases/v4.7.0, \
+  #   https://gitlab.com/libtiff/libtiff/-/commit/8a7a48d7a645992ca83062b3a1873c951661e2b3)
+  - uses: patch
+    with:
+      patches: |
+        CVE-2024-13978.patch
+        CVE-2025-8176.patch
+        CVE-2025-8177.patch
+        CVE-2025-8961.patch
+        CVE-2025-9165.patch
 
   - runs: |
       autoreconf -fiv

--- a/tiff/CVE-2024-13978.patch
+++ b/tiff/CVE-2024-13978.patch
@@ -1,0 +1,42 @@
+From 2ebfffb0e8836bfb1cd7d85c059cd285c59761a4 Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Sat, 5 Oct 2024 09:45:30 -0700
+Subject: [PATCH] Check TIFFTAG_TILELENGTH and TIFFTAGTILEWIDTH for valid
+ input, addresses issue #650
+
+---
+ tools/tiff2pdf.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index 6dfc239f1..2010feea8 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -1371,8 +1371,24 @@ void t2p_read_tiff_init(T2P *t2p, TIFF *input)
+             t2p->pdf_xrefcount += (t2p->tiff_tiles[i].tiles_tilecount - 1) * 2;
+             TIFFGetField(input, TIFFTAG_TILEWIDTH,
+                          &(t2p->tiff_tiles[i].tiles_tilewidth));
++            if (t2p->tiff_tiles[i].tiles_tilewidth < 1)
++            {
++                TIFFError(TIFF2PDF_MODULE, "Invalid tile width (%d), %s",
++                          t2p->tiff_tiles[i].tiles_tilewidth,
++                          TIFFFileName(input));
++                t2p->t2p_error = T2P_ERR_ERROR;
++                return;
++            }
+             TIFFGetField(input, TIFFTAG_TILELENGTH,
+                          &(t2p->tiff_tiles[i].tiles_tilelength));
++            if (t2p->tiff_tiles[i].tiles_tilelength < 1)
++            {
++                TIFFError(TIFF2PDF_MODULE, "Invalid tile length (%d), %s",
++                          t2p->tiff_tiles[i].tiles_tilelength,
++                          TIFFFileName(input));
++                t2p->t2p_error = T2P_ERR_ERROR;
++                return;
++            }
+             t2p->tiff_tiles[i].tiles_tiles = (T2P_TILE *)_TIFFmalloc(
+                 TIFFSafeMultiply(tmsize_t, t2p->tiff_tiles[i].tiles_tilecount,
+                                  sizeof(T2P_TILE)));
+-- 
+GitLab
+

--- a/tiff/CVE-2025-8176.patch
+++ b/tiff/CVE-2025-8176.patch
@@ -1,0 +1,113 @@
+From 3994cf3b3bc6b54c32f240ca5a412cffa11633fa Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Mon, 19 May 2025 10:53:30 -0700
+Subject: [PATCH 1/3] Don't skip the first line of the input image.  Addresses
+ issue #703
+
+---
+ tools/tiffdither.c | 4 ++--
+ tools/tiffmedian.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tools/tiffdither.c b/tools/tiffdither.c
+index 714fe03d4..bfed6df18 100644
+--- a/tools/tiffdither.c
++++ b/tools/tiffdither.c
+@@ -98,7 +98,7 @@ static int fsdither(TIFF *in, TIFF *out)
+     nextptr = nextline;
+     for (j = 0; j < imagewidth; ++j)
+         *nextptr++ = *inptr++;
+-    for (i = 1; i < imagelength; ++i)
++    for (i = 0; i < imagelength; ++i)
+     {
+         tmpptr = thisline;
+         thisline = nextline;
+@@ -146,7 +146,7 @@ static int fsdither(TIFF *in, TIFF *out)
+                     nextptr[0] += v / 16;
+             }
+         }
+-        if (TIFFWriteScanline(out, outline, i - 1, 0) < 0)
++        if (TIFFWriteScanline(out, outline, i, 0) < 0)
+             goto skip_on_error;
+     }
+     goto exit_label;
+diff --git a/tools/tiffmedian.c b/tools/tiffmedian.c
+index 02b0bc2b4..f6cf26c2c 100644
+--- a/tools/tiffmedian.c
++++ b/tools/tiffmedian.c
+@@ -917,7 +917,7 @@ static void quant_fsdither(TIFF *in, TIFF *out)
+     outline = (unsigned char *)_TIFFmalloc(TIFFScanlineSize(out));
+ 
+     GetInputLine(in, 0, goto bad); /* get first line */
+-    for (i = 1; i <= imagelength; ++i)
++    for (i = 0; i <= imagelength; ++i)
+     {
+         SWAP(short *, thisline, nextline);
+         lastline = (i >= imax);
+@@ -997,7 +997,7 @@ static void quant_fsdither(TIFF *in, TIFF *out)
+                 nextptr += 3;
+             }
+         }
+-        if (TIFFWriteScanline(out, outline, i - 1, 0) < 0)
++        if (TIFFWriteScanline(out, outline, i, 0) < 0)
+             break;
+     }
+ bad:
+-- 
+GitLab
+
+
+From ce46f002eca4148497363f80fab33f9396bcbeda Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Sat, 24 May 2025 21:25:16 -0700
+Subject: [PATCH 2/3] Fix tiffmedian bug #707
+
+---
+ tools/tiffmedian.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tools/tiffmedian.c b/tools/tiffmedian.c
+index f6cf26c2c..8c9978bab 100644
+--- a/tools/tiffmedian.c
++++ b/tools/tiffmedian.c
+@@ -414,7 +414,10 @@ static void get_histogram(TIFF *in, Colorbox *box)
+     for (i = 0; i < imagelength; i++)
+     {
+         if (TIFFReadScanline(in, inputline, i, 0) <= 0)
+-            break;
++        {
++            fprintf(stderr, "Error reading scanline\n");
++            exit(EXIT_FAILURE);
++        }
+         inptr = inputline;
+         for (j = imagewidth; j-- > 0;)
+         {
+-- 
+GitLab
+
+
+From ecc4ddbf1f0fed7957d1e20361e37f01907898e0 Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Sat, 24 May 2025 21:38:09 -0700
+Subject: [PATCH 3/3] conflict resolution
+
+---
+ tools/tiffmedian.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/tiffmedian.c b/tools/tiffmedian.c
+index 8c9978bab..47e0524bc 100644
+--- a/tools/tiffmedian.c
++++ b/tools/tiffmedian.c
+@@ -920,7 +920,7 @@ static void quant_fsdither(TIFF *in, TIFF *out)
+     outline = (unsigned char *)_TIFFmalloc(TIFFScanlineSize(out));
+ 
+     GetInputLine(in, 0, goto bad); /* get first line */
+-    for (i = 0; i <= imagelength; ++i)
++    for (i = 0; i < imagelength; ++i)
+     {
+         SWAP(short *, thisline, nextline);
+         lastline = (i >= imax);
+-- 
+GitLab
+

--- a/tiff/CVE-2025-8177.patch
+++ b/tiff/CVE-2025-8177.patch
@@ -1,0 +1,60 @@
+From 75d8eca6f106c01aadf76b8500a7d062b12f2d82 Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Thu, 19 Jun 2025 11:51:33 -0700
+Subject: [PATCH 1/2] Fix for thumbnail issue #715
+
+---
+ tools/thumbnail.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/tools/thumbnail.c b/tools/thumbnail.c
+index 9cade913..63e6fad7 100644
+--- a/tools/thumbnail.c
++++ b/tools/thumbnail.c
+@@ -620,7 +620,15 @@ static void setrow(uint8_t *row, uint32_t nrows, const uint8_t *rows[])
+             }
+             acc += bits[*src & mask1];
+         }
+-        *row++ = cmap[(255 * acc) / area];
++        if (255 * acc / area < 256)
++        {
++            *row++ = cmap[(255 * acc) / area];
++        }
++        else
++        {
++            fprintf(stderr, "acc=%d, area=%d\n", acc, area);
++            row++;
++        }
+     }
+ }
+ 
+-- 
+GitLab
+
+
+From e8c9d6c616b19438695fd829e58ae4fde5bfbc22 Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Mon, 23 Jun 2025 10:09:07 -0700
+Subject: [PATCH 2/2] set a default value - assumes cmap[0] was not, itself,
+ uninitialized
+
+---
+ tools/thumbnail.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/thumbnail.c b/tools/thumbnail.c
+index 63e6fad7..7e21f521 100644
+--- a/tools/thumbnail.c
++++ b/tools/thumbnail.c
+@@ -627,7 +627,7 @@ static void setrow(uint8_t *row, uint32_t nrows, const uint8_t *rows[])
+         else
+         {
+             fprintf(stderr, "acc=%d, area=%d\n", acc, area);
+-            row++;
++            *row++ = cmap[0];
+         }
+     }
+ }
+-- 
+GitLab
+

--- a/tiff/CVE-2025-8961.patch
+++ b/tiff/CVE-2025-8961.patch
@@ -1,0 +1,72 @@
+From c1300ea559e6346f832f30b57643e54e0a8fa313 Mon Sep 17 00:00:00 2001
+From: Lee Howard <faxguy@howardsilvan.com>
+Date: Fri, 5 Sep 2025 11:14:42 -0700
+Subject: [PATCH] fix double-free and memory leak exposed by issue #721
+
+---
+ tools/tiffcrop.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index ae414efc..be250cc9 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -1072,6 +1072,7 @@ static int readContigTilesIntoBuffer(TIFF *in, uint8_t *buf,
+                                           "Unable to extract row %" PRIu32
+                                           " from tile %" PRIu32,
+                                           row, TIFFCurrentTile(in));
++                                _TIFFfree(tilebuf);
+                                 return 1;
+                             }
+                             break;
+@@ -1086,6 +1087,7 @@ static int readContigTilesIntoBuffer(TIFF *in, uint8_t *buf,
+                                               "Unable to extract row %" PRIu32
+                                               " from tile %" PRIu32,
+                                               row, TIFFCurrentTile(in));
++                                    _TIFFfree(tilebuf);
+                                     return 1;
+                                 }
+                                 break;
+@@ -1098,6 +1100,7 @@ static int readContigTilesIntoBuffer(TIFF *in, uint8_t *buf,
+                                           "Unable to extract row %" PRIu32
+                                           " from tile %" PRIu32,
+                                           row, TIFFCurrentTile(in));
++                                _TIFFfree(tilebuf);
+                                 return 1;
+                             }
+                             break;
+@@ -1110,6 +1113,7 @@ static int readContigTilesIntoBuffer(TIFF *in, uint8_t *buf,
+                                           "Unable to extract row %" PRIu32
+                                           " from tile %" PRIu32,
+                                           row, TIFFCurrentTile(in));
++                                _TIFFfree(tilebuf);
+                                 return 1;
+                             }
+                             break;
+@@ -1124,12 +1128,14 @@ static int readContigTilesIntoBuffer(TIFF *in, uint8_t *buf,
+                                           "Unable to extract row %" PRIu32
+                                           " from tile %" PRIu32,
+                                           row, TIFFCurrentTile(in));
++                                _TIFFfree(tilebuf);
+                                 return 1;
+                             }
+                             break;
+                         default:
+                             TIFFError("readContigTilesIntoBuffer",
+                                       "Unsupported bit depth %" PRIu16, bps);
++                            _TIFFfree(tilebuf);
+                             return 1;
+                     }
+                 }
+@@ -2924,7 +2930,7 @@ failure:
+      * all buffers need to be released. */
+ 
+     /* If we did not use the read buffer as the crop buffer */
+-    if (read_buff)
++    if (read_buff && read_buff != crop_buff)
+         _TIFFfree(read_buff);
+ 
+     if (crop_buff)
+-- 
+GitLab
+

--- a/tiff/CVE-2025-9165.patch
+++ b/tiff/CVE-2025-9165.patch
@@ -1,0 +1,28 @@
+From ed141286a37f6e5ddafb5069347ff5d587e7a4e0 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 8 Aug 2025 21:35:30 +0200
+Subject: [PATCH] tiffcmp: fix memory leak when second file cannot be opened.
+
+Closes #728, #729
+---
+ tools/tiffcmp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/tools/tiffcmp.c b/tools/tiffcmp.c
+index 529c1cdc7..88d9470f5 100644
+--- a/tools/tiffcmp.c
++++ b/tools/tiffcmp.c
+@@ -105,7 +105,10 @@ int main(int argc, char *argv[])
+         return (2);
+     tif2 = TIFFOpen(argv[optind + 1], "r");
+     if (tif2 == NULL)
++    {
++        TIFFClose(tif1);
+         return (2);
++    }
+     dirnum = 0;
+     while (tiffcmp(tif1, tif2))
+     {
+-- 
+GitLab
+


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

CVEs remediated:
 - CVE-2024-13978
 - CVE-2025-8176
 - CVE-2025-8177
 - CVE-2025-8961
 - CVE-2025-9165

CVE-2025-8851 is fixed since v4.7.0: https://gitlab.com/libtiff/libtiff/-/releases/v4.7.0

<!--ci-cve-scan:fail-any-->
