### PR TITLE
ffmpeg-7: remediate cve and fix ftbfs

### DIFF
--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -2,7 +2,7 @@
 package:
   name: ffmpeg-7
   version: "7.1.1"
-  epoch: 10
+  epoch: 11
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -35,6 +35,7 @@ environment:
       - dav1d-dev
       - expat-dev
       - fontconfig-dev
+      - freetype-dev
       - harfbuzz-dev
       - lame-dev
       - libogg-dev
@@ -68,6 +69,10 @@ pipeline:
       tag: n${{package.version}}
       cherry-picks: |
         master/d1ed5c06e3edc5f2b5f3664c80121fa55b0baa95: unbreak build with latest svtav1
+
+  - uses: patch
+    with:
+      patches: CVE-2025-9951.patch
 
   - runs: |
       ./configure \

--- a/ffmpeg-7/CVE-2025-9951.patch
+++ b/ffmpeg-7/CVE-2025-9951.patch
@@ -1,0 +1,59 @@
+From 9e056ef14574b0f33a3e3348159c18c61fbc885e Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Tue, 5 Aug 2025 23:42:23 +0200
+Subject: [PATCH] avcodec/jpeg2000dec: implement cdef remapping during pixel
+ format matching
+
+Fixes: out of array access
+Fixes: poc.jp2
+
+Found-by: Andy Nguyen <theflow@google.com>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+(cherry picked from commit 01a292c7e36545ddeb3c7f79cd02e2611cd37d73)
+---
+ libavcodec/jpeg2000dec.c | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/jpeg2000dec.c b/libavcodec/jpeg2000dec.c
+index 2e09b279dc..c3f6806e5b 100644
+--- a/libavcodec/jpeg2000dec.c
++++ b/libavcodec/jpeg2000dec.c
+@@ -271,6 +271,25 @@ static int get_siz(Jpeg2000DecoderContext *s)
+         return AVERROR_INVALIDDATA;
+     }
+
++    for (i = 0; i < s->ncomponents; i++) {
++        if (s->cdef[i] < 0) {
++            for (i = 0; i < s->ncomponents; i++) {
++                s->cdef[i] = i + 1;
++            }
++            if ((s->ncomponents & 1) == 0)
++                s->cdef[s->ncomponents-1] = 0;
++        }
++    }
++    // after here we no longer have to consider negative cdef
++
++    int cdef_used = 0;
++    for (i = 0; i < s->ncomponents; i++)
++        cdef_used |= 1<<s->cdef[i];
++
++    // Check that the channels we have are what we expect for the number of components
++    if (cdef_used != ((int[]){0,2,3,14,15})[s->ncomponents])
++        return AVERROR_INVALIDDATA;
++
+     for (i = 0; i < s->ncomponents; i++) { // Ssiz_i XRsiz_i, YRsiz_i
+         uint8_t x    = bytestream2_get_byteu(&s->g);
+         s->cbps[i]   = (x & 0x7f) + 1;
+@@ -283,7 +302,9 @@ static int get_siz(Jpeg2000DecoderContext *s)
+             av_log(s->avctx, AV_LOG_ERROR, "Invalid sample separation %d/%d\n", s->cdx[i], s->cdy[i]);
+             return AVERROR_INVALIDDATA;
+         }
+-        log2_chroma_wh |= s->cdy[i] >> 1 << i * 4 | s->cdx[i] >> 1 << i * 4 + 2;
++        int i_remapped = s->cdef[i] ? s->cdef[i]-1 : (s->ncomponents-1);
++
++        log2_chroma_wh |= s->cdy[i] >> 1 << i_remapped * 4 | s->cdx[i] >> 1 << i_remapped * 4 + 2;
+     }
+
+     s->numXtiles = ff_jpeg2000_ceildiv(s->width  - s->tile_offset_x, s->tile_width);
+--
+2.51.0


### PR DESCRIPTION
Fix ftbfs:
Add freetype-dev as a dependency to build ffmpeg-7

Remediate CVE-2025-9951:
A bit of archaeology was needed to find the right patch.
From the advisory page we can see that Andy Nguyen was the reporter.
Found the correct patch as it was sent upstream by Andy Nguyen and did
fix the JPEG2000 decoder.
Patch was sent upstream to the ffmpeg mailing list:
https://lists.ffmpeg.org/archives/list/ffmpeg-devel@ffmpeg.org/message/DPO4IYMR6CK44OSEDAXOIHTLJL2NWQRJ/

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
