### PR TITLE
orthanc*: pin boost to 1.88

### DIFF
--- a/orthanc-dicomweb.yaml
+++ b/orthanc-dicomweb.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-dicomweb
   version: "1.21"
-  epoch: 0
+  epoch: 1
   description: DICOMweb plugin for Orthanc DICOM server - RESTful DICOM services
   copyright:
     - license: AGPL-3.0-or-later
@@ -15,7 +15,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - cmake-3

--- a/orthanc-explorer2.yaml
+++ b/orthanc-explorer2.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-explorer2
   version: "1.9.0"
-  epoch: 0
+  epoch: 1
   description: Modern web interface for Orthanc DICOM server - Enhanced Explorer
   copyright:
     - license: AGPL-3.0-or-later
@@ -15,7 +15,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - e2fsprogs-dev

--- a/orthanc-ohif.yaml
+++ b/orthanc-ohif.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-ohif
   version: "1.7"
-  epoch: 0
+  epoch: 1
   description: OHIF plugin for Orthanc DICOM server - modern DICOM web viewer
   copyright:
     - license: AGPL-3.0-or-later
@@ -17,7 +17,7 @@ environment:
   contents:
     packages:
       - bash
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - cmake-3

--- a/orthanc-postgresql.yaml
+++ b/orthanc-postgresql.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-postgresql
   version: "9.0"
-  epoch: 1
+  epoch: 2
   description: PostgreSQL plugin for Orthanc DICOM server
   copyright:
     - license: AGPL-3.0-or-later
@@ -18,7 +18,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - e2fsprogs-dev

--- a/orthanc-webviewer.yaml
+++ b/orthanc-webviewer.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-webviewer
   version: "2.10"
-  epoch: 2
+  epoch: 3
   description: Web viewer plugin for Orthanc DICOM server - medical image visualization
   copyright:
     - license: AGPL-3.0-or-later
@@ -15,7 +15,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - cmake-3

--- a/orthanc.yaml
+++ b/orthanc.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc
   version: "1.12.9"
-  epoch: 1
+  epoch: 2
   description: "Orthanc - a lightweight DICOM server for medical imaging"
   copyright:
     - license: "AGPL-3.0-or-later"
@@ -16,7 +16,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - curl-dev


### PR DESCRIPTION
orthanc is not compatible with the headers only version of boost system
in 1.89; fix to 1.88 until upstream moves forward.
