### PR TITLE
boost-1.89: transition

### DIFF
--- a/libcmis.yaml
+++ b/libcmis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcmis
   version: 0.6.2
-  epoch: 5
+  epoch: 6
   description: C/C++ CMIS client library
   copyright:
     - license: GPL-2.0-or-later

--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: pdns-5.2
   version: "5.2.5"
-  epoch: 0
+  epoch: 1
   description: PowerDNS Authoritative Server
   copyright:
     - license: GPL-2.0-or-later

--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -105,6 +105,8 @@ pipeline:
       repository: https://github.com/PowerDNS/pdns
       expected-commit: 3955b468e9f9cbf81590f86f8e2cc6a75f4ff889
       tag: rec-${{package.version}}
+      cherry-picks: |
+        master/e096f48218dd2ea82fc907ff62e4cbced121ca8b: Fix Boost system lib dependency: it is no longer available since 1.89
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
no change rebuild for a handful of packages that have not moved to the
new boost release yet.
