### PR TITLE
grafana-image-renderer: remediate cve

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: "4.0.14"
-  epoch: 0
+  epoch: 1
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,7 @@ pipeline:
   - runs: |
       npm pkg set resolutions.on-headers=1.1.0
       npm pkg set resolutions.@eslint/plugin-kit=0.3.4
+      npm pkg set resolutions.axios=1.12.0
       yarn install --frozen-lockfile
       yarn build
 


### PR DESCRIPTION
Remediate GHSA-4hjh-wcwx-xvwj
bump axios to 1.12.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
