### PR TITLE
glycin-2: add package

### DIFF
--- a/glycin-2.yaml
+++ b/glycin-2.yaml
@@ -1,0 +1,53 @@
+package:
+  name: glycin-2
+  version: 2.0.0
+  epoch: 0
+  description: Glycin allows to decode, edit, and create images and read metadata.
+  copyright:
+    - license: MPL-2.0 OR LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - aom-libs
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cairo-dev
+      - glib-dev
+      - glib-gir
+      - gobject-introspection-dev
+      - gtk-4-dev
+      - lcms2-dev
+      - libbz2-1
+      - libheif-dev
+      - libjxl-dev
+      - librsvg-dev
+      - libseccomp-dev
+      - meson
+      - pkgconf-dev
+      - rust
+      - shared-mime-info
+      - vala
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.gnome.org/GNOME/glycin.git
+      tag: ${{package.version}}
+      expected-commit: 724f18c5f3519885995428a7e2e6e5df9ca2ab27
+
+  - uses: meson/configure
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+update:
+  enabled: true
+  git:
+    tag-filter-prefix: 2.

--- a/libjxl.yaml
+++ b/libjxl.yaml
@@ -1,0 +1,89 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: libjxl
+  version: 0.10.4_git20250914
+  epoch: 0
+  description: JPEG XL image format reference implementation
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - brotli-dev
+      - build-base
+      - clang
+      - cmake
+      - giflib-dev
+      - highway-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - lld
+      - ninja
+      - pkgconf
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/libjxl/libjxl
+      branch: main
+      expected-commit: b662606edeba62fb7c4dc907bd3a00caf6885f1a
+      recurse-submodules: true
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_TESTING=OFF
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: libjxl-dev
+    description: libjxl development files
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          # It conflicts with brotli-dev, so remove the file and provide it via brotli-dev
+          rm -rf "${{targets.subpkgdir}}"/usr/include/brotli
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/libbrotlicommon.so
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/libbrotlidec.so
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/pkgconfig/libbrotlicommon.pc
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/pkgconfig/libbrotlidec.pc
+          rm -rf "${{targets.subpkgdir}}"/usr/lib/pkgconfig/libbrotlienc.pc
+    dependencies:
+      runtime:
+        - libjxl
+        - brotli-dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - name: libjxl-tools
+    description: JPEG XL command-line tools (cjxl, djxl, benchmark_xl)
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          for b in cjxl djxl benchmark_xl brotli cjpegli djpegli jxlinfo jxltran; do
+            if [ -x "${{targets.destdir}}/usr/bin/$b" ]; then
+              mv "${{targets.destdir}}/usr/bin/$b" "${{targets.subpkgdir}}/usr/bin/"
+            fi
+          done
+    test:
+      pipeline:
+        - runs: |
+            for b in cjxl djxl benchmark_xl brotli cjpegli djpegli jxlinfo jxltran; do
+              $b --help
+            done
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: This project doesn't do releases for long time and everything is commit based


### PR DESCRIPTION
Adds needed dependencies for gdk-pixbuf.

Related: https://github.com/wolfi-dev/os/pull/66066

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
