### PR TITLE
openjdk-25: GA release

### DIFF
--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -235,7 +235,7 @@ update:
   enabled: true
   shared: true
   version-transform:
-    - match: ^(.+)_pre(\d+)$
+    - match: ^(\d+)_pre(\d+)$
       replace: $1+$2
   github:
     identifier: openjdk/jdk25u

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,6 +1,6 @@
 package:
   name: openjdk-25
-  version: "25_pre36"
+  version: "25_rc36"
   epoch: 0
   description: OpenJDK 25
   copyright:
@@ -24,7 +24,7 @@ package:
 
 var-transforms:
   - from: ${{package.version}}
-    match: _pre
+    match: _rc
     replace: +
     to: upstream-tag
 
@@ -221,7 +221,7 @@ update:
   shared: true
   version-transform:
     - match: ^(\d+)\+(\d+)$
-      replace: $1_pre$2
+      replace: ${1}_rc${2}
   github:
     identifier: openjdk/jdk25u
     strip-prefix: jdk-

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -92,7 +92,7 @@ pipeline:
         --enable-dtrace=no \
         --with-zlib=system \
         --with-debug-level=release \
-        --with-native-debug-symbols=none \
+        --with-native-debug-symbols=external \
         --with-external-symbols-in-bundles=none \
         --with-cacerts-file=/etc/ssl/certs/java/cacerts \
         --with-jvm-variants=server \

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -105,7 +105,7 @@ pipeline:
         --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
-        --with-version-string=""
+        --with-version-string="${{vars.upstream-tag}}-wolfi-r0"
 
   - runs: make jdk-image legacy-jre-image
 

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -21,6 +21,8 @@ package:
       - libxtst
       - ttf-dejavu
       - zlib
+    provides:
+      - ${{package.name}}-jmods
 
 var-transforms:
   - from: ${{package.version}}
@@ -191,10 +193,18 @@ subpackages:
       runtime:
         - java-common-jre
         - ${{package.name}}-jre
+      provides:
+        - default-jvm=1.25
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: default-jvm
+            real-pkg-name: ${{subpkg.name}}
 
   - name: "${{package.name}}-default-jdk"
     description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
@@ -204,6 +214,7 @@ subpackages:
         - ${{package.name}}
       provider-priority: 5
       provides:
+        - default-jdk=1.25
         - ${{package.name}}-jre=${{package.full-version}}
     pipeline:
       - runs: |
@@ -211,6 +222,10 @@ subpackages:
           ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
     test:
       pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: default-jdk
+            real-pkg-name: ${{subpkg.name}}
         - uses: test/virtualpackage
           with:
             virtual-pkg-name: ${{package.name}}-jre

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -7,20 +7,8 @@ package:
     - license: GPL-2.0-with-classpath-exception
   dependencies:
     runtime:
-      - alsa-lib
-      - freetype
-      - giflib
       - java-cacerts
-      - lcms2
-      - libfontconfig1
-      - libjpeg-turbo
-      - libx11
-      - libxext
-      - libxi
-      - libxrender
-      - libxtst
       - ttf-dejavu
-      - zlib
     provides:
       - ${{package.name}}-jmods
 
@@ -141,17 +129,7 @@ subpackages:
     description: "OpenJDK 25 Java Runtime Environment"
     dependencies:
       runtime:
-        - alsa-lib
-        - freetype
-        - giflib
         - java-cacerts
-        - libfontconfig1
-        - libjpeg-turbo
-        - libx11
-        - libxext
-        - libxi
-        - libxrender
-        - libxtst
         - ttf-dejavu
       provider-priority: 10
     pipeline:

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -185,7 +185,7 @@ subpackages:
             real-pkg-name: ${{subpkg.name}}
 
   - name: "${{package.name}}-default-jdk"
-    description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
+    description: "Use the openjdk-25 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
         - java-common

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -21,8 +21,6 @@ package:
       - libxtst
       - ttf-dejavu
       - zlib
-    provides:
-      - ${{package.name}}-jmods
 
 var-transforms:
   - from: ${{package.version}}
@@ -193,18 +191,10 @@ subpackages:
       runtime:
         - java-common-jre
         - ${{package.name}}-jre
-      provides:
-        - default-jvm=1.25
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: default-jvm
-            real-pkg-name: ${{subpkg.name}}
 
   - name: "${{package.name}}-default-jdk"
     description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
@@ -214,7 +204,6 @@ subpackages:
         - ${{package.name}}
       provider-priority: 5
       provides:
-        - default-jdk=1.25
         - ${{package.name}}-jre=${{package.full-version}}
     pipeline:
       - runs: |
@@ -222,10 +211,6 @@ subpackages:
           ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
     test:
       pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: default-jdk
-            real-pkg-name: ${{subpkg.name}}
         - uses: test/virtualpackage
           with:
             virtual-pkg-name: ${{package.name}}-jre

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,6 +1,6 @@
 package:
   name: openjdk-25
-  version: "25_beta36"
+  version: "25"
   epoch: 0
   description: OpenJDK 25
   copyright:
@@ -66,7 +66,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openjdk/jdk25u
-      tag: jdk-${{vars.mangled-package-version}}
+      tag: jdk-${{vars.mangled-package-version}}-ga
       expected-commit: 6c48f4ed707bf0b15f9b6098de30db8aae6fa40f
 
   - working-directory: /home/build/googletest
@@ -241,7 +241,7 @@ update:
     identifier: openjdk/jdk25u
     strip-prefix: jdk-
     strip-suffix: -ga
-    tag-filter-contains: +
+    tag-filter-contains: ga
     use-tag: true
 
 test:

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,0 +1,284 @@
+package:
+  name: openjdk-25
+  version: "25_pre36"
+  epoch: 0
+  description: OpenJDK 25
+  copyright:
+    - license: GPL-2.0-with-classpath-exception
+  dependencies:
+    runtime:
+      - alsa-lib
+      - freetype
+      - giflib
+      - java-cacerts
+      - lcms2
+      - libfontconfig1
+      - libjpeg-turbo
+      - libx11
+      - libxext
+      - libxi
+      - libxrender
+      - libxtst
+      - ttf-dejavu
+      - zlib
+    provides:
+      - ${{package.name}}-jmods
+
+var-transforms:
+  - from: ${{package.version}}
+    match: _pre
+    replace: +
+    to: upstream-tag
+
+environment:
+  contents:
+    packages:
+      - alsa-lib-dev
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cups-dev
+      - file
+      - fontconfig-dev
+      - freetype-dev
+      - giflib-dev
+      - java-cacerts
+      - lcms2-dev
+      - libffi-dev
+      - libjpeg-turbo-dev
+      - libx11-dev
+      - libxext-dev
+      - libxi-dev
+      - libxrandr-dev
+      - libxrender-dev
+      - libxt-dev
+      - libxtst-dev
+      - openjdk-24-default-jdk
+      - zip
+  environment:
+    # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    SOURCE_DATE_EPOCH: 315532900
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openjdk/jdk25u
+      tag: jdk-${{vars.upstream-tag}}
+      expected-commit: 6c48f4ed707bf0b15f9b6098de30db8aae6fa40f
+
+  - working-directory: /home/build/googletest
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://github.com/google/googletest/archive/v1.14.0.tar.gz
+          expected-sha512: 765c326ccc1b87a01027385e69238266e356361cd4ee3e18e3c9d137a5d11fa5d657c164d02dd1be8fe693c8e10f2b580588dbfa57d27f070e2750f50d3e662c
+
+  - runs: chmod +x configure
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-boot-jdk=/usr/lib/jvm/java-24-openjdk \
+        --prefix=/usr/lib/jvm/java-25-openjdk \
+        --with-vendor-name=wolfi \
+        --with-vendor-url=https://wolfi.dev \
+        --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --enable-dtrace=no \
+        --with-zlib=system \
+        --with-debug-level=release \
+        --with-native-debug-symbols=none \
+        --with-external-symbols-in-bundles=none \
+        --with-cacerts-file=/etc/ssl/certs/java/cacerts \
+        --with-jvm-variants=server \
+        --with-jtreg=no  \
+        --with-libpng=system \
+        --with-jvm-variants=server \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-lcms=system \
+        --enable-linkable-runtime \
+        --with-gtest="/home/build/googletest" \
+        --with-version-pre="no" \
+        --with-version-string=""
+
+  - runs: make jdk-image legacy-jre-image
+
+  # Check we built something valid
+  - runs: |
+      _java_bin="./build/*-server-release/images/jdk/bin"
+
+      $_java_bin/javac -d . HelloWorld.java
+      $_java_bin/java HelloWorld
+
+      # NOTE: Disable flakey tests on aarch64 for now as we're seeing builds hang
+      if [ "${{build.arch}}" != "aarch64" ]; then
+        # run the gtest unittest suites
+        make test-hotspot-gtest
+      fi
+
+  - runs: |
+      _java_home="usr/lib/jvm/java-25-openjdk"
+
+      mkdir -p "${{targets.destdir}}"/$_java_home
+      cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
+      rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+
+      # symlink to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      ln -sf /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      # symlink for `java-common` to work (which expects jre in $_java_home/jre)
+      ln -sf . "${{targets.contextdir}}/$_java_home/jre"
+
+subpackages:
+  - name: "${{package.name}}-jre"
+    description: "OpenJDK 25 Java Runtime Environment"
+    dependencies:
+      runtime:
+        - alsa-lib
+        - freetype
+        - giflib
+        - java-cacerts
+        - libfontconfig1
+        - libjpeg-turbo
+        - libx11
+        - libxext
+        - libxi
+        - libxrender
+        - libxtst
+        - ttf-dejavu
+      provider-priority: 10
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-25-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+
+          # symlink for `java-common` to work (which expects jre in $_java_home/jre)
+          ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+  # Disabled doc subpackage for now.
+  # Upstream has switched from troff manpages in the repository to pandoc.
+  # See: https://bugs.openjdk.org/browse/JDK-8344056
+  # - name: "${{package.name}}-doc"
+  #   description: "OpenJDK 25 Documentation"
+  #   pipeline:
+  #     - runs: |
+  #         mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-25-openjdk
+  #         mv "${{targets.destdir}}"/usr/lib/jvm/java-25-openjdk/man \
+  #            "${{targets.subpkgdir}}"/usr/lib/jvm/java-25-openjdk
+  - name: "${{package.name}}-demos"
+    description: "OpenJDK 25 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-25-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-25-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-25-openjdk
+
+  - name: "${{package.name}}-default-jvm"
+    description: "Use the openjdk-25 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - java-common-jre
+        - ${{package.name}}-jre
+      provides:
+        - default-jvm=1.25
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: default-jvm
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: "${{package.name}}-default-jdk"
+    description: "Use the openjdk-24 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - java-common
+        - ${{package.name}}
+      provider-priority: 5
+      provides:
+        - default-jdk=1.25
+        - ${{package.name}}-jre=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-25-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: default-jdk
+            real-pkg-name: ${{subpkg.name}}
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: ${{package.name}}-jre
+            real-pkg-name: ${{subpkg.name}}
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: openjdk/jdk25u
+    strip-prefix: jdk-
+    strip-suffix: -ga
+    tag-filter-contains: -ga
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-25-default-jdk
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-25-openjdk
+  pipeline:
+    # Test a basic Hello World
+    - working-directory: basic
+      runs: |
+        javac HelloWorld.java
+        java HelloWorld | grep -qi "Hello World!"
+    # Test a basic HTTP connection
+    - working-directory: basic
+      runs: |
+        javac RequestTest.java
+        java RequestTest | grep -qi "Successfully connected to example.org"
+    # Test modules
+    - working-directory: advanced/module-project
+      runs: |
+        mkdir output
+        javac -d output --module-source-path modules $(find modules -name "*.java")
+
+        # Create a jar with the compiled classes
+        jar --verbose --create --file app.jar \
+          --main-class dev.chainguard.module.main.Main \
+          --module-version 1.0 \
+          -C output/test.modules . \
+          -C output/main.app .
+
+        # Test the jar
+        java -jar app.jar
+
+        # Test jlink
+        jlink --verbose --module-path "app.jar" \
+          --add-modules test.modules \
+          --output test-project-jre
+
+        # Test custom JRE
+        test-project-jre/bin/java -jar app.jar

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -234,11 +234,14 @@ subpackages:
 update:
   enabled: true
   shared: true
+  version-transform:
+    - match: ^(.+)_pre(\d+)$
+      replace: $1+$2
   github:
     identifier: openjdk/jdk25u
     strip-prefix: jdk-
     strip-suffix: -ga
-    tag-filter-contains: -ga
+    tag-filter-contains: +
     use-tag: true
 
 test:

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -220,8 +220,8 @@ update:
   enabled: true
   shared: true
   version-transform:
-    - match: ^(\d+)_pre(\d+)$
-      replace: $1+$2
+    - match: ^(\d+)\+(\d+)$
+      replace: $1_pre$2
   github:
     identifier: openjdk/jdk25u
     strip-prefix: jdk-

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -105,7 +105,7 @@ pipeline:
         --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
-        --with-version-string="${{vars.mangled-package-version}}-wolfi-r0"
+        --with-version-string=""
 
   - runs: make jdk-image legacy-jre-image
 

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,6 +1,6 @@
 package:
   name: openjdk-25
-  version: "25_rc36"
+  version: "25_beta36"
   epoch: 0
   description: OpenJDK 25
   copyright:
@@ -24,9 +24,9 @@ package:
 
 var-transforms:
   - from: ${{package.version}}
-    match: _rc
+    match: _beta
     replace: +
-    to: upstream-tag
+    to: mangled-package-version
 
 environment:
   contents:
@@ -64,7 +64,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openjdk/jdk25u
-      tag: jdk-${{vars.upstream-tag}}
+      tag: jdk-${{vars.mangled-package-version}}
       expected-commit: 6c48f4ed707bf0b15f9b6098de30db8aae6fa40f
 
   - working-directory: /home/build/googletest
@@ -103,7 +103,7 @@ pipeline:
         --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
-        --with-version-string="${{vars.upstream-tag}}-wolfi-r0"
+        --with-version-string="${{vars.mangled-package-version}}-wolfi-r0"
 
   - runs: make jdk-image legacy-jre-image
 
@@ -221,7 +221,7 @@ update:
   shared: true
   version-transform:
     - match: ^(\d+)\+(\d+)$
-      replace: ${1}_rc${2}
+      replace: ${1}_beta${2}
   github:
     identifier: openjdk/jdk25u
     strip-prefix: jdk-

--- a/openjdk-25/HelloWorld.java
+++ b/openjdk-25/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-25/advanced/module-project/modules/main.app/dev/chainguard/module/main/Main.java
+++ b/openjdk-25/advanced/module-project/modules/main.app/dev/chainguard/module/main/Main.java
@@ -1,0 +1,9 @@
+package dev.chainguard.module.main;
+
+import dev.chainguard.module.test.Test;
+
+public class Main {
+    public static void main(String[] args) {
+        Test.doTest();
+    }
+}

--- a/openjdk-25/advanced/module-project/modules/main.app/module-info.java
+++ b/openjdk-25/advanced/module-project/modules/main.app/module-info.java
@@ -1,0 +1,3 @@
+module main.app {
+    requires test.modules;
+}

--- a/openjdk-25/advanced/module-project/modules/test.modules/dev.chainguard.module.test/Test.java
+++ b/openjdk-25/advanced/module-project/modules/test.modules/dev.chainguard.module.test/Test.java
@@ -1,0 +1,7 @@
+package dev.chainguard.module.test;
+
+public class Test {
+    public static void doTest() {
+        System.out.println("testing a module output");
+    }
+}

--- a/openjdk-25/advanced/module-project/modules/test.modules/module-info.java
+++ b/openjdk-25/advanced/module-project/modules/test.modules/module-info.java
@@ -1,0 +1,3 @@
+module test.modules {
+    exports dev.chainguard.module.test;
+}

--- a/openjdk-25/basic/HelloWorld.java
+++ b/openjdk-25/basic/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-25/basic/RequestTest.java
+++ b/openjdk-25/basic/RequestTest.java
@@ -1,0 +1,26 @@
+import javax.management.RuntimeErrorException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class RequestTest {
+    public static void main(String[] args) throws Exception {
+        // Remote connections can flake, so try a few times
+        int attempt = 0;
+        while (true) {
+            URL url = new URL("http://example.org");
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            if (urlConnection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                break;
+            }
+
+            Thread.sleep(5000); // 5 seconds in millis is 5000
+
+            if (attempt++ >= 5) {
+                throw new RuntimeException("Failed to check connection to example.org");
+            }
+        }
+
+        System.out.println("Successfully connected to example.org");
+    }
+}


### PR DESCRIPTION
Create new openjdk-25 package based on openjdk-24.

Drop glibc related patch as its not required for this release.

Re-instate tests on x86_64 (skip on aarch64 for now).
