### PR TITLE
Disable GNU sim on GDB and binutils

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.45"
-  epoch: 1
+  epoch: 2
   description: "GNU binutils"
   copyright:
     - license: GPL-2.0
@@ -50,6 +50,7 @@ pipeline:
         --disable-gprofng \
         --disable-gdb \
         --disable-gdbserver \
+        --disable-sim \
         --enable-deterministic-archives \
         --enable-ld=default \
         --enable-gold \

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.3"
-  epoch: 3
+  epoch: 4
   description: The GNU Debugger
   copyright:
     - license: GPL-2.0
@@ -39,6 +39,7 @@ pipeline:
         --with-python=/usr/bin/python3 \
         --disable-nls \
         --disable-werror \
+        --disable-sim \
         --mandir=/usr/share/man \
         --infodir=/usr/share/info \
         --with-system-readline \


### PR DESCRIPTION
There's no reason for us to build and ship GNU sim binaries.

Relates: https://github.com/chainguard-dev/internal-dev/issues/20236