### PR TITLE
opensearch-dashboards-3: remediate CVE

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.1.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 4
+  epoch: 5
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -95,6 +95,10 @@ pipeline:
 
       # fix CVE-2025-9287
       devDependencies='{"cipher-base": "^1.0.5"}'
+      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
+
+      # fix CVE-2025-58754
+      devDependencies='{"axios": "^1.12.0"}'
       jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
 
       yarn osd bootstrap --allow-root

--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -79,7 +79,9 @@ pipeline:
       unset LDFLAGS
 
       # fix CVE-2024-47764, CVE-2025-27789, CVE-2025-5889, CVE-2025-6545, CVE-2025-7783
-      resolutions='{"**/cookie": "^0.7.0", "@babel/runtime": "^7.26.10", "@babel/runtime-corejs3": "^7.26.10", "brace-expansion": "1.1.12", "pbkdf2": "3.1.3", "form-data": "4.0.4"}'
+      resolutions='{"**/cookie": "^0.7.0", "@babel/runtime": "^7.26.10",
+      "@babel/runtime-corejs3": "^7.26.10", "brace-expansion": "1.1.12",
+      "pbkdf2": "3.1.3", "form-data": "4.0.4", "axios": "^1.12.0"}'
       jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
       # CVE-2025-7783


### PR DESCRIPTION
Remediate CVE-2025-58754
Bump axios to v1.12.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
