### PR TITLE
systemd - Fix paths in package systemd-boot-installed

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -2,7 +2,7 @@ package:
   name: systemd
   # 35712.patch can be dropped when 258 releases
   version: "257.9"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -298,13 +298,13 @@ subpackages:
     description: "systemd bootloader (installed for EFI)"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/boot/efi/EFI/BOOT/
+          mkdir -p ${{targets.subpkgdir}}/boot/EFI/BOOT/
       - if: ${{build.arch}} == 'aarch64'
         runs: |
-          cp ${{targets.destdir}}/usr/lib/systemd/boot/efi/systemd-bootaa64.efi ${{targets.subpkgdir}}/boot/efi/EFI/BOOT/BOOTAA64.EFI
+          cp ${{targets.destdir}}/usr/lib/systemd/boot/efi/systemd-bootaa64.efi ${{targets.subpkgdir}}/boot/EFI/BOOT/BOOTAA64.EFI
       - if: ${{build.arch}} == 'x86_64'
         runs: |
-          cp ${{targets.destdir}}/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${{targets.subpkgdir}}/boot/efi/EFI/BOOT/BOOTX64.EFI
+          cp ${{targets.destdir}}/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${{targets.subpkgdir}}/boot/EFI/BOOT/BOOTX64.EFI
     test:
       environment:
         contents:
@@ -314,10 +314,10 @@ subpackages:
       pipeline:
         - if: ${{build.arch}} == 'aarch64'
           runs: |
-            file /boot/efi/EFI/BOOT/BOOTAA64.EFI | grep "executable for EFI"
+            file /boot/EFI/BOOT/BOOTAA64.EFI | grep "executable for EFI"
         - if: ${{build.arch}} == 'x86_64'
           runs: |
-            file /boot/efi/EFI/BOOT/BOOTX64.EFI | grep "executable for EFI"
+            file /boot/EFI/BOOT/BOOTX64.EFI | grep "executable for EFI"
     dependencies:
       runtime:
         - merged-lib


### PR DESCRIPTION
We were creating the paths /boot/efi/EFI/BOOT/BOOTX64.EFI, which imply loader/ directories at /boot/efi/loader which is wrong.

The fallout of this was that systemd would mount efi partition to /efi rather than directly to /boot.

Per https://uapi-group.org/specifications/specs/boot_loader_specification/

> Note: In all cases the /loader/entries/ directory should be located
> directly in the root of the ESP or XBOOTLDR filesystem. Specifically,
> the /loader/entries/ directory should not be located under the /EFI/
> subdirectory on the ESP.
