### PR TITLE
tileserver-gl: remediate cve

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 0
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -63,7 +63,7 @@ pipeline:
     pipeline:
       - uses: patch
         with:
-          patches: ../CVE-2025-48387.patch
+          patches: ../CVE-2025-48387.patch ../CVE-2025-58754.patch
 
   # install packages
   - working-directory: app

--- a/tileserver-gl/CVE-2025-58754.patch
+++ b/tileserver-gl/CVE-2025-58754.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 5f50d1b..0e38a28 100644
+--- a/package.json
++++ b/package.json
+@@ -45,7 +45,7 @@
+     "@maplibre/maplibre-gl-style-spec": "23.3.0",
+     "@sindresorhus/fnv1a": "3.1.0",
+     "advanced-pool": "0.3.3",
+-    "axios": "^1.11.0",
++    "axios": "^1.12.0",
+     "canvas": "3.1.2",
+     "chokidar": "4.0.3",
+     "clone": "2.1.2",


### PR DESCRIPTION
Remediate GHSA-4hjh-wcwx-xvwj
Bump axios to 1.12.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
