### PR TITLE
feat(prism): bump dep to remediate GHSA-4hjh-wcwx-xvwj

### DIFF
--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: "5.14.2"
-  epoch: 7
+  epoch: 8
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:
@@ -41,6 +41,9 @@ pipeline:
 
       # Fix tmp CVE GHSA-52f5-9888-hmc6
       npm pkg set resolutions.tmp=0.2.4
+
+      # Fix tmp CVE GHSA-4hjh-wcwx-xvwj
+      npm pkg set resolutions.axios=1.12.0
 
       # See 'compiler' build stage of prism/Dockerfile (https://github.com/stoplightio/prism/blob/master/Dockerfile)
       yarn && yarn build

--- a/prism/CVE-2025-1302.patch
+++ b/prism/CVE-2025-1302.patch
@@ -10,7 +10,6 @@ index 26135a8..f89a71a 100644
 +    "jsonpath-plus": "10.3.0",
 +    "braces": "3.0.3",
 +    "micromatch": "4.0.8",
-+    "axios": "1.8.2",
 +    "cross-spawn": "7.0.6",
 +    "brace-expansion": "2.0.2"
    },


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-4hjh-wcwx-xvwj

<!--ci-cve-scan:fail-any-->
