### PR TITLE
fix(restored-packages.txt/withdrawn-packages.txt): restore py3-supported-numpy-1.26.5-r0.apk to unblock elastic-builds

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -29,3 +29,5 @@ kubectl-bash-completion-1.30-1.30.3-r0.apk
 
 llvm-lld-15.0.7-r0.apk
 zig-0.10.0-r0.apk
+
+py3-supported-numpy-1.26.5-r0.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -90,4 +90,3 @@ py3-supported-numpy-1.26.4-r5.apk
 py3-supported-numpy-1.26.4-r6.apk
 py3-supported-numpy-1.26.4-r7.apk
 py3-supported-numpy-1.26.4-r8.apk
-py3-supported-numpy-1.26.5-r0.apk


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/66219 withdrew py3-supported-numpy-1.26.5-r0.apk as the package had already been removed.

This was premature as there appears to be packages still depending on this package.

py3-supported-numpy was deprecated in favor of version streamed packages but none provide the same name.

This commit restores this package until we can resolve the elastic-builds issue.

Builds issue

```
gdal-3.8-3.8.5-r10: unable to resolve dependency py3-supported-numpy<2.0: nothing provides "py3-supported-numpy"
onnxruntime-cuda-12.9-1.22.2-r2: unable to resolve dependency py3-numpy<2.0: nothing provides "py3-numpy"
py3-accelerate-cuda-12.9-1.10.1-r1: unable to resolve dependency py3-supported-numpy<2.0: nothing provides "py3-supported-numpy"
py3-opencv-python-headless-4.11-4.11.0.86-r1: unable to resolve dependency py3-supported-numpy<2.0: nothing provides "py3-supported-numpy"
py3-torch-tensorrt-cuda-12.6-2.6.1-r3: unable to resolve dependency py3-supported-numpy<2.0: nothing provides "py3-supported-numpy"
py3-torch-tensorrt-cuda-12.9-2.8.0-r1: unable to resolve dependency py3-supported-numpy<2.0: nothing provides "py3-supported-numpy"
```

Signed-off-by: philroche <phil.roche@chainguard.dev>
