### PR TITLE
fix(restored-packages.txt/withdrawn-packages.txt): restore py3-numpy-1.26.5-r0.apk to unblock elastic-builds

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -31,3 +31,6 @@ llvm-lld-15.0.7-r0.apk
 zig-0.10.0-r0.apk
 
 py3-supported-numpy-1.26.5-r0.apk
+
+py3-numpy-1.26.5-r0.apk
+


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/66214 withdrew py3-numpy-1.26.5-r0.apk as the package had already been removed.

This was premature as there appears to be packages still depending on this package.

py3-numpy was deprecated in favor of version streamed packages but none provide the same name.

This commit restores this package until we can resolve the elastic-builds issue.

Builds issue

```
Error: unable to build graph:
onnxruntime-cuda-12.9-1.22.2-r2: unable to resolve dependency py3-numpy<2.0: nothing provides "py3-numpy"
```

Signed-off-by: philroche <phil.roche@chainguard.dev>
