### PR TITLE
Restore py3.10-numpy-1.26.5-r0.apk need for py3.10-matplotlib

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -34,3 +34,4 @@ py3-supported-numpy-1.26.5-r0.apk
 
 py3-numpy-1.26.5-r0.apk
 
+py3.10-numpy-1.26.5-r0.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -44,7 +44,6 @@ py3.10-numpy-1.26.4-r5.apk
 py3.10-numpy-1.26.4-r6.apk
 py3.10-numpy-1.26.4-r7.apk
 py3.10-numpy-1.26.4-r8.apk
-py3.10-numpy-1.26.5-r0.apk
 
 py3.10-numpy-bin-1.26.4-r5.apk
 py3.10-numpy-bin-1.26.4-r6.apk


### PR DESCRIPTION
This'll sort the following error:
```
solving "py3.10-matplotlib" constraint: resolving "py3.10-matplotlib-3.10.6-r1.apk" deps:
solving "py3.10-numpy<2.0" constraint:   py3.10-numpy-1.26-1.26.5-r0.apk disqualified because parsing "": invalid version , could not parse
  py3.10-numpy-1.25-1.25.2-r0.apk disqualified because parsing "": invalid version , could not parse
make: *** [Makefile:163: test/py3-captum-cuda-12.9] Error 1
```