### PR TITLE
qt6-qtbase: use GCC instead of clang

### DIFF
--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -3,7 +3,7 @@
 package:
   name: qt6-qtbase
   version: "6.9.2"
-  epoch: 0
+  epoch: 1
   description: qt
   copyright:
     - license: LGPL-3.0-or-later

--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -11,17 +11,12 @@ package:
     cpu: 16
     memory: 16Gi
 
-vars:
-  llvm-vers: 19
-
 environment:
   contents:
     packages:
       - bison
       - build-base
       - busybox
-      - clang-${{vars.llvm-vers}}
-      - clang-${{vars.llvm-vers}}-extras
       - cmake
       - cups-dev
       - dbus-dev
@@ -38,8 +33,6 @@ environment:
       - libxkbcommon
       - libxkbcommon-dev
       - libxxf86vm-dev
-      - llvm-${{vars.llvm-vers}}
-      - llvm-${{vars.llvm-vers}}-dev
       - mesa
       - mesa-dev
       - mesa-egl
@@ -66,14 +59,9 @@ pipeline:
   - runs: |
       pip install html5lib
 
-  - runs: |
-      ln -s /usr/lib/llvm-19/lib/LLVMgold.so /usr/lib/ # I cannot convince ld to find this here
-      # Needed to find our llvm libs
-      export CXXFLAGS="$CXXFLAGS -I/usr/lib/llvm-${{vars.llvm-vers}}/include"
-      export CC=clang
-      export CXX=clang++
-
-      cmake -B build -G Ninja -Wno-dev \
+  - uses: cmake/configure
+    with:
+      opts: |
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
@@ -88,8 +76,9 @@ pipeline:
         -DQT_FEATURE_journald=OFF \
         -DQT_FEATURE_reduce_relocations=OFF
 
-      cmake --build build
-      DESTDIR="${{targets.destdir}}" cmake --install build
+  - uses: cmake/build
+
+  - uses: cmake/install
 
   - uses: strip
 

--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -39,7 +39,7 @@ environment:
       - mesa-glx
       - nodejs
       - perl
-      - py3-pip
+      - py3-html5lib
       - samurai
       - wolfi-base
 
@@ -55,9 +55,6 @@ pipeline:
       repository: https://github.com/qt/qtbase
       tag: v${{vars.mangled-package-version}}
       expected-commit: 6f0d27d2e4ba5fa6562f738aaaf8eaf98ebf51e7
-
-  - runs: |
-      pip install html5lib
 
   - uses: cmake/configure
     with:

--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -59,8 +59,6 @@ pipeline:
   - uses: cmake/configure
     with:
       opts: |
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
         -DINSTALL_BINDIR=lib/qt6/bin \
         -DINSTALL_PUBLICBINDIR=usr/bin \


### PR DESCRIPTION
GCC has less dependencies and is using the OpenSSF security hardening
flags