### PR TITLE
fix(selenium): adjust paths to align with upstream; confs should be 0644

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: "4.35.0.20250828"
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -54,7 +54,7 @@ environment:
       - x11vnc
       - yq
   environment:
-    TC: UTC
+    TZ: UTC
     SEL_USER: seluser
     SEL_PASSWD: secret
 
@@ -76,6 +76,7 @@ subpackages:
         - bash
         - busybox
         - coreutils
+        - gettext
         - selenium-server-compat~${{vars.selenium-version}}
         - sudo-rs
         - supervisor
@@ -100,6 +101,8 @@ subpackages:
           - runs: |
               install -Dm755 check-grid.sh ${{targets.contextdir}}/opt/bin/
               install -Dm755 entry_point.sh ${{targets.contextdir}}/opt/bin/
+              install -Dm755 handle_heap_dump.sh ${{targets.contextdir}}/opt/bin/
+              install -Dm755 mask ${{targets.contextdir}}/opt/bin/
               install -Dm644 supervisord.conf ${{targets.contextdir}}/etc/
               mkdir -p ${{targets.contextdir}}/var/run/supervisor
           # TODO: Implement malware scan for jars retrieved by coursier
@@ -163,13 +166,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/etc
           cd ./Base
-          install supervisord.conf ${{targets.contextdir}}/etc
-          mv ${{targets.contextdir}}/etc/supervisord.conf ${{targets.contextdir}}/etc
-
-          # Unset setuid bit
-          # jason@ copied this directly from https://serverfault.com/a/238964
-          # The extra 0 is to unset the setuid bit apparently.
-          chmod 0775 ${{targets.contextdir}}/etc/supervisord.conf
+          install -m644 supervisord.conf ${{targets.contextdir}}/etc
     test:
       pipeline:
         - uses: test/virtualpackage
@@ -190,7 +187,7 @@ subpackages:
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
               install -Dm755 start-selenium-standalone.sh ${{targets.contextdir}}/opt/bin/
-              install -Dm755 selenium.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
     test:
       environment:
         contents:
@@ -240,7 +237,7 @@ subpackages:
         pipeline:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
-              install -Dm755 selenium-grid-hub.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium-grid-hub.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-hub.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -310,13 +307,13 @@ subpackages:
           - runs: |
               install -Dm755 start-selenium-node.sh ${{targets.contextdir}}/opt/bin/
               install -Dm755 start-xvfb.sh ${{targets.contextdir}}/opt/bin/
-              install -Dm755 selenium.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-vnc.sh ${{targets.contextdir}}/opt/bin/
               install -Dm755 start-novnc.sh ${{targets.contextdir}}/opt/bin/
-              install -Dm755 selenium_grid_logo.png ${{targets.contextdir}}/usr/share/images/fluxbox/ubuntu-light.png
+              install -Dm644 selenium_grid_logo.png ${{targets.contextdir}}/usr/share/images/fluxbox/ubuntu-light.png
               install -Dm755 generate_config ${{targets.contextdir}}/opt/bin/
-              install -Dm755 json_merge.py ${{targets.contextdir}}/opt/bin/
               install -Dm755 generate_relay_config ${{targets.contextdir}}/opt/bin/
+              install -Dm755 json_merge.py ${{targets.contextdir}}/opt/bin/
               echo "${SEL_PASSWD}" | x11vnc -storepasswd - ${{targets.contextdir}}/home/$SEL_USER/.vnc/passwd
     test:
       environment:
@@ -354,7 +351,7 @@ subpackages:
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 wrap_chromium_binary ${{targets.contextdir}}/opt/bin/
               install -Dm755 chrome-cleanup.sh ${{targets.contextdir}}/opt/bin/
-              install -Dm755 chrome-cleanup.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 chrome-cleanup.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
     test:
       environment:
         environment:
@@ -391,7 +388,7 @@ subpackages:
               chmod 775 ${{targets.contextdir}}/opt/selenium/
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 firefox-cleanup.sh ${{targets.contextdir}}/opt/bin/firefox-cleanup.sh
-              install -Dm755 firefox-cleanup.conf ${{targets.contextdir}}/etc/supervisor/conf.d/firefox-cleanup.conf
+              install -Dm644 firefox-cleanup.conf ${{targets.contextdir}}/etc/supervisor/conf.d/firefox-cleanup.conf
               echo "firefox" > ${{targets.contextdir}}/opt/selenium/browser_name
               firefox --version | awk '{print $3}' > ${{targets.contextdir}}/opt/selenium/browser_version
               echo "\"moz:firefoxOptions\": {\"binary\": \"/usr/bin/firefox\"}" > ${{targets.contextdir}}/opt/selenium/browser_binary_location
@@ -456,7 +453,7 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-eventbus.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium-grid-eventbus.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-eventbus.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -484,7 +481,7 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-distributor.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium-grid-distributor.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-distributor.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -524,7 +521,9 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-docker.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              mkdir -p ${{targets.contextdir}}/opt/selenium
+              install -Dm644 config.toml ${{targets.contextdir}}/opt/selenium/docker.toml
+              install -Dm644 selenium-grid-docker.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-docker.sh ${{targets.contextdir}}/opt/bin/
               install -Dm755 start-socat.sh ${{targets.contextdir}}/opt/bin/
     test:
@@ -568,7 +567,7 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-router.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium-grid-router.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-router.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -608,7 +607,7 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-session-queue.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm644 selenium-grid-session-queue.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-session-queue.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -640,7 +639,8 @@ subpackages:
           - runs: |
               mkdir -p ${{targets.contextdir}}/etc/supervisor/conf.d
               mkdir -p ${{targets.contextdir}}/opt/bin
-              install -Dm755 selenium-grid-sessions.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
+              install -Dm755 generate_config ${{targets.contextdir}}/opt/bin/
+              install -Dm644 selenium-grid-sessions.conf ${{targets.contextdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-sessions.sh ${{targets.contextdir}}/opt/bin/
     test:
       environment:
@@ -711,9 +711,9 @@ subpackages:
           DRAIN_AFTER_SESSION_COUNT: 10
           SE_DRAIN_AFTER_SESSION_COUNT: 4
           SE_NODE_MAX_SESSIONS: 10
-          SE_NODE_BROWSER_NAME: chrome
+          SE_NODE_BROWSER_NAME: firefox
           SE_NODE_BROWSER_VERSION: test
-          SE_BROWSER_BINARY_LOCATION: '"binary": "/usr/bin/chromium-browser"'
+          SE_BROWSER_BINARY_LOCATION: '"binary": "/usr/bin/firefox"'
           SE_BIND_HOST: false
           CONFIG_FILE: /opt/selenium/config.toml
       pipeline:


### PR DESCRIPTION
Match upstream dockerfiles wrt installing files in our subpkgs.

- *.conf files were being installed with +x permissions but don't need to be, so this PR also `s/755/644` where appropriate
- make the firefox test accurately test firefox