### PR TITLE
py3-lxml: depend on libxml<2.15, to fix incompatibility

### DIFF
--- a/py3-lxml.yaml
+++ b/py3-lxml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lxml
   version: "6.0.1"
-  epoch: 0
+  epoch: 1
   description: Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
   copyright:
     - license: BSD-3-Clause
@@ -25,7 +25,7 @@ environment:
     packages:
       - cython
       - gcc
-      - libxml2-dev
+      - libxml2-dev<2.15
       - libxslt-dev
       - py3-supported-build-base-dev
       - py3-supported-cython
@@ -45,6 +45,8 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
+      runtime:
+        - libxml2<2.15
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -57,6 +59,7 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+              from ${{vars.import}} import etree
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
Specifically, we currently see:
```
# python3.13 -c 'from lxml import etree'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from lxml import etree
ImportError: /usr/lib/python3.13/site-packages/lxml/etree.cpython-313-x86_64-linux-gnu.so: undefined symbol: xmlSchematronFree
```