### PR TITLE
fix(withdrawn-packages.txt): withdraw all py3-numpy packages and subpackages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,10 @@
 # NOTE: always replace the contents of this file!
+py3-numpy-1.26.5-r0.apk
+py3-supported-numpy-1.26.5-r0.apk
+py3.10-numpy-bin-1.26.5-r0.apk
+py3.11-numpy-1.26.5-r0.apk
+py3.11-numpy-bin-1.26.5-r0.apk
+py3.12-numpy-1.26.5-r0.apk
+py3.12-numpy-bin-1.26.5-r0.apk
+py3.13-numpy-1.26.5-r0.apk
+py3.13-numpy-bin-1.26.5-r0.apk


### PR DESCRIPTION
With the introduction of version streamed py3*-numpy packages @ https://github.com/wolfi-dev/os/pull/56095
we removed py3-numpy.yaml. The version streamed packages added `provides` for `py3*-numpy`, just as py3-numpy did.

This was fine and any request to install py3*-numpy would result in the version streamed packages being installed
as they had a higher version number..... until we added a change in runtime dependencies @ https://github.com/chainguard-dev/extra-packages/pull/3792
to depend on `py${{vars.python-version}}-numpy<2.0`. Adding a version constraint like this changes how the APK resolver
works and it will give preference to a package with name `py${{vars.python-version}}-numpy` EVEN if there is another package
with a different name but with the same `provides` and a higher package version.

As such we need to withdraw these packages that have been superseded by the version streamed packages.

This commit withdraws all packages with origin py3-numpy.

Signed-off-by: philroche <phil.roche@chainguard.dev>
