### PR TITLE
test(varnish-modules): ensure compat with available varnish

### DIFF
--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: varnish-modules
   version: "0.26.0"
-  epoch: 1
+  epoch: 2
   description: "Collection of Varnish Cache modules (vmods) by Varnish Software"
   copyright:
     - license: BSD-2-Clause
@@ -58,5 +58,23 @@ update:
     identifier: varnish/varnish-modules
 
 test:
+  environment:
+    contents:
+      packages:
+        - varnish
+        - varnish-dev
   pipeline:
     - uses: test/tw/ldd-check
+    - name: "Verify varnish / vmod compatibility"
+      # Confirm this varnish-modules build is compatible with our current Varnish packages.
+      # If this fails, ensure a compatible varnish package is available in our repos:
+      #   https://github.com/varnish/varnish-modules/releases
+      runs: |
+        cat > /tmp/default.vcl <<'EOF'
+        vcl 4.1;
+        backend default {
+          .host = "127.0.0.1";
+          .port = "8080";
+        }
+        EOF
+        varnishd -C -f /tmp/default.vcl

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -61,6 +61,7 @@ test:
   environment:
     contents:
       packages:
+        - gcc
         - varnish
         - varnish-dev
   pipeline:


### PR DESCRIPTION
`varnish-modules` needs to be rebuilt for compat with the recent build of `varnish`.  This isn't the [first time](https://github.com/wolfi-dev/os/pull/35759) we've had to resync the varnish pkg builds.

We just need an epoch bump / rebuild to fix this. Let's also add a test to ensure whatever we build here is compatible with the currently available varnish[-dev] packages; when this test fails, it will be a fast signal in our pkg update queue that we're out of sync.