### PR TITLE
Remove py3-lxml dependency on pinned libxml2

### DIFF
--- a/py3-lxml.yaml
+++ b/py3-lxml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lxml
   version: "6.0.1"
-  epoch: 1
+  epoch: 2
   description: Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
   copyright:
     - license: BSD-3-Clause
@@ -25,10 +25,12 @@ environment:
     packages:
       - cython
       - gcc
-      - libxml2-dev<2.15
+      - libxml2-dev
       - libxslt-dev
       - py3-supported-build-base-dev
       - py3-supported-cython
+  environment:
+    CFLAGS: -Wno-incompatible-pointer-types
 
 pipeline:
   - uses: git-checkout
@@ -45,8 +47,6 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
-      runtime:
-        - libxml2<2.15
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
libxml2 bump from 2.14 to 2.15.0 made py3-lxml fail to compile with current gcc (15.2).  Previously a change was made to in #66421 to make it build with old libxml2, but that means
1. the runtime dependency is now on old libxml2 , which is not even available in a current package, and wont be patched
2. anything that depends on py3-lxml will _also_ need to get that old libxml2

Instead, build with -Wno-incompatible-pointer-types which makes the build and the test work.
