### PR TITLE
feat(py3-numpy-1.26.yaml): As part of continuing to support packages in OS that depend on py3-numpy-1*

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,10 +1,2 @@
 # NOTE: always replace the contents of this file!
-py3-numpy-1.26.5-r0.apk
-py3-supported-numpy-1.26.5-r0.apk
-py3.10-numpy-bin-1.26.5-r0.apk
-py3.11-numpy-1.26.5-r0.apk
-py3.11-numpy-bin-1.26.5-r0.apk
-py3.12-numpy-1.26.5-r0.apk
-py3.12-numpy-bin-1.26.5-r0.apk
-py3.13-numpy-1.26.5-r0.apk
-py3.13-numpy-bin-1.26.5-r0.apk
+py3.10-numpy-1.26.5-r0.apk


### PR DESCRIPTION
There are still packages in OS that depend on py3-numpy-1* but EOL mover moved  py3-numpy-1* packages to
enterprise. As such we need to move it back to OS until these dependencies have been resolved.

This commits adds the missing py3.10-numpy package to the withdrawal list

Signed-off-by: philroche <phil.roche@chainguard.dev>
