### PR TITLE
chore(lifecycle): Grant read access to detection job

### DIFF
--- a/.github/chainguard/lifecycle-cve-detection.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-detection.sts.yaml
@@ -1,9 +1,10 @@
 issuer: https://accounts.google.com
 
 # Have more than one service account
-# - cve-detection-sa@prod-images-c6e5.iam.gserviceaccount.com 107176869706106619885
-# - cve-detection-sa@staging-images-183e.iam.gserviceaccount.com 108595486951512447790
-subject_pattern: "(107176869706106619885|108595486951512447790)"
+# - cve-detection-sa@prod-images-c6e5.iam.gserviceaccount.com     107176869706106619885
+# - cve-detection-sa@staging-images-183e.iam.gserviceaccount.com  108595486951512447790
+# - cve-detection-sa@staging-enforce-cd1e.iam.gserviceaccount.com 101982940773329773733
+subject_pattern: "(107176869706106619885|108595486951512447790|101982940773329773733)"
 
 # Allow CVE detection automation to use Melange package information.
 permissions:


### PR DESCRIPTION
Needs this to read the package definitions to make decisions about detection.

See https://github.com/chainguard-dev/internal-dev/issues/20128
