### PR TITLE
fix(apache-nifi): Bump spring-security-core to remediate GHSA-8v5q-rhf3-jphm

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: "2.5.0"
-  epoch: 7 # GHSA-fghv-69vj-qj49
+  epoch: 8 # GHSA-8v5q-rhf3-jphm
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0

--- a/apache-nifi/pombump-deps.yaml
+++ b/apache-nifi/pombump-deps.yaml
@@ -23,3 +23,6 @@ patches:
   - groupId: org.eclipse.jetty.http2
     artifactId: jetty-http2-common
     version: 12.0.25
+  - groupId: org.springframework
+    artifactId: spring-security-core
+    version: 6.5.4


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: GHSA-8v5q-rhf3-jphm-->
<!--ci-cve-scan:must-fix: CVE-2025-41248-->



