### PR TITLE
fix(jenkins-2): Bump spring-core to remediate GHSA-jmp9-x22r-554x

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
-  version: "2.527"
-  epoch: 0
+  version: "2.528"
+  epoch: 0 # GHSA-jmp9-x22r-554x
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -46,7 +46,7 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
-      expected-commit: 7c17018e75beb7ce00d5cbd663a7e5ccdd864f8b
+      expected-commit: 1fbaa7ccedf8a695e272e89376d4cd405c72127a
 
   - uses: maven/pombump
 

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.528"
-  epoch: 0 # GHSA-jmp9-x22r-554x
+  epoch: 0 # GHSA-jmp9-x22r-554x | GHSA-8v5q-rhf3-jphm
   description: Open-source CI/CD application.
   copyright:
     - license: MIT

--- a/jenkins-2/pombump-deps.yaml
+++ b/jenkins-2/pombump-deps.yaml
@@ -9,33 +9,38 @@ patches:
     artifactId: jetty-http2-common
     version: 12.0.25
   - groupId: org.springframework
+    artifactId: spring-security-bom
+    version: 6.5.4
+    type: pom
+    scope: compile
+  - groupId: org.springframework
     artifactId: spring-core
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework
     artifactId: spring-aop
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework
     artifactId: spring-beans
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework
     artifactId: spring-context
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework
     artifactId: spring-expression
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework
     artifactId: spring-web
-    version: 6.2.11
+    version: 6.5.4
     type: pom
     scope: compile
   - groupId: org.springframework.security

--- a/jenkins-2/pombump-deps.yaml
+++ b/jenkins-2/pombump-deps.yaml
@@ -38,4 +38,18 @@ patches:
     version: 6.2.11
     type: pom
     scope: compile
- 
+  - groupId: org.springframework.security
+    artifactId: spring-security-crypto
+    version: 6.5.4
+    type: pom
+    scope: compile
+  - groupId: org.springframework.security
+    artifactId: spring-security-core
+    version: 6.5.4
+    type: pom
+    scope: compile
+  - groupId: org.springframework.security
+    artifactId: spring-security-web
+    version: 6.5.4
+    type: pom
+    scope: compile

--- a/jenkins-2/pombump-deps.yaml
+++ b/jenkins-2/pombump-deps.yaml
@@ -8,3 +8,34 @@ patches:
   - groupId: org.eclipse.jetty.http2
     artifactId: jetty-http2-common
     version: 12.0.25
+  - groupId: org.springframework
+    artifactId: spring-core
+    version: 6.2.11
+    type: pom
+    scope: compile
+  - groupId: org.springframework
+    artifactId: spring-aop
+    version: 6.2.11
+    type: pom
+    scope: compile
+  - groupId: org.springframework
+    artifactId: spring-beans
+    version: 6.2.11
+    type: pom
+    scope: compile
+  - groupId: org.springframework
+    artifactId: spring-context
+    version: 6.2.11
+    type: pom
+    scope: compile
+  - groupId: org.springframework
+    artifactId: spring-expression
+    version: 6.2.11
+    type: pom
+    scope: compile
+  - groupId: org.springframework
+    artifactId: spring-web
+    version: 6.2.11
+    type: pom
+    scope: compile
+ 


### PR DESCRIPTION
This PR bumps spring-core to 6.2.11 to remediate GHSA-jmp9-x22r-554x and spring-core-security to 6.5.4 to remediate GHSA-8v5q-rhf3-jphm. 
<!--ci-cve-scan:must-fix: GHSA-jmp9-x22r-554x-->
<!--ci-cve-scan:must-fix: CVE-2025-41249-->
<!--ci-cve-scan:must-fix:GHSA-8v5q-rhf3-jphm -->
<!--ci-cve-scan:must-fix: CVE-2025-41248-->

