### PR TITLE
Restore numpy 1.26 which was accidentally EOL moved

### DIFF
--- a/py3-numpy-1.26.yaml
+++ b/py3-numpy-1.26.yaml
@@ -1,0 +1,155 @@
+package:
+  name: py3-numpy-1.26
+  version: 1.26.5
+  epoch: 5
+  description: The fundamental package for scientific computing with Python.
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
+vars:
+  pypi-package: numpy
+
+data:
+  # Numpy 1.26 only supports up to 3.12, but we were previously building for 3.13 and it *mostly* works
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - cython
+      - gfortran
+      - git
+      - meson
+      - openblas-dev
+      - py3-supported-pip
+      - py3-supported-python-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/numpy/numpy
+      tag: v${{package.version}}
+      expected-commit: 93fdebfcb4bc4cd53c959ccd0117a612d5f13f1a
+      recurse-submodules: true
+      cherry-picks: |
+        main/e48fdef5d7bf8ba2f90972c531cdfa07481ae535: numpy.test() segfault fix (remove NPY_ALIGNMENT_REQUIRED)
+
+# The main package is empty, and expected to stay that way
+test:
+  pipeline:
+    - uses: test/emptypackage
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    description: ${{vars.pypi-package}}-${{vars.major-minor-version}} installed for python${{range.key}}
+    pipeline:
+      - runs: python${{range.key}} -m pip install . "--root=${{targets.contextdir}}" --prefix=/usr
+      - uses: strip
+    dependencies:
+      runtime:
+        - py${{range.key}}-pygments
+      provides:
+        - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
+        - py3-${{vars.pypi-package}}=${{package.version}}
+        - numpy
+      provider-priority: ${{range.value}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import numpy
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}
+      provides:
+        - f2py
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr
+          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}/usr/bin ${{targets.contextdir}}/usr
+    test:
+      environment:
+        contents:
+          packages:
+            - gcc
+            - git
+            - gfortran
+            - meson
+            - python-${{range.key}}-dev
+            - py${{range.key}}-pytest
+            - py${{range.key}}-pip
+      pipeline:
+        - name: "Downgrade Setuptools for Python < 3.12"
+          runs: |
+            # Reference: https://numpy.org/devdocs/reference/distutils_status_migration.html
+            # The lack of this downgrade causes issues revealed through numpy.test()
+            # and our downgrade is overridden when the test build pulls in py3-setuptools-wheel, which can't be sufficiently downgraded
+            if [[ "${{range.value}}" -lt 312 ]]; then
+              pip${{range.key}} install "setuptools<60" --root-user-action ignore
+            fi
+        - runs: |
+            f2py -v
+        - runs: |
+            # Only run numpy.test() for Python < 3.13 because numpy doesn't support it and a test fails due to changed behavior.
+            # We are only including numpy 1.26 on 3.13 because we had it before, not because it's supported or recommended.
+            if [[ "${{range.value}}" -lt 313 ]]; then
+              # We have no Wolfi package for hypothesis (yet)
+              pip${{range.key}} install hypothesis --root-user-action ignore
+              python${{range.key}} -c "import numpy, sys; sys.exit(numpy.test() is False)"
+            fi
+        - runs: |
+            git clone --branch v${{package.version}} https://github.com/numpy/numpy.git py${{range.key}}-numpy
+            cd py${{range.key}}-numpy/numpy
+            cp -r tests ../..
+            cd ../../tests
+            python${{range.key}} -m pytest . -k "not test_api_importable"
+
+  - name: py3-supported-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    description: meta package providing ${{vars.pypi-package}}-${{vars.major-minor-version}} for supported python versions.
+    dependencies:
+      provides:
+        - py3-supported-${{vars.pypi-package}}=${{package.version}}
+      runtime:
+        - py3.10-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.11-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.12-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.13-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  git:
+    # Some reverse dependencies don't work with v2
+    tag-filter-prefix: v1.26
+    strip-prefix: v
+    strip-suffix: .dev0


### PR DESCRIPTION
EOL mover automation apparently isn't properly excluding this and I accidentally merged the PRs :(