### PR TITLE
feat: add systemctl as a standalone binary package

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -18,6 +18,7 @@ package:
       - merged-usrsbin
       - quota-tools
       - systemd-boot
+      - systemd-systemctl
       - wolfi-baselayout
 
 vars:
@@ -358,6 +359,26 @@ subpackages:
             bootctl --help
             kernel-install --version
             kernel-install --help
+
+  - name: "systemd-systemctl"
+    description: "systemd systemctl utility"
+    dependencies:
+      runtime:
+        - libsystemd-shared
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/systemctl ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/verify-service
+        - runs: |
+            systemctl --help
+            systemctl --version
 
   - name: systemd-container
     description: "systemd container tools"
@@ -709,7 +730,6 @@ test:
         skip-files: syslog.socket # intentionally shipped without a corresponding service
     - name: "Check systemctl version"
       runs: |
-        systemctl --version
         busctl --version
         busctl --help
         coredumpctl --version
@@ -730,7 +750,6 @@ test:
         resolvectl --help
         run0 --version
         run0 --help
-        systemctl --help
         systemd-ac-power --version
         systemd-ac-power --help
         systemd-analyze --help

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -2,7 +2,7 @@ package:
   name: systemd
   # 35712.patch can be dropped when 258 releases
   version: "257.9"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -365,10 +365,6 @@ subpackages:
     dependencies:
       runtime:
         - libsystemd-shared
-        - merged-lib
-        - merged-sbin
-        - merged-usrsbin
-        - wolfi-baselayout
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -375,7 +375,6 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/systemctl ${{targets.subpkgdir}}/usr/bin/
     test:
       pipeline:
-        - uses: test/verify-service
         - runs: |
             systemctl --help
             systemctl --version


### PR DESCRIPTION
It is needed sometime to have systemctl but not the whole systemd package