### PR TITLE
Fix a FTBFS with xmlsec

### DIFF
--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.7
-  epoch: 2
+  epoch: 3
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT
@@ -41,6 +41,10 @@ pipeline:
       repository: https://github.com/lsh123/xmlsec
       expected-commit: 344a375d312c5de4c49ed02828aacea9d3956d53
       tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: fix-const-qualifier.patch
 
   - name: Autogen
     runs: |

--- a/xmlsec/fix-const-qualifier.patch
+++ b/xmlsec/fix-const-qualifier.patch
@@ -1,0 +1,11 @@
+--- a/src/xmltree.c
++++ b/src/xmltree.c
+@@ -718,7 +718,7 @@ xmlSecReplaceNodeBufferAndReturn(xmlNodePtr node, const xmlSecByte *buffer, xml
+     node->doc->encoding = NULL;
+     ret = xmlParseInNodeContext(node->parent, (const char*)buffer, len,
+             xmlSecParserGetDefaultOptions(), &results);
+-    node->doc->encoding = oldenc;
++    node->doc->encoding = (xmlChar *)oldenc;
+     if(ret != XML_ERR_OK) {
+         xmlSecXmlError("xmlParseInNodeContext", NULL);
+         return(-1);


### PR DESCRIPTION
xmlsec was failing to build from source with the following error before this patch:

```
2025/09/18 07:55:01 WARN xmltree.c: In function 'xmlSecReplaceNodeBufferAndReturn':
2025/09/18 07:55:01 WARN xmltree.c:721:25: error: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
2025/09/18 07:55:01 WARN   721 |     node->doc->encoding = oldenc;
2025/09/18 07:55:01 WARN       |                         ^
2025/09/18 07:55:01 INFO make[3]: Leaving directory '/home/build/src'
2025/09/18 07:55:01 WARN make[3]: *** [Makefile:723: xmltree.lo] Error 1
2025/09/18 07:55:01 WARN make[2]: *** [Makefile:743: all-recursive] Error 1
2025/09/18 07:55:01 INFO make[2]: Leaving directory '/home/build/src'
2025/09/18 07:55:01 INFO make[1]: Leaving directory '/home/build'
2025/09/18 07:55:01 WARN make[1]: *** [Makefile:770: all-recursive] Error 1
2025/09/18 07:55:01 WARN make: *** [Makefile:588: all] Error 2
2025/09/18 07:55:01 ERRO Failed to run command "/bin/sh -c 'set -e \n[ -d '\\''/home/build'\\'' ] || mkdir -p '\\''/home/build'\\''\ncd '\\''/home/build'\\''\ngit clean -fdx . && NOCONFIGURE=1\n./autogen.sh \\\n\t--prefix=/usr \\\n\t--with-openssl=/usr \\\n\t--enable-static \\\n\t--enable-static-linking \\\n\t--without-gnutls \\\n\t--without-gcrypt \\\n\t--without-nss \\\n\t--with-default-crypto=openssl\nmake\n\nexit 0'": Process exited with status 2
```