### PR TITLE
fix(py3-numpy-1.26.yaml): Bump py3-numpy-1.26.yaml epoch so it is the latest version - and NOT enterprise

### DIFF
--- a/py3-numpy-1.26.yaml
+++ b/py3-numpy-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-1.26
   version: 1.26.5
-  epoch: 5
+  epoch: 6
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
PR https://github.com/wolfi-dev/os/pull/66533 restored py3-numpy-1.26.yaml but did not bump the epoch so we had conflicting versions in enterprise and os
os should have the latest version

Signed-off-by: philroche <phil.roche@chainguard.dev>
