### PR TITLE
backfill: keycloak~23

### DIFF
--- a/backfill-packages.txt
+++ b/backfill-packages.txt
@@ -1,1 +1,1 @@
-zig-0.10.0-r0.apk
+keycloak-23.0.7-r0.apk


### PR DESCRIPTION
As requested in https://github.com/orgs/wolfi-dev/discussions/63043
backfill keycloak~23 as a temporary restore until Octobers GC event.
