### PR TITLE
openjdk-25: drop debuginfo, enable tests

### DIFF
--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-25
   version: "25"
-  epoch: 0
+  epoch: 1
   description: OpenJDK 25
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -97,18 +97,19 @@ pipeline:
 
   - runs: make jdk-image legacy-jre-image
 
-  # Check we built something valid
   - runs: |
       _java_bin="./build/*-server-release/images/jdk/bin"
 
+      # Check we built something valid
       $_java_bin/javac -d . HelloWorld.java
       $_java_bin/java HelloWorld
 
-      # NOTE: Disable flakey tests on aarch64 for now as we're seeing builds hang
-      if [ "${{build.arch}}" != "aarch64" ]; then
-        # run the gtest unittest suites
-        make test-hotspot-gtest
-      fi
+      # run the gtest unittest suites
+      make test-hotspot-gtest
+
+  # Purge any debuginfo files generated to support testing
+  - runs: |
+      find ./build -name "*.debuginfo" -delete
 
   - runs: |
       _java_home="usr/lib/jvm/java-25-openjdk"


### PR DESCRIPTION
Purge .debuginfo files from build directories to ensure we don't explode
the size of the built APK's.

Enable tests on aarch64 as they seem to be reliable now.
