### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "21.0.0"
-  epoch: 2
+  epoch: 3
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ environment:
       - protoc
       - py3-supported-build-base-dev
       - py3-supported-cython
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - rapidjson-dev
       - re2-dev
       - snappy-dev
@@ -135,7 +135,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
         - pyarrow
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - working-directory: /home/build/apache-arrow/python
         pipeline:

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.4"
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -77,7 +77,7 @@ environment:
       - postgresql-17-dev
       - postgresql-dev
       - proj-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-python
       - py3-supported-python-dev
       - py3-supported-setuptools
@@ -201,7 +201,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
       pipeline:
         - runs: |
             python${{range.key}} -c "from osgeo import gdal_array"

--- a/py3-apache-beam.yaml
+++ b/py3-apache-beam.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-apache-beam
   version: "2.67.0"
-  epoch: 1
+  epoch: 2
   description: Apache Beam SDK for Python
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ subpackages:
         - py${{range.key}}-grpcio
         - py${{range.key}}-hdfs
         - py${{range.key}}-httplib2
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-objsize
         - py${{range.key}}-orjson
         - py${{range.key}}-packaging

--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-bokeh
   version: "3.8.0"
-  epoch: 1
+  epoch: 2
   description: Interactive plots and applications in the browser from Python
   copyright:
     - license: BSD-3-Clause
@@ -48,7 +48,7 @@ subpackages:
       runtime:
         - py${{range.key}}-jinja2
         - py${{range.key}}-contourpy
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pandas
         - py${{range.key}}-pillow

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: "0.12.0"
-  epoch: 3
+  epoch: 4
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-scipy
     pipeline:
       - uses: py/pip-build-install

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: "1.3.3"
-  epoch: 1
+  epoch: 2
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause
@@ -43,7 +43,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-dask.yaml
+++ b/py3-dask.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dask
   version: "2025.9.0"
-  epoch: 1
+  epoch: 2
   description: Dask is a flexible parallel computing library for analytics.
   annotations:
     cgr.dev/ecosystem: python
@@ -110,7 +110,7 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-${{vars.pypi-package}}
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-faiss-cpu.yaml
+++ b/py3-faiss-cpu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-faiss-cpu
   version: "1.12.0"
-  epoch: 1
+  epoch: 2
   description: Community-maintained faiss wheel builder
   annotations:
     cgr.dev/ecosystem: python
@@ -31,7 +31,7 @@ environment:
       - gfortran
       - openblas-dev
       - py3-supported-build-base-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - swig
 
 pipeline:
@@ -61,7 +61,7 @@ subpackages:
     dependencies:
       runtime:
         - faiss-cpu
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-setuptools
     pipeline:
@@ -73,7 +73,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
       pipeline:
         - uses: python/import
           with:

--- a/py3-forestci.yaml
+++ b/py3-forestci.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-forestci
   version: '0.7'
-  epoch: 6
+  epoch: 7
   description: 'forestci: confidence intervals for scikit-learn forest algorithms'
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-scikit-learn
     pipeline:
       - uses: py/pip-build-install

--- a/py3-gguf.yaml
+++ b/py3-gguf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gguf
   version: 0.17.1
-  epoch: 1
+  epoch: 2
   description: Python package for writing binary files in the GGUF format
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-tqdm
         - py${{range.key}}-pyyaml
     pipeline:

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 9
+  epoch: 10
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD-3-Clause
@@ -39,7 +39,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-cloudpickle
         - py${{range.key}}-future
         - py${{range.key}}-networkx

--- a/py3-itables.yaml
+++ b/py3-itables.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-itables
   version: "2.5.2"
-  epoch: 1
+  epoch: 2
   description: Interactive Tables in Jupyter
   copyright:
     - license: MIT
@@ -47,7 +47,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-ipython
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pandas
     pipeline:

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-preprocessing
   version: 1.1.2
-  epoch: 6
+  epoch: 7
   description: Easy data preprocessing and data augmentation for deep learning models
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-six
     pipeline:
       - uses: py/pip-build-install

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: "3.10.6"
-  epoch: 1
+  epoch: 2
   description: Python plotting package
   copyright:
     - license: PSF-2.0
@@ -30,7 +30,7 @@ environment:
       - py3-supported-fonttools
       - py3-supported-kiwisolver
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pillow
       - py3-supported-pybind11
       - py3-supported-pyparsing
@@ -56,7 +56,7 @@ subpackages:
         - py${{range.key}}-dateutil
         - py${{range.key}}-fonttools
         - py${{range.key}}-kiwisolver
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pillow
         - py${{range.key}}-pyparsing

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.9.1
-  epoch: 7
+  epoch: 8
   description: Natural Language Toolkit
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-click
         - py${{range.key}}-joblib
         - py${{range.key}}-matplotlib

--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-opt-einsum
   version: 3.4.0
-  epoch: 6
+  epoch: 7
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: "4.5.0"
-  epoch: 1
+  epoch: 2
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-alembic
         - py${{range.key}}-cmaes
         - py${{range.key}}-colorlog

--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: "2.3.2"
-  epoch: 1
+  epoch: 2
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ environment:
       - meson
       - py3-supported-cython
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pip
       - py3-supported-python-dev
       - py3-supported-versioneer
@@ -51,7 +51,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-pytz
         - py${{range.key}}-dateutil
         - py${{range.key}}-tzdata

--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: "0.18.0"
-  epoch: 2
+  epoch: 3
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD-3-Clause
@@ -46,7 +46,7 @@ subpackages:
         - py${{range.key}}-beniget
         - py${{range.key}}-gast
         - py${{range.key}}-ply
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-setuptools
       provides:
         - py3-${{vars.pypi-package}}

--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sacrebleu
   version: 2.5.1
-  epoch: 2
+  epoch: 3
   description: Reference BLEU implementation that auto-downloads test sets and reports a version string to facilitate cross-lab comparisons
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ subpackages:
       runtime:
         - py${{range.key}}-colorama
         - py${{range.key}}-lxml
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-portalocker
         - py${{range.key}}-regex
         - py${{range.key}}-tabulate

--- a/py3-safetensors.yaml
+++ b/py3-safetensors.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-safetensors
   version: "0.6.2"
-  epoch: 1
+  epoch: 2
   description: Fast and Safe Tensor serialization
   copyright:
     - license: Apache-2.0
@@ -59,7 +59,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
             - py${{range.key}}-pip
             - py${{range.key}}-packaging
       pipeline:

--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: "1.7.2"
-  epoch: 1
+  epoch: 2
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ environment:
       - py3-supported-cython
       - py3-supported-joblib
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-python-dev
@@ -54,7 +54,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-joblib
         - py${{range.key}}-scipy
         - py${{range.key}}-threadpoolctl

--- a/py3-scikit-optimize.yaml
+++ b/py3-scikit-optimize.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-optimize
   version: 0.9.0
-  epoch: 8
+  epoch: 9
   description: Sequential model-based optimization toolbox.
   copyright:
     - license: BSD-3-Clause
@@ -25,7 +25,7 @@ environment:
     packages:
       - cython
       - py3-supported-build-base-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-scipy
 
 pipeline:
@@ -44,7 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-joblib
         - py${{range.key}}-matplotlib
         - py${{range.key}}-pillow

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scipy
   version: "1.16.2"
-  epoch: 1
+  epoch: 2
   description: Fundamental algorithms for scientific computing in Python
   copyright:
     - license: BSD-3-Clause
@@ -35,7 +35,7 @@ environment:
       - openblas-dev
       - py3-pythran-bin
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-pybind11
@@ -63,7 +63,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-seaborn
   version: 0.13.2
-  epoch: 5
+  epoch: 6
   description: Statistical data visualization
   copyright:
     - license: BSD-3-Clause
@@ -43,7 +43,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-pandas
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-matplotlib
     pipeline:
       - uses: py/pip-build-install

--- a/py3-transformers.yaml
+++ b/py3-transformers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-transformers
   version: "4.56.2"
-  epoch: 1
+  epoch: 2
   description: State-of-the-art Machine Learning for PyTorch, TensorFlow, and JAX
   copyright:
     - license: Apache-2.0
@@ -47,7 +47,7 @@ subpackages:
         - py${{range.key}}-fsspec
         - py${{range.key}}-huggingface-hub
         - py${{range.key}}-idna
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pyyaml
         - py${{range.key}}-regex


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>
