### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "21.0.0"
-  epoch: 2
+  epoch: 3
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ environment:
       - protoc
       - py3-supported-build-base-dev
       - py3-supported-cython
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - rapidjson-dev
       - re2-dev
       - snappy-dev
@@ -135,7 +135,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
         - pyarrow
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - working-directory: /home/build/apache-arrow/python
         pipeline:


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>
