### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "21.0.0"
-  epoch: 2
+  epoch: 3
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ environment:
       - protoc
       - py3-supported-build-base-dev
       - py3-supported-cython
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - rapidjson-dev
       - re2-dev
       - snappy-dev
@@ -135,7 +135,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
         - pyarrow
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - working-directory: /home/build/apache-arrow/python
         pipeline:

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.4"
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -77,7 +77,7 @@ environment:
       - postgresql-17-dev
       - postgresql-dev
       - proj-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-python
       - py3-supported-python-dev
       - py3-supported-setuptools
@@ -201,7 +201,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
       pipeline:
         - runs: |
             python${{range.key}} -c "from osgeo import gdal_array"

--- a/py3-apache-beam.yaml
+++ b/py3-apache-beam.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-apache-beam
   version: "2.67.0"
-  epoch: 1
+  epoch: 2
   description: Apache Beam SDK for Python
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ subpackages:
         - py${{range.key}}-grpcio
         - py${{range.key}}-hdfs
         - py${{range.key}}-httplib2
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-objsize
         - py${{range.key}}-orjson
         - py${{range.key}}-packaging

--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-bokeh
   version: "3.8.0"
-  epoch: 1
+  epoch: 2
   description: Interactive plots and applications in the browser from Python
   copyright:
     - license: BSD-3-Clause
@@ -48,7 +48,7 @@ subpackages:
       runtime:
         - py${{range.key}}-jinja2
         - py${{range.key}}-contourpy
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pandas
         - py${{range.key}}-pillow


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>
