### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: "0.12.0"
-  epoch: 3
+  epoch: 4
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-scipy
     pipeline:
       - uses: py/pip-build-install

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: "1.3.3"
-  epoch: 1
+  epoch: 2
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause
@@ -43,7 +43,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-dask.yaml
+++ b/py3-dask.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dask
   version: "2025.9.0"
-  epoch: 1
+  epoch: 2
   description: Dask is a flexible parallel computing library for analytics.
   annotations:
     cgr.dev/ecosystem: python
@@ -110,7 +110,7 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-${{vars.pypi-package}}
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-faiss-cpu.yaml
+++ b/py3-faiss-cpu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-faiss-cpu
   version: "1.12.0"
-  epoch: 1
+  epoch: 2
   description: Community-maintained faiss wheel builder
   annotations:
     cgr.dev/ecosystem: python
@@ -31,7 +31,7 @@ environment:
       - gfortran
       - openblas-dev
       - py3-supported-build-base-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - swig
 
 pipeline:
@@ -61,7 +61,7 @@ subpackages:
     dependencies:
       runtime:
         - faiss-cpu
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-setuptools
     pipeline:
@@ -73,7 +73,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
       pipeline:
         - uses: python/import
           with:


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>