### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-preprocessing
   version: 1.1.2
-  epoch: 6
+  epoch: 7
   description: Easy data preprocessing and data augmentation for deep learning models
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-six
     pipeline:
       - uses: py/pip-build-install

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: "3.10.6"
-  epoch: 1
+  epoch: 2
   description: Python plotting package
   copyright:
     - license: PSF-2.0
@@ -30,7 +30,7 @@ environment:
       - py3-supported-fonttools
       - py3-supported-kiwisolver
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pillow
       - py3-supported-pybind11
       - py3-supported-pyparsing
@@ -56,7 +56,7 @@ subpackages:
         - py${{range.key}}-dateutil
         - py${{range.key}}-fonttools
         - py${{range.key}}-kiwisolver
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pillow
         - py${{range.key}}-pyparsing

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.9.1
-  epoch: 7
+  epoch: 8
   description: Natural Language Toolkit
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-click
         - py${{range.key}}-joblib
         - py${{range.key}}-matplotlib

--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-opt-einsum
   version: 3.4.0
-  epoch: 6
+  epoch: 7
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT
@@ -44,7 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>