### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: "4.5.0"
-  epoch: 1
+  epoch: 2
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-alembic
         - py${{range.key}}-cmaes
         - py${{range.key}}-colorlog

--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: "2.3.2"
-  epoch: 1
+  epoch: 2
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ environment:
       - meson
       - py3-supported-cython
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pip
       - py3-supported-python-dev
       - py3-supported-versioneer
@@ -51,7 +51,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-pytz
         - py${{range.key}}-dateutil
         - py${{range.key}}-tzdata

--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: "0.18.0"
-  epoch: 2
+  epoch: 3
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD-3-Clause
@@ -46,7 +46,7 @@ subpackages:
         - py${{range.key}}-beniget
         - py${{range.key}}-gast
         - py${{range.key}}-ply
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-setuptools
       provides:
         - py3-${{vars.pypi-package}}

--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sacrebleu
   version: 2.5.1
-  epoch: 2
+  epoch: 3
   description: Reference BLEU implementation that auto-downloads test sets and reports a version string to facilitate cross-lab comparisons
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ subpackages:
       runtime:
         - py${{range.key}}-colorama
         - py${{range.key}}-lxml
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-portalocker
         - py${{range.key}}-regex
         - py${{range.key}}-tabulate


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>