### PR TITLE
ffmpeg-7: remediate CVE

### DIFF
--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -2,7 +2,7 @@
 package:
   name: ffmpeg-7
   version: "7.1.1"
-  epoch: 11
+  epoch: 12
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -69,6 +69,7 @@ pipeline:
       tag: n${{package.version}}
       cherry-picks: |
         master/d1ed5c06e3edc5f2b5f3664c80121fa55b0baa95: unbreak build with latest svtav1
+        master/bedfb6eca402037f5cbb115fa767d106b8c14f1c: remediate CVE-2025-1594
 
   - uses: patch
     with:


### PR DESCRIPTION
Remediate CVE-2025-1594
Cherry-pick
https://github.com/FFmpeg/FFmpeg/commit/bedfb6eca402037f5cbb115fa767d106b8c14f1c

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
