### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-apache-beam.yaml
+++ b/py3-apache-beam.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-apache-beam
   version: "2.67.0"
-  epoch: 1
+  epoch: 2
   description: Apache Beam SDK for Python
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ subpackages:
         - py${{range.key}}-grpcio
         - py${{range.key}}-hdfs
         - py${{range.key}}-httplib2
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-objsize
         - py${{range.key}}-orjson
         - py${{range.key}}-packaging


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>