### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-bokeh
   version: "3.8.0"
-  epoch: 1
+  epoch: 2
   description: Interactive plots and applications in the browser from Python
   copyright:
     - license: BSD-3-Clause
@@ -48,7 +48,7 @@ subpackages:
       runtime:
         - py${{range.key}}-jinja2
         - py${{range.key}}-contourpy
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pandas
         - py${{range.key}}-pillow


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>