### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-faiss-cpu.yaml
+++ b/py3-faiss-cpu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-faiss-cpu
   version: "1.12.0"
-  epoch: 1
+  epoch: 2
   description: Community-maintained faiss wheel builder
   annotations:
     cgr.dev/ecosystem: python
@@ -31,7 +31,7 @@ environment:
       - gfortran
       - openblas-dev
       - py3-supported-build-base-dev
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - swig
 
 pipeline:
@@ -61,7 +61,7 @@ subpackages:
     dependencies:
       runtime:
         - faiss-cpu
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-setuptools
     pipeline:
@@ -73,7 +73,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy<2.0
+            - py${{range.key}}-numpy-1.26
       pipeline:
         - uses: python/import
           with:


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>