### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-gguf.yaml
+++ b/py3-gguf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gguf
   version: 0.17.1
-  epoch: 1
+  epoch: 2
   description: Python package for writing binary files in the GGUF format
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ subpackages:
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-tqdm
         - py${{range.key}}-pyyaml
     pipeline:


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>