### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: "3.10.6"
-  epoch: 1
+  epoch: 2
   description: Python plotting package
   copyright:
     - license: PSF-2.0
@@ -30,7 +30,7 @@ environment:
       - py3-supported-fonttools
       - py3-supported-kiwisolver
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pillow
       - py3-supported-pybind11
       - py3-supported-pyparsing
@@ -56,7 +56,7 @@ subpackages:
         - py${{range.key}}-dateutil
         - py${{range.key}}-fonttools
         - py${{range.key}}-kiwisolver
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-packaging
         - py${{range.key}}-pillow
         - py${{range.key}}-pyparsing


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>