### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: "0.18.0"
-  epoch: 2
+  epoch: 3
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD-3-Clause
@@ -46,7 +46,7 @@ subpackages:
         - py${{range.key}}-beniget
         - py${{range.key}}-gast
         - py${{range.key}}-ply
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-setuptools
       provides:
         - py3-${{vars.pypi-package}}


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>