### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sacrebleu
   version: 2.5.1
-  epoch: 2
+  epoch: 3
   description: Reference BLEU implementation that auto-downloads test sets and reports a version string to facilitate cross-lab comparisons
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ subpackages:
       runtime:
         - py${{range.key}}-colorama
         - py${{range.key}}-lxml
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-portalocker
         - py${{range.key}}-regex
         - py${{range.key}}-tabulate


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>