### PR TITLE
fix(py3-numpy<2.0): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy<2.0

### DIFF
--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: "1.7.2"
-  epoch: 1
+  epoch: 2
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ environment:
       - py3-supported-cython
       - py3-supported-joblib
       - py3-supported-meson-python
-      - py3-supported-numpy<2.0
+      - py3-supported-numpy-1.26
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-python-dev
@@ -54,7 +54,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy<2.0
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-joblib
         - py${{range.key}}-scipy
         - py${{range.key}}-threadpoolctl


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used. APK does not have this issue
but as these packages are used in image builds, built using apko, they will fail to resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>