### PR TITLE
fix(py3-numpy): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy

### DIFF
--- a/modelmesh-runtime-adapter.yaml
+++ b/modelmesh-runtime-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: modelmesh-runtime-adapter
   version: 0.12.0
-  epoch: 16
+  epoch: 17
   description: Unified runtime-adapter package of the sidecar containers which run in the modelmesh pods
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - py3-google-auth
       - py3-google-auth-oauthlib
       - py3-importlib-metadata
-      - py3-numpy
+      - py3-numpy-1.26
       - py3-oauthlib
       - py3-requests-oauthlib
       - py3-rsa


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used AND also if numpy 1.x and 2.x are conflicting.

APK does not have this issue but as these packages are used in image builds, built using apko, they will fail to
resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of <2.0.

Signed-off-by: philroche <phil.roche@chainguard.dev>
