### PR TITLE
bugfix/explicit py3 numpy 1.26 dependencies tensorflow core

### DIFF
--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: "2.19.0"
-  epoch: 4
+  epoch: 5
   copyright:
     - license: Apache-2.0
   resources:
@@ -157,7 +157,7 @@ subpackages:
         - py${{range.key}}-google-pasta # needed by tf_upgrade_v2
         - py${{range.key}}-keras # needed by toco, tflite_convert
         - py${{range.key}}-ml-dtypes
-        - py${{range.key}}-numpy
+        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-opt-einsum
         - py${{range.key}}-pip
         - py${{range.key}}-protobuf


### PR DESCRIPTION
fix(py3-numpy): Pin explicitly to py3-numpy-1.26 packages instead of py3-numpy

https://github.com/chainguard-dev/apko/issues/1861 details an issue with apko where it is unable to
correctly resolve depdnencies if a provides AND a constraint is used AND also if numpy 1.x and 2.x are conflicting.

APK does not have this issue but as these packages are used in image builds, built using apko, they will fail to
resolve and as such, fail to build.

As there are no more planned numpy 1.x versions, we can safely depend on 1.26 explicitly instead of py3-numpy without version specified.

Signed-off-by: philroche <phil.roche@chainguard.dev>
