### PR TITLE
feat(jenkins-2): bump dep to remediate GHSA-jmp9-x22r-554x and GHSA-8v5q-rhf3-jphm

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,6 +1,6 @@
 package:
   name: jenkins-2
-  version: "2.527"
+  version: "2.528"
   epoch: 0
   description: Open-source CI/CD application.
   copyright:
@@ -46,9 +46,14 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
-      expected-commit: 7c17018e75beb7ce00d5cbd663a7e5ccdd864f8b
+      expected-commit: 1fbaa7ccedf8a695e272e89376d4cd405c72127a
 
   - uses: maven/pombump
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps-bom.yaml
+      pom: bom/pom.xml
 
   - runs: mvn spotless:apply
 

--- a/jenkins-2/pombump-deps-bom.yaml
+++ b/jenkins-2/pombump-deps-bom.yaml
@@ -1,0 +1,11 @@
+patches:
+  - groupId: org.springframework.security
+    artifactId: spring-security-bom
+    version: 6.5.4
+    type: pom
+    scope: import
+  - groupId: org.springframework
+    artifactId: spring-framework-bom
+    version: 6.2.11
+    type: pom
+    scope: import


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump deps to remediate GHSA-jmp9-x22r-554x and GHSA-8v5q-rhf3-jphm
<!--ci-cve-scan:fail-any-->
