### PR TITLE
openjdk-25: add -dbg package and generate internal symbols

### DIFF
--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-25
   version: "25"
-  epoch: 1
+  epoch: 2
   description: OpenJDK 25
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -80,7 +80,7 @@ pipeline:
         --enable-dtrace=no \
         --with-zlib=system \
         --with-debug-level=release \
-        --with-native-debug-symbols=external \
+        --with-native-debug-symbols=internal \
         --with-external-symbols-in-bundles=none \
         --with-cacerts-file=/etc/ssl/certs/java/cacerts \
         --with-jvm-variants=server \
@@ -107,10 +107,6 @@ pipeline:
       # run the gtest unittest suites
       make test-hotspot-gtest
 
-  # Purge any debuginfo files generated to support testing
-  - runs: |
-      find ./build -name "*.debuginfo" -delete
-
   - runs: |
       _java_home="usr/lib/jvm/java-25-openjdk"
 
@@ -126,6 +122,14 @@ pipeline:
       ln -sf . "${{targets.contextdir}}/$_java_home/jre"
 
 subpackages:
+  - name: "${{package.name}}-dbg"
+    description: "OpenJDK 25 Java Debug Symbols"
+    pipeline:
+      - uses: split/debug
+    dependencies:
+      runtime:
+        - ${{package.name}}
+
   - name: "${{package.name}}-jre"
     description: "OpenJDK 25 Java Runtime Environment"
     dependencies:


### PR DESCRIPTION
Generate internal debug symbols (which ensures tests pass) and split into a separate -dbg package.