### PR TITLE
py3-keras: update numpy dependency

### DIFF
--- a/py3-h5py.yaml
+++ b/py3-h5py.yaml
@@ -3,7 +3,7 @@ package:
   description: Read and write HDF5 files from Python
   url: https://www.h5py.org
   version: "3.14.0"
-  epoch: 2
+  epoch: 3
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -28,7 +28,7 @@ environment:
       - hdf5-dev
       - liblzf-dev
       - py3-supported-cython
-      - py3-supported-numpy-2.2
+      - py3-supported-numpy-2.1
       - py3-supported-pip
       - py3-supported-pkgconfig
       - py3-supported-python-dev
@@ -54,7 +54,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy-2.2
+        - py${{range.key}}-numpy-2.1
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-keras-applications.yaml
+++ b/py3-keras-applications.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-applications
   version: 1.0.8
-  epoch: 6
+  epoch: 7
   description: Reference implementations of popular deep learning models
   copyright:
     - license: MIT
@@ -40,7 +40,6 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy
         - py${{range.key}}-h5py
     pipeline:
       - uses: py/pip-build-install

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-preprocessing
   version: 1.1.2
-  epoch: 7
+  epoch: 8
   description: Easy data preprocessing and data augmentation for deep learning models
   copyright:
     - license: MIT
@@ -40,7 +40,6 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy-1.26
         - py${{range.key}}-six
     pipeline:
       - uses: py/pip-build-install

--- a/py3-keras.yaml
+++ b/py3-keras.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras
   version: "3.11.3"
-  epoch: 0
+  epoch: 1
   description: Deep learning for humans.
   copyright:
     - license: Apache-2.0
@@ -47,7 +47,6 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-absl-py
-        - py${{range.key}}-numpy
         - py${{range.key}}-rich
         - py${{range.key}}-namex
         - py${{range.key}}-h5py


### PR DESCRIPTION
Update dependency on numpy to be the 2.2 version stream. This is because:
 * h5py requires numpy 2.2
 * both keras packages need to be in sync wrt. what numpy version to use

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
