### PR TITLE
fix(juicefs-csi-driver): add busybox

### DIFF
--- a/juicefs-csi-driver.yaml
+++ b/juicefs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-csi-driver
   version: "0.30.0"
-  epoch: 0
+  epoch: 1
   description: JuiceFS CSI Driver implements the CSI specification, allowing JuiceFS to be integrated with container orchestration systems. Under Kubernetes, JuiceFS can provide storage service to Pods via PersistentVolume.
   copyright:
     - license: Apache-2.0

--- a/juicefs-csi-driver.yaml
+++ b/juicefs-csi-driver.yaml
@@ -7,6 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - busybox # the controller now calls umask which is a shell builtin
       - coreutils # Needed for working with volumes
       - juicefs # Needed for JuiceFS CSI Driver functions, attached symlinks too.
       - lsof # Check which process is using a file, mount point, or socket.


### PR DESCRIPTION
Juicefs inserted [a `umask` call](https://github.com/juicedata/juicefs-csi-driver/commit/f9e09364b9db434ed3fe2bd59f124a668ad44a35) to the controller in the last release, so setting quotas started to fail because the command wasn't available.

