### PR TITLE
feat(ruby3.x-fluentd-kubernetes-daemonset-1.18): bump dep to remediate GHSA-c2f4-jgmc-q2r5

### DIFF
--- a/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.1-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 5
+  epoch: 6
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
           # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
-          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+          sed -i 's/rexml (3\.2\.9)/rexml (3.4.2)/' Gemfile.lock
 
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.2-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 4
+  epoch: 5
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
           # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
-          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+          sed -i 's/rexml (3\.2\.9)/rexml (3.4.2)/' Gemfile.lock
 
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 4
+  epoch: 5
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
           # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
-          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+          sed -i 's/rexml (3\.2\.9)/rexml (3.4.2)/' Gemfile.lock
 
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.18.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.4-fluentd-kubernetes-daemonset-1.18
   version: 1.18.0.1.0
-  epoch: 4
+  epoch: 5
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
           # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
-          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+          sed -i 's/rexml (3\.2\.9)/rexml (3.4.2)/' Gemfile.lock
 
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-c2f4-jgmc-q2r5

<!--ci-cve-scan:fail-any-->
