### PR TITLE
thingsboard/GHSA-jmp9-x22r-554x/GHSA-8v5q-rhf3-jphm fix

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.2"
-  epoch: 7 # GHSA-8v5q-rhf3-jphm
+  epoch: 6 # GHSA-8v5q-rhf3-jphm
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.2"
-  epoch: 6 # GHSA-8v5q-rhf3-jphm
+  epoch: 7 # GHSA-8v5q-rhf3-jphm
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,11 @@ pipeline:
     with:
       patch-file: proto-pombump-deps.yaml
       pom: common/proto/pom.xml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pompbump-deps-util.yaml
+      pom: common/util/pom.xml
 
   - uses: maven/pombump
     with:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.2"
-  epoch: 5 # GHSA-fghv-69vj-qj49
+  epoch: 6 # GHSA-8v5q-rhf3-jphm
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/thingsboard/pombump-deps-util.yaml
+++ b/thingsboard/pombump-deps-util.yaml
@@ -1,7 +1,4 @@
 patches:
-  - groupId: com.squareup.wire
-    artifactId: wire-schema-jvm
-    version: 4.9.9
   - groupId: org.springframework.security
     artifactId: spring-core
     version: 6.2.11

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -2,3 +2,6 @@ patches:
   - groupId: com.squareup.wire
     artifactId: wire-schema-jvm
     version: 4.9.9
+  - groupId: org.springframework.security
+    artifactId: spring-security-core
+    version: 6.4.10

--- a/thingsboard/pombump-properties.yaml
+++ b/thingsboard/pombump-properties.yaml
@@ -2,6 +2,6 @@ properties:
   - property: jgit.version
     value: "7.2.1.202505142326-r"
   - property: spring-boot.version
-    value: "3.4.9"
+    value: "3.4.10"
   - property: netty.version
     value: "4.1.125.Final"


### PR DESCRIPTION
  ## Summary

  Updates ThingsBoard package to address security vulnerabilities and dependency updates.

  ## Changes
  - **Spring Boot**: 3.4.9 → 3.4.10
  - **Spring Core**: Updated to 6.2.11
  - **Security patches**: Added pombump-deps file for relevant `thingsboard-tb-mqtt-transport` and `thingsboard-tb-node` pom.xml for spring-core and spring-security-core


  ## Testing

  - [X] Package builds successfully
  - [X] Security scan confirms vulnerability resolution
  - [X] ThingsBoard functionality validated with `make/test`
