### PR TITLE
feat(gst-plugins-bad): enable openh264enc plugin for gst-plugins-bad package

### DIFF
--- a/gst-plugins-bad.yaml
+++ b/gst-plugins-bad.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-bad
   version: "1.27.2"
-  epoch: 0
+  epoch: 1
   description: GStreamer streaming media framework bad plug-ins
   copyright:
     - license: LGPL-2.1
@@ -37,6 +37,7 @@ environment:
       - mesa-glx
       - mesa-libgallium
       - meson
+      - openh264-dev # needed for openh264enc plugin
       - opus-dev
       - orc-compiler
       - orc-dev

--- a/gst-plugins-bad.yaml
+++ b/gst-plugins-bad.yaml
@@ -96,4 +96,7 @@ test:
     - runs: |
         gst-transcoder-1.0 --help
         playout --help
+    - runs: |
+        # Verify the OpenH264 encoder plugin is present
+        gst-inspect-1.0 openh264enc | grep -Eq "OpenH264 encoder/decoder plugin"
     - uses: test/tw/ldd-check


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

**NOTES:**
- livekit-egress fails when trying to create an egress worker job with the following error: `could not create element: could not create element: x264enc`
- `x264enc` is in gst-plugins-ugly (patent/licensing issues). Currently not in our packages.
- `OpenH264` is an alternative and is available with gst-plugins-bad, which we do have. But needs to be enabled

**Related:**
Will be runtime dep of livekit-egress package.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
- [ ] Functional tests are present.
- [ ] We cannot write functional tests, but smoke tests are present (e.g. `--help/--version` checks) - explain why in notes below.
- [ ] Tests fail **and** pass when it's expected.

##### Notes:
Add notes if required.

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/chainguard-dev/enterprise-packages/blob/main/withdrawn-packages.txt))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/chainguard-dev/enterprise-advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented