### PR TITLE
Reformat openssf GCC spec files

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 27
+  epoch: 28
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
@@ -1,8 +1,23 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=2 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -mbranch-protection=standard \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/12/openssf.spec
@@ -1,8 +1,24 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=3 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -ftrivial-auto-var-init=zero \
+  -mbranch-protection=standard \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/13/openssf.spec
@@ -1,8 +1,24 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=3 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -ftrivial-auto-var-init=zero \
+  -mbranch-protection=standard \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf.spec
@@ -1,8 +1,22 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  -fhardened \
+  -Wno-error=hardened \
+  -Wno-hardened \
+  -mbranch-protection=standard \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -1,8 +1,23 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  -fhardened \
+  -Wno-error=hardened \
+  -Wno-hardened \
+  -mbranch-protection=standard \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now -z gcs=never
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now \
+  -z gcs=never
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
@@ -1,8 +1,23 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=2 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -fcf-protection=full \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/12/openssf.spec
@@ -1,8 +1,24 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=3 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -ftrivial-auto-var-init=zero \
+  -fcf-protection=full \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/13/openssf.spec
@@ -1,8 +1,24 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -ftrivial-auto-var-init=zero -fcf-protection=full -fstack-clash-protection -fstack-protector-strong
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer \
+  -Wp,-D_FORTIFY_SOURCE=3 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
+  -ftrivial-auto-var-init=zero \
+  -fcf-protection=full \
+  -fstack-clash-protection \
+  -fstack-protector-strong
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf.spec
@@ -1,8 +1,21 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  -fhardened \
+  -Wno-error=hardened \
+  -Wno-hardened \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
@@ -1,8 +1,21 @@
 *self_spec:
-+ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing %{!fomit-frame-pointer:-fno-omit-frame-pointer} -mno-omit-leaf-frame-pointer
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
+  -fhardened \
+  -Wno-error=hardened \
+  -Wno-hardened \
+  %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \
+  -fno-strict-overflow \
+  -fno-strict-aliasing \
+  %{!fomit-frame-pointer:-fno-omit-frame-pointer} \
+  -mno-omit-leaf-frame-pointer
 
 *link:
-+ --as-needed -O1 --sort-common -z noexecstack -z relro -z now
++ --as-needed \
+  -O1 \
+  --sort-common \
+  -z noexecstack \
+  -z relro \
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
Use multi-line formatting to make it easier to understand what changed and which flags are being applied.

This change doesn't introduce any modifications to the flags we're using.