### PR TITLE
Extend OpenSSF tests to all available compilers

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 28
+  epoch: 29
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -8,7 +8,7 @@ package:
     - license: CC-BY-4.0
 
 vars:
-  clang-major-versions: 14 15 16 17 18 19 20
+  clang-major-versions: 15 16 17 18 19 20
   gcc-major-versions: 11 12 13 14 15
 
 environment:

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -43,14 +43,16 @@ test:
   environment:
     contents:
       packages:
-        - clang-18
+        - clang-20
         - gcc
         - gcc-11
         - gcc-12
+        - gcc-13
+        - gcc-14
   pipeline:
     - uses: test/compiler/hardening-check
       with:
-        cc: clang-18
+        cc: clang-20
     - uses: test/compiler/hardening-check
       with:
         cc: gcc
@@ -60,6 +62,12 @@ test:
     - uses: test/compiler/hardening-check
       with:
         cc: gcc-12
+    - uses: test/compiler/hardening-check
+      with:
+        cc: gcc-13
+    - uses: test/compiler/hardening-check
+      with:
+        cc: gcc-14
     - name: Ensure gcc_s is linked
       runs: |
         touch foo.c


### PR DESCRIPTION
We're only testing a subset of our existing compilers.  Let's test everything, since they're all covered by our OpenSSF flags.

Unfortunately the clang compilers are not co-installable, so let's just test the latest one.