### PR TITLE
py3-numpy-1.26: Make it conflict with all curret 2.X versions

### DIFF
--- a/py3-numpy-1.26.yaml
+++ b/py3-numpy-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-1.26
   version: 1.26.5
-  epoch: 6
+  epoch: 7
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause
@@ -69,6 +69,9 @@ subpackages:
       provides:
         - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
         - py3-${{vars.pypi-package}}=${{package.version}}
+        - "!py${{range.key}}-numpy-2.2"
+        - "!py${{range.key}}-numpy-2.1"
+        - "!py${{range.key}}-numpy-2.3"
         - numpy
       provider-priority: ${{range.value}}
     test:


### PR DESCRIPTION
This should make debugging and fixing things a bit easier and leave the sovler some room to find better matches itself.

Before:

```
2025/09/22 16:04:34 INFO installing py3.12-numpy-1.26 (1.26.5-r6) arch=x86_64
2025/09/22 16:04:34 INFO installing py3.12-numpy-2.2 (2.2.6-r0) arch=x86_64
Error: building "amd64" layer: installing apk packages: installing packages: installing py3.12-numpy-2.2 (ver:2.2.6-r0 arch:x86_64): unable to install files for pkg py3.12-numpy-2.2: writing header for "usr/lib/python3.12/site-packages/numpy/__config__.py": packages map[py3.12-numpy-1.26:py3-numpy-1.26 py3.12-numpy-2.2:py3-numpy-2.2] has conflicting file: "usr/lib/python3.12/site-packages/numpy/__config__.py"
2025/09/22 16:04:34 INFO error during command execution: building "amd64" layer: installing apk packages: installing packages: installing py3.12-numpy-2.2 (ver:2.2.6-r0 arch:x86_64): unable to install files for pkg py3.12-numpy-2.2: writing header for "usr/lib/python3.12/site-packages/numpy/__config__.py": packages map[py3.12-numpy-1.26:py3-numpy-1.26 py3.12-numpy-2.2:py3-numpy-2.2] has conflicting file: "usr/lib/python3.12/site-packages/numpy/__config__.py"
```

after:

```
2025/09/22 16:05:19 WARN getting local index /Users/justin/src/wolfi-dev/wolfi/packages/x86_64/APKINDEX.tar.gz: stat: stat /Users/justin/src/wolfi-dev/wolfi/packages/x86_64/APKINDEX.tar.gz: no such file or directory
Error: locking config: resolving apk packages: for arch "amd64": solving "py3.12-numpy-1.26=1.26.5-r7" constraint:   py3.12-numpy-1.26-1.26.5-r0.apk disqualified because "1.26.5-r0" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r4.apk disqualified because "1.26.5-r4" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r5.apk disqualified because "1.26.5-r5" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r6.apk disqualified because "1.26.5-r6" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
2025/09/22 16:05:19 INFO error during command execution: locking config: resolving apk packages: for arch "amd64": solving "py3.12-numpy-1.26=1.26.5-r7" constraint:   py3.12-numpy-1.26-1.26.5-r0.apk disqualified because "1.26.5-r0" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r4.apk disqualified because "1.26.5-r4" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r5.apk disqualified because "1.26.5-r5" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
  py3.12-numpy-1.26-1.26.5-r6.apk disqualified because "1.26.5-r6" does not satisfy "py3.12-numpy-1.26=1.26.5-r7"
```

keep in mind for this to work all possible resolutions of py3-numpy-1.26 need to have this so we need to withdraw the existing py3.X numpy-1.26 packages.

