### PR TITLE
fix(rancher-api-ui): Bump bootstrap to remediate GHSA-q58r-hwc8-rm9j

### DIFF
--- a/rancher-api-ui.yaml
+++ b/rancher-api-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-api-ui
   version: "1.2.3"
-  epoch: 2
+  epoch: 3 # GHSA-q58r-hwc8-rm9j
   description: Embedded UI for any service that implements the Rancher API spec
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,10 @@ pipeline:
   - uses: patch
     with:
       patches: CVE-2024-4068.patch fix-GHSA-v6h2-p8h4-qcjw.patch
+
+  - runs: |
+      # Remediate GHSA-q58r-hwc8-rm9j
+      sed -i 's/"bootstrap": "3.4.1"/"bootstrap": "5.0.2"/' package.json
 
   - runs: |
       yarn build --omit=dev


### PR DESCRIPTION
Bump bootstrap from 3.4.1 to 5.0.2 to remeidate GHSA-q58r-hwc8-rm9j
Bumping to intermediate versions like 4.x.x introduced other vulnerabilities. 
Bumping to 5.0.2 makes the package CVE free.

<!--ci-cve-scan:fail-any-->

