### PR TITLE
tshark-4.4: test privileged version of tshark + add timelimit

### DIFF
--- a/tshark-4.4.yaml
+++ b/tshark-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: tshark-4.4
   version: "4.4.9"
-  epoch: 0
+  epoch: 1
   description: "TShark is a network protocol analyzer to dump and analyze network traffic"
   copyright:
     - license: GPL-2.0-only
@@ -121,11 +121,21 @@ subpackages:
       environment:
         contents:
           packages:
+            - curl
             - libcap-utils
+        accounts:
+          run-as: build
       pipeline:
         - runs: |
             getcap /usr/bin/tshark | cut -d ' ' -f2 | grep -q -E '^cap_net_admin,cap_net_raw=eip$'
             getcap /usr/bin/dumpcap | cut -d ' ' -f2 | grep -q -E '^cap_net_admin,cap_net_raw=eip$'
+        - name: Test packet capture
+          runs: |
+            tshark -w /tmp/out.pcap -c 20 -a duration:10 host example.com &
+            PID=$!
+            sleep 1; curl -sI http://example.com; sleep 1
+            tshark -r /tmp/out.pcap -Y "http" |grep '200 OK'
+            kill $PID
         - uses: test/tw/ldd-check
 
 update:
@@ -147,7 +157,7 @@ test:
         tshark --version | grep -F -e "${{package.version}}"
     - name: Test packet capture
       runs: |
-        tshark -w /tmp/out.pcap -c 20 host example.com &
+        tshark -w /tmp/out.pcap -c 20 -a duration:10 host example.com &
         PID=$!
         sleep 1; curl -sI http://example.com; sleep 1
         tshark -r /tmp/out.pcap -Y "http" |grep '200 OK'


### PR DESCRIPTION
Test that the variant of tshark with filesystemp capabilities set can capture packets as an unprivileged user ("build") and also limit the duration of the packet capture tests to 10 seconds, to ensure that tshark eventually quits in the face of network problems.
