### PR TITLE
linkerd2-proxy-init: remediate CVE

### DIFF
--- a/linkerd2-proxy-init.yaml
+++ b/linkerd2-proxy-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-proxy-init
   version: "2.4.3"
-  epoch: 2
+  epoch: 3
   description: "Init container that sets up the iptables rules to forward traffic into the Linkerd2 sidecar proxy"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Remediate CVE-2025-47906
Bump epoch to build with latest go

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
