### PR TITLE
stakater-reloader: remediate CVE

### DIFF
--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: "1.4.8"
-  epoch: 1
+  epoch: 2
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Remediate CVE-2025-47906
Bump epoch to build with latest go

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
