### PR TITLE
py3-numpy-2.3: Allow it to be used as py3-numpy and conflict with others

### DIFF
--- a/py3-numpy-2.3.yaml
+++ b/py3-numpy-2.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-2.3
   version: "2.3.3"
-  epoch: 0
+  epoch: 1
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause
@@ -58,10 +58,9 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-pygments
-      # Intentionally disabled for now to ensure a smooth migration
-      #provides:
-      #  - py${{range.key}}-${{vars.pypi-package}}
-      #  - numpy
+      provides:
+        - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
+        - numpy
       provider-priority: ${{range.value}}
     test:
       pipeline:
@@ -78,6 +77,8 @@ subpackages:
       runtime:
         - py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}
       provides:
+        - py3-numpy-bin
+        - py${{range.key}}-numpy-bin=${{package.version}}
         - f2py
         - numpy-config
       provider-priority: ${{range.value}}
@@ -128,6 +129,8 @@ subpackages:
   - name: py3-supported-${{vars.pypi-package}}-${{vars.major-minor-version}}
     description: meta package providing ${{vars.pypi-package}}-${{vars.major-minor-version}} for supported python versions.
     dependencies:
+      provides:
+        - py3-supported-numpy=${{package.version}}
       runtime:
         - py3.11-${{vars.pypi-package}}-${{vars.major-minor-version}}
         - py3.12-${{vars.pypi-package}}-${{vars.major-minor-version}}


### PR DESCRIPTION
This makes py3-numpy-2.3 provide `py3-numpy` so that `py3-numpy`_can_ install it.
It also provides `py${{range.key}}-numpy=${{package.version}}` so that other python version modules providing numpy conflict. Additionally it provides `py3-numpy-supported=${{package.version}}` to conflict with other numpy supported packages. This is not strictly needed since the `py3.XX-numpy...` package will conflict but this should cause the solver to point out that supported is conflicting instead of the module.