### PR TITLE
Numpy 2.2 move from enterprise

### DIFF
--- a/py3-numpy-2.2.yaml
+++ b/py3-numpy-2.2.yaml
@@ -68,7 +68,7 @@ subpackages:
         - py${{range.key}}-pygments
       provides:
         - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
-        - py3-${{vars.pypi-package}}=${{package.version}}
+        - py3-${{vars.pypi-package}}
         - numpy
       provider-priority: ${{range.value}}
     test:

--- a/py3-numpy-2.2.yaml
+++ b/py3-numpy-2.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-2.2
   version: 2.2.6
-  epoch: 3
+  epoch: 4
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause

--- a/py3-numpy-2.2.yaml
+++ b/py3-numpy-2.2.yaml
@@ -1,0 +1,158 @@
+package:
+  name: py3-numpy-2.2
+  version: 2.2.6
+  epoch: 3
+  description: The fundamental package for scientific computing with Python.
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
+vars:
+  pypi-package: numpy
+
+data:
+  # Numpy 2.2 only supports Python 3.10-3.13 (and probably not 3.14 when it comes out)
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - cython
+      - gfortran
+      - git
+      - meson
+      - openblas-dev
+      - py3-supported-pip
+      - py3-supported-python-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/numpy/numpy
+      tag: v${{package.version}}
+      expected-commit: 2b686f659642080e2fc708719385de6e8be0955f
+      recurse-submodules: true
+      cherry-picks: |
+        main/e48fdef5d7bf8ba2f90972c531cdfa07481ae535: numpy.test() segfault fix (remove NPY_ALIGNMENT_REQUIRED)
+
+# The main package is empty, and expected to stay that way
+test:
+  pipeline:
+    - uses: test/emptypackage
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    description: ${{vars.pypi-package}}-${{vars.major-minor-version}} installed for python${{range.key}}
+    pipeline:
+      - runs: python${{range.key}} -m pip install . "--root=${{targets.contextdir}}" --prefix=/usr
+      - uses: strip
+    dependencies:
+      runtime:
+        - py${{range.key}}-pygments
+      provides:
+        - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
+        - py3-${{vars.pypi-package}}=${{package.version}}
+        - numpy
+      provider-priority: ${{range.value}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import numpy
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}
+      provides:
+        - f2py
+        - numpy-config
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr
+          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}-${{vars.major-minor-version}}/usr/bin ${{targets.contextdir}}/usr
+    test:
+      environment:
+        contents:
+          packages:
+            - gcc
+            - git
+            - meson
+            - py${{range.key}}-pytest
+            - py${{range.key}}-pip
+            - py${{range.key}}-meson
+            - python-${{range.key}}-dev
+            - gfortran
+      pipeline:
+        - name: "Downgrade Setuptools for Python < 3.12"
+          runs: |
+            # Reference: https://numpy.org/devdocs/reference/distutils_status_migration.html
+            # The lack of this downgrade causes issues revealed through numpy.test()
+            # and our downgrade is overridden when the test build pulls in py3-setuptools-wheel, which can't be sufficiently downgraded
+            if [[ "${{range.value}}" -lt 312 ]]; then
+              pip${{range.key}} install "setuptools<60" --root-user-action ignore
+            fi
+        - runs: |
+            f2py -v
+            numpy-config -h
+            numpy-config --version | grep ${{package.version}}
+        - runs: |
+            # We have no Wolfi package for hypothesis (yet)
+            pip${{range.key}} install hypothesis --root-user-action ignore
+            python${{range.key}} -c "import numpy, sys; sys.exit(numpy.test() is False)"
+        - runs: |
+            git clone --branch v${{package.version}} https://github.com/numpy/numpy.git py${{range.key}}-numpy
+            cd py${{range.key}}-numpy/numpy
+            cp -r tests ../..
+            cd ../../tests
+
+            # This whole test suite appears to be broken in numpy 2.1+
+            rm -f test_ctypeslib.py
+            # test_NPY_NO_EXPORT fails due to trying to test code (_multiarray_tests) that isn't shipped in production, so we skip it.
+            python${{range.key}} -m pytest . -k "not test_api_importable and not test_NPY_NO_EXPORT"
+
+  - name: py3-supported-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    description: meta package providing ${{vars.pypi-package}}-${{vars.major-minor-version}} for supported python versions.
+    dependencies:
+      provides:
+        - py3-supported-numpy=${{package.version}}
+      runtime:
+        - py3.10-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.11-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.12-${{vars.pypi-package}}-${{vars.major-minor-version}}
+        - py3.13-${{vars.pypi-package}}-${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  git:
+    tag-filter-prefix: v2.2
+    strip-prefix: v
+    strip-suffix: .dev0


### PR DESCRIPTION
Necessary for some dependencies, see https://chainguard-dev.slack.com/archives/C09G50ZCA9W/p1758652599810379?thread_ts=1758650526.872959&cid=C09G50ZCA9W