### PR TITLE
Revert "openssf-compiler-options: Remove clang-14 from supported list"

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -8,7 +8,7 @@ package:
     - license: CC-BY-4.0
 
 vars:
-  clang-major-versions: 15 16 17 18 19 20
+  clang-major-versions: 14 15 16 17 18 19 20
   gcc-major-versions: 11 12 13 14 15
 
 environment:


### PR DESCRIPTION
We still have users of clang-14.

This reverts commit 4c3de5f9c11ebc667cb2e23b8259d6980597ec52.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
