### PR TITLE
systemd: cherry-pick upstream patch exposing system UIDs/GIDs in pkgconf

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,6 +1,5 @@
 package:
   name: systemd
-  # 35712.patch can be dropped when 258 releases
   version: "258"
   epoch: 0
   description: The systemd System and Service Manager

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "258"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -93,6 +93,10 @@ pipeline:
       repository: https://github.com/systemd/systemd
       tag: v${{package.version}}
       expected-commit: 781d9d0789379d1ea1f2ecefb804d41e9c8b6c38
+
+  - uses: patch
+    with:
+      patches: pkgconf-expose-variables-for-system-alloc-uid-gid-min.patch
 
   # systemd-detect is currently broken for aarch64 GCP VM's https://github.com/systemd/systemd/pull/38125
   # https://github.com/chainguard-dev/internal-dev/issues/17776

--- a/systemd/pkgconf-expose-variables-for-system-alloc-uid-gid-min.patch
+++ b/systemd/pkgconf-expose-variables-for-system-alloc-uid-gid-min.patch
@@ -1,0 +1,32 @@
+From 346b7b6b4931fc6bee9e820e0160dd024a86ed52 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markus.boehme@mailbox.org>
+Date: Wed, 27 Aug 2025 22:49:29 +0200
+Subject: [PATCH] pkgconf: expose variables for system-alloc-{uid,gid}-min
+
+Expose variables for system-alloc-uid-min and system-alloc-gid-min
+similar to the UID/GID ranges already exposed for the respective
+maximums, and other UID/GID ranges.
+---
+ src/core/systemd.pc.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
+index 58f2463104..dcf7bbc9a3 100644
+--- a/src/core/systemd.pc.in
++++ b/src/core/systemd.pc.in
+@@ -90,8 +90,12 @@ modulesloaddir=${modules_load_dir}
+ catalog_dir=${prefix}/lib/systemd/catalog
+ catalogdir=${catalog_dir}
+ 
++system_alloc_uid_min={{SYSTEM_ALLOC_UID_MIN}}
++systemallocuidmin=${system_alloc_uid_min}
+ system_uid_max={{SYSTEM_UID_MAX}}
+ systemuidmax=${system_uid_max}
++system_alloc_gid_min={{SYSTEM_ALLOC_GID_MIN}}
++systemallocgidmin=${system_alloc_gid_min}
+ system_gid_max={{SYSTEM_GID_MAX}}
+ systemgidmax=${system_gid_max}
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
Cherry-pick upstream patch 346b7b6b ("pkgconf: expose variables for system-alloc-{uid,gid}-min") that will likely only land in systemd v259. It will be useful to sanity check UID/GID values added to login.defs owned by the shadow package.

Related: https://github.com/wolfi-dev/os/pull/64005 (which does this for maximum UIDs already)

### Pre-review Checklist

#### For PRs that add patches

- [X] Patch source is documented (cherry-pick of upstream commit, commit ID in patch and commit message)
