### PR TITLE
systemd/258 package update

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,8 +1,8 @@
 package:
   name: systemd
   # 35712.patch can be dropped when 258 releases
-  version: "257.9"
-  epoch: 2
+  version: "258"
+  epoch: 0
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -93,7 +93,7 @@ pipeline:
     with:
       repository: https://github.com/systemd/systemd
       tag: v${{package.version}}
-      expected-commit: 147c30b613960bc24595435bd902a5c4beb5aba9
+      expected-commit: 781d9d0789379d1ea1f2ecefb804d41e9c8b6c38
 
   # systemd-detect is currently broken for aarch64 GCP VM's https://github.com/systemd/systemd/pull/38125
   # https://github.com/chainguard-dev/internal-dev/issues/17776
@@ -156,7 +156,8 @@ subpackages:
             - tzdata
             - busybox
             - tpm2-tss
-            - libidn2 # There's a lot of dlopen tests
+            - libgcrypt # There's a lot of dlopen tests
+            - libidn2
             - libbpf
             - libzstd1
             - libarchive
@@ -428,6 +429,7 @@ subpackages:
           # Misc utilties
           mv usr/lib/systemd/systemd-pull ${{targets.subpkgdir}}/usr/lib/systemd/
           mv usr/bin/systemd-dissect ${{targets.subpkgdir}}/usr/bin/
+          mv usr/lib/systemd/system/systemd-loop@.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
     test:
       environment:
         contents:
@@ -564,9 +566,12 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd/system/sockets.target.wants
           mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-logind.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/systemd-logind-varlink.socket ${{targets.subpkgdir}}/usr/lib/systemd/system/
           mv ${{targets.destdir}}/usr/lib/systemd/system/dbus-org.freedesktop.login1.service ${{targets.subpkgdir}}/usr/lib/systemd/system/
           mv ${{targets.destdir}}/usr/lib/systemd/system/multi-user.target.wants/systemd-logind.service ${{targets.subpkgdir}}/usr/lib/systemd/system/multi-user.target.wants/
+          mv ${{targets.destdir}}/usr/lib/systemd/system/sockets.target.wants/systemd-logind-varlink.socket ${{targets.subpkgdir}}/usr/lib/systemd/system/sockets.target.wants/
           mv ${{targets.destdir}}/usr/lib/systemd/systemd-logind ${{targets.subpkgdir}}/usr/lib/systemd/
     test:
       pipeline:
@@ -809,9 +814,7 @@ test:
         reboot --help
         resolvconf --version
         resolvconf --help
-        runlevel --help
         shutdown --help
-        telinit --help
     - name: "Check libsystemd"
       runs: |
         ldconfig -p | grep libsystemd.so


### PR DESCRIPTION
Pick up https://github.com/wolfi-dev/os/pull/66385 where the auto-update failed. A couple changes to the packaging are needed to due to new upstream units with dependencies on subpackages:

- Move systemd-logind-varlink.socket into system-logind-service
- Move systemd-loop@.service into systemd-container

Having them in the main package would make the test/verify-service pipeline fail, and since they are ancillary to the service they have a dependency on, they're best kept in the respective subpackages.

Furthermore, the legacy runlevel and telinit commands have been removed in systemd v258, so drop the corresponding test invocations.

### Pre-review Checklist

#### For version bump PRs

- [X] The `epoch` field is reset to 0