### PR TITLE
py3-numpy-1.26: Don't provide py3-numpy at a version this makes it un…

### DIFF
--- a/py3-numpy-1.26.yaml
+++ b/py3-numpy-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-numpy-1.26
   version: 1.26.5
-  epoch: 7
+  epoch: 8
   description: The fundamental package for scientific computing with Python.
   copyright:
     - license: BSD-3-Clause
@@ -68,7 +68,7 @@ subpackages:
         - py${{range.key}}-pygments
       provides:
         - py${{range.key}}-${{vars.pypi-package}}=${{package.version}}
-        - py3-${{vars.pypi-package}}=${{package.version}}
+        - py3-${{vars.pypi-package}}
         - "!py${{range.key}}-numpy-2.2"
         - "!py${{range.key}}-numpy-2.1"
         - "!py${{range.key}}-numpy-2.3"


### PR DESCRIPTION
This should've been `py3-numpy` without the full version so it can be coinstallable
Fixes:
```
2025/09/23 21:36:05 ERRO failed to build package: unable to build guest: unable to lock image configuration: resolving apk packages: for arch "amd64": solving "py3-supported-numpy-1.26" constraint: resolving "py3-supported-numpy-1.26-1.26.5-r7.apk" deps:
solving "py3.11-numpy-1.26" constraint:   py3.11-numpy-1.26-1.26.5-r7.apk disqualified because py3.10-numpy-1.26-1.26.5-r7.apk already provides py3-numpy
make[1]: *** [Makefile:157: packages/x86_64/apache-arrow-21.0.0-r3.apk] Error 1
make[1]: Leaving directory '/home/justin_vreeland_chainguard_dev/src/wolfi-dev/wolfi'
make: *** [Makefile:151: package/apache-arrow] Error 2
```