### PR TITLE
fix(rancher-charts): Retain latest git commit

### DIFF
--- a/rancher-2.12.yaml
+++ b/rancher-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.12
   version: "2.12.1"
-  epoch: 2 # GHSA-mh63-6h87-95cp
+  epoch: 3
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -47,7 +47,6 @@ package:
       - rancher-charts-${{vars.major-minor-version}}
       - rancher-dashboard-${{vars.major-minor-version}}
       - rancher-helm-3
-      - rancher-helm3-charts
       - rancher-kontainer-driver-metadata-${{vars.major-minor-version}}
       - rancher-machine
       - rancher-partner-charts

--- a/rancher-charts-2.12.yaml
+++ b/rancher-charts-2.12.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-charts-2.12
   version: "0_git20250923"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - charts
   copyright:
     - license: Apache-2.0
@@ -10,43 +10,44 @@ package:
     provides:
       - rancher-charts=${{package.full-version}}
 
+var-transforms:
+  - from: ${{package.name}}
+    match: .*(\d+\.\d+)$
+    replace: "$1"
+    to: major-minor-version
+
 environment:
   contents:
     packages:
       - busybox
-      - perl-utils
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/rancher/charts
-      branch: release-v2.12
+      branch: release-v${{vars.major-minor-version}}
       expected-commit: 424cf23fc2e9780c623b1cc5763e1c9ae1097cdb
       destination: ./charts
-      depth: -1
+      depth: 1
 
-  - working-directory: ./charts
-    runs: |
-      shasum256=$(echo -n "https://git.rancher.io/charts" |shasum -a 256 | awk '{ print $1 }')
-      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256
-      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256
-
-      git checkout master
-      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/library
-      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/library
+  - runs: |
+      sum=$(echo -n "https://git.rancher.io/charts" | sha256sum | awk '{ print $1 }')
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts
+      mv ./charts ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$sum
 
 test:
   environment:
     contents:
       packages:
-        - perl-utils
+        - git
   pipeline:
     - runs: |
-        shasum256=$(echo -n "https://git.rancher.io/charts" |shasum -a 256 | awk '{ print $1 }')
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256/`
-        test -f /var/lib/rancher-data/local-catalogs/v2/rancher-charts/$shasum256/README.md
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/library/`
-        test -f /var/lib/rancher-data/local-catalogs/library/README.md
+        sum=$(echo -n "https://git.rancher.io/charts" | sha256sum | awk '{ print $1 }')
+        cd /var/lib/rancher-data/local-catalogs/v2/rancher-charts/$sum
+
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
 
 update:
   enabled: true

--- a/rancher-helm3-charts.yaml
+++ b/rancher-helm3-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-helm3-charts
   version: "0_git20250923"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - helm3 charts
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,6 @@ environment:
   contents:
     packages:
       - busybox
-      - perl-utils
 
 pipeline:
   - uses: git-checkout
@@ -20,14 +19,19 @@ pipeline:
       branch: master
       destination: ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/helm3-library
       expected-commit: c6986e9372b206e9c93f4d53de5a8fa46f210960
-
-  - runs: rm -rf ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/helm3-library/.git
+      depth: 1
 
 test:
+  environment:
+    contents:
+      packages:
+        - git
   pipeline:
-    - runs: |
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/helm3-library/`
-        test -f /var/lib/rancher-data/local-catalogs/helm3-library/README.md
+    - working-directory: /var/lib/rancher-data/local-catalogs/helm3-library
+      runs: |
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
 
 update:
   enabled: true

--- a/rancher-partner-charts.yaml
+++ b/rancher-partner-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-partner-charts
   version: "0_git20250923"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - partner charts
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,6 @@ environment:
   contents:
     packages:
       - busybox
-      - perl-utils
 
 pipeline:
   - uses: git-checkout
@@ -20,23 +19,26 @@ pipeline:
       branch: main
       destination: ./charts
       expected-commit: ba0576318a20b922d02b29e8fa7d8f343ae572f5
+      depth: 1
 
-  - working-directory: ./charts
-    runs: |
-      shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
-      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$shasum256
-      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$shasum256
+  - runs: |
+      sum=$(echo -n "https://git.rancher.io/partner-charts" | sha256sum | awk '{ print $1 }')
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts
+      mv ./charts ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$sum
 
 test:
   environment:
     contents:
       packages:
-        - perl-utils
+        - git
   pipeline:
     - runs: |
-        shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$shasum256/`
-        test -f /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$shasum256/README.md
+        sum=$(echo -n "https://git.rancher.io/partner-charts" | sha256sum | awk '{ print $1 }')
+        cd /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/$sum
+
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
 
 update:
   enabled: true

--- a/rancher-rke2-charts.yaml
+++ b/rancher-rke2-charts.yaml
@@ -2,7 +2,7 @@
 package:
   name: rancher-rke2-charts
   version: "0_git20250923"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - rke2 charts
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,6 @@ environment:
   contents:
     packages:
       - busybox
-      - perl-utils
 
 pipeline:
   - uses: git-checkout
@@ -19,24 +18,27 @@ pipeline:
       repository: https://github.com/rancher/rke2-charts
       branch: main
       destination: ./charts
-      expected-commit: b1b33d2a7bed51aff3993042efe115d4fb363fd5
+      expected-commit: f86dd4fa2fdec46c930345b3241a3beee0f5f179
+      depth: 1
 
-  - working-directory: ./charts
-    runs: |
-      shasum256=$(echo -n "https://git.rancher.io/rke2-charts" |shasum -a 256 | awk '{ print $1 }')
-      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$shasum256
-      cp -r ./* ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$shasum256
+  - runs: |
+      sum=$(echo -n "https://git.rancher.io/rke2-charts" | sha256sum | awk '{ print $1 }')
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts
+      mv ./charts ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$sum
 
 test:
   environment:
     contents:
       packages:
-        - perl-utils
+        - git
   pipeline:
     - runs: |
-        shasum256=$(echo -n "https://git.rancher.io/rke2-charts" |shasum -a 256 | awk '{ print $1 }')
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$shasum256/`
-        test -f /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$shasum256/README.md
+        sum=$(echo -n "https://git.rancher.io/rke2-charts" | sha256sum | awk '{ print $1 }')
+        cd /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/$sum
+
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
 
 update:
   enabled: true

--- a/rancher-system-charts-2.10.yaml
+++ b/rancher-system-charts-2.10.yaml
@@ -2,13 +2,19 @@
 package:
   name: rancher-system-charts-2.10
   version: "0_git20250923"
-  epoch: 0
+  epoch: 1
   description: Complete container management platform - system charts
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - rancher-system-charts=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*(\d+\.\d+)$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -19,17 +25,22 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/rancher/system-charts
-      branch: release-v2.10
+      branch: release-v${{vars.major-minor-version}}
       destination: ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/system-library
       expected-commit: 653a0337600f04df3a975106468a17bd64d6e1f9
-
-  - runs: rm -rf ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/system-library/.git
+      depth: 1
 
 test:
+  environment:
+    contents:
+      packages:
+        - git
   pipeline:
-    - runs: |
-        # check the expected files are available at the expected location at `/var/lib/rancher-data/local-catalogs/system-library/`
-        test -f /var/lib/rancher-data/local-catalogs/system-library/README.md
+    - working-directory: /var/lib/rancher-data/local-catalogs/system-library
+      runs: |
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
 
 update:
   enabled: true


### PR DESCRIPTION
The latest commit is used to determine the version of the repository containing charts used by Rancher

Also drop Helm 3 charts as a runtime dependency of Rancher 2.12