### PR TITLE
DNM: OpenSSF update

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
-  version: 20240627
-  epoch: 33
+  version: 20250904
+  epoch: 0
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -1,6 +1,17 @@
+# For GCC 15, -fhardened enables:
+#
+# -D_FORTIFY_SOURCE=3
+# -D_GLIBCXX_ASSERTIONS
+# -ftrivial-auto-var-init=zero
+# -fPIE  -pie  -Wl,-z,relro,-z,now
+# -fstack-protector-strong
+# -fstack-clash-protection
+#
+# https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
 *self_spec:
 + %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
   -fhardened \
+  -fzero-init-padding-bits=all \
   -Wno-error=hardened \
   -Wno-hardened \
   -mbranch-protection=standard \
@@ -16,8 +27,7 @@
   --sort-common \
   -z noexecstack \
   -z relro \
-  -z now \
-  -z gcs=never
+  -z now
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/15/openssf.spec
@@ -1,6 +1,18 @@
+# For GCC 15, -fhardened enables:
+#
+# -D_FORTIFY_SOURCE=3
+# -D_GLIBCXX_ASSERTIONS
+# -ftrivial-auto-var-init=zero
+# -fPIE  -pie  -Wl,-z,relro,-z,now
+# -fstack-protector-strong
+# -fstack-clash-protection
+# -fcf-protection=full (x86 GNU/Linux only)
+#
+# https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
 *self_spec:
 + %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} \
   -fhardened \
+  -fzero-init-padding-bits=all \
   -Wno-error=hardened \
   -Wno-hardened \
   %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} \


### PR DESCRIPTION
Update our compiler flags according to version 20250904.

This pretty much entails adding `-fzero-init-padding-bits=all` to the
list of compilation flags.  There have not been many updates to the
OpenSSF list since our last update.

I'm taking this opportunity to re-enable ARM64's GCS support.  This is
an important security feature which had to be disabled due to
https://github.com/wolfi-dev/os/issues/58294.  That issue is no longer
applicable because our ARM64 golang defaults to using GNU `ld` now,
which has proper support for GCS.

This has been tested by rebuilding the archive.  I also did some
manual tests to make sure the GCS feature works as expected.

Relates: https://github.com/chainguard-dev/internal-dev/issues/14606