### PR TITLE
fix(mattermost-10.12): Remediate GHSA-jc7w-c686-c4v9 and GHSA-fv92-fjc5-jj9h

### DIFF
--- a/mattermost-10.12.yaml
+++ b/mattermost-10.12.yaml
@@ -3,7 +3,7 @@ package:
   # Note the npm version has been pinned to 10.8.3 to avoid the error:
   # "npm error notsup Required: {"node":">=18.10.0","npm":"^9.0.0 || ^10.0.0"}"
   version: "10.12.0"
-  epoch: 0 # GHSA-jc7w-c686-c4v9
+  epoch: 1 # GHSA-jc7w-c686-c4v9 | GHSA-fv92-fjc5-jj9h
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT
@@ -51,6 +51,23 @@ pipeline:
       for dir in bin data logs config plugins fonts i18n templates client test; do
         mkdir -p ${{targets.contextdir}}/etc/mattermost/$dir
       done
+
+  - runs: |
+      # Avoid go mod tidy from pulling enterprise go modules.
+      # Enterprise go modules need authentication to be fetched.
+      # This is reversed post go/bump
+      mv server/enterprise/external_imports.go server/enterprise/external_imports.go.orig
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/go-viper/mapstructure/v2@v2.4.0
+        github.com/ulikunitz/xz@v0.5.15
+      modroot: server
+
+  - runs: |
+      # Restore code importing enterprise go modules.
+      mv server/enterprise/external_imports.go.orig server/enterprise/external_imports.go
 
   - working-directory: server
     pipeline:


### PR DESCRIPTION
go/bumps to remediate GHSA-jc7w-c686-c4v9 and GHSA-fv92-fjc5-jj9h
Since Mattermost enterprise modules need authentication to be fetched, added a workaround to skip fetching those modules during go/bump.
<!--ci-cve-scan:fail-any-->