### PR TITLE
fix(datadog-agent): rtloader init issue 

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.70.2"
-  epoch: 1 # GHSA-jc7w-c686-c4v9
+  epoch: 2 # GHSA-jc7w-c686-c4v9
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -235,6 +235,17 @@ pipeline:
       # Create embedded directory structure
       mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/bin
       mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/lib
+
+      # Create Python 3.12 directory structure to match what the subpackage will create
+      # subpackage expects this directory structure to exist when it runs
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/lib/python3.12
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/lib/python3.12/site-packages
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/lib/python3.12/lib-dynload
+
+      # Copy Python 3.12 standard library from system
+      if [ -d /usr/lib/python3.12 ]; then
+        cp -r /usr/lib/python3.12/* ${{targets.contextdir}}${{vars.destd}}/embedded/lib/python3.12/
+      fi
 
       # Create Python binary symlinks
       cd ${{targets.contextdir}}${{vars.destd}}/embedded/bin


### PR DESCRIPTION
the python initialization failed with path mismatch, caused rtloader initialization error. Main package created python symlinks before subpackage created the python 3.12 directory structure, causing a timing conflict

the PR creates python 3.12 directory structure upfront