### PR TITLE
py3-pandas: use numpy 2.2

### DIFF
--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: "2.3.2"
-  epoch: 4
+  epoch: 5
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: BSD-3-Clause
@@ -29,7 +29,7 @@ environment:
       - meson
       - py3-supported-cython
       - py3-supported-meson-python
-      - py3-supported-numpy-1.26
+      - py3-supported-numpy-2.2
       - py3-supported-pip
       - py3-supported-python-dev
       - py3-supported-versioneer
@@ -51,7 +51,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-numpy-1.26
+        - py${{range.key}}-numpy-2.2
         - py${{range.key}}-pytz
         - py${{range.key}}-dateutil
         - py${{range.key}}-tzdata


### PR DESCRIPTION
Using older numpy leads to dependency tree problems.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
