### PR TITLE
py3-apache-beam: numpy-2.2: update dependant packages to use it

### DIFF
--- a/py3-apache-beam.yaml
+++ b/py3-apache-beam.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-apache-beam
   version: "2.67.0"
-  epoch: 2
+  epoch: 3
   description: Apache Beam SDK for Python
   copyright:
     - license: Apache-2.0
@@ -48,7 +48,7 @@ subpackages:
         - py${{range.key}}-grpcio
         - py${{range.key}}-hdfs
         - py${{range.key}}-httplib2
-        - py${{range.key}}-numpy-1.26
+        - py${{range.key}}-numpy-2.2
         - py${{range.key}}-objsize
         - py${{range.key}}-orjson
         - py${{range.key}}-packaging


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
