### PR TITLE
py3-graph-tool: numpy-2.2: update dependant packages to use it

### DIFF
--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -5,7 +5,7 @@ package:
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
-    memory: 128Gi
+    memory: 256Gi
   copyright:
     - license: GPL-3.0-only
 
@@ -16,7 +16,7 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
+      # no py3.10 support because dependency (py3-scipy) doesn't support it
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -191,7 +191,6 @@ subpackages:
     description: Meta-package providing ${{vars.pypi-package}} for supported Python versions.
     dependencies:
       runtime:
-        - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}

--- a/py3-graph-tool.yaml
+++ b/py3-graph-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-graph-tool
   version: "2.98"
-  epoch: 0
+  epoch: 1
   description: graph-tool is an efficient Python module for manipulation and statistical analysis of graphs (a.k.a. networks).
   resources:
     cpu: 65
@@ -45,7 +45,7 @@ environment:
       - py3-supported-cairo
       - py3-supported-gobject3
       - py3-supported-libboost
-      - py3-supported-numpy
+      - py3-supported-numpy-2.2
       - py3-supported-scipy
       - sparsehash-dev
       - zlib-dev
@@ -74,7 +74,7 @@ subpackages:
         - py${{range.key}}-cairo
         - py${{range.key}}-matplotlib
         - py${{range.key}}-gobject3
-        - py${{range.key}}-numpy
+        - py${{range.key}}-numpy-2.2
         - py${{range.key}}-scipy
         - glib-gir
     pipeline:
@@ -108,7 +108,7 @@ subpackages:
       environment:
         contents:
           packages:
-            - py${{range.key}}-numpy
+            - py${{range.key}}-numpy-2.2
             - py${{range.key}}-scipy
       pipeline:
         - uses: python/import


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
