### PR TITLE
py3-hyperopt: numpy-2.2: update dependant packages to use it

### DIFF
--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 10
+  epoch: 11
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD-3-Clause
@@ -39,7 +39,7 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - py${{range.key}}-numpy-1.26
+        - py${{range.key}}-numpy-2.2
         - py${{range.key}}-cloudpickle
         - py${{range.key}}-future
         - py${{range.key}}-networkx

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -15,7 +15,7 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
+      # no py3.10 support because dependency py3-scipy doesn't support it
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -88,7 +88,6 @@ subpackages:
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
       runtime:
-        - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
