### PR TITLE
numpy-2.2: update dependant packages to use it

### DIFF
--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: "0.18.0"
-  epoch: 3
+  epoch: 4
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD-3-Clause
@@ -46,7 +46,7 @@ subpackages:
         - py${{range.key}}-beniget
         - py${{range.key}}-gast
         - py${{range.key}}-ply
-        - py${{range.key}}-numpy-1.26
+        - py${{range.key}}-numpy-2.2
         - py${{range.key}}-setuptools
       provides:
         - py3-${{vars.pypi-package}}


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
