### PR TITLE
shadow: add minimum system user id to login.defs

### DIFF
--- a/shadow.yaml
+++ b/shadow.yaml
@@ -2,7 +2,7 @@
 package:
   name: shadow
   version: "4.18.0"
-  epoch: 3
+  epoch: 4
   description: PAM login and passwd utilities
   copyright:
     - license: BSD-3-Clause
@@ -90,11 +90,14 @@ pipeline:
       rm ${{targets.destdir}}/usr/share/man/man5/passwd.5*
 
       # /etc/login.defs is not very useful - replace it with an *almost* blank file.
-      # On systems with systemd, systemd manages UID and GID ranges. Add SYS_UID_MAX
-      # for compatibility only.
+      # On systems with systemd, systemd manages UID and GID ranges. Add SYS_UID_MIN
+      # and SYS_UID_MAX for compatibility only.
       rm ${{targets.destdir}}/etc/login.defs
-      echo "USERGROUPS_ENAB yes" > ${{targets.destdir}}/etc/login.defs
-      echo "SYS_UID_MAX 999" >> ${{targets.destdir}}/etc/login.defs
+      cat <<EOF >${{targets.destdir}}/etc/login.defs
+      USERGROUPS_ENAB yes
+      SYS_UID_MIN 1
+      SYS_UID_MAX 999
+      EOF
 
       # Used e.g. for unprivileged LXC containers.
       install -m644 /dev/null ${{targets.destdir}}/etc/subuid
@@ -281,6 +284,10 @@ test:
     # don't silently splice the value from systemd into the configuration, as
     # we want to be alerted if the value changes).
     - runs: |
+        sys_uid_min=$(pkgconf --variable=system_alloc_uid_min systemd)
+        [ -n "${sys_uid_min}" ]
+        grep -q "^SYS_UID_MIN ${sys_uid_min}\$" /etc/login.defs
+
         sys_uid_max=$(pkgconf --variable=system_uid_max systemd)
         [ -n "${sys_uid_max}" ]
         grep -q "^SYS_UID_MAX ${sys_uid_max}\$" /etc/login.defs


### PR DESCRIPTION
systemd manages UID and GID ranges on systems that have it installed. The ranges are defined at compile time. Populate the minimum system UID in login.defs with the systemd-defined value for compatibility with anything looking there.

A similar change for the maximum system UID was already added in commit 6756618a ("shadow: add maximum system user id to login.defs"). The upstream change to expose the minimum UID in systemd's pkgconf as well was missing until now.