### PR TITLE
php-8.*-imagick: ensure package version is being set

### DIFF
--- a/php-8.1-imagick.yaml
+++ b/php-8.1-imagick.yaml
@@ -65,3 +65,6 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - name: Ensure versioning got passed to module
+      runs: |
+        php --info | grep -F -e imagick | grep -E -e "${{package.version}}"

--- a/php-8.1-imagick.yaml
+++ b/php-8.1-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-imagick
   version: "3.8.0"
-  epoch: 1
+  epoch: 2
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -33,6 +33,9 @@ pipeline:
       repository: https://github.com/Imagick/imagick
       tag: "${{package.version}}"
       expected-commit: 555bf68b592a8d9d0a0a2f37d1256a8b6cf2d39e
+
+  # Apply package version template as `package.xml` does not seem to apply this automatically
+  - runs: sed -i "s/@PACKAGE_VERSION@/${{package.version}}/g" ./*.h
 
   - name: Prepare build
     runs: phpize

--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-imagick
   version: "3.8.0"
-  epoch: 2
+  epoch: 3
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -33,6 +33,9 @@ pipeline:
       repository: https://github.com/Imagick/imagick
       tag: "${{package.version}}"
       expected-commit: 555bf68b592a8d9d0a0a2f37d1256a8b6cf2d39e
+
+  # Apply package version template as `package.xml` does not seem to apply this automatically
+  - runs: sed -i "s/@PACKAGE_VERSION@/${{package.version}}/g" ./*.h
 
   - name: Prepare build
     runs: phpize

--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -65,3 +65,6 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - name: Ensure versioning got passed to module
+      runs: |
+        php --info | grep -F -e imagick | grep -E -e "${{package.version}}"

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -65,3 +65,6 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - name: Ensure versioning got passed to module
+      runs: |
+        php --info | grep -F -e imagick | grep -E -e "${{package.version}}"

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: "3.8.0"
-  epoch: 2
+  epoch: 3
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -33,6 +33,9 @@ pipeline:
       repository: https://github.com/Imagick/imagick
       tag: "${{package.version}}"
       expected-commit: 555bf68b592a8d9d0a0a2f37d1256a8b6cf2d39e
+
+  # Apply package version template as `package.xml` does not seem to apply this automatically
+  - runs: sed -i "s/@PACKAGE_VERSION@/${{package.version}}/g" ./*.h
 
   - name: Prepare build
     runs: phpize

--- a/php-8.4-imagick.yaml
+++ b/php-8.4-imagick.yaml
@@ -65,3 +65,6 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - name: Ensure versioning got passed to module
+      runs: |
+        php --info | grep -F -e imagick | grep -E -e "${{package.version}}"

--- a/php-8.4-imagick.yaml
+++ b/php-8.4-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-imagick
   version: "3.8.0"
-  epoch: 3
+  epoch: 4
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -33,6 +33,9 @@ pipeline:
       repository: https://github.com/Imagick/imagick
       tag: "${{package.version}}"
       expected-commit: 555bf68b592a8d9d0a0a2f37d1256a8b6cf2d39e
+
+  # Apply package version template as `package.xml` does not seem to apply this automatically
+  - runs: sed -i "s/@PACKAGE_VERSION@/${{package.version}}/g" ./*.h
 
   - name: Prepare build
     runs: phpize


### PR DESCRIPTION
Seems that these packages were not getting their versions properly set during build because `package.xml`, even though it specifies a mutation of a header changing the @PACKAGE_VERSION@ variable to (whatever the tag is), it doesn't seem to do so at any point in the build. This does the naive approach of replacing @PACKAGE_VERSION@ on any headers with ${{package.version}}

Old output:
```
09051c1e7c6e:/work/packages# php --info | grep imagick
Additional .ini files parsed => /etc/php/conf.d/imagick.ini
imagick
imagick module => enabled
imagick module version => @PACKAGE_VERSION@
imagick classes => Imagick, ImagickDraw, ImagickPixel, ImagickPixelIterator, ImagickKernel
imagick.allow_zero_dimension_images => 0 => 0
imagick.locale_fix => 0 => 0
imagick.progress_monitor => 0 => 0
imagick.set_single_thread => 1 => 1
imagick.shutdown_sleep_count => 10 => 10
imagick.skip_version_check => 0 => 0
```

New output:
```
09051c1e7c6e:/work/packages# php --info | grep imagick
Additional .ini files parsed => /etc/php/conf.d/imagick.ini
imagick
imagick module => enabled
imagick module version => 3.8.0
imagick classes => Imagick, ImagickDraw, ImagickPixel, ImagickPixelIterator, ImagickKernel
imagick.allow_zero_dimension_images => 0 => 0
imagick.locale_fix => 0 => 0
imagick.progress_monitor => 0 => 0
imagick.set_single_thread => 1 => 1
imagick.shutdown_sleep_count => 10 => 10
imagick.skip_version_check => 0 => 0
```