### PR TITLE
feat(mlflow): bump dep to remediate GHSA-9ggr-2464-2j32

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.4.0"
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -70,6 +70,9 @@ pipeline:
 
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip install --upgrade "requests>=2.32.4"
+
+      # Upgrade requests to fix GHSA-9ggr-2464-2j32
+      pip install --upgrade "authlib>=1.6.4"
 
       # Remove pip
       pip uninstall --yes pip


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-9ggr-2464-2j32

<!--ci-cve-scan:fail-any-->
