### PR TITLE
feat(open-webui): bump dep to remediate GHSA-9ggr-2464-2j32

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.30"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -76,6 +76,9 @@ pipeline:
 
       # GHSA-847f-9342-265h
       uv pip install --upgrade h2==4.3.0
+
+      # GHSA-9ggr-2464-2j32
+      uv pip install --upgrade authlib>=1.6.4
 
       uv pip uninstall pip
 


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-9ggr-2464-2j32
<!--ci-cve-scan:fail-any-->
