### PR TITLE
fix(superset-5.0): correct conditional usage

### DIFF
--- a/superset-5.0.yaml
+++ b/superset-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset-5.0
   version: "5.0.0"
-  epoch: 5
+  epoch: 6
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -42,6 +42,7 @@ environment:
       - npm<11.0.0 # Fixes an unsupported engine error
       - nvm
       - openldap-dev
+      - patch
       - py${{vars.python-version}}-pip
       - py${{vars.python-version}}-sqlparse
       - python-${{vars.python-version}}-dev
@@ -178,7 +179,40 @@ subpackages:
           # as root inside bubblewrap, otherwise we can't test on aarch64
           sed -i 's~export SUPERSET_DAEMON_USER="superset"~export SUPERSET_DAEMON_USER=${SUPERSET_DAEMON_USER:-"superset"}~g' /opt/iamguarded/scripts/superset-env.sh
           sed -i 's~export SUPERSET_DAEMON_GROUP="superset"~export SUPERSET_DAEMON_GROUP=${SUPERSET_DAEMON_GROUP:-"superset"}~g' /opt/iamguarded/scripts/superset-env.sh
-          sed -i 's~if am_i_root; then~if \[\[ am_i_root \&\& "$SUPERSET_DAEMON_USER" != "root" \]\]; then~' /opt/iamguarded/scripts/superset/run.sh
+
+          cat << EOF > run.patch
+          --- /opt/iamguarded/scripts/superset/run.sh
+          +++ run.sh
+          @@ -22,6 +22,17 @@
+           . /opt/iamguarded/scripts/libos.sh
+           . /opt/iamguarded/scripts/libsuperset.sh
+
+          +should_i_switch_user(){
+          +  if am_i_root; then
+          +    if [[ "\$SUPERSET_DAEMON_USER" != "root" ]]; then
+          +       # Switch User
+          +       return 0
+          +    fi
+          +  fi
+          +  # Return false
+          +  return 1
+          +}
+          +
+           if [[ "\$SUPERSET_ROLE" = "webserver" ]]; then
+               command="gunicorn"
+               args=(
+          @@ -55,7 +66,7 @@
+           fi
+
+           info "** Starting Superset \${SUPERSET_ROLE} **"
+          -if am_i_root; then
+          +if should_i_switch_user; then
+               exec_as_user "\$SUPERSET_DAEMON_USER" "\${command}" "\${args[@]}"
+           else
+               exec "\${command}" "\${args[@]}"
+          EOF
+
+          patch /opt/iamguarded/scripts/superset/run.sh  < run.patch
       - uses: iamguarded/finalize-compat
         with:
           package: superset


### PR DESCRIPTION
The previous change introduced square brackets `[[` resulting in the conditional being evaluated with `test`. 

`test` does not look at exit statuses and so `am_i_root` always evaluated true.

This PR also switches to using a patch rather than `sed` to help make the logic clearer when reviewing YAML.
