### PR TITLE
R packages: add tw/ldd-check tests

### DIFF
--- a/R-classInt.yaml
+++ b/R-classInt.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-classInt
   version: 0.4.11
-  epoch: 0
+  epoch: 1
   description: Choose Univariate Class Intervals
   copyright:
     - license: GPL-2.0-only OR GPL-3.0-only
@@ -42,6 +42,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(classInt)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-e1071.yaml
+++ b/R-e1071.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-e1071
   version: 1.7.16
-  epoch: 2
+  epoch: 3
   description: Misc Functions of the Department of Statistics, Probability Theory Group
   copyright:
     - license: GPL-2.0-only OR GPL-3.0-only
@@ -42,6 +42,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(e1071)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-magrittr.yaml
+++ b/R-magrittr.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-magrittr
   version: "2.0.4"
-  epoch: 0
+  epoch: 1
   description: Improve the readability of R code with the pipe
   copyright:
     - license: MIT
@@ -34,6 +34,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(magrittr)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-proxy.yaml
+++ b/R-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-proxy
   version: 0.4.27
-  epoch: 1
+  epoch: 2
   description: Distance and similarity measures
   copyright:
     - license: GPL-2.0-or-later
@@ -40,6 +40,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(proxy)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-s2.yaml
+++ b/R-s2.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-s2
   version: "1.1.9"
-  epoch: 2
+  epoch: 3
   description: Spherical Geometry Operators Using the S2 Geometry Library
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(s2)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-sf.yaml
+++ b/R-sf.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-sf
   version: "1.0.21"
-  epoch: 3
+  epoch: 4
   description: Simple Features for R
   copyright:
     - license: GPL-2.0-only AND MIT
@@ -61,6 +61,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(sf)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-showtext.yaml
+++ b/R-showtext.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-showtext
   version: 0.9.7
-  epoch: 1
+  epoch: 2
   description: Using Fonts More Easily in R Graphs
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(showtext)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-sysfonts.yaml
+++ b/R-sysfonts.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-sysfonts
   version: 0.8.9
-  epoch: 1
+  epoch: 2
   description: Loading Fonts into R
   copyright:
     - license: GPL-2.0-only
@@ -40,6 +40,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(sysfonts)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-units.yaml
+++ b/R-units.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-units
   version: "0.8.7"
-  epoch: 0
+  epoch: 1
   description: Measurement Units for R Vectors
   copyright:
     - license: GPL-2.0-or-later
@@ -44,6 +44,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(units)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/R-wk.yaml
+++ b/R-wk.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-wk
   version: 0.9.4
-  epoch: 2
+  epoch: 3
   description: Lightweight Well-Known Geometry Parsing
   copyright:
     - license: MIT
@@ -34,6 +34,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(wk)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true

--- a/Rcpp.yaml
+++ b/Rcpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: Rcpp
   version: "1.1.0"
-  epoch: 2
+  epoch: 3
   description: Seamless R and C++ Integration
   copyright:
     - license: GPL-2.0-or-later
@@ -34,6 +34,9 @@ test:
   pipeline:
     - runs: |
         Rscript -e 'library(Rcpp)'
+    - uses: test/tw/ldd-check
+      with:
+        extra-library-paths: "/usr/lib/R/lib/"
 
 update:
   enabled: true


### PR DESCRIPTION
Noticed the lddcheck lint warnings while preparing improvements to the R/build pipeline in melange in https://github.com/chainguard-dev/melange/pull/2160

Ideally, this would not be merged until the R/build pipeline changes in melange land.