### PR TITLE
chore(neo4j): bump io.netty bom vs individual components

### DIFF
--- a/neo4j-2025.08.yaml
+++ b/neo4j-2025.08.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-2025.08
   version: "2025.08.0"
-  epoch: 1 # GHSA-fghv-69vj-qj49
+  epoch: 2 # GHSA-fghv-69vj-qj49
   description:
   copyright:
     - license: GPL-3.0-or-later

--- a/neo4j-2025.08/pombump-deps.yaml
+++ b/neo4j-2025.08/pombump-deps.yaml
@@ -3,11 +3,5 @@ patches:
     artifactId: commons-lang3
     version: 3.18.0
   - groupId: io.netty
-    artifactId: netty-codec-http2
-    version: 4.2.4.Final
-  - groupId: io.netty
-    artifactId: netty-codec-compression
-    version: 4.2.5.Final
-  - groupId: io.netty
-    artifactId: netty-codec-http
+    artifactId: netty-bom
     version: 4.2.5.Final


### PR DESCRIPTION
We need to bump all the netty.io components together to avoid runtime issues like this when trying to login:
```
java.lang.NoClassDefFoundError: Could not initialize class org.neo4j.bolt.protocol.common.handler.TransportSelectionHandler
...
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: io/netty/handler/codec/http/HttpServerCodec [in thread "neo4j.BoltNetworkIO-4"]
```
We did a similar fix for 2025.07 in https://github.com/wolfi-dev/os/pull/65840 :disappointed: 