### PR TITLE
rootlesskit: remediate CVE

### DIFF
--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,7 +1,7 @@
 package:
   name: rootlesskit
   version: "2.3.5"
-  epoch: 5 # CVE-2025-47910
+  epoch: 6 # CVE-2025-47910
   description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   copyright:
     - license: Apache-2.0

--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,7 +1,7 @@
 package:
   name: rootlesskit
   version: "2.3.5"
-  epoch: 5 # CVE-2025-47907
+  epoch: 5 # CVE-2025-47910
   description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Remediate CVE-2025-47910
Bump epoch to rebuild with latest go

Signed-off-by: David Negreira <david.negreira@chainguard.dev>

<!--ci-cve-scan:fail-any-->
