### PR TITLE
bats: actually include and test bats libraries

### DIFF
--- a/bats.yaml
+++ b/bats.yaml
@@ -1,7 +1,7 @@
 package:
   name: bats
   version: "1.12.0"
-  epoch: 2
+  epoch: 3
   description: Bash Automated Testing System
   copyright:
     - license: MIT
@@ -29,10 +29,13 @@ pipeline:
       ./install.sh "${{targets.contextdir}}/usr"
       mkdir -p "${{targets.contextdir}}/tmp/"
       cp -r ./docker "${{targets.contextdir}}/tmp/docker"
+      # XXX This has to be exported this way, as ${{targets.contextdir}}
+      # is not expanded in the environment variable declaration section.
+      export BATS_LIBS_DEST_DIR="${{targets.contextdir}}/usr/lib/bats"
       "${{targets.contextdir}}/tmp/docker/install_libs.sh" support 0.3.0
       "${{targets.contextdir}}/tmp/docker/install_libs.sh" file 0.4.0
-      "${{targets.contextdir}}/tmp/docker/install_libs.sh" assert 2.1.0
-      "${{targets.contextdir}}/tmp/docker/install_libs.sh" detik 1.3.1
+      "${{targets.contextdir}}/tmp/docker/install_libs.sh" assert 2.2.0
+      "${{targets.contextdir}}/tmp/docker/install_libs.sh" detik 1.4.0
       find "${{targets.contextdir}}" -type f -perm /2000 -exec chmod g-s {} \;
       rm -rf "${{targets.contextdir}}/tmp/"
 
@@ -94,6 +97,18 @@ test:
         # Create the inline_test.bats script using heredocs
         cat << 'EOF' > /tmp/inline_test.bats
         #!/usr/bin/env bats
+
+        # ensure the included modules can be loaded
+        bats_load_library bats-support
+        bats_load_library bats-assert
+        bats_load_library bats-file
+        # bats-detik doesn't include a load.bats
+        load "/usr/lib/bats/bats-detik/detik"
+
+        # test that the bats-assert (and bats-support) libs work
+        @test 'assert_equal()' {
+          assert_equal 'have' 'have'
+        }
 
         load_file() {
           source "/tmp/example.sh"


### PR DESCRIPTION
The docker/install_libs.sh was installing the included bats libraries into the buld environment's system libraries, not into the staging area for the bats packaging, so they weren't being included in the resulting apk. Fix this by setting the script's BATS_LIBS_DEST_DIR env variable to point to the melange staging area -- unfortunately this cannot be set in the environment section as the ${{targets.contextdir}} variable does not get evaluated at that point.

Bump the bats-assert and bats-detik versions to their latest releases (need a better way to track this to make automatic updates happen).

Also extend the test script to attempt to load the four included libraries and add a smoke test for the assert library.

With the changes in the PR, this is the added files in the bats apk:
```diff
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-assert
+-rwxr-xr-x root/root      1545 2025-07-18 18:20 usr/lib/bats/bats-assert/load.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-assert/src
+-rwxr-xr-x root/root      1006 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert.bash
+-rwxr-xr-x root/root       821 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_equal.bash
+-rwxr-xr-x root/root      2227 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_failure.bash
+-rwxr-xr-x root/root      9498 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_line.bash
+-rwxr-xr-x root/root       884 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_not_equal.bash
+-rwxr-xr-x root/root      6798 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_output.bash
+-rwxr-xr-x root/root      1633 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_regex.bash
+-rwxr-xr-x root/root       934 2025-07-18 18:20 usr/lib/bats/bats-assert/src/assert_success.bash
+-rwxr-xr-x root/root      1076 2025-07-18 18:20 usr/lib/bats/bats-assert/src/refute.bash
+-rwxr-xr-x root/root     10564 2025-07-18 18:20 usr/lib/bats/bats-assert/src/refute_line.bash
+-rwxr-xr-x root/root      6767 2025-07-18 18:20 usr/lib/bats/bats-assert/src/refute_output.bash
+-rwxr-xr-x root/root      2051 2025-07-18 18:20 usr/lib/bats/bats-assert/src/refute_regex.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-detik
+-rwxr-xr-x root/root     11991 2025-07-18 18:20 usr/lib/bats/bats-detik/detik.bash
+-rwxr-xr-x root/root      6397 2025-07-18 18:20 usr/lib/bats/bats-detik/linter.bash
+-rwxr-xr-x root/root      3282 2025-07-18 18:20 usr/lib/bats/bats-detik/utils.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-file
+-rwxr-xr-x root/root       108 2025-07-18 18:20 usr/lib/bats/bats-file/load.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-file/src
+-rwxr-xr-x root/root     29869 2025-07-18 18:20 usr/lib/bats/bats-file/src/file.bash
+-rwxr-xr-x root/root      4601 2025-07-18 18:20 usr/lib/bats/bats-file/src/temp.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-support
+-rwxr-xr-x root/root       165 2025-07-18 18:20 usr/lib/bats/bats-support/load.bash
+drwxr-xr-x root/root         0 2025-07-18 18:20 usr/lib/bats/bats-support/src
+-rwxr-xr-x root/root      1044 2025-07-18 18:20 usr/lib/bats/bats-support/src/error.bash
+-rwxr-xr-x root/root      2031 2025-07-18 18:20 usr/lib/bats/bats-support/src/lang.bash
+-rwxr-xr-x root/root      6604 2025-07-18 18:20 usr/lib/bats/bats-support/src/output.bash
```
