### PR TITLE
New package: pkgdiff

### DIFF
--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -1,0 +1,54 @@
+package:
+  name: perl-config-autoconf
+  version: "0.319"
+  epoch: 0
+  description: Config::AutoConf - A module to implement some of AutoConf macros in pure perl
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ambs/Config-AutoConf.git
+      expected-commit: 7acb5b386469f68ecb344ccdaff7193a8869bdd8
+      tag: ${{package.version}}
+
+  - runs: PERL_MM_USE_DEFAULT=1 perl Makefile.PL
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-config-autoconf-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-config-autoconf manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+update:
+  enabled: true
+  github:
+    identifier: houseabsolute/File-LibMagic
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v
+# test:
+#   pipeline:
+#     - uses: test/tw/ldd-check

--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -49,6 +49,3 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v
-# test:
-#   pipeline:
-#     - uses: test/tw/ldd-check

--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -45,7 +45,5 @@ subpackages:
 update:
   enabled: true
   github:
-    identifier: houseabsolute/File-LibMagic
-    strip-prefix: v
+    identifier: ambs/Config-AutoConf
     use-tag: true
-    tag-filter: v

--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -132,8 +132,8 @@ test:
 update:
   enabled: true
   version-transform:
-  - match: _
-    replace: .
+    - match: _
+      replace: .
   github:
     identifier: ambs/Config-AutoConf
     use-tag: true

--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -131,6 +131,9 @@ test:
 
 update:
   enabled: true
+  version-transform:
+  - match: _
+    replace: .
   github:
     identifier: ambs/Config-AutoConf
     use-tag: true

--- a/perl-config-autoconf.yaml
+++ b/perl-config-autoconf.yaml
@@ -33,14 +33,101 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: perl-config-autoconf-doc
-    pipeline:
-      - uses: split/manpages
-    description: perl-config-autoconf manpages
-    test:
-      pipeline:
-        - uses: test/docs
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - gcc
+        - perl
+        - perl-capture-tiny
+  pipeline:
+    - name: Verify module loading
+      runs: |
+        perl -e "use Config::AutoConf; print 'Config::AutoConf loaded successfully\n'" || exit 1
+    - name: Test basic functionality
+      runs: |
+        perl <<-'EOF'
+        use Config::AutoConf;
+        use strict;
+        use warnings;
+
+        # Create a Config::AutoConf instance
+        my $ac = Config::AutoConf->new();
+
+        # Test basic methods exist and work
+        eval {
+          # Test check_prog method
+          my $cc = $ac->check_prog('cc');
+          print "Found C compiler: " . ($cc || "none") . "\n";
+
+          # Test check_header method with standard C header
+          my $has_stdio = $ac->check_header('stdio.h');
+          print "stdio.h header check: " . ($has_stdio ? "found" : "not found") . "\n";
+          unless ($has_stdio) {
+            print "FAIL: Expected stdio.h to be found\n";
+            exit 1;
+          }
+
+          # Test check_lib method with standard C library
+          my $has_c_lib = $ac->check_lib('c', 'printf');
+          print "libc printf check: " . ($has_c_lib ? "found" : "not found") . "\n";
+          unless ($has_c_lib) {
+            print "FAIL: Expected libc printf to be found\n";
+            exit 1;
+          }
+
+          # Test check_func method
+          my $has_malloc = $ac->check_func('malloc');
+          print "malloc function check: " . ($has_malloc ? "found" : "not found") . "\n";
+          unless ($has_malloc) {
+            print "FAIL: Expected malloc function to be found\n";
+            exit 1;
+          }
+
+          print "All basic functionality tests completed successfully!\n";
+        };
+
+        if ($@) {
+          print "Test failed with error: $@\n";
+          exit 1;
+        }
+        EOF
+    - name: Test compilation checks
+      runs: |
+        perl <<-'EOF'
+        use Config::AutoConf;
+        use strict;
+        use warnings;
+
+        my $ac = Config::AutoConf->new();
+
+        eval {
+          # Test that we can compile simple C code
+          my $can_compile = $ac->compile_if_else('#include <stdio.h>
+          int main() { printf("test"); return 0; }');
+          print "Basic C compilation test: " . ($can_compile ? "passed" : "failed") . "\n";
+          unless ($can_compile) {
+            print "FAIL: Expected basic C compilation to succeed\n";
+            exit 1;
+          }
+
+          # Test check_type functionality
+          my $has_int = $ac->check_type('int');
+          print "int type check: " . ($has_int ? "found" : "not found") . "\n";
+          unless ($has_int) {
+            print "FAIL: Expected int type to be found\n";
+            exit 1;
+          }
+
+          print "Compilation tests completed successfully!\n";
+        };
+
+        if ($@) {
+          print "Compilation test failed: $@\n";
+          exit 1;
+        }
+        EOF
 
 update:
   enabled: true

--- a/perl-file-libmagic.yaml
+++ b/perl-file-libmagic.yaml
@@ -1,0 +1,57 @@
+package:
+  name: perl-file-libmagic
+  version: "1.23"
+  epoch: 0
+  description: File::LibMagic - Determine MIME types of data or files using libmagic
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl-dev
+      - perl-config-autoconf 
+      - perl-capture-tiny
+      - libmagic-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/houseabsolute/File-LibMagic.git
+      expected-commit: ab55dcf3fef341c2bcf22c8ef497cca7b8eee4d7
+      tag: v${{package.version}}
+
+  - runs: PERL_MM_USE_DEFAULT=1 perl Makefile.PL
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-libmagic-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-libmagic manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+update:
+  enabled: true
+  github:
+    identifier: houseabsolute/File-LibMagic
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v
+# test:
+#   pipeline:
+#     - uses: test/tw/ldd-check

--- a/perl-file-libmagic.yaml
+++ b/perl-file-libmagic.yaml
@@ -36,14 +36,119 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: perl-file-libmagic-doc
-    pipeline:
-      - uses: split/manpages
-    description: perl-file-libmagic manpages
-    test:
-      pipeline:
-        - uses: test/docs
+test:
+  environment:
+    contents:
+      packages:
+        - libmagic
+        - perl
+  pipeline:
+    - name: Verify module loading
+      runs: |
+        perl -e "use File::LibMagic; print 'File::LibMagic loaded successfully\n'" || exit 1
+    - name: Test MIME type detection
+      runs: |
+        perl <<-'EOF'
+        use File::LibMagic;
+        use strict;
+        use warnings;
+
+        # Create a File::LibMagic instance
+        my $flm = File::LibMagic->new();
+        unless ($flm) {
+          print "FAIL: Could not create File::LibMagic instance\n";
+          exit 1;
+        }
+
+        # Create test files with known content
+        open(my $txt_fh, '>', '/tmp/test.txt') or die "Cannot create test.txt: $!";
+        print $txt_fh "Hello, World!\n";
+        close($txt_fh);
+
+        open(my $html_fh, '>', '/tmp/test.html') or die "Cannot create test.html: $!";
+        print $html_fh "<html><body><h1>Test</h1></body></html>\n";
+        close($html_fh);
+
+        # Test MIME type detection from file
+        my $txt_mime = $flm->checktype_filename('/tmp/test.txt');
+        print "Text file MIME type: $txt_mime\n";
+        unless ($txt_mime && $txt_mime =~ /text/) {
+          print "FAIL: Expected text MIME type for .txt file, got: " . ($txt_mime || "undef") . "\n";
+          exit 1;
+        }
+
+        my $html_mime = $flm->checktype_filename('/tmp/test.html');
+        print "HTML file MIME type: $html_mime\n";
+        unless ($html_mime && $html_mime =~ /text/) {
+          print "FAIL: Expected text MIME type for .html file, got: " . ($html_mime || "undef") . "\n";
+          exit 1;
+        }
+
+        print "MIME type detection tests passed!\n";
+        EOF
+    - name: Test file description detection
+      runs: |
+        perl <<-'EOF'
+        use File::LibMagic;
+        use strict;
+        use warnings;
+
+        my $flm = File::LibMagic->new();
+
+        # Test file description detection
+        my $txt_desc = $flm->describe_filename('/tmp/test.txt');
+        print "Text file description: $txt_desc\n";
+        unless ($txt_desc && $txt_desc =~ /text/) {
+          print "FAIL: Expected text description for .txt file, got: " . ($txt_desc || "undef") . "\n";
+          exit 1;
+        }
+
+        my $html_desc = $flm->describe_filename('/tmp/test.html');
+        print "HTML file description: $html_desc\n";
+        unless ($html_desc && ($html_desc =~ /text/ || $html_desc =~ /HTML/i)) {
+          print "FAIL: Expected text or HTML description for .html file, got: " . ($html_desc || "undef") . "\n";
+          exit 1;
+        }
+
+        print "File description tests passed!\n";
+        EOF
+    - name: Test data detection from memory
+      runs: |
+        perl <<-'EOF'
+        use File::LibMagic;
+        use strict;
+        use warnings;
+
+        my $flm = File::LibMagic->new();
+
+        # Test MIME detection from data in memory
+        my $text_data = "This is plain text content\n";
+        my $mime_from_data = $flm->checktype_contents($text_data);
+        print "MIME type from text data: $mime_from_data\n";
+        unless ($mime_from_data && $mime_from_data =~ /text/) {
+          print "FAIL: Expected text MIME type from data, got: " . ($mime_from_data || "undef") . "\n";
+          exit 1;
+        }
+
+        # Test description from data in memory
+        my $desc_from_data = $flm->describe_contents($text_data);
+        print "Description from text data: $desc_from_data\n";
+        unless ($desc_from_data && $desc_from_data =~ /text/) {
+          print "FAIL: Expected text description from data, got: " . ($desc_from_data || "undef") . "\n";
+          exit 1;
+        }
+
+        # Test with HTML data
+        my $html_data = "<html><head><title>Test</title></head><body>Content</body></html>";
+        my $html_mime_from_data = $flm->checktype_contents($html_data);
+        print "MIME type from HTML data: $html_mime_from_data\n";
+        unless ($html_mime_from_data && $html_mime_from_data =~ /text/) {
+          print "FAIL: Expected text MIME type from HTML data, got: " . ($html_mime_from_data || "undef") . "\n";
+          exit 1;
+        }
+
+        print "Data detection tests passed!\n";
+        EOF
 
 update:
   enabled: true

--- a/perl-file-libmagic.yaml
+++ b/perl-file-libmagic.yaml
@@ -14,10 +14,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - perl-dev
-      - perl-config-autoconf 
-      - perl-capture-tiny
       - libmagic-dev
+      - perl-capture-tiny
+      - perl-config-autoconf
+      - perl-dev
 
 pipeline:
   - uses: git-checkout
@@ -52,6 +52,3 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v
-# test:
-#   pipeline:
-#     - uses: test/tw/ldd-check

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -22,7 +22,6 @@ environment:
       - file
       - libmagic-dev
       - perl-dev
-      
 
 pipeline:
   - uses: git-checkout
@@ -40,11 +39,6 @@ pipeline:
     with:
       opts: |
         PREFIX=${{targets.destdir}}/usr
-
-  # - runs: |
-  #     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::LibMagic' # NOTE: running with 'notest' doesn't install the module correctly for some reason
-  #     mkdir -p ${{targets.destdir}}/usr/local/lib
-  #     cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
 
 update:
   enabled: true

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -7,23 +7,21 @@ package:
     - license: GPL-2.0
   dependencies:
     runtime:
-    - wdiff
-    - libmagic
-    - perl
-
+      - libmagic
+      - perl
+      - wdiff
 
 environment:
   contents:
     packages:
       - bash
-      - busybox
-      - build-base
-      - perl-dev
-      - libmagic-dev
       - binutils
+      - build-base
+      - busybox
       - file
+      - libmagic-dev
+      - perl-dev
 
-       
 pipeline:
   - uses: git-checkout
     with:
@@ -43,7 +41,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/local/lib
       cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
 
-
 update:
   enabled: true
   github:
@@ -54,8 +51,7 @@ test:
     - name: Test help commands
       runs: |-
         pkgdiff --help
-
-    - name : Compare two tgz files
+    - name: Compare two tgz files
       runs: |
         echo "This is a test file" >file1.txt
         echo "This is a test file with changes" >file2.txt
@@ -65,5 +61,3 @@ test:
         grep "file: 1 to 2 changes report" pkgdiff_reports/file/1_to_2/changes_report.html || exit 1
         rm file1.txt file2.txt file1.tar.gz file2.tar.gz
         rm -rf pkgdiff_reports
-
-

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -9,6 +9,7 @@ package:
     runtime:
       - libmagic
       - perl
+      - perl-file-libmagic
       - wdiff
 
 environment:
@@ -21,6 +22,7 @@ environment:
       - file
       - libmagic-dev
       - perl-dev
+      
 
 pipeline:
   - uses: git-checkout
@@ -39,10 +41,10 @@ pipeline:
       opts: |
         PREFIX=${{targets.destdir}}/usr
 
-  - runs: |
-      PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::LibMagic' # NOTE: running with 'notest' doesn't install the module correctly for some reason
-      mkdir -p ${{targets.destdir}}/usr/local/lib
-      cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
+  # - runs: |
+  #     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::LibMagic' # NOTE: running with 'notest' doesn't install the module correctly for some reason
+  #     mkdir -p ${{targets.destdir}}/usr/local/lib
+  #     cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
 
 update:
   enabled: true

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -35,9 +35,12 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/usr/share
 
   - uses: autoconf/make-install
+    with:
+      opts: |
+        PREFIX=${{targets.destdir}}/usr
 
   - runs: |
-      PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'notest File::LibMagic'
+      PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::LibMagic' # NOTE: running with 'notest' doesn't install the module correctly for some reason
       mkdir -p ${{targets.destdir}}/usr/local/lib
       cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
 
@@ -52,13 +55,20 @@ test:
     - name: Test help commands
       runs: |-
         pkgdiff --help
-    - name: Compare two tgz files
+    - name: Compare different tgz files
       runs: |
         echo "This is a test file" >file1.txt
         echo "This is a test file with changes" >file2.txt
         tar czf file1.tar.gz file1.txt
         tar czf file2.tar.gz file2.txt
-        pkgdiff file1.tar.gz file2.tar.gz || exit 1
+        pkgdiff file1.tar.gz file2.tar.gz || true  # pkgdiff returns non-0 exit when differences are found
         grep "file: 1 to 2 changes report" pkgdiff_reports/file/1_to_2/changes_report.html || exit 1
         rm file1.txt file2.txt file1.tar.gz file2.tar.gz
         rm -rf pkgdiff_reports
+    - name: Compare same tgz files
+      runs: |
+        echo "This is a test file" >file1.txt
+        tar czf file1.tar.gz file1.txt
+        pkgdiff file1.tar.gz file1.tar.gz || exit 1
+        rm file1.txt file1.tar.gz
+        

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -44,6 +44,7 @@ pipeline:
 update:
   enabled: true
   github:
+    identifier: lvc/pkgdiff
     use-tag: true
 
 test:

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -71,4 +71,3 @@ test:
         tar czf file1.tar.gz file1.txt
         pkgdiff file1.tar.gz file1.tar.gz || exit 1
         rm file1.txt file1.tar.gz
-        

--- a/pkgdiff.yaml
+++ b/pkgdiff.yaml
@@ -1,0 +1,69 @@
+package:
+  name: pkgdiff
+  version: 1.8
+  epoch: 0
+  description: A tool for visualizing changes in Linux software packages
+  copyright:
+    - license: GPL-2.0
+  dependencies:
+    runtime:
+    - wdiff
+    - libmagic
+    - perl
+
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - build-base
+      - perl-dev
+      - libmagic-dev
+      - binutils
+      - file
+
+       
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/lvc/pkgdiff.git
+      expected-commit: 56af1b018404f6efcf05063c1db5490e77bf6b00
+      tag: ${{package.version}}
+
+  - runs: |
+      # create dir structure expected by make-install
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      mkdir -p "${{targets.destdir}}"/usr/share
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'notest File::LibMagic'
+      mkdir -p ${{targets.destdir}}/usr/local/lib
+      cp -r /usr/local/lib/perl5 ${{targets.destdir}}/usr/local/lib
+
+
+update:
+  enabled: true
+  github:
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Test help commands
+      runs: |-
+        pkgdiff --help
+
+    - name : Compare two tgz files
+      runs: |
+        echo "This is a test file" >file1.txt
+        echo "This is a test file with changes" >file2.txt
+        tar czf file1.tar.gz file1.txt
+        tar czf file2.tar.gz file2.txt
+        pkgdiff file1.tar.gz file2.tar.gz || exit 1
+        grep "file: 1 to 2 changes report" pkgdiff_reports/file/1_to_2/changes_report.html || exit 1
+        rm file1.txt file2.txt file1.tar.gz file2.tar.gz
+        rm -rf pkgdiff_reports
+
+


### PR DESCRIPTION
Adding this as it will be useful for Wolfi/Chainguard image users to compare apks between builds.

Implements #67425 

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

