### PR TITLE
py3-nltk: py3.10: drop support

### DIFF
--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.9.1
-  epoch: 9
+  epoch: 10
   description: Natural Language Toolkit
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,6 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -104,7 +103,6 @@ subpackages:
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
       runtime:
-        - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}


### PR DESCRIPTION
Because dependency on `py3-scipy`, which doesn't support `py3.10`.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
