### PR TITLE
py3-rouge-score: py3.10: drop support

### DIFF
--- a/py3-rouge-score.yaml
+++ b/py3-rouge-score.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rouge-score
   version: 0.1.2
-  epoch: 5
+  epoch: 6
   description: Pure python implementation of ROUGE-1.5.5
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,6 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: '310'
       3.11: '311'
       3.12: '312'
       3.13: '313'
@@ -66,7 +65,6 @@ subpackages:
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
       runtime:
-        - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}


### PR DESCRIPTION
Because dependency on `py3-scipy`, which doesn't support `py3.10`.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
