### PR TITLE
feat(flyway): remove dep bump to fix several CVEs

### DIFF
--- a/flyway.yaml
+++ b/flyway.yaml
@@ -1,7 +1,7 @@
 package:
   name: flyway
   version: "11.13.2"
-  epoch: 0 # GHSA-fghv-69vj-qj49
+  epoch: 1
   description: "Flyway is a database migration tool to evolve your database schema easily and reliably across all your instances."
   copyright:
     - license: Apache-2.0

--- a/flyway/pombump-deps.yaml
+++ b/flyway/pombump-deps.yaml
@@ -1,9 +1,4 @@
 patches:
-  - groupId: com.databricks
-    artifactId: databricks-jdbc
-    version: 2.6.40
-    scope: runtime
-    type: jar
   - groupId: net.snowflake.client.jdbc.SnowflakeDriver
     artifactId: snowflake-jdbc
     version: 3.23.1


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


Remove databricks-jdbc bump to v2.6.40 in order to pull upstream updated version at 2.7.3.
This is allowing to fix:
- CVE-2023-2976
- CVE-2024-47535
- CVE-2020-8908

<!--ci-cve-scan:fail-any-->
