### PR TITLE
libtool: switch to building from tarball

### DIFF
--- a/libtool.yaml
+++ b/libtool.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtool
   version: 2.4.7
-  epoch: 6
+  epoch: 7
   description: "GNU libtool"
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later
@@ -27,17 +27,14 @@ environment:
     M4: /usr/bin/m4
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.savannah.gnu.org/git/libtool.git
-      expected-commit: 6d7ce133ce54898cf28abd89d167cccfbc3c9b2b
-      tag: v${{package.version}}
+      uri: https://ftpmirror.gnu.org/gnu/libtool/libtool-${{ package.version }}.tar.gz
+      expected-sha512: 27acef46d9eb67203d708b57d80b853f76fa4b9c2720ff36ec161e6cdf702249e7982214ddf60bae75511aa79bc7d92aa27e3eab7ef9c0f5c040e8e42e76a385
 
   - uses: patch
     with:
       patches: libtool-fix-cross-compile.patch
-
-  - runs: ./bootstrap
 
   - uses: autoconf/configure
 
@@ -68,11 +65,8 @@ subpackages:
 
 update:
   enabled: true
-  ignore-regex-patterns:
-    - ^\d+\.[13579]\.\d+$ # Ignore odd-numbered minor versions as these are pre-release
-  git:
-    tag-filter-prefix: v
-    strip-prefix: v
+  release-monitor:
+    identifier: 1741
 
 test:
   environment:


### PR DESCRIPTION
The `bootstrap` script performs a `git clone` from an unreliable server, currently experiencing a days-long outage.

This also stops ignoring odd-minor-versioned releases: those are no longer reserved for development snapshots.

Closes: #66525