### PR TITLE
py3 extension

### DIFF
--- a/py3-google-crc32c.yaml
+++ b/py3-google-crc32c.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-crc32c
   version: "1.7.1"
-  epoch: 1
+  epoch: 2
   description: A python wrapper of the C library 'Google CRC32C'
   copyright:
     - license: Apache-2.0
@@ -21,9 +21,12 @@ data:
       3.13: '313'
 
 environment:
+  environment:
+    CRC32C_PURE_PYTHON: 0
   contents:
     packages:
-      - py3-supported-build-base
+      - crc32c-dev
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: git-checkout

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 23
+  epoch: 24
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -68,7 +68,7 @@ pipeline:
         install -m644 vendor/${i} "${{targets.destdir}}"/${i}
       done
 
-      install -m600 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
+      install -m000 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
 
       ln -s /etc/crontabs "${{targets.destdir}}"/var/spool/cron/crontabs
       ln -s /proc/mounts "${{targets.destdir}}"/etc/mtab
@@ -87,6 +87,7 @@ test:
       runs: |
         test -f /etc/passwd
         test -f /etc/shadow
+        [ "$(stat -c %a /etc/shadow)" = "0" ]
         test -f /etc/os-release
         test -f /etc/host.conf
         test -d /var/empty


### PR DESCRIPTION
- **wolfi-baselayout: correct shadow permissions**
  Note shadow file can be 0000 which many security hardened operating
  systems use. In practice it is modified by setuid / priviledged
  processes or an external hypervisor, and thus its permissions are
  largely irrelevant.
  
  Tested VMs and docker, but possibly this change needs to be tested in
  other container implementations too (podman, k8s).
  

- **py3-google-crc32c: compile with extension**
  Set environment variable to force build failure, if C extension fails
  to build. This ensures we always build the module with acceleration.
  
  Add build-time dependencies to compile the C extension.
  
  This remove the following runtime warning from tests
  
  ```
  2025/09/27 10:54:43 WARN /usr/lib/python3.13/site-packages/google_crc32c/__init__.py:29: RuntimeWarning: As the c extension couldn't be imported, `google-crc32c` is using a pure python implementation that is significantly slower. If possible, please configure a c build environment and compile the extension
  2025/09/27 10:54:43 WARN   warnings.warn(_SLOW_CRC32C_WARNING, RuntimeWarning)
  2025/09/27 10:54:43 INFO python3.13 -c "import google_crc32c": PASS
  ```
  
  And a python extension is now shipped.
  