### PR TITLE
py3-google-crc32c: compile with extension

### DIFF
--- a/py3-google-crc32c.yaml
+++ b/py3-google-crc32c.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-crc32c
   version: "1.7.1"
-  epoch: 1
+  epoch: 2
   description: A python wrapper of the C library 'Google CRC32C'
   copyright:
     - license: Apache-2.0
@@ -21,9 +21,12 @@ data:
       3.13: '313'
 
 environment:
+  environment:
+    CRC32C_PURE_PYTHON: 0
   contents:
     packages:
-      - py3-supported-build-base
+      - crc32c-dev
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Set environment variable to force build failure, if C extension fails
to build. This ensures we always build the module with acceleration.

Add build-time dependencies to compile the C extension.

This remove the following runtime warning from tests

```
2025/09/27 10:54:43 WARN /usr/lib/python3.13/site-packages/google_crc32c/__init__.py:29: RuntimeWarning: As the c extension couldn't be imported, `google-crc32c` is using a pure python implementation that is significantly slower. If possible, please configure a c build environment and compile the extension
2025/09/27 10:54:43 WARN   warnings.warn(_SLOW_CRC32C_WARNING, RuntimeWarning)
2025/09/27 10:54:43 INFO python3.13 -c "import google_crc32c": PASS
```

And a python extension is now shipped.
