### PR TITLE
fix(rancher-dashboard-2.12): Embed Harvester UI extension

### DIFF
--- a/rancher-dashboard-2.12.yaml
+++ b/rancher-dashboard-2.12.yaml
@@ -1,22 +1,27 @@
 package:
   name: rancher-dashboard-2.12
   version: "2.12.2"
-  epoch: 0
-  description: Rancher UI
+  epoch: 1
+  description: Rancher UI Dashboard
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - rancher-dashboard=${{package.full-version}}
 
+vars:
+  nodejs-version: '22'
+  ui-dir: '/usr/share/rancher/ui-dashboard'
+
 environment:
   contents:
     packages:
       - bash
       - busybox
-      - nodejs-20 # Only nodejs-20 is supported, later versions are not supported (v2.10.x)
-      - py3-build-base-dev
+      - curl
+      - nodejs-${{vars.nodejs-version}}
       - yarn
+      - yq
 
 pipeline:
   - uses: git-checkout
@@ -27,16 +32,24 @@ pipeline:
       recurse-submodules: true
 
   - runs: |
-      export NODE_OPTIONS=--openssl-legacy-provider
-      yarn install
-      ./scripts/build-hosted
+      # Parse URL to embedded Harvester extension
+      EMBED_PKG=$(yq '.jobs."build-and-upload-embedded".steps[] | select(.id=="build-embedded").env.EMBED_PKG' .github/workflows/build-and-upload.yaml)
+      if [ "${EMBED_PKG//harvester}" = "$EMBED_PKG" ]; then
+        echo "Unable to parse URL to Harvester extension!"
+        echo "Please reference EMBED_PKG at:"
+        echo "- https://github.com/rancher/dashboard/blob/v${{package.version}}/.github/workflows/build-and-upload.yaml"
+        exit 1
+      fi
 
-  - name: Install files
-    runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/rancher/ui-dashboard/dashboard
-      cp -r dist/v${{package.version}}/* ${{targets.destdir}}/usr/share/rancher/ui-dashboard/dashboard
-      cp -r shell/public/* ${{targets.destdir}}/usr/share/rancher/ui-dashboard/dashboard
-      ln -sf /usr/share/rancher/ui-dashboard/dashboard/index.html ${{targets.destdir}}/usr/share/rancher/ui-dashboard/index.html
+      # Build dashboard and embed Harvester extension
+      ./scripts/build-embedded
+
+      # Extract and install dashboard
+      mkdir -p ${{targets.destdir}}/${{vars.ui-dir}}/dashboard
+      tar xvf dist/v${{package.version}}.tar.gz \
+        -C ${{targets.contextdir}}/${{vars.ui-dir}}/dashboard \
+        --strip-components=2
+      ln -s dashboard/index.html ${{targets.contextdir}}/${{vars.ui-dir}}/
 
   - uses: strip
 
@@ -52,31 +65,15 @@ test:
   environment:
     contents:
       packages:
-        - rancher-api-ui # Check if rancher-api-ui is properly installed without conflicts
         - curl
-        - nodejs
+        - nodejs-${{vars.nodejs-version}}
         - npm
         - wait-for-it
   pipeline:
-    - runs: |
-        for f in js img fonts index.html loading-indicator.html favicon.ico favicon.png; do
-          # File or folder must be present
-          [ -d /usr/share/rancher/ui-dashboard/dashboard/$f ] || [ -f /usr/share/rancher/ui-dashboard/dashboard/$f ] || {
-            echo "File or folder /usr/share/rancher/ui-dashboard/dashboard/$f not found"
-            exit 1
-          }
-          # Size must be greater than 0
-          [ $(du -s /usr/share/rancher/ui-dashboard/dashboard/$f | cut -f1) -gt 0 ] || {
-            echo "File or folder /usr/share/rancher/ui-dashboard/dashboard/$f is empty"
-            exit 1
-          }
-        done
-    - name: Check symlink
-      runs: test "$(readlink /usr/share/rancher/ui-dashboard/index.html)" = "/usr/share/rancher/ui-dashboard/dashboard/index.html"
     - name: "Test UI"
       uses: test/daemon-check-output
       with:
-        start: "npx http-server /usr/share/rancher/ui-dashboard/dashboard -p 8080"
+        start: "npx http-server ${{vars.ui-dir}}/dashboard -p 8080"
         timeout: 60
         expected_output: |
           serving


### PR DESCRIPTION
This embeds the Harvester extension in the dashboard. The Harvester UI extension is required by Rancher (as it provides the UI for Harvester in Rancher). This addresses the UI failing to load

We use the version referenced in Rancher's CI directly to avoid an incompatibility between Harvester's docker machine driver and the interface

Also remove tests that aren't necessarily testing anything. Reasons:
- Serving the dashboard will fail if required assets are missing
- We know the package isn't empty as we explicity extract assets to the directory (and previously copied them)
- rancher-api-ui doesn't provide conflicting files as it doesn't write to the dashboard directory so installing the package during tests isn't necessary
- Validating softlinks is redundant; if creating the link fails, ln will fail verbosely

Serving the dashboard is sufficient