### PR TITLE
fix(grafana-image-renderer): Bump tar-fs to remediate GHSA-vj76-c3g6-qr5v

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: "4.0.15"
-  epoch: 1
+  epoch: 2 # GHSA-vj76-c3g6-qr5v
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0
@@ -36,11 +36,14 @@ pipeline:
 
   - uses: patch
     with:
-      patches: bump-axios-CVE-2025-58754.patch
+      patches: |
+        bump-axios-CVE-2025-58754.patch
+        bump-tar-fs-GHSA-vj76-c3g6-qr5v.patch
 
   - runs: |
       npm pkg set resolutions.on-headers=1.1.0
       npm pkg set resolutions.@eslint/plugin-kit=0.3.4
+      npm pkg set resolutions.tar-fs=3.1.1
       yarn install
       yarn build
 

--- a/grafana-image-renderer/bump-tar-fs-GHSA-vj76-c3g6-qr5v.patch
+++ b/grafana-image-renderer/bump-tar-fs-GHSA-vj76-c3g6-qr5v.patch
@@ -1,0 +1,25 @@
+From d9329870ca9d2313ee680a6133340b595f577776 Mon Sep 17 00:00:00 2001
+From: Ankush Pathak <ankush.pathak@chainguard.dev>
+Date: Mon, 29 Sep 2025 05:49:42 +0000
+Subject: [PATCH] Bump tar-fs to 3.1.1 to remediate GHSA-vj76-c3g6-qr5v
+
+---
+ package.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 8579230..205b759 100644
+--- a/package.json
++++ b/package.json
+@@ -52,7 +52,7 @@
+     "puppeteer": "^22.8.2",
+     "puppeteer-cluster": "^0.24.0",
+     "rate-limiter-flexible": "^7.0.0",
+-    "tar-fs": "^3.0.9",
++    "tar-fs": "^3.1.1",
+     "unique-filename": "^2.0.1",
+     "winston": "^3.8.2"
+   },
+-- 
+2.51.0
+


### PR DESCRIPTION
Bump tar-fs to 3.1.1 to remediate GHSA-vj76-c3g6-qr5v
<!--ci-cve-scan:fail-any-->