### PR TITLE
liblangtag: refresh package for new upstream version 0.6.8

### DIFF
--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/community/liblangtag/APKBUILD
 package:
   name: liblangtag
-  version: 0.6.7
-  epoch: 3
+  version: 0.6.8
+  epoch: 0
   description: Interface library to access/deal with tags for identifying languages
   copyright:
     - license: LGPL-3.0-or-later OR MPL-2.0
@@ -11,22 +11,37 @@ environment:
   contents:
     packages:
       - autoconf
+      - autoconf-archive
       - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - curl
       - glib-dev
+      - glib-gir
       - gobject-introspection
+      - gobject-introspection-dev
+      - gtk-doc
       - libtool
+      - libx11-dev
       - libxml2-dev
+      - pkgconf-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 5ed6bcd4ae3f3c05c912e62f216cd1a44123846147f729a49fb5668da51e030e
-      uri: https://bitbucket.org/tagoh/liblangtag/downloads/liblangtag-${{package.version}}.tar.bz2
+      expected-commit: 5f3c3a3887caf79b35a544417a066f3e61893208
+      tag: ${{package.version}}
+      # NOTE: the code was previously hosted at https://bitbucket.org/tagoh/liblangtag
+      # and it was relocated to gitlab. I'm leaving this comment/pointer here in case
+      # they go back anytime soon. If not, you can drop this comment.
+      repository: https://gitlab.com/tagoh/liblangtag.git
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-locale-alias \
+        --disable-Werror
 
   - uses: autoconf/make
 
@@ -48,11 +63,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: liblangtag-doc
-    pipeline:
-      - uses: split/manpages
-    description: liblangtag manpages
 
 update:
   enabled: true


### PR DESCRIPTION
Rebuild package to verify source code URL is correct.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
