### PR TITLE
feat(dex): rebuild Dex to avoid dirty version for main module

### DIFF
--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: "2.44.0"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
@@ -36,8 +36,8 @@ pipeline:
       export GOBIN="$GOPATH/bin"
       LD_FLAGS="-w -X main.version=v${{package.version}} -extldflags \"-static\""
 
-      go build -o "$GOBIN/dex" -v -ldflags "$LD_FLAGS" ./cmd/dex
-      go build -o "$GOBIN/docker-entrypoint" -v -ldflags "$LD_FLAGS" ./cmd/docker-entrypoint
+      go build -o "$GOBIN/dex" -v -ldflags "$LD_FLAGS" -buildvcs=false ./cmd/dex
+      go build -o "$GOBIN/docker-entrypoint" -v -ldflags "$LD_FLAGS" -buildvcs=false ./cmd/docker-entrypoint
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/srv/dex


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


Add `-buildvcs=false` in order to build package with main module in SemVer format (more in the issue linked below).

<!--ci-cve-scan:fail-any-->
