### PR TITLE
feat(solr): bump dep to remediate GHSA-2hmj-97jw-28jh

### DIFF
--- a/solr.yaml
+++ b/solr.yaml
@@ -1,7 +1,7 @@
 package:
   name: solr
   version: "9.9.0"
-  epoch: 2 # GHSA-3p8m-j85q-pgmj
+  epoch: 3
   description: Apache Solr open-source search software
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ pipeline:
       tag: releases/solr/${{package.version}}
 
   - runs: |
-      sed -i -e 's|org.apache.zookeeper:\*=3.9.2|org.apache.zookeeper:\*=3.9.3|g' versions.props
+      sed -i -e 's|org.apache.zookeeper:\*=3.9.3|org.apache.zookeeper:\*=3.9.4|g' versions.props
       sed -i -e 's|com.jayway.jsonpath:json-path=2.8.0|com.jayway.jsonpath:json-path=2.9.0|g' versions.props
       # Resolve GHSA-g8m5-722r-8whq and GHSA-mmxm-8w33-wc4h
       sed -i -e 's|org.eclipse.jetty\*:\*=10.0.22|org.eclipse.jetty\*:\*=10.0.26|g' versions.props


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump to remediate GHSA-2hmj-97jw-28jh

<!--ci-cve-scan:fail-any-->
