### PR TITLE
feat(strimzi-kafka-operator): bump dep to remediate GHSA-2hmj-97jw-28jh

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.47.0"
-  epoch: 7 # GHSA-3p8m-j85q-pgmj
+  epoch: 8
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -53,6 +53,11 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 40b9fa269ba87283bb0651711557922b14d715b3
 
+  - uses: patch
+    with:
+      # temporary hack from https://github.com/strimzi/strimzi-kafka-operator/commit/9a0f0ca37c63906b5e8ee29f6a686976884efe15
+      patches: move-access-operator-dependency-to-systemtest.patch
+
   - uses: maven/pombump
 
   - uses: maven/pombump

--- a/strimzi-kafka-operator/move-access-operator-dependency-to-systemtest.patch
+++ b/strimzi-kafka-operator/move-access-operator-dependency-to-systemtest.patch
@@ -1,0 +1,100 @@
+diff --git a/pom.xml b/pom.xml
+index 3dd18ef04..65c5e8aae 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -39,23 +39,6 @@
+         </developer>
+     </developers>
+ 
+-    <repositories>
+-        <repository>
+-            <!--
+-            Until there is a new release of Kafka Access Operator we are using the Sonatype repository with its SNAPSHOT.
+-            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
+-            -->
+-            <id>oss-sonatype</id>
+-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+-            <releases>
+-                <enabled>false</enabled>
+-            </releases>
+-            <snapshots>
+-                <enabled>true</enabled>
+-            </snapshots>
+-        </repository>
+-    </repositories>
+-
+     <properties>
+         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+         <maven.compiler.release>17</maven.compiler.release>
+@@ -147,12 +130,6 @@
+         <skodjob.test-frame.version>1.0.0</skodjob.test-frame.version>
+         <skodjob-doc.version>0.4.0</skodjob-doc.version>
+         <helm-client.version>0.0.15</helm-client.version>
+-        <!--
+-            Currently, there are no released versions in Maven repository of this module,
+-            using SNAPSHOT for having the `api` module available and usable in the STs.
+-            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
+-        -->
+-        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
+         <!-- properties to skip surefire tests during failsafe execution -->
+         <skipTests>false</skipTests>
+         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+@@ -852,11 +829,6 @@
+                 <artifactId>docker-java-api</artifactId>
+                 <version>${docker-java.version}</version>
+             </dependency>
+-            <dependency>
+-                <groupId>io.strimzi.access-operator</groupId>
+-                <artifactId>api</artifactId>
+-                <version>${access-operator.version}</version>
+-            </dependency>
+         </dependencies>
+     </dependencyManagement>
+ 
+diff --git a/systemtest/pom.xml b/systemtest/pom.xml
+index 8b027fd5c..249f593c6 100644
+--- a/systemtest/pom.xml
++++ b/systemtest/pom.xml
+@@ -14,11 +14,34 @@
+     <properties>
+         <skipTests>true</skipTests>
+         <failsafe.forkCount>0</failsafe.forkCount>
++        <!--
++            Currently, there are no released versions in Maven repository of this module,
++            using SNAPSHOT for having the `api` module available and usable in the STs.
++            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
++        -->
++        <access-operator.version>0.2.0-SNAPSHOT</access-operator.version>
+ 
+         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
+         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>
+     </properties>
+ 
++    <repositories>
++        <repository>
++            <!--
++            Until there is a new release of Kafka Access Operator we are using the Sonatype repository with its SNAPSHOT.
++            Tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/11207.
++            -->
++            <id>oss-sonatype</id>
++            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
++            <releases>
++                <enabled>false</enabled>
++            </releases>
++            <snapshots>
++                <enabled>true</enabled>
++            </snapshots>
++        </repository>
++    </repositories>
++
+     <dependencies>
+         <dependency>
+             <groupId>io.strimzi</groupId>
+@@ -264,6 +287,7 @@
+         <dependency>
+             <groupId>io.strimzi.access-operator</groupId>
+             <artifactId>api</artifactId>
++            <version>${access-operator.version}</version>
+         </dependency>
+         <dependency>
+             <groupId>com.marcnuri.helm-java</groupId>

--- a/strimzi-kafka-operator/pombump-deps-cc.yaml
+++ b/strimzi-kafka-operator/pombump-deps-cc.yaml
@@ -23,3 +23,6 @@ patches:
   - groupId: org.apache.commons
     artifactId: commons-lang3
     version: 3.18.0
+  - groupId: org.apache.zookeeper
+    artifactId: zookeeper
+    version: 3.9.4


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-2hmj-97jw-28jh

<!--ci-cve-scan:fail-any-->
