### PR TITLE
feat(apache-activemq-artemis): bump dep to remediate GHSA-2hmj-97jw-28jh

### DIFF
--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.42.0"
-  epoch: 8 # GHSA-3p8m-j85q-pgmj
+  epoch: 9
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0

--- a/apache-activemq-artemis/pombump-properties.yaml
+++ b/apache-activemq-artemis/pombump-properties.yaml
@@ -5,3 +5,5 @@ properties:
     value: "4.1.125.Final"
   - property: commons.lang.version
     value: "3.18.0"
+  - property: zookeeper.version
+    value: "3.9.4"


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-2hmj-97jw-28jh

<!--ci-cve-scan:fail-any-->
