### PR TITLE
Replace 'vars.py-version' with 'vars.python-version'

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -18,8 +18,8 @@ package:
       - merged-usrsbin
       - netcat-openbsd # nc is required
       - posix-libc-utils # genconf is required
-      - py${{vars.py-version}}-packaging # Airflow uses this at runtime for config loading
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-packaging # Airflow uses this at runtime for config loading
+      - python-${{vars.python-version}}
       - tzdata
       - unixodbc
       - wolfi-baselayout
@@ -31,7 +31,7 @@ package:
 vars:
   # As of now (2025/04/28), airflow is primarily available for python 3.12 and will break for python 3.13
   # For ref: https://airflow.apache.org/blog/airflow-2.9.0
-  py-version: 3.12
+  python-version: 3.12
   # This list is based on providers that were part of the 2.x version of this package, as well as manually added dependencies
   # to ensure we're building dependent providers too (not pulling from PyPi). This is an ordered list.
   # Use / as a separator
@@ -65,11 +65,11 @@ environment:
       - pkgconf-dev
       - pnpm
       - postgresql-dev
-      - py${{vars.py-version}}-build-bin
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-xmlsec
-      - python-${{vars.py-version}}
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-build-bin
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-xmlsec
+      - python-${{vars.python-version}}
+      - python-${{vars.python-version}}-dev
       - rust
       - uv
       - wget
@@ -107,7 +107,7 @@ pipeline:
       # To install mysqlclient wheel
       export MYSQLCLIENT_CFLAGS=`mysql_config --cflags`
 
-      python${{vars.py-version}} -m build --wheel
+      python${{vars.python-version}} -m build --wheel
       # We need to use uv to avoid `resolution to deep` errors`
       uv pip install --verbose --upgrade --resolution highest --prefix=${{targets.contextdir}}/opt/airflow dist/*.whl
 
@@ -151,7 +151,7 @@ pipeline:
         fi
 
         # Build and install the wheel
-        python${{vars.py-version}} -m build --wheel
+        python${{vars.python-version}} -m build --wheel
         uv pip install --verbose --upgrade --resolution highest --prefix=${{targets.contextdir}}/opt/airflow dist/*.whl
         cd -
       done
@@ -175,15 +175,15 @@ pipeline:
 
   - name: "Remove litellm log file that generates secret alerts from trivy"
     runs: |
-      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.py-version}} -name 'litellm.log' -exec rm -f {} +
+      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.python-version}} -name 'litellm.log' -exec rm -f {} +
 
   - name: "Replace hooks.slack.com with something obviously not hooks.slack.com to avoid secret alert from trivy"
     runs: |
-      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.py-version}}/site-packages/litellm -name _types.py -exec sed -i "s/hooks.slack.com/nothooks.slack.com/g" {} +
+      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.python-version}}/site-packages/litellm -name _types.py -exec sed -i "s/hooks.slack.com/nothooks.slack.com/g" {} +
 
   - name: "Remove any patch related files from the install tree"
     runs: |
-      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.py-version}} -name "*.orig" -print -exec rm -f {} +
+      find ${{targets.contextdir}}/opt/airflow/lib/python${{vars.python-version}} -name "*.orig" -print -exec rm -f {} +
 
   - runs: |
       chmod 0644 ${{targets.contextdir}}/opt/airflow/.lock
@@ -195,7 +195,7 @@ pipeline:
       # The first time you run Airflow, it will create a file called `airflow.cfg` in
       # `$AIRFLOW_HOME` directory
       # However, for production case it is advised to generate the configuration
-      export PYTHONPATH=${{targets.contextdir}}/opt/airflow:${{targets.contextdir}}/opt/airflow/lib/python${{vars.py-version}}/site-packages
+      export PYTHONPATH=${{targets.contextdir}}/opt/airflow:${{targets.contextdir}}/opt/airflow/lib/python${{vars.python-version}}/site-packages
       export PATH=${{targets.contextdir}}/opt/airflow/bin:$PATH
 
       ${{targets.destdir}}/opt/airflow/bin/airflow config list --defaults > ${{targets.destdir}}/"airflow.cfg"
@@ -320,33 +320,33 @@ test:
   environment:
     contents:
       packages:
-        - py${{vars.py-version}}-pip
+        - py${{vars.python-version}}-pip
   pipeline:
     - name: "Ensure no airflow 2.x components are pulled in by mistake"
       runs: |
-        pip list --path=/opt/airflow/lib/python${{vars.py-version}}/site-packages/ | grep airflow
-        ls -lah /opt/airflow/lib/python${{vars.py-version}}/site-packages/
+        pip list --path=/opt/airflow/lib/python${{vars.python-version}}/site-packages/ | grep airflow
+        ls -lah /opt/airflow/lib/python${{vars.python-version}}/site-packages/
 
         # A known bad file example: apache_airflow-2.10.5.dist-info
-        if ls -1 /opt/airflow/lib/python${{vars.py-version}}/site-packages | grep -q "apache_airflow-2.*.dist-info"; then
+        if ls -1 /opt/airflow/lib/python${{vars.python-version}}/site-packages | grep -q "apache_airflow-2.*.dist-info"; then
             echo "Error: apache_airflow-2.* file(s) found! Please diagnose"
             exit 1
         fi
     - name: "Test Python package import and version"
       runs: |
         export PATH=/opt/airflow/bin:$PATH
-        export PYTHONPATH=/opt/airflow/lib/python${{vars.py-version}}/site-packages
+        export PYTHONPATH=/opt/airflow/lib/python${{vars.python-version}}/site-packages
         HOME=/home/build airflow version | grep ${{package.version}}
-        python${{vars.py-version}} -c "import airflow"
+        python${{vars.python-version}} -c "import airflow"
     - name: "Test Flask is at the supported version"
       runs: |
         set -e
-        export PYTHONPATH=/opt/airflow/lib/python${{vars.py-version}}/site-packages
+        export PYTHONPATH=/opt/airflow/lib/python${{vars.python-version}}/site-packages
         python -c "from flask.json import JSONEncoder"
     - name: "List providers"
       runs: |
         export PATH=/opt/airflow/bin:$PATH
-        export PYTHONPATH=/opt/airflow/lib/python${{vars.py-version}}/site-packages
+        export PYTHONPATH=/opt/airflow/lib/python${{vars.python-version}}/site-packages
 
         PROVIDERS_LIST=$(airflow providers list)
         echo $PROVIDERS_LIST

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -7,7 +7,7 @@ package:
     - license: GPL-2.0-or-later
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -20,8 +20,8 @@ environment:
       - git
       - libxml2-utils
       - libxslt
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-pip
+      - python-${{vars.python-version}}
       - wolfi-base
 
 pipeline:
@@ -48,11 +48,11 @@ pipeline:
 
   - uses: autoconf/make
     with:
-      opts: PYTHON=python${{vars.py-version}}
+      opts: PYTHON=python${{vars.python-version}}
 
   - uses: autoconf/make-install
     with:
-      opts: PYTHON=python${{vars.py-version}}
+      opts: PYTHON=python${{vars.python-version}}
 
 update:
   enabled: true

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -7,7 +7,7 @@ package:
     - license: GPL-2.0-or-later
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -23,7 +23,7 @@ environment:
       - linux-headers
       - lzo-dev
       - pkgconf-dev
-      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.python-version}}-build-base-dev
       - systemd-dev
       - zlib-dev
       - zstd-dev
@@ -37,7 +37,7 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        PYTHON=python${{vars.py-version}} \
+        PYTHON=python${{vars.python-version}} \
         --with-crypto=libgcrypt \
         --disable-backtrace \
         --disable-documentation # documentation requires a _ton_ of python3 dependencices that should be added to sphinx instead

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -9,7 +9,7 @@ package:
     runtime:
       - curl
       - jemalloc
-      - python-${{vars.py-version}} # needed for cqlsh
+      - python-${{vars.python-version}} # needed for cqlsh
     provides:
       - cassandra=${{package.full-version}}
 
@@ -20,7 +20,7 @@ var-transforms:
     to: major-minor-version
 
 vars:
-  py-version: 3.11
+  python-version: 3.11
   java-version: 17
 
 environment:
@@ -33,11 +33,11 @@ environment:
       - ca-certificates-bundle
       - go # for documentation generation
       - openjdk-${{vars.java-version}}-default-jdk
-      - py${{vars.py-version}}-build
-      - py${{vars.py-version}}-cython-bin
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-build
+      - py${{vars.python-version}}-cython-bin
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-dev
   environment:
     JAVA_HOME: /usr/lib/jvm/java-${{vars.java-version}}-openjdk
 
@@ -105,8 +105,8 @@ subpackages:
   - name: cqlsh-${{vars.major-minor-version}}
     dependencies:
       runtime:
-        - py${{vars.py-version}}-cassandra-driver
-        - py${{vars.py-version}}-wcwidth
+        - py${{vars.python-version}}-cassandra-driver
+        - py${{vars.python-version}}-wcwidth
       provides:
         - cqlsh=${{package.full-version}}
     pipeline:
@@ -114,12 +114,12 @@ subpackages:
         working-directory: pylib
         uses: py/pip-build-install
         with:
-          python: python${{vars.py-version}}
+          python: python${{vars.python-version}}
       - name: "Install cqlsh executable"
         runs: |
           mkdir -p ${{targets.contextdir}}/usr/bin
           cp ./bin/cqlsh.py ${{targets.contextdir}}/usr/bin/cqlsh
-          python=python${{vars.py-version}}
+          python=python${{vars.python-version}}
           sed -i "1s,.*,#!/usr/bin/$python,g" ${{targets.contextdir}}/usr/bin/cqlsh
           head -n 1 ${{targets.contextdir}}/usr/bin/cqlsh
     test:

--- a/ceph.yaml
+++ b/ceph.yaml
@@ -31,25 +31,25 @@ package:
       - openssl
       - parted
       - podman
-      - py${{vars.py-version}}-bcrypt-3.2
-      - py${{vars.py-version}}-cherrypy
-      - py${{vars.py-version}}-cryptography
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-jsonpatch
-      - py${{vars.py-version}}-kubernetes
-      - py${{vars.py-version}}-packaging
-      - py${{vars.py-version}}-pecan
-      - py${{vars.py-version}}-prettytable
-      - py${{vars.py-version}}-pyopenssl
-      - py${{vars.py-version}}-python-dateutil
-      - py${{vars.py-version}}-pyyaml
-      - py${{vars.py-version}}-requests
-      - py${{vars.py-version}}-routes
-      - py${{vars.py-version}}-scikit-learn
-      - py${{vars.py-version}}-scipy
-      - py${{vars.py-version}}-urllib3
-      - py${{vars.py-version}}-werkzeug
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-bcrypt-3.2
+      - py${{vars.python-version}}-cherrypy
+      - py${{vars.python-version}}-cryptography
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-jsonpatch
+      - py${{vars.python-version}}-kubernetes
+      - py${{vars.python-version}}-packaging
+      - py${{vars.python-version}}-pecan
+      - py${{vars.python-version}}-prettytable
+      - py${{vars.python-version}}-pyopenssl
+      - py${{vars.python-version}}-python-dateutil
+      - py${{vars.python-version}}-pyyaml
+      - py${{vars.python-version}}-requests
+      - py${{vars.python-version}}-routes
+      - py${{vars.python-version}}-scikit-learn
+      - py${{vars.python-version}}-scipy
+      - py${{vars.python-version}}-urllib3
+      - py${{vars.python-version}}-werkzeug
+      - python-${{vars.python-version}}
       - sgdisk
       - smartmontools
       - systemd
@@ -58,7 +58,7 @@ package:
       - xfsprogs
 
 vars:
-  py-version: 3.11
+  python-version: 3.11
   lua-version: 5.4
 
 environment:
@@ -109,12 +109,12 @@ environment:
       - openssl-dev
       - pkgconf
       - posix-libc-utils
-      - py${{vars.py-version}}-cython
-      - py${{vars.py-version}}-prettytable
-      - py${{vars.py-version}}-pyyaml
-      - py${{vars.py-version}}-setuptools
-      - py${{vars.py-version}}-sphinx-bin
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-cython
+      - py${{vars.python-version}}-prettytable
+      - py${{vars.python-version}}-pyyaml
+      - py${{vars.python-version}}-setuptools
+      - py${{vars.python-version}}-sphinx-bin
+      - python-${{vars.python-version}}-dev
       - re2-dev
       - snappy-dev
       - swagger
@@ -155,11 +155,11 @@ pipeline:
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
-        -DPython3_LIBRARIES=/usr/lib/python${{vars.py-version}} \
+        -DPython3_LIBRARIES=/usr/lib/python${{vars.python-version}} \
         -DCMAKE_INSTALL_SYSCONFDIR=/etc \
         -DNINJA_MAX_COMPILE_JOBS=$(nproc) \
         -DWITH_GTEST_PARALLEL=ON \
-        -DWITH_PYTHON3=${{vars.py-version}} \
+        -DWITH_PYTHON3=${{vars.python-version}} \
         -DENABLE_GIT_VERSION=ON \
         -DLUA_LIBRARIES=/usr/lib/lua${{vars.lua-version}}/liblua.so \
         -DWITH_BABELTRACE=OFF \

--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -10,14 +10,14 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - py${{vars.py-version}}-setuptools # To fix `No module named 'distutils'`
+      - py${{vars.python-version}}-setuptools # To fix `No module named 'distutils'`
 
 vars:
   # This will compile with py3.13, however tests will fail with errors:
   # 'ModuleNotFoundError: No module named 'pipes'
   # - https://github.com/jupyter/nbclassic/issues/308
   # Upstream may have to make some code changes to be compatible with py3.13.
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -25,8 +25,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cython
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-gpep517
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-gpep517
 
 pipeline:
   - uses: git-checkout
@@ -44,7 +44,7 @@ pipeline:
       echo 'urllib3>=2.5.0' >> requirements.txt
 
   - runs: |
-      python3=python${{vars.py-version}}
+      python3=python${{vars.python-version}}
       $python3 -m gpep517 build-wheel \
         --wheel-dir dist \
         --output-fd 3 3>&1 >&2
@@ -55,7 +55,7 @@ pipeline:
         "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
 
   - runs: |
-      python3=python${{vars.py-version}}
+      python3=python${{vars.python-version}}
       # `--use-deprecated=legacy-resolver` is used force ignore the dependency check.
       # `docker-compose` was requiring `PyYAML<6` and also `PyYAML==5.4.1` was causing
       # `AttributeError: cython_sources` issue.
@@ -64,7 +64,7 @@ pipeline:
       find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
 
   - runs: |
-      python3=python${{vars.py-version}}
+      python3=python${{vars.python-version}}
       _py3ver=$($python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
       mkdir -p ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages/confluent/docker_utils
       cp -r confluent/docker_utils/* ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages/confluent/docker_utils/

--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -10,7 +10,7 @@ package:
       - cython=${{package.version}}-r${{package.epoch}}
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -18,7 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.python-version}}-build-base-dev
 
 pipeline:
   - uses: git-checkout

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -7,18 +7,18 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - py${{vars.py-version}}-aiohttp
-      - py${{vars.py-version}}-click
-      - py${{vars.py-version}}-cloudpickle
-      - py${{vars.py-version}}-msgpack
-      - py${{vars.py-version}}-packaging
-      - py${{vars.py-version}}-psutil
-      - py${{vars.py-version}}-pyyaml
-      - py${{vars.py-version}}-sortedcontainers
-      - py${{vars.py-version}}-tornado
+      - py${{vars.python-version}}-aiohttp
+      - py${{vars.python-version}}-click
+      - py${{vars.python-version}}-cloudpickle
+      - py${{vars.python-version}}-msgpack
+      - py${{vars.python-version}}-packaging
+      - py${{vars.python-version}}-psutil
+      - py${{vars.python-version}}-pyyaml
+      - py${{vars.python-version}}-sortedcontainers
+      - py${{vars.python-version}}-tornado
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -27,9 +27,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-gpep517
-      - py${{vars.py-version}}-hatchling
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-gpep517
+      - py${{vars.python-version}}-hatchling
       - wolfi-base
 
 pipeline:
@@ -43,10 +43,10 @@ pipeline:
       cd ${{package.name}}
 
       # Build package
-      python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python${{vars.python-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
       # Setup venv and install package
-      python${{vars.py-version}} -m venv .venv --system-site-packages
+      python${{vars.python-version}} -m venv .venv --system-site-packages
       .venv/bin/pip install -I --no-deps --no-compile dist/*.whl
       .venv/bin/pip install -I --no-deps --no-compile dask
       .venv/bin/pip install -I --no-deps --no-compile distributed
@@ -76,21 +76,21 @@ subpackages:
     description: A multi-tenant server for securely deploying and managing Dask clusters
     dependencies:
       runtime:
-        - py${{vars.py-version}}-kubernetes-asyncio
-        - py${{vars.py-version}}-colorlog
-        - py${{vars.py-version}}-sqlalchemy
-        - py${{vars.py-version}}-traitlets
-        - py${{vars.py-version}}-cryptography
+        - py${{vars.python-version}}-kubernetes-asyncio
+        - py${{vars.python-version}}-colorlog
+        - py${{vars.python-version}}-sqlalchemy
+        - py${{vars.python-version}}-traitlets
+        - py${{vars.python-version}}-cryptography
     pipeline:
       - name: Python Build
         runs: |
           cd ${{package.name}}-server
 
           # Build package
-          python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+          python${{vars.python-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
           # Setup venv and install package
-          python${{vars.py-version}} -m venv .venv --system-site-packages
+          python${{vars.python-version}} -m venv .venv --system-site-packages
           .venv/bin/pip install -I --no-deps --no-compile dist/*.whl
 
           mkdir -p ${{targets.subpkgdir}}/usr/share/${{package.name}}-server
@@ -119,7 +119,7 @@ subpackages:
 
             # Test imports in virtual environment
             source /usr/share/${{package.name}}-server/.venv/bin/activate
-            python${{vars.py-version}} -c "import dask_gateway_server"
+            python${{vars.python-version}} -c "import dask_gateway_server"
             dask-gateway-jobqueue-launcher --version
             dask-gateway-jobqueue-launcher --help
             dask-gateway-server --help
@@ -141,8 +141,8 @@ test:
 
         # Test imports in virtual environment
         source /usr/share/${{package.name}}/.venv/bin/activate
-        python${{vars.py-version}} -c "import dask_gateway"
-        python${{vars.py-version}} -c "from dask_gateway import Gateway"
+        python${{vars.python-version}} -c "import dask_gateway"
+        python${{vars.python-version}} -c "from dask_gateway import Gateway"
         dask --help
         dask-scheduler --help
         dask-ssh --help

--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -7,10 +7,10 @@ package:
     - license: "BSD-3-Clause"
   dependencies:
     runtime:
-      - python-${{vars.py-version}}-base
+      - python-${{vars.python-version}}-base
 
 vars:
-  py-version: "3.10"
+  python-version: "3.10"
   pypi-package: dask_kubernetes
 
 environment:
@@ -22,11 +22,11 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-      - py${{vars.py-version}}-hatch
-      - py${{vars.py-version}}-hatch-bin
-      - py${{vars.py-version}}-hatch-vcs
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-hatch
+      - py${{vars.python-version}}-hatch-bin
+      - py${{vars.python-version}}-hatch-vcs
+      - py${{vars.python-version}}-pip
+      - python-${{vars.python-version}}
       - wolfi-base
 
 pipeline:
@@ -38,7 +38,7 @@ pipeline:
 
   - runs: |
       mkdir -p /usr/share/dask-kubernetes
-      python${{vars.py-version}} -m venv /usr/share/dask-kubernetes
+      python${{vars.python-version}} -m venv /usr/share/dask-kubernetes
       source /usr/share/dask-kubernetes/bin/activate
 
       # Build and install wheel
@@ -60,9 +60,9 @@ pipeline:
         /usr/share/dask-kubernetes/pyvenv.cfg
 
       # Include virtual environment's site-packages in system path
-      mkdir -p ${{targets.contextdir}}/usr/lib/python${{vars.py-version}}/site-packages
-      echo /usr/share/dask-kubernetes/lib/python${{vars.py-version}}/site-packages > \
-        ${{targets.contextdir}}/usr/lib/python${{vars.py-version}}/site-packages/${{package.name}}.pth
+      mkdir -p ${{targets.contextdir}}/usr/lib/python${{vars.python-version}}/site-packages
+      echo /usr/share/dask-kubernetes/lib/python${{vars.python-version}}/site-packages > \
+        ${{targets.contextdir}}/usr/lib/python${{vars.python-version}}/site-packages/${{package.name}}.pth
 
       # Symlink scripts to path
       mkdir -p ${{targets.contextdir}}/usr/bin
@@ -85,7 +85,7 @@ test:
   pipeline:
     - uses: python/import
       with:
-        python: python${{vars.py-version}}
+        python: python${{vars.python-version}}
         import: ${{vars.pypi-package}}
 
 update:

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -25,7 +25,7 @@ capabilities:
     - CAP_SYS_ADMIN # This is needed to run unshare(1).
 
 vars:
-  py-version: "3.12"
+  python-version: "3.12"
   destd: /opt/datadog-agent
 
 var-transforms:
@@ -78,8 +78,8 @@ environment:
       - ninja
       - openssf-compiler-options
       - procps-dev
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-semver
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-semver
       - systemd-dev
       - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian
@@ -124,10 +124,10 @@ pipeline:
   # these won't leak into the package.
   - runs: |
       # install `invoke` and its dependencies
-      python${{vars.py-version}} -m pip install invoke requests toml pyyaml packaging codeowners
+      python${{vars.python-version}} -m pip install invoke requests toml pyyaml packaging codeowners
 
       # install `gitlab`
-      python${{vars.py-version}} -m pip install python-gitlab
+      python${{vars.python-version}} -m pip install python-gitlab
 
   - uses: go/bump
     with:
@@ -375,7 +375,7 @@ subpackages:
         - busybox
         - coreutils
         - findutils
-        - python-${{vars.py-version}}-base
+        - python-${{vars.python-version}}-base
     pipeline:
       - working-directory: /home/integrations
         pipeline:
@@ -392,22 +392,22 @@ subpackages:
               SOURCE_DATE_EPOCH=315532800
 
               # Create virtual environment
-              python${{vars.py-version}} -m venv .venv
+              python${{vars.python-version}} -m venv .venv
 
               # Install locked dependencies
-              .venv/bin/pip${{vars.py-version}} install --require-hashes --only-binary=:all: --no-deps -r .deps/resolved/linux-${{build.arch}}_${{vars.py-version}}.txt
+              .venv/bin/pip${{vars.python-version}} install --require-hashes --only-binary=:all: --no-deps -r .deps/resolved/linux-${{build.arch}}_${{vars.python-version}}.txt
 
               excludes="datadog_checks_base datadog_checks_dev datadog_checks_tests_helper docker_daemon esxi teleport"
               checks=$(invoke -r /home/build agent.collect-integrations /home/integrations/ 3 linux --excluded "$excludes")
 
               # Install core, downloader, and dependencies
-              .venv/bin/pip${{vars.py-version}} install \
+              .venv/bin/pip${{vars.python-version}} install \
                 "./datadog_checks_base[deps, http]" \
                 "./datadog_checks_downloader" \
                 $(echo ${checks} | xargs -n1 echo | sed 's|^|./|')
 
               # Remediate GHSA-5rjg-fvgr-3xxf
-              .venv/bin/pip${{vars.py-version}} install --upgrade setuptools==78.1.1 protobuf==5.29.5
+              .venv/bin/pip${{vars.python-version}} install --upgrade setuptools==78.1.1 protobuf==5.29.5
 
               find .venv -name "*.pyc" -delete
               find .venv -name "__pycache__" -exec rm -rf {} +
@@ -415,7 +415,7 @@ subpackages:
               find .venv -name "pymqe.cpython*.so" -delete
 
               mkdir -p ${{targets.contextdir}}${{vars.destd}}
-              .venv/bin/pip${{vars.py-version}} freeze > ${{targets.contextdir}}${{vars.destd}}/final_constraints-py3.txt
+              .venv/bin/pip${{vars.python-version}} freeze > ${{targets.contextdir}}${{vars.destd}}/final_constraints-py3.txt
 
               # Include the agent's requirements for the core integrations.
               cp requirements-agent-release.txt ${{targets.contextdir}}${{vars.destd}}/
@@ -708,12 +708,12 @@ test:
     - name: Ensure checks can be loaded (base)
       uses: python/import
       with:
-        python: ${{vars.destd}}/embedded/bin/python${{vars.py-version}}
+        python: ${{vars.destd}}/embedded/bin/python${{vars.python-version}}
         import: datadog_checks.base
     - name: Ensure checks can be loaded (downloader)
       uses: python/import
       with:
-        python: ${{vars.destd}}/embedded/bin/python${{vars.py-version}}
+        python: ${{vars.destd}}/embedded/bin/python${{vars.python-version}}
         import: datadog_checks.downloader
     - name: Execute bins
       runs: |

--- a/dnsdist-2.0.yaml
+++ b/dnsdist-2.0.yaml
@@ -16,7 +16,7 @@ package:
       exit 0
 
 vars:
-  py-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
+  python-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
   lua-version: 5.4 # Pinning latest lua version to pass cmake
 
 environment:
@@ -44,8 +44,8 @@ environment:
       - openssl-dev
       - pkgconf-dev
       - protobuf-dev
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-pyyaml
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-pyyaml
       - quiche
       - ragel-dev
       - re2-dev
@@ -101,8 +101,8 @@ subpackages:
       provides:
         - dnsdist-compat=${{package.full-version}}
       runtime:
-        - python-${{vars.py-version}}
-        - py${{vars.py-version}}-jinja2
+        - python-${{vars.python-version}}
+        - py${{vars.python-version}}-jinja2
         - tini
         - libcap-utils
         - coreutils # For env -S support

--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -12,7 +12,7 @@ package:
       - merged-sbin
       - nfs-utils
       - openssl
-      - py${{vars.py-version}}-botocore
+      - py${{vars.python-version}}-botocore
       - stunnel
       - systemd
       - util-linux
@@ -20,7 +20,7 @@ package:
 
 vars:
   # pick a version of python so we can add that version and boto as a dep.
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -77,7 +77,7 @@ pipeline:
     runs: |
       d=${{targets.destdir}}
       for p in $d/usr/bin/amazon-efs-mount-watchdog $d/usr/bin/mount.efs ; do
-         sed -i -e '1s,^#!.*python3$,#!/usr/bin/python${{vars.py-version}},' "$p"
+         sed -i -e '1s,^#!.*python3$,#!/usr/bin/python${{vars.python-version}},' "$p"
       done
 
 # This package exists separately because aws-efs-csi-driver requires a custom efs-utils.
@@ -96,7 +96,7 @@ subpackages:
         - merged-sbin
         - nfs-utils
         - openssl
-        - py${{vars.py-version}}-botocore
+        - py${{vars.python-version}}-botocore
         - stunnel
         - stunnel-compat
         - systemd
@@ -145,7 +145,7 @@ subpackages:
             runs: |
               d=${{targets.destdir}}
               for p in $d/usr/bin/amazon-efs-mount-watchdog $d/usr/bin/mount.efs ; do
-                sed -i -e '1s,^#!.*python3$,#!/usr/bin/python${{vars.py-version}},' "$p"
+                sed -i -e '1s,^#!.*python3$,#!/usr/bin/python${{vars.python-version}},' "$p"
               done
     test:
       pipeline:

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -8,12 +8,12 @@ package:
   dependencies:
     runtime:
       - git
-      - py${{vars.py-version}}-certifi
-      - py${{vars.py-version}}-packaging
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-certifi
+      - py${{vars.python-version}}-packaging
+      - python-${{vars.python-version}}
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -25,10 +25,10 @@ environment:
       - curl
       - openssf-compiler-options
       # pinning build and runtime deps to 3.12 because pyinstaller version project is using doesn't work with 3.13 python.
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-setuptools
-      - py${{vars.py-version}}-wheel
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-setuptools
+      - py${{vars.python-version}}-wheel
+      - python-${{vars.python-version}}
       - wolfi-base
 
 pipeline:

--- a/glib-gir.yaml
+++ b/glib-gir.yaml
@@ -11,7 +11,7 @@ package:
 vars:
   # build uses rst2man from py3-docutils and also invokes 'python3'
   # installed /usr/bin/gtester-report gets correct shbang (/usr/bin/python3.XX)
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -33,8 +33,8 @@ environment:
       - libxslt-dev
       - meson
       - pcre2-dev
-      - py${{vars.py-version}}-docutils-bin
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-docutils-bin
+      - python-${{vars.python-version}}
       - util-linux-dev
       - zlib-dev
 

--- a/glib.yaml
+++ b/glib.yaml
@@ -9,7 +9,7 @@ package:
 vars:
   # build uses rst2man from py3-docutils and also invokes 'python3'
   # installed /usr/bin/gtester-report gets correct shbang (/usr/bin/python3.XX)
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -29,8 +29,8 @@ environment:
       - libxslt-dev
       - meson
       - pcre2-dev
-      - py${{vars.py-version}}-docutils-bin
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-docutils-bin
+      - python-${{vars.python-version}}
       - util-linux-dev
       - zlib-dev
 
@@ -65,7 +65,7 @@ pipeline:
       # replace usr/bin/env python3
       d=${{targets.destdir}}/usr/bin
       # change '/usr/bin/env python3' or '/usr/bin/python3' to /usr/bin/python3.XX
-      op='1s,^#!/usr/bin/\(env python3\|python3\)$,#!/usr/bin/python${{vars.py-version}},'
+      op='1s,^#!/usr/bin/\(env python3\|python3\)$,#!/usr/bin/python${{vars.python-version}},'
       for f in "$d"/*; do
          [ -f "$f" ] || continue
          sed -i -e "$op" "$f";

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -7,7 +7,7 @@ package:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
   bins: "g-ir-annotation-tool g-ir-compiler g-ir-generate g-ir-inspect g-ir-scanner"
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
@@ -38,8 +38,8 @@ environment:
       - libtool
       - meson
       - posix-libc-utils
-      - py${{vars.py-version}}-build-base-dev
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-build-base-dev
+      - python-${{vars.python-version}}
 
 pipeline:
   - uses: fetch
@@ -60,7 +60,7 @@ pipeline:
       # replace usr/bin/env python3
       d=${{targets.destdir}}/usr/bin
       # change '/usr/bin/env python3' or '/usr/bin/python3' to /usr/bin/python3.XX
-      op='1s,^#!/usr/bin/\(env python3\|python3\)$,#!/usr/bin/python${{vars.py-version}},'
+      op='1s,^#!/usr/bin/\(env python3\|python3\)$,#!/usr/bin/python${{vars.python-version}},'
       for f in "$d"/*; do
          [ -f "$f" ] || continue
          sed -i -e "$op" "$f";
@@ -83,7 +83,7 @@ subpackages:
         # g-ir-annotation-tool as of version 1.82.0 still imports distutils and
         # will fail with any python 3.12+ unless we add setuptools.
         # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
-        - py${{vars.py-version}}-setuptools
+        - py${{vars.python-version}}-setuptools
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/share \

--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -11,7 +11,7 @@ package:
       - wolfi-baselayout
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -24,7 +24,7 @@ environment:
       - ca-certificates-bundle
       - libcap-dev
       - ncurses-dev
-      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.python-version}}-build-base-dev
       - scons
 
 pipeline:
@@ -41,8 +41,8 @@ pipeline:
       CPPFLAGS="$CPPFLAGS -I./pps-tools/ -DHAVE_SYS_TIMEPPS_H"
       scons -j${JOBS:-1} \
       	prefix=/usr \
-      	target_python=python${{vars.py-version}} \
-      	python_shebang=/usr/bin/python${{vars.py-version}} \
+      	target_python=python${{vars.python-version}} \
+      	python_shebang=/usr/bin/python${{vars.python-version}} \
       	dbus_export=no \
       	systemd=no
 
@@ -85,7 +85,7 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: py${{vars.py-version}}-gpsd
+  - name: py${{vars.python-version}}-gpsd
     dependencies:
       provides:
         - py3-gpsd

--- a/in-toto.yaml
+++ b/in-toto.yaml
@@ -8,7 +8,7 @@ package:
 
 # pinning to 3.12 since the install fails on 3.13
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -18,8 +18,8 @@ environment:
       - gcc
       - libffi-dev
       - openssl
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-pip
+      - python-${{vars.python-version}}-dev
   environment:
     SOURCE_DATE_EPOCH: 315532800
 

--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -7,10 +7,10 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - python-${{vars.py-version}} # gives correct /usr/bin/python3 for any callers.
+      - python-${{vars.python-version}} # gives correct /usr/bin/python3 for any callers.
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -18,7 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-pip
+      - py${{vars.python-version}}-pip
       - wolfi-base
 
 pipeline:

--- a/kserve.yaml
+++ b/kserve.yaml
@@ -7,16 +7,16 @@ package:
     - license: Apache-2.0
 
 vars:
-  py-version: 3.11 # Upstream https://github.com/kserve/kserve/blob/release-0.15/python/storage-initializer.Dockerfile uses python-3.11
+  python-version: 3.11 # Upstream https://github.com/kserve/kserve/blob/release-0.15/python/storage-initializer.Dockerfile uses python-3.11
 
 environment:
   contents:
     packages:
       - go
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-poetry
-      - py${{vars.py-version}}-poetry-bin
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-poetry
+      - py${{vars.python-version}}-poetry-bin
+      - python-${{vars.python-version}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -134,7 +134,7 @@ subpackages:
 
           cd ${{targets.contextdir}}/storage-initializer/scripts/
           # update shbang to point to the python used rather than '/usr/bin/env python'
-          sed -i.dist "1s,#!/usr/bin/env python[^ ]*,#!$(which python${{vars.py-version}})," initializer-entrypoint
+          sed -i.dist "1s,#!/usr/bin/env python[^ ]*,#!$(which python${{vars.python-version}})," initializer-entrypoint
           # exit fail if it did not change anything
           diff -u initializer-entrypoint.dist initializer-entrypoint && exit 1
           rm initializer-entrypoint.dist

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -8,10 +8,10 @@ package:
   dependencies:
     runtime:
       - bash
-      - py${{vars.py-version}}-gunicorn-bin
+      - py${{vars.python-version}}-gunicorn-bin
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -24,8 +24,8 @@ environment:
       - npm
       - openssl
       - openssl-provider-legacy
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-urllib3
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-urllib3
       - wolfi-base
 
 pipeline:
@@ -36,8 +36,8 @@ pipeline:
       expected-commit: 90e987bf87d3e7c900926310b00bfa16b59e41eb
 
   - runs: |
-      python3=python${{vars.py-version}}
-      pip=pip${{vars.py-version}}
+      python3=python${{vars.python-version}}
+      pip=pip${{vars.python-version}}
 
       # Build the backend common libs into a wheel
       cd components/crud-web-apps/common/backend
@@ -50,7 +50,7 @@ pipeline:
       $pip install . --prefix=/usr --root="${{targets.destdir}}"
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       $pip install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
-      ls -latr /usr/lib/python${{vars.py-version}}/site-packages
+      ls -latr /usr/lib/python${{vars.python-version}}/site-packages
 
       cd ../../jupyter/backend
       # pip install -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  py-version: 3.11
+  python-version: 3.11
 
 environment:
   contents:
@@ -19,8 +19,8 @@ environment:
       - go
       - hdf5-dev
       - pcre-dev
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-pip
+      - python-${{vars.python-version}}-dev
 
 data:
   - name: go-builds
@@ -79,8 +79,8 @@ subpackages:
     description: Kubeflow Katib earlystopping
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
-        - python-${{vars.py-version}}
+        - py${{vars.python-version}}-pip
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-earlystopping --system-site-packages
@@ -104,7 +104,7 @@ subpackages:
     dependencies:
       runtime:
         - openmp-17
-        - py${{vars.py-version}}-pip
+        - py${{vars.python-version}}-pip
     pipeline:
       - runs: |
           python -m venv .venv-metricscollector --system-site-packages
@@ -125,9 +125,9 @@ subpackages:
     description: Kubeflow Katib suggestion-hyperband
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
+        - py${{vars.python-version}}-pip
         - libgomp
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-hyperband --system-site-packages
@@ -148,8 +148,8 @@ subpackages:
     description: Kubeflow Katib suggestion-hyperopt
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
-        - python-${{vars.py-version}}
+        - py${{vars.python-version}}-pip
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-hyperopt --system-site-packages
@@ -170,8 +170,8 @@ subpackages:
     description: Kubeflow Katib suggestion-nas-darts
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
-        - python-${{vars.py-version}}
+        - py${{vars.python-version}}-pip
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-darts --system-site-packages
@@ -193,7 +193,7 @@ subpackages:
     dependencies:
       runtime:
         - openmp-17
-        - py${{vars.py-version}}-pip
+        - py${{vars.python-version}}-pip
     pipeline:
       - runs: |
           python -m venv .venv-enas --system-site-packages
@@ -214,8 +214,8 @@ subpackages:
     description: Kubeflow Katib suggestion-optuna-enas
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
-        - python-${{vars.py-version}}
+        - py${{vars.python-version}}-pip
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-optuna --system-site-packages
@@ -236,8 +236,8 @@ subpackages:
     description: Kubeflow Katib suggestion-pbt-enas
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
-        - python-${{vars.py-version}}
+        - py${{vars.python-version}}-pip
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-pbt --system-site-packages
@@ -258,9 +258,9 @@ subpackages:
     description: Kubeflow Katib suggestion-skopt-enas
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pip
+        - py${{vars.python-version}}-pip
         - libgomp
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           python -m venv .venv-skopt --system-site-packages

--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -9,23 +9,23 @@ package:
     - x86_64 # Since tensorflow-data-validation is not available for aarch64 yet
   dependencies:
     runtime:
-      - py${{vars.py-version}}-google-cloud-sdk
-      - py${{vars.py-version}}-packaging
-      - py${{vars.py-version}}-typing-extensions
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-google-cloud-sdk
+      - py${{vars.python-version}}-packaging
+      - py${{vars.python-version}}-typing-extensions
+      - python-${{vars.python-version}}
 
 vars:
-  py-version: 3.11
+  python-version: 3.11
 
 environment:
   contents:
     packages:
       - build-base
       - ca-certificates-bundle
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-crcmod
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-pip-tools-bin
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-crcmod
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-pip-tools-bin
 
 pipeline:
   - uses: git-checkout
@@ -75,7 +75,7 @@ test:
       packages:
         - curl
         - bash
-        - py${{vars.py-version}}-typing-extensions
+        - py${{vars.python-version}}-typing-extensions
   pipeline:
     - runs: |
         #!/bin/bash

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -10,7 +10,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  py-version: '3.10'
+  python-version: '3.10'
 
 environment:
   contents:
@@ -22,9 +22,9 @@ environment:
       - kubectl
       - nodejs
       - npm
-      - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-gpep517
-      - py${{vars.py-version}}-urllib3
+      - py${{vars.python-version}}-build-base-dev
+      - py${{vars.python-version}}-gpep517
+      - py${{vars.python-version}}-urllib3
 
 data:
   - name: backends-go-builds
@@ -106,10 +106,10 @@ subpackages:
             # GHSA-79v4-65xg-pq4g
             echo "cryptography==44.0.1" >> requirements.txt
 
-            pip${{vars.py-version}} install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
+            pip${{vars.python-version}} install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
 
             # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
-            pip${{vars.py-version}} install --upgrade "requests>=2.32.4" --prefix=/usr --root=${{targets.subpkgdir}}
+            pip${{vars.python-version}} install --upgrade "requests>=2.32.4" --prefix=/usr --root=${{targets.subpkgdir}}
             cp -r ../samples/* ${{targets.subpkgdir}}/samples
             cp ./src/$path/config/sample_config.json ${{targets.subpkgdir}}/samples/sample_config.json
             mkdir -p ${{targets.subpkgdir}}/config
@@ -214,37 +214,37 @@ subpackages:
     description: "Kubeflow Pipelines metadata_writer"
     dependencies:
       runtime:
-        - python-${{vars.py-version}}
-        - py${{vars.py-version}}-absl-py
-        - py${{vars.py-version}}-attrs
-        - py${{vars.py-version}}-cachetools
-        - py${{vars.py-version}}-certifi
-        - py${{vars.py-version}}-charset-normalizer
-        - py${{vars.py-version}}-google-auth
-        - py${{vars.py-version}}-grpcio
-        - py${{vars.py-version}}-idna
-        - py${{vars.py-version}}-kubernetes
-        - py${{vars.py-version}}-lru-dict
-        - py${{vars.py-version}}-ml-metadata
-        - py${{vars.py-version}}-oauthlib
-        - py${{vars.py-version}}-protobuf
-        - py${{vars.py-version}}-pyasn1-modules
-        - py${{vars.py-version}}-pyasn1
-        - py${{vars.py-version}}-dateutil
-        - py${{vars.py-version}}-pyyaml
-        - py${{vars.py-version}}-requests-oauthlib
-        - py${{vars.py-version}}-requests
-        - py${{vars.py-version}}-rsa
-        - py${{vars.py-version}}-six
-        - py${{vars.py-version}}-urllib3
-        - py${{vars.py-version}}-websocket-client
+        - python-${{vars.python-version}}
+        - py${{vars.python-version}}-absl-py
+        - py${{vars.python-version}}-attrs
+        - py${{vars.python-version}}-cachetools
+        - py${{vars.python-version}}-certifi
+        - py${{vars.python-version}}-charset-normalizer
+        - py${{vars.python-version}}-google-auth
+        - py${{vars.python-version}}-grpcio
+        - py${{vars.python-version}}-idna
+        - py${{vars.python-version}}-kubernetes
+        - py${{vars.python-version}}-lru-dict
+        - py${{vars.python-version}}-ml-metadata
+        - py${{vars.python-version}}-oauthlib
+        - py${{vars.python-version}}-protobuf
+        - py${{vars.python-version}}-pyasn1-modules
+        - py${{vars.python-version}}-pyasn1
+        - py${{vars.python-version}}-dateutil
+        - py${{vars.python-version}}-pyyaml
+        - py${{vars.python-version}}-requests-oauthlib
+        - py${{vars.python-version}}-requests
+        - py${{vars.python-version}}-rsa
+        - py${{vars.python-version}}-six
+        - py${{vars.python-version}}-urllib3
+        - py${{vars.python-version}}-websocket-client
     pipeline:
       - runs: |
           cd backend/metadata_writer
-          python${{vars.py-version}} -m gpep517 build-wheel \
+          python${{vars.python-version}} -m gpep517 build-wheel \
             --wheel-dir dist \
             --output-fd 3 3>&1 >&2
-          python${{vars.py-version}} -m installer -d "${{targets.subpkgdir}}" \
+          python${{vars.python-version}} -m installer -d "${{targets.subpkgdir}}" \
             dist/*.whl
           find ${{targets.subpkgdir}} -name "*.pyc" -exec rm -rf '{}' +
 
@@ -256,7 +256,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/kfp/metadata_writer
-          ln -s /usr/lib/python${{vars.py-version}}/site-packages/metadata_writer.py "${{targets.subpkgdir}}"/kfp/metadata_writer/
+          ln -s /usr/lib/python${{vars.python-version}}/site-packages/metadata_writer.py "${{targets.subpkgdir}}"/kfp/metadata_writer/
 
   - name: kubeflow-pipelines-metadata-envoy-config
     description: Kubeflow Pipelines Metadata-Envoy Config

--- a/llvm-15.yaml
+++ b/llvm-15.yaml
@@ -12,7 +12,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-15"
   clang-prefix: "/usr/lib/llvm-15/lib/clang/15"
-  py-version: 3.11
+  python-version: 3.11
 
 var-transforms:
   - from: ${{package.version}}
@@ -38,7 +38,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -52,7 +52,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -278,7 +278,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -295,7 +295,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/llvm-16.yaml
+++ b/llvm-16.yaml
@@ -12,7 +12,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-16"
   clang-prefix: "/usr/lib/llvm-16/lib/clang/16"
-  py-version: 3.11
+  python-version: 3.11
 
 var-transforms:
   - from: ${{package.version}}
@@ -38,7 +38,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -58,7 +58,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -313,7 +313,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -330,7 +330,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/llvm-17.yaml
+++ b/llvm-17.yaml
@@ -12,7 +12,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-17"
   clang-prefix: "/usr/lib/llvm-17/lib/clang/17"
-  py-version: 3.13
+  python-version: 3.13
 
 var-transforms:
   - from: ${{package.version}}
@@ -39,7 +39,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -65,7 +65,7 @@ pipeline:
       fi
 
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -321,7 +321,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -338,7 +338,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -12,7 +12,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-18"
   clang-prefix: "/usr/lib/llvm-18/lib/clang/18"
-  py-version: 3.13
+  python-version: 3.13
 
 var-transforms:
   - from: ${{package.version}}
@@ -38,7 +38,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -58,7 +58,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -312,7 +312,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -329,7 +329,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/llvm-19.yaml
+++ b/llvm-19.yaml
@@ -12,7 +12,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-19"
   clang-prefix: "/usr/lib/llvm-19/lib/clang/19"
-  py-version: 3.13
+  python-version: 3.13
 
 var-transforms:
   - from: ${{package.version}}
@@ -37,7 +37,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -57,7 +57,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -311,7 +311,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -328,7 +328,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -15,7 +15,7 @@ package:
 vars:
   llvm-prefix: "/usr/lib/llvm-20"
   clang-prefix: "/usr/lib/llvm-20/lib/clang/20"
-  py-version: 3.13
+  python-version: 3.13
 
 var-transforms:
   - from: ${{package.version}}
@@ -40,7 +40,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -54,7 +54,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -323,7 +323,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -337,7 +337,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -14,7 +14,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -30,9 +30,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -68,7 +68,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -14,7 +14,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -30,9 +30,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -64,7 +64,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -14,7 +14,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -29,9 +29,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -61,7 +61,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -13,7 +13,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -29,9 +29,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -63,7 +63,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -13,7 +13,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -28,9 +28,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -65,7 +65,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -13,7 +13,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -28,9 +28,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -64,7 +64,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-24.yaml
+++ b/nodejs-24.yaml
@@ -13,7 +13,7 @@ package:
     memory: 64Gi
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -28,9 +28,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -64,7 +64,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python${{vars.py-version}} configure.py --prefix=/usr \
+      python${{vars.python-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/ohif-viewer.yaml
+++ b/ohif-viewer.yaml
@@ -7,7 +7,7 @@ package:
     - license: "MIT"
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -16,7 +16,7 @@ environment:
       - busybox
       - nodejs
       - npm
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - yarn
 
 pipeline:

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -18,7 +18,7 @@ package:
       - libx11
       - libxcb
       - libxext
-      - python-${{vars.py-version}}-base
+      - python-${{vars.python-version}}-base
   options:
     # Don't depend on external libraries included in virtual environments
     no-depends: true
@@ -27,7 +27,7 @@ package:
 
 vars:
   # Matching the counterpart image (ghcr.io/open-webui/open-webui:latest) Python version
-  py-version: 3.11
+  python-version: 3.11
 
 environment:
   contents:
@@ -36,7 +36,7 @@ environment:
       # Does not support NodeJS 23 (as of v0.6.13)
       - nodejs-22
       - npm
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - uv
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -133,8 +133,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/app ${{targets.contextdir}}/app/backend
           ln -sf /usr/share/${{package.name}}/backend/start.sh ${{targets.contextdir}}/app/backend/start.sh
           ln -sf /usr/share/${{package.name}}/backend/data/ ${{targets.contextdir}}/app/backend/data
-          ln -sf /usr/share/${{package.name}}/lib/python${{vars.py-version}}/site-packages/open_webui ${{targets.contextdir}}/app/backend/open_webui
-          ln -sf /usr/share/${{package.name}}/lib/python${{vars.py-version}}/site-packages/open_webui/frontend/ ${{targets.contextdir}}/app/build
+          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui ${{targets.contextdir}}/app/backend/open_webui
+          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/ ${{targets.contextdir}}/app/build
           ln -sf /usr/share/${{package.name}}/package.json ${{targets.contextdir}}/app/package.json
           ln -sf /usr/share/${{package.name}}/CHANGELOG.md ${{targets.contextdir}}/app/CHANGELOG.md
     test:
@@ -147,8 +147,8 @@ subpackages:
           runs: |
             readlink -f /app/backend/start.sh | grep /usr/share/${{package.name}}/backend/start.sh
             readlink -f /app/backend/data | grep /usr/share/${{package.name}}/backend/data
-            readlink -f /app/backend/open_webui | grep /usr/share/${{package.name}}/lib/python${{vars.py-version}}/site-packages/open_webui
-            readlink -f /app/build | grep /usr/share/${{package.name}}/lib/python${{vars.py-version}}/site-packages/open_webui/frontend
+            readlink -f /app/backend/open_webui | grep /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui
+            readlink -f /app/build | grep /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend
             readlink -f /app/package.json | grep /usr/share/${{package.name}}/package.json
             readlink -f /app/CHANGELOG.md | grep /usr/share/${{package.name}}/CHANGELOG.md
 

--- a/openscap.yaml
+++ b/openscap.yaml
@@ -7,7 +7,7 @@ package:
     - license: LGPL-2.1-or-later
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -37,8 +37,8 @@ environment:
       - perl-xml-parser
       - popt-dev
       - procps
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-dev
       # TODO: Needed for rpm/apt scanning
       # - perl-xml-xpath
       # - opendbx-dev
@@ -77,8 +77,8 @@ pipeline:
       # change /usr/bin/python3 to /usr/bin/python3.XX
       for f in ${{targets.destdir}}/usr/bin/*; do
         [ -f "$f" ] || continue
-        sed -i '1s,^#!/usr/bin/python3$,#!/usr/bin/python${{vars.py-version}},' "$f"
-        sed -i '1s,^#!/usr/sbin/python3$,#!/usr/sbin/python${{vars.py-version}},' "$f"
+        sed -i '1s,^#!/usr/bin/python3$,#!/usr/bin/python${{vars.python-version}},' "$f"
+        sed -i '1s,^#!/usr/sbin/python3$,#!/usr/sbin/python${{vars.python-version}},' "$f"
       done
 
   - uses: strip
@@ -89,13 +89,13 @@ subpackages:
     dependencies:
       runtime:
         - openscap
-        - py${{vars.py-version}}-docker
+        - py${{vars.python-version}}-docker
         - docker-cli
     test:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             imports: |
               import openscap_py
               import oscap_docker_python

--- a/orthanc-dicomweb.yaml
+++ b/orthanc-dicomweb.yaml
@@ -10,7 +10,7 @@ package:
       - orthanc
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -26,7 +26,7 @@ environment:
       - orthanc-dev
       - patch
       - pugixml-dev
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - util-linux-dev
       - zlib-dev
 

--- a/orthanc-docker.yaml
+++ b/orthanc-docker.yaml
@@ -17,11 +17,11 @@ package:
       - orthanc-ohif
       - orthanc-postgresql
       - orthanc-python
-      - py${{vars.py-version}}-envsubst
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-envsubst
+      - python-${{vars.python-version}}
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:

--- a/orthanc-explorer2.yaml
+++ b/orthanc-explorer2.yaml
@@ -10,7 +10,7 @@ package:
       - orthanc
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -28,7 +28,7 @@ environment:
       - npm
       - orthanc-dev
       - patch
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - util-linux-dev
 
 pipeline:

--- a/orthanc-gdcm.yaml
+++ b/orthanc-gdcm.yaml
@@ -23,11 +23,11 @@ environment:
       - libuuid
       - orthanc-dev
       - patch
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - util-linux-dev
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 pipeline:
   - uses: fetch

--- a/orthanc-ohif.yaml
+++ b/orthanc-ohif.yaml
@@ -11,7 +11,7 @@ package:
       - orthanc-dicomweb
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -30,7 +30,7 @@ environment:
       - ohif-viewer
       - orthanc-dev
       - patch
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - util-linux-dev
       - zlib-dev
 

--- a/orthanc-postgresql.yaml
+++ b/orthanc-postgresql.yaml
@@ -12,7 +12,7 @@ package:
       - postgresql-${{vars.pg-version}}-client
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
   pg-version: "17"
 
 environment:
@@ -29,7 +29,7 @@ environment:
       - patch
       - postgresql-${{vars.pg-version}}-dev
       - protobuf-dev
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - util-linux-dev
       - zlib-dev
 

--- a/orthanc-python.yaml
+++ b/orthanc-python.yaml
@@ -10,7 +10,7 @@ package:
       - orthanc
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -25,9 +25,9 @@ environment:
       - libuuid
       - orthanc-dev
       - patch
-      - py${{vars.py-version}}-pystache
-      - python-${{vars.py-version}}
-      - python-${{vars.py-version}}-dev
+      - py${{vars.python-version}}-pystache
+      - python-${{vars.python-version}}
+      - python-${{vars.python-version}}-dev
       - util-linux-dev
       - zlib-dev
 
@@ -46,7 +46,7 @@ pipeline:
         -DUSE_SYSTEM_ORTHANC_SDK=ON \
         -DUSE_SYSTEM_JSONCPP=ON \
         -DUSE_SYSTEM_BOOST=ON \
-        -DPYTHON_VERSION=${{vars.py-version}}
+        -DPYTHON_VERSION=${{vars.python-version}}
 
   - uses: cmake/build
 
@@ -73,7 +73,7 @@ test:
     contents:
       packages:
         - curl
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
   pipeline:
     - uses: test/tw/ldd-check
     - runs: stat /usr/share/orthanc/plugins/libOrthancPython.so
@@ -131,7 +131,7 @@ test:
           curl -s http://localhost:18051/system | grep -q "Version" && echo "Orthanc system endpoint working"
 
           # Test Python plugin integration
-          curl -s http://localhost:18051/python-test | python${{vars.py-version}} -m json.tool > /dev/null && echo "Python plugin JSON response valid"
+          curl -s http://localhost:18051/python-test | python${{vars.python-version}} -m json.tool > /dev/null && echo "Python plugin JSON response valid"
 
 update:
   enabled: true

--- a/orthanc-webviewer.yaml
+++ b/orthanc-webviewer.yaml
@@ -10,7 +10,7 @@ package:
       - orthanc
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -25,7 +25,7 @@ environment:
       - libuuid
       - orthanc-dev
       - patch
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - sqlite-dev
 
 pipeline:

--- a/orthanc.yaml
+++ b/orthanc.yaml
@@ -11,7 +11,7 @@ package:
 
 vars:
   lua-version: "5.4"
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:
@@ -32,7 +32,7 @@ environment:
       - patch
       - protobuf-dev
       - pugixml-dev
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - sqlite-dev
       - tzdata
 

--- a/patroni.yaml
+++ b/patroni.yaml
@@ -7,18 +7,18 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - py${{vars.py-version}}-boto3
-      - py${{vars.py-version}}-charset-normalizer
-      - py${{vars.py-version}}-click
-      - py${{vars.py-version}}-prettytable
-      - py${{vars.py-version}}-psutil
-      - py${{vars.py-version}}-psycopg
-      - py${{vars.py-version}}-pysyncobj
-      - py${{vars.py-version}}-pyyaml
-      - py${{vars.py-version}}-ydiff
+      - py${{vars.python-version}}-boto3
+      - py${{vars.python-version}}-charset-normalizer
+      - py${{vars.python-version}}-click
+      - py${{vars.python-version}}-prettytable
+      - py${{vars.python-version}}-psutil
+      - py${{vars.python-version}}-psycopg
+      - py${{vars.python-version}}-pysyncobj
+      - py${{vars.python-version}}-pyyaml
+      - py${{vars.python-version}}-ydiff
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 environment:
   contents:

--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -8,12 +8,12 @@ package:
   dependencies:
     provider-priority: 10
     runtime:
-      - py${{vars.py-version}}-pyelftools
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-pyelftools
+      - python-${{vars.python-version}}
       - scanelf
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -26,7 +26,7 @@ environment:
       - libseccomp-dev
       - meson
       - pkgconf-dev
-      - py${{vars.py-version}}-pyelftools
+      - py${{vars.python-version}}-pyelftools
       - wolfi-baselayout
       - xz
 

--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -12,7 +12,7 @@ package:
       - pdns=${{package.full-version}}
 
 vars:
-  py-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
+  python-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr
   lua-version: 5.4 # Pinning latest lua version to pass cmake
 
 environment:
@@ -48,8 +48,8 @@ environment:
       - pkgconf-dev
       - postgresql-dev
       - protobuf-dev
-      - py${{vars.py-version}}-virtualenv
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-virtualenv
+      - python-${{vars.python-version}}
       - ragel
       - rust
       - sqlite-dev
@@ -221,8 +221,8 @@ subpackages:
       provides:
         - pdns-recursor-compat=${{package.full-version}}
       runtime:
-        - python-${{vars.py-version}}
-        - py${{vars.py-version}}-jinja2
+        - python-${{vars.python-version}}
+        - py${{vars.python-version}}-jinja2
         - tini
         - libcap-utils
         - coreutils # For env -S support

--- a/pipx.yaml
+++ b/pipx.yaml
@@ -8,20 +8,20 @@ package:
   dependencies:
     runtime:
       - bash # pipx ensurepath
-      - py${{vars.py-version}}-argcomplete
-      - py${{vars.py-version}}-packaging
-      - py${{vars.py-version}}-platformdirs
-      - py${{vars.py-version}}-userpath
+      - py${{vars.python-version}}-argcomplete
+      - py${{vars.python-version}}-packaging
+      - py${{vars.python-version}}-platformdirs
+      - py${{vars.python-version}}-userpath
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
     packages:
-      - py${{vars.py-version}}-build-base
-      - py${{vars.py-version}}-hatch-vcs
-      - py${{vars.py-version}}-hatchling
+      - py${{vars.python-version}}-build-base
+      - py${{vars.python-version}}-hatch-vcs
+      - py${{vars.python-version}}-hatchling
 
 pipeline:
   - uses: git-checkout

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -12,17 +12,17 @@ package:
   dependencies:
     runtime:
       - merged-bin
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - wolfi-baselayout
 
 vars:
   # NOTE: align with py-version in cassandra* packages.
-  py-version: 3.11
+  python-version: 3.11
 
 environment:
   contents:
     packages:
-      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.python-version}}-build-base-dev
 
 pipeline:
   - uses: git-checkout
@@ -35,7 +35,7 @@ pipeline:
     runs: |
       # As of 0.22.3, this package is incompatible with poetry 2.0.
       # See: https://github.com/thelastpickle/cassandra-medusa/commit/fd044f92d9a5ea245c61d1df9c58462de51496e4
-      pip${{vars.py-version}} install 'poetry>=1.0.0,<2.0.0'
+      pip${{vars.python-version}} install 'poetry>=1.0.0,<2.0.0'
       poetry add "pyOpenSSL@^24.0.0"
       poetry add "cryptography@^44.0.1"
       # GHSA-34jh-p97f-mpxf: urllib3
@@ -51,16 +51,16 @@ pipeline:
       poetry build
 
       # Setup the virtualenv
-      python${{vars.py-version}} -m venv .venv
+      python${{vars.python-version}} -m venv .venv
 
-      .venv/bin/pip${{vars.py-version}} install -I -r requirements.txt --no-compile
-      .venv/bin/pip${{vars.py-version}} install -I --no-compile dist/*.whl
+      .venv/bin/pip${{vars.python-version}} install -I -r requirements.txt --no-compile
+      .venv/bin/pip${{vars.python-version}} install -I --no-compile dist/*.whl
 
       # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
-      .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile
+      .venv/bin/pip${{vars.python-version}} install -I python-snappy --no-compile
 
       # Install poetry
-      .venv/bin/pip${{vars.py-version}} install 'poetry>=1.0.0,<2.0.0'
+      .venv/bin/pip${{vars.python-version}} install 'poetry>=1.0.0,<2.0.0'
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -s /home/cassandra/.venv/bin/poetry ${{targets.destdir}}/usr/bin/poetry
 
@@ -117,7 +117,7 @@ test:
       runs: |
         set +e
         fail() { echo "$@" 1>&2; exit 1; }
-        out=$(/home/cassandra/.venv/bin/python${{vars.py-version}} -m medusa.service.grpc.server 2>&1)
+        out=$(/home/cassandra/.venv/bin/python${{vars.python-version}} -m medusa.service.grpc.server 2>&1)
         status=$?
         echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message. Exit status $status: $out"
         echo "medusa.service.grpc.server exited with expected error message"

--- a/py3-tensorflow-serving-api.yaml
+++ b/py3-tensorflow-serving-api.yaml
@@ -7,15 +7,15 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - py${{vars.py-version}}-grpcio
-      - py${{vars.py-version}}-protobuf
-      - py${{vars.py-version}}-tensorflow-core
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-grpcio
+      - py${{vars.python-version}}-protobuf
+      - py${{vars.python-version}}-tensorflow-core
+      - python-${{vars.python-version}}
 
 vars:
   # tensorflow-core doesn't yet support Python 3.13:
   # https://github.com/tensorflow/tensorflow/issues/78774
-  py-version: 3.12
+  python-version: 3.12
 
 environment:
   contents:
@@ -23,10 +23,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-installer
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-installer
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}
       - wolfi-base
 
 pipeline:

--- a/pylint.yaml
+++ b/pylint.yaml
@@ -7,14 +7,14 @@ package:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - py${{vars.py-version}}-astroid
-      - py${{vars.py-version}}-dill
-      - py${{vars.py-version}}-isort
-      - py${{vars.py-version}}-platformdirs
-      - py${{vars.py-version}}-tomlkit
+      - py${{vars.python-version}}-astroid
+      - py${{vars.python-version}}-dill
+      - py${{vars.python-version}}-isort
+      - py${{vars.python-version}}-platformdirs
+      - py${{vars.python-version}}-tomlkit
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -22,7 +22,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-build-base
+      - py${{vars.python-version}}-build-base
       - wolfi-base
 
 pipeline:

--- a/rancher-2.12.yaml
+++ b/rancher-2.12.yaml
@@ -42,7 +42,7 @@ package:
       - openssl
       - pigz
       - posix-libc-utils
-      - py${{vars.py-version}}-tox
+      - py${{vars.python-version}}-tox
       - rancher-api-ui
       - rancher-charts-${{vars.major-minor-version}}
       - rancher-dashboard-${{vars.major-minor-version}}
@@ -77,7 +77,7 @@ environment:
       - gpgme-dev
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
   k3s-major-minor-version: 1.33
 
 var-transforms:
@@ -207,9 +207,9 @@ pipeline:
 
   - name: Create symlinks
     runs: |
-      ln -sf /usr/bin/cattle-${{vars.py-version}} ${{targets.contextdir}}/usr/bin/cattle
-      ln -sf /usr/bin/gdapi-${{vars.py-version}} ${{targets.contextdir}}/usr/bin/gdapi
-      ln -sf /usr/bin/tox-${{vars.py-version}} ${{targets.contextdir}}/usr/bin/tox
+      ln -sf /usr/bin/cattle-${{vars.python-version}} ${{targets.contextdir}}/usr/bin/cattle
+      ln -sf /usr/bin/gdapi-${{vars.python-version}} ${{targets.contextdir}}/usr/bin/gdapi
+      ln -sf /usr/bin/tox-${{vars.python-version}} ${{targets.contextdir}}/usr/bin/tox
       mkdir -p ${{targets.contextdir}}/opt/drivers/management-state/bin
       ln -sf /usr/bin/docker-machine-driver-harvester ${{targets.contextdir}}/opt/drivers/management-state/bin/docker-machine-driver-harvester
       ln -sf /usr/bin/docker-machine-driver-linode ${{targets.contextdir}}/opt/drivers/management-state/bin/docker-machine-driver-linode

--- a/rancher-ui-2.12.yaml
+++ b/rancher-ui-2.12.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  py-version: 3.10
+  python-version: 3.10
 
 environment:
   contents:
@@ -15,8 +15,8 @@ environment:
       - bash
       - busybox
       - nvm
-      - py${{vars.py-version}}-build-base-dev
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-build-base-dev
+      - python-${{vars.python-version}}
       - yarn
   environment:
     CI_BRANCH: ${{package.version}}

--- a/rrdtool.yaml
+++ b/rrdtool.yaml
@@ -12,7 +12,7 @@ package:
 
 vars:
   lua-version: 5.4
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -46,8 +46,8 @@ environment:
       - perl-xml-parser
       - pkgconf-dev
       - posix-libc-utils
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}-base-dev
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}-base-dev
       - readline-dev
       - zlib-dev
 
@@ -61,8 +61,8 @@ pipeline:
   - runs: |
       ln -sf lua${{vars.lua-version}} /usr/bin/lua
       ln -sf lua5.4/liblua.so /usr/lib/liblua.so
-      ln -sf python${{vars.py-version}} /usr/bin/python3
-      ln -sf python${{vars.py-version}} /usr/bin/python
+      ln -sf python${{vars.python-version}} /usr/bin/python3
+      ln -sf python${{vars.python-version}} /usr/bin/python
 
   - runs: |
       autoreconf -fiv
@@ -152,7 +152,7 @@ subpackages:
         - merged-usrsbin
         - wolfi-baselayout
 
-  - name: py${{vars.py-version}}-rrdtool
+  - name: py${{vars.python-version}}-rrdtool
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/

--- a/samba.yaml
+++ b/samba.yaml
@@ -12,7 +12,7 @@ package:
       - wolfi-baselayout
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -47,11 +47,11 @@ environment:
       - perl-parse-yapp
       - pkgconf-dev
       - popt-dev
-      - py${{vars.py-version}}-dnspython
-      - py${{vars.py-version}}-markdown
-      - py${{vars.py-version}}-talloc-dev
-      - py${{vars.py-version}}-tdb
-      - py${{vars.py-version}}-tevent
+      - py${{vars.python-version}}-dnspython
+      - py${{vars.python-version}}-markdown
+      - py${{vars.python-version}}-talloc-dev
+      - py${{vars.python-version}}-tdb
+      - py${{vars.python-version}}-tevent
       - python3-dev
       - rpcgen
       - subunit-dev
@@ -472,7 +472,7 @@ subpackages:
             eventlogadm --help
             nmbd --help
 
-  - name: py${{vars.py-version}}-samba
+  - name: py${{vars.python-version}}-samba
     description: Samba python libraries
     pipeline:
       - runs: |
@@ -482,7 +482,7 @@ subpackages:
       runtime:
         - merged-usrsbin
         - merged-lib
-        - py${{vars.py-version}}-tdb
+        - py${{vars.python-version}}-tdb
         - samba-libs-py3
         - samba-server
         - samba-server-libs
@@ -497,7 +497,7 @@ subpackages:
     description: Samba server and client testing tools
     dependencies:
       runtime:
-        - py${{vars.py-version}}-tdb
+        - py${{vars.python-version}}-tdb
         - samba-libs-py3
         - samba-server-libs
         - merged-lib

--- a/scons.yaml
+++ b/scons.yaml
@@ -8,10 +8,10 @@ package:
   dependencies:
     runtime:
       # needs setuptools for distuils use
-      - py${{vars.py-version}}-setuptools
+      - py${{vars.python-version}}-setuptools
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -22,8 +22,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - py${{vars.py-version}}-build-base
-      - py${{vars.py-version}}-gpep517
+      - py${{vars.python-version}}-build-base
+      - py${{vars.python-version}}-gpep517
 
 pipeline:
   - uses: git-checkout
@@ -40,7 +40,7 @@ pipeline:
       extract: false
 
   - runs: |
-      python3=python${{vars.py-version}}
+      python3=python${{vars.python-version}}
       tar -xzf SCons-${{package.version}}.tar.gz
 
       $python3 -m gpep517 build-wheel --wheel-dir .dist --output-fd 3 3>&1 >&2

--- a/spark-4.0.yaml
+++ b/spark-4.0.yaml
@@ -14,7 +14,7 @@ package:
 vars:
   debian-version: "12"
   java-version: "17" # https://issues.apache.org/jira/browse/SPARK-45315
-  py-version: "3.11"
+  python-version: "3.11"
   scala-version: "2.13" # https://issues.apache.org/jira/browse/SPARK-45314
 
 var-transforms:
@@ -40,9 +40,9 @@ environment:
       - perl-utils
       - procps
       - protobuf-dev
-      - py${{vars.py-version}}-pip
-      - py${{vars.py-version}}-setuptools
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-setuptools
+      - python-${{vars.python-version}}
       - yaml-dev
   environment:
     APACHE_MIRROR: "https://repo.maven.apache.org/maven2/org"

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -7,16 +7,16 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - py${{vars.py-version}}-setuptools
+      - py${{vars.python-version}}-setuptools
       - supervisor-config
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
     packages:
-      - py${{vars.py-version}}-build-base
+      - py${{vars.python-version}}-build-base
 
 pipeline:
   - uses: git-checkout
@@ -27,7 +27,7 @@ pipeline:
 
   - name: Python Install
     runs: |
-      sitepackages=$(python${{vars.py-version}} -c 'import site; print(site.getsitepackages()[0])')
+      sitepackages=$(python${{vars.python-version}} -c 'import site; print(site.getsitepackages()[0])')
       concatenated_path="${{targets.destdir}}${sitepackages}"
 
       echo "sitepackages=$sitepackages"
@@ -49,7 +49,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}/etc/logrotate.d"
       mkdir -p "${{targets.destdir}}/usr/bin/"
 
-      pip${{vars.py-version}} install supervisor
+      pip${{vars.python-version}} install supervisor
 
       /usr/bin/echo_supervisord_conf > "${{targets.destdir}}/etc/supervisord.conf"
       cat "${{targets.destdir}}/etc/supervisord.conf"
@@ -89,7 +89,7 @@ subpackages:
     description: Precompiled Python bytecode for supervisor
     pipeline:
       - runs: |
-          sitepackages=$(python${{vars.py-version}} -c 'import site; print(site.getsitepackages()[0])')
+          sitepackages=$(python${{vars.python-version}} -c 'import site; print(site.getsitepackages()[0])')
           destdir_concatenated_path="${{targets.destdir}}${sitepackages}"
           subpkg_concatenated_path="${{targets.subpkgdir}}${sitepackages}"
           mkdir -p "${subpkg_concatenated_path}/supervisor/__pycache__/"

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -22,7 +22,7 @@ package:
 
 vars:
   llvm-vers: 19
-  py-version: 3.13
+  python-version: 3.13
 
 data:
   - name: standalone-binaries
@@ -76,10 +76,10 @@ environment:
       - openssf-compiler-options
       - pcre2-dev
       - posix-libc-utils
-      - py${{vars.py-version}}-jinja2
-      - py${{vars.py-version}}-pefile
-      - py${{vars.py-version}}-pyelftools
-      - python-${{vars.py-version}}
+      - py${{vars.python-version}}-jinja2
+      - py${{vars.python-version}}-pefile
+      - py${{vars.python-version}}-pyelftools
+      - python-${{vars.python-version}}
       - quota-tools
       - rsync
       - tpm2-tss
@@ -688,9 +688,9 @@ subpackages:
     description: "tool for creating unified kernel images"
     dependencies:
       runtime:
-        - py${{vars.py-version}}-pefile
-        - py${{vars.py-version}}-cryptography
-        - py${{vars.py-version}}-lz4
+        - py${{vars.python-version}}-pefile
+        - py${{vars.python-version}}-cryptography
+        - py${{vars.python-version}}-lz4
         - systemd-boot
     pipeline:
       - runs: |
@@ -700,7 +700,7 @@ subpackages:
           done
 
           # just replace the first line with '#!/usr/bin/python3.XX'
-          sed -i -e '1s,.*,#!/usr/bin/python${{vars.py-version}},' \
+          sed -i -e '1s,.*,#!/usr/bin/python${{vars.python-version}},' \
             "${{targets.subpkgdir}}/usr/bin/ukify"
     test:
       pipeline:

--- a/wal-g.yaml
+++ b/wal-g.yaml
@@ -15,7 +15,7 @@ environment:
       - openssl-dev
 
 vars:
-  py-version: "3.13"
+  python-version: "3.13"
 
 pipeline:
   - uses: git-checkout
@@ -65,7 +65,7 @@ subpackages:
             - jq
             - shadow
             - sudo-rs
-            - python-${{vars.py-version}}
+            - python-${{vars.python-version}}
         environment:
           PGDATA: /tmp/pgdata
           PGUSER: wally

--- a/yamllint.yaml
+++ b/yamllint.yaml
@@ -7,11 +7,11 @@ package:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
-      - py${{vars.py-version}}-pathspec
-      - py${{vars.py-version}}-pyyaml
+      - py${{vars.python-version}}-pathspec
+      - py${{vars.python-version}}-pyyaml
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 environment:
   contents:
@@ -19,7 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-build-base
+      - py${{vars.python-version}}-build-base
       - wolfi-base
 
 pipeline:


### PR DESCRIPTION
Consistency makes things easier.

Prior to this change, the we had mixed use of 'py-version' or 'python-version' across repos.  The following shows number of yaml files using one versus the other (containing 'vars.<name>'):

    repo       | py-version | python-version |
    ---        | ----       | ---            |
    enterprise |    67      |   25           |
    extras     |    11      |   27           |
    wolfi      |    66      |   3            |
    total      |   144      |   55           |

Even though py-version occurrences were ~2.5:1 more common there is value in the more explicit 'python-version' name.

This commit is simply the result of:

    sed -i
       -e 's,py-version:,python-version:,g'
       -e 's, to:\([ ]\+\)py-version, to:\1python-version,g'
       -e 's,${{[ ]*vars.py-version[ ]*}},\${{vars.python-version}},g'
       $(git grep -l py-version)
