### PR TITLE
fix(fluentd): properly look up target version dir

### DIFF
--- a/ruby3.2-fluentd-1.19.yaml
+++ b/ruby3.2-fluentd-1.19.yaml
@@ -58,6 +58,10 @@ pipeline:
 
   - working-directory: ${{vars.gem}}
     pipeline:
+      - name: Allow zstd-ruby >= 1.5
+        runs: |
+          # Fixes "Could not find 'zstd-ruby' (~> 1.5) among 121 total gem(s)" error on runtime test
+          sed -E -i 's@gem\.add_runtime_dependency\("zstd-ruby", \["~> 1\.5"\]\)@gem.add_runtime_dependency("zstd-ruby", [">= 1.5"])@' fluentd.gemspec
       - uses: ruby/build
         with:
           gem: ${{vars.gem}}

--- a/ruby3.2-fluentd-1.19.yaml
+++ b/ruby3.2-fluentd-1.19.yaml
@@ -2,7 +2,7 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.2-fluentd-1.19
   version: "1.19.0"
-  epoch: 1
+  epoch: 2
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
@@ -85,12 +85,12 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          git clone https://github.com/kube-logging/fluentd-images.git
+          git clone https://github.com/kube-logging/fluentd-images.git --depth 1
           cd fluentd-images
-          git checkout 773503fd12bcdb75f042ea3deb712ccb86a31d61
-          install -Dm755 ./v1.16/entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
-          install -Dm755 ./v1.16/healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
-          install -Dm644 ./v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+          cd v1.17-* # Upstream doesn't have v1.18 and v1.19 folders, so hardcode to v1.17 for now.
+          install -Dm755 ./entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
+          install -Dm755 ./healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
+          install -Dm644 ./fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
 
   - name: ${{package.name}}-iamguarded-compat
     description: Compatibility package for iamguarded variant of fluentd
@@ -258,3 +258,7 @@ var-transforms:
     match: ^(\d+)\.\d+\.\d+$
     replace: "$1"
     to: major-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*
+    replace: $1
+    to: major-minor-version

--- a/ruby3.3-fluentd-1.17.yaml
+++ b/ruby3.3-fluentd-1.17.yaml
@@ -2,7 +2,7 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.3-fluentd-1.17
   version: 1.17.1
-  epoch: 32
+  epoch: 33
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
@@ -80,12 +80,12 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          git clone https://github.com/kube-logging/fluentd-images.git
+          git clone https://github.com/kube-logging/fluentd-images.git --depth 1
           cd fluentd-images
-          git checkout 773503fd12bcdb75f042ea3deb712ccb86a31d61
-          install -Dm755 ./v1.16/entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
-          install -Dm755 ./v1.16/healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
-          install -Dm644 ./v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+          cd v${{vars.major-minor-version}}-*
+          install -Dm755 ./entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
+          install -Dm755 ./healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
+          install -Dm644 ./fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
 
   - name: ${{package.name}}-iamguarded-compat
     description: Compatibility package for iamguarded variant of fluentd
@@ -253,3 +253,7 @@ var-transforms:
     match: ^(\d+)\.\d+\.\d+$
     replace: "$1"
     to: major-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*
+    replace: $1
+    to: major-minor-version

--- a/ruby3.4-fluentd-1.17.yaml
+++ b/ruby3.4-fluentd-1.17.yaml
@@ -2,7 +2,7 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.4-fluentd-1.17
   version: 1.17.1
-  epoch: 32
+  epoch: 33
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
@@ -80,12 +80,12 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          git clone https://github.com/kube-logging/fluentd-images.git
+          git clone https://github.com/kube-logging/fluentd-images.git --depth 1
           cd fluentd-images
-          git checkout 773503fd12bcdb75f042ea3deb712ccb86a31d61
-          install -Dm755 ./v1.16/entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
-          install -Dm755 ./v1.16/healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
-          install -Dm644 ./v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+          cd v${{vars.major-minor-version}}-*
+          install -Dm755 ./entrypoint.sh "${{targets.subpkgdir}}/usr/bin/entrypoint.sh"
+          install -Dm755 ./healthy.sh "${{targets.subpkgdir}}/usr/bin/healthy.sh"
+          install -Dm644 ./fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
 
   - name: ${{package.name}}-iamguarded-compat
     description: Compatibility package for iamguarded variant of fluentd
@@ -253,3 +253,7 @@ var-transforms:
     match: ^(\d+)\.\d+\.\d+$
     replace: "$1"
     to: major-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*
+    replace: $1
+    to: major-minor-version


### PR DESCRIPTION
I noticed that `rubyM.M-fluentd-X.Y` packages were looking up wrong directory when building `${{package.name}}-logging-operator-compat`, so let's properly pin the version.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
