### PR TITLE
fio: disable native builds

### DIFF
--- a/fio.yaml
+++ b/fio.yaml
@@ -1,7 +1,7 @@
 package:
   name: fio
   version: "3.41"
-  epoch: 0
+  epoch: 1
   description: Flexible I/O Tester
   copyright:
     - license: GPL-2.0-or-later
@@ -25,7 +25,7 @@ pipeline:
       expected-commit: ed675d3477a70a42d2e757b713f6c7125a27cdca
 
   - runs: |
-      ./configure --prefix=/usr
+      ./configure --prefix=/usr --disable-native
       make
       make DESTDIR="${{targets.contextdir}}" install
 


### PR DESCRIPTION
Otherwise we end up with AVX512 instructions and we can't run on some AMD platforms (and presumably, many older x86_64-v2 CPUs which we would otherwise support).

