### PR TITLE
py3-cassandra-medusa: bump epoch to rebuild with updated pip dependency

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.25.0"
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
## Summary

Bumps epoch to force rebuild with updated pip dependency.

## GHSA-4xh5-x5gv-qwph

**Vulnerability**: pip @ 25.1.1 is affected by GHSA-4xh5-x5gv-qwph

**Analysis**: py3-cassandra-medusa builds a Python virtual environment that includes pip as a transitive dependency through Python wheels. Rebuilding will pull in the latest pip version that includes the fix.

**Note**: An advisory will be created in a separate PR to document that remaining affected pip versions are transitive dependencies brought in via Python wheels, and upstream maintainers of these wheels are required to remediate.

## Verification

After building:
```bash
wolfictl scan packages/*/py3-cassandra-medusa-*.apk
```

Related: https://github.com/chainguard-dev/CVE-Dashboard/issues/30750