### PR TITLE
sqlpad: bump epoch to rebuild with updated tar-fs dependency

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: "7.5.7" # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 0
+  epoch: 1
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT


### PR DESCRIPTION
## Summary

Bumps epoch to force rebuild with updated tar-fs dependency.

## GHSA-vj76-c3g6-qr5v

**Vulnerability**: tar-fs @ 2.1.3 is affected by GHSA-vj76-c3g6-qr5v

**Analysis**: sqlpad includes tar-fs as a yarn resolution. Rebuilding will pull in the latest tar-fs version that includes the fix.

**Note**: An advisory will be created in a separate PR for CVE-2025-57350 (csvtojson vulnerability).

## Verification

After building:
```bash
wolfictl scan packages/*/sqlpad-*.apk
```

Related: https://github.com/chainguard-dev/CVE-Dashboard/issues/30796