### PR TITLE
need-root: package builds that do setcap need to run as root

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: "0.36.0"
-  epoch: 0 # GHSA-jc7w-c686-c4v9
+  epoch: 1
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,9 @@ environment:
       - go
       - libcap-utils
       - wolfi-baselayout
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: "1.12.4"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,9 @@ environment:
     packages:
       - libcap-utils
       - make
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/dumb-init.yaml
+++ b/dumb-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: dumb-init
   version: 1.2.5
-  epoch: 8
+  epoch: 9
   description: "minimal init system for Linux containers"
   copyright:
     - license: MIT
@@ -14,6 +14,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libcap-utils
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: "3.10.0"
-  epoch: 10 # CVE-2025-47910
+  epoch: 11
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,9 @@ environment:
       - libcap-utils
       - py3-supported-pip
       - rust
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: "5.4"
-  epoch: 0
+  epoch: 1
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only
@@ -19,6 +19,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libcap-utils
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.5"
-  epoch: 0
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -34,6 +34,9 @@ environment:
       - lua5.3-dev
       - openssl-dev
       - pcre2-dev
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 27
+  epoch: 28
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -101,6 +101,9 @@ environment:
       - libtool
       - linux-headers
       - pkgconf-dev
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.1"
-  epoch: 0 # CVE-2025-4674 GHSA-j5pm-7495-qmr3
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,9 @@ environment:
       - libcap-utils
       - linux-headers
       - rsync
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 var-transforms:
   - from: ${{package.name}}

--- a/shadow.yaml
+++ b/shadow.yaml
@@ -2,7 +2,7 @@
 package:
   name: shadow
   version: "4.18.0"
-  epoch: 4
+  epoch: 5
   description: PAM login and passwd utilities
   copyright:
     - license: BSD-3-Clause
@@ -31,6 +31,9 @@ environment:
       - libxslt-dev
       - linux-pam-dev
       - m4
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: fetch

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: "1.13.1"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,9 @@ environment:
       - git
       - go
       - libcap-utils
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout

--- a/tshark-4.4.yaml
+++ b/tshark-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: tshark-4.4
   version: "4.4.9"
-  epoch: 0
+  epoch: 1
   description: "TShark is a network protocol analyzer to dump and analyze network traffic"
   copyright:
     - license: GPL-2.0-only
@@ -28,6 +28,9 @@ environment:
       - speexdsp-dev
       - wolfi-base
       - zlib-dev
+  accounts:
+    # Need to run with privilege to be able to do setcap
+    run-as: root
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Set the build phase to run as root for packages that set filesystem capabilities on some of the binaries.