### PR TITLE
libheif: address openjph dependency and remove /home/build from installed directories

### DIFF
--- a/libheif.yaml
+++ b/libheif.yaml
@@ -68,6 +68,11 @@ pipeline:
 
   - uses: strip
 
+  # not sure why cmake install ends up copying /home/build into
+  # ${{targets.destdir}}, but it does, so remove it.
+  - runs: |
+      rm -rf "${{targets.destdir}}/home/"
+
 update:
   enabled: true
   github:

--- a/libheif.yaml
+++ b/libheif.yaml
@@ -21,9 +21,7 @@ environment:
       - openh264-dev
       - openjpeg-dev
       - openjpeg-tools
-      # something was pulling in openjph 0.22, leading to a dependency conflict
-      - openjph-dev>=0.24.0
-      - openjph>=0.24.0
+      - openjph-dev
       - rav1e-dev
       - svt-av1-dev
       - tiff-dev

--- a/libheif.yaml
+++ b/libheif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libheif
   version: "1.20.2"
-  epoch: 2
+  epoch: 3
   description: libheif is an HEIF and AVIF file format decoder and encoder.
   copyright:
     - license: LGPL-3.0-or-later AND MIT
@@ -21,7 +21,9 @@ environment:
       - openh264-dev
       - openjpeg-dev
       - openjpeg-tools
-      - openjph-dev
+      # something was pulling in openjph 0.22, leading to a dependency conflict
+      - openjph-dev>=0.24.0
+      - openjph>=0.24.0
       - rav1e-dev
       - svt-av1-dev
       - tiff-dev

--- a/openjph.yaml
+++ b/openjph.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjph
   version: "0.24.1"
-  epoch: 0
+  epoch: 1
   description: Open source implementation of High-throughput JPEG2000 (HTJ2K)
   copyright:
     - license: BSD-2-Clause
@@ -11,6 +11,12 @@ environment:
     packages:
       - build-base
       - tiff-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*
+    replace: $1
+    to: soversion
 
 pipeline:
   - uses: git-checkout
@@ -39,6 +45,16 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
         - uses: test/pkgconf
+
+  - name: lib${{package.name}}${{vars.soversion}}
+    description: ${{package.name} libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
 test:
   pipeline:


### PR DESCRIPTION
Two issues being worked around here:

1. libheif FTBFS due to an earlier version of openjph (0.2.0-r0) getting pulled in as a dependency, which then conflicts with openjph-0.24.0-r0 (the latest version of openjph):
   ```
   ERRO failed to build package: unable to build guest: unable to lock image configuration: resolving apk packages: for arch "amd64": solving "openjph-dev" constraint: resolving "openjph-dev-0.24.1-r0.apk" deps:
   solving "so:libopenjph.so.0.24" constraint:   openjph-0.24.0-r0.apk disqualified because openjph-0.22.0-r0.apk already provides cmd:ojph_compress
      openjph-0.24.1-r0.apk disqualified because openjph-0.22.0-r0.apk already provides cmd:ojph_compress
    ```
    Work around this by forcing openjph and openjph-dev to be >= 0.24.0

2. For some reason the cmake install step for libheif is pulling in the /home/build/melange-out directory tree, which ends up in the generated apk, like so:

    ```
    $ cg apk ls https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz --full -P libheif  --latest  | xargs curl -s | tar tzv 2>/dev/null home
    drwxr-xr-x root/root         0 2025-08-26 09:45 home
    drwxr-xr-x root/root         0 2025-08-26 09:45 home/build
    drwxr-xr-x root/root         0 2025-08-26 09:45 home/build/melange-out
    drwxr-xr-x root/root         0 2025-08-26 09:45 home/build/melange-out/libheif
    drwxr-xr-x root/root         0 2025-08-26 09:45 home/build/melange-out/libheif/usr
    drwxr-xr-x root/root         0 2025-08-26 09:45 home/build/melange-out/libheif/usr/lib
    ```
    This ends up with the /home/build/melange-out tree being owned by root. This causes problems when building as non-root as packages are then unable to create directories for subpackages, causing builds to fail.

    This is not the right fix, but work around it by deleting the /home/ tree in the target.destdir so it doesn't get picked up in the apk package.
