### PR TITLE
downgrade flask to v2.2.2 for querybook compatibility

### DIFF
--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-flask
-  version: "3.1.2"
+  version: "2.2.2"
   epoch: 0
   description: A simple framework for building complex web applications.
   copyright:
@@ -29,8 +29,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87
-      uri: https://files.pythonhosted.org/packages/source/f/flask/flask-${{package.version}}.tar.gz
+      expected-sha256: 642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b
+      uri: https://files.pythonhosted.org/packages/source/F/Flask/Flask-${{package.version}}.tar.gz
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
querybook requires flask v2.2.2 due to usage of `flask_json.JSONEncoder`, which was removed in flask 2.3+, we are downgrading the package inline for this use case
