### PR TITLE
llvm-21 - Replace 'vars.py-version' with 'vars.python-version'

### DIFF
--- a/llvm-21.yaml
+++ b/llvm-21.yaml
@@ -13,7 +13,7 @@ package:
       - llvm=${{package.full-version}}
 
 vars:
-  py-version: 3.13
+  python-version: 3.13
 
 var-transforms:
   - from: ${{package.version}}
@@ -46,7 +46,7 @@ environment:
       - libffi-dev
       - libxml2-dev
       - pkgconf
-      - python-${{vars.py-version}}
+      - python-${{vars.python-version}}
       - samurai
       - wolfi-base
       - zlib-dev
@@ -60,7 +60,7 @@ pipeline:
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
-      python_version=$(python${{vars.py-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+      python_version=$(python${{vars.python-version}} -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
 
       cmake -B output -G Ninja -S llvm -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
@@ -329,7 +329,7 @@ subpackages:
       runtime:
         - libLLVM-${{vars.major-version}}=${{package.full-version}}
         - libclang-cpp-${{vars.major-version}}=${{package.full-version}}
-        - python-${{vars.py-version}}
+        - python-${{vars.python-version}}
     pipeline:
       - runs: |
           sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
@@ -343,7 +343,7 @@ subpackages:
       pipeline:
         - uses: python/import
           with:
-            python: python${{vars.py-version}}
+            python: python${{vars.python-version}}
             import: libscanbuild
 
   - name: clang-${{vars.major-version}}


### PR DESCRIPTION
See #67643.  For some reason this file was missed.
