### PR TITLE
fix(py3-pip): Build with patch for CVE-2025-8869

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.2"
-  epoch: 0
+  epoch: 1 # CVE-2025-8869
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
@@ -32,6 +32,18 @@ pipeline:
       repository: https://github.com/pypa/pip
       expected-commit: 2e05cae3da2cfafa6dce58167a25b7dba4bc2a33
       tag: ${{package.version}}
+      # Commits to remediate CVE-2025-8869 from PR https://github.com/pypa/pip/pull/13550
+      cherry-picks: |
+        main/2490eb2acffc619b53cdf1418a1e356d5e7e7c05: CVE-2025-8869
+        main/3e158244d3b5e331fd6f81736de71d73f2335490: CVE-2025-8869
+        main/bbe7cc76a8a2ada11c518cb1c52bcd9d6a35a41d: CVE-2025-8869
+        main/7f2a97991e449dbe99d00cefe2a8f7edcf3110a3: CVE-2025-8869
+        main/3390548a63f92af083c8ab008c9556bb78fad378: CVE-2025-8869
+        main/eaee1818a8e6be08aad1bcfa776b3261b5343e70: CVE-2025-8869
+        main/dcd1ff5b159de03dcce56530b2dfba7d6f6a6963: CVE-2025-8869
+        main/399f4ea139345a21a2e93b3b4a90b437ace91f94: CVE-2025-8869
+        main/fb0a8e6331df1de5343db2e25ddae48a81e1b072: CVE-2025-8869
+        main/b154d0600f1712c0d5127cf59c9abf94c87d04b3: CVE-2025-8869
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
CVE-2025-8869: This CVE has been fixed through cherry picking the patch. Upstream PR https://github.com/pypa/pip/pull/13550

<!--ci-cve-scan:fail-any-->
