### PR TITLE
dash: Fix typo in pmatch for wildcard search

### DIFF
--- a/dash.yaml
+++ b/dash.yaml
@@ -3,7 +3,7 @@
 package:
   name: dash
   version: "0.5.13"
-  epoch: 0
+  epoch: 1
   description: Small and fast POSIX-compliant shell
   copyright:
     - license: BSD-3-Clause AND GPL-2.0-or-later
@@ -28,6 +28,8 @@ pipeline:
       repository: https://git.kernel.org/pub/scm/utils/dash/dash.git
       tag: v${{package.version}}
       expected-commit: 1365bb36a92656eb52b64cb04d249c47a1d3c4cf
+      cherry-picks: |
+        master/6dcc007a72f13c3e518a65bffef571795ad6678c: expand: Fix typo in pmatch for wildcard search
 
   - runs: ./autogen.sh
 


### PR DESCRIPTION
This is causing problems especially on ARM64.