### PR TITLE
Java giving errors on pulumi image build

### DIFF
--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: "1.16.1"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
The java test for pulumi is giving errors. Appears that the java package fell behind the times having not been updated in about a month.

