### PR TITLE
jenkins-docker-agent: add missing runtime deps

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.530"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -158,6 +158,18 @@ subpackages:
       runtime:
         - bash-binsh
         - openjdk-17-default-jvm
+        - shadow
+        - curl
+        - findutils
+        - git
+        - git-lfs
+        - gnutar
+        - krb5-libs
+        - perl
+        - gzip
+        - openssh-client
+        - grep
+        - sed
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -160,16 +160,20 @@ subpackages:
         - openjdk-17-default-jvm
         - shadow
         - curl
+        - diffutils
         - findutils
         - git
         - git-lfs
         - gnutar
         - krb5-libs
+        - less
+        - patch
         - perl
         - gzip
         - openssh-client
         - grep
         - sed
+        - tzdata
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.530"
-  epoch: 1
+  epoch: 2
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -9,37 +9,22 @@ package:
     provides:
       - jenkins=${{package.full-version}}
     runtime:
-      # Jenkins requires both bash and busybox.
-      - bash
-      - busybox
-      - coreutils
-      - glibc-locale-en
       # The entrypoint script is pulled from a separate repo, which we'e packaged.
       - jenkins-entrypoint
-      - openjdk-17-default-jvm
-      - ttf-dejavu
-      - tzdata
+      - jenkins-utils
+      - openjdk-${{vars.java-version}}-default-jvm
+
+vars:
+  java-version: '17'
 
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
-      - bash
-      - build-base
       - busybox
-      - ca-certificates-bundle
-      - coreutils
-      - git
-      - glibc-locale-en
+      - libstdc++
       - libxml2-utils
       - maven
-      - openjdk-17-default-jdk
-      - openssh-client
-      - patch
-      - tini
-      - ttf-dejavu
-      - tzdata
+      - openjdk-${{vars.java-version}}-default-jdk
 
 pipeline:
   - uses: git-checkout
@@ -91,6 +76,35 @@ pipeline:
       mv war/target/jenkins.war ${{targets.destdir}}/usr/share/java/jenkins/
 
 subpackages:
+  - name: "jenkins-utils"
+    description: "Metapackage for utilities used across Jenkins"
+    dependencies:
+      runtime:
+        - bash
+        - bash-binsh
+        - coreutils
+        - debianutils
+        - diffutils
+        - findutils
+        - git
+        - git-lfs
+        - glibc-locale-en
+        - gnutar
+        - gzip
+        - krb5-libs
+        - less
+        - patch
+        - perl
+        - openssh-client
+        - ttf-dejavu
+        - sed
+        - shadow
+        - tzdata
+        - unzip
+    test:
+      pipeline:
+        - uses: test/metapackage
+
   # The Jenkins entrypoint script expects directories to exist, and the .war file
   # under a different location.
   - name: "jenkins-compat"
@@ -156,24 +170,8 @@ subpackages:
   - name: jenkins-docker-agent
     dependencies:
       runtime:
-        - bash-binsh
-        - openjdk-17-default-jvm
-        - shadow
-        - curl
-        - diffutils
-        - findutils
-        - git
-        - git-lfs
-        - gnutar
-        - krb5-libs
-        - less
-        - patch
-        - perl
-        - gzip
-        - openssh-client
-        - grep
-        - sed
-        - tzdata
+        - jenkins-utils
+        - openjdk-${{vars.java-version}}-default-jvm
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin
@@ -211,7 +209,6 @@ test:
     contents:
       packages:
         - jenkins-compat
-        - jenkins-entrypoint
   pipeline:
     - name: "start daemon on localhost"
       uses: test/daemon-check-output


### PR DESCRIPTION
Add other missing runtime deps: `syft -q --select-catalogers=apk,dpkg,rpm jenkins/inbound-agent:latest`

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
