### PR TITLE
net-kourier-1.19: fix provides on compat package

### DIFF
--- a/net-kourier-1.19.yaml
+++ b/net-kourier-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: net-kourier-1.19
   version: "1.19.5"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Purpose-built Knative Ingress implementation using just Envoy with no additional CRDs
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,9 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-compat
     description: "To match with the upstream image entrypoint"
+    dependencies:
+      provides:
+        - net-kourier-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/ko-app


### PR DESCRIPTION
Discovered in https://github.com/chainguard-images/images-private/pull/21031 that `net-kourier-compat` wasn't pointing at new packages.