### PR TITLE
Migration openjdk-24 -> openjdk-25

### DIFF
--- a/cilium-envoy-1.18.yaml
+++ b/cilium-envoy-1.18.yaml
@@ -96,7 +96,7 @@ pipeline:
       ln -sf /usr/bin/llvm-ar /usr/bin/llvm-ar-17
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-25-openjdk
       mkdir -p .cache/bazel/_bazel_root
       mkdir -p ${{targets.destdir}}/usr/bin
 

--- a/cilium-envoy-1.18.yaml
+++ b/cilium-envoy-1.18.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-envoy-1.18
   version: "1.18.2"
-  epoch: 0
+  epoch: 1
   description: Envoy with additional cilium plugins
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,7 @@ environment:
       - lld-17
       - lld-17-dev
       - llvm-17-dev
-      - openjdk-24
+      - openjdk-25
       - patch
       - python3-dev
       - samurai

--- a/trino.yaml
+++ b/trino.yaml
@@ -45,7 +45,7 @@ pipeline:
 
   - working-directory: ./airlift/launcher
     runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-25-openjdk
       ./mvnw package
 
   - uses: maven/pombump
@@ -53,7 +53,7 @@ pipeline:
   - runs: |
       set -x
 
-      export JAVA_HOME=/usr/lib/jvm/java-24-openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-25-openjdk
 
       ./mvnw package -q -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all -T 8  -pl '!:trino-docs,!:trino-tests,!:trino-product-tests,!:trino-product-tests-launcher,!:trino-web-ui' -am
 

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "476"
-  epoch: 9 # GHSA-2hmj-97jw-28jh
+  epoch: 10 # GHSA-2hmj-97jw-28jh
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
     memory: 64Gi
   dependencies:
     runtime:
-      - openjdk-24-default-jvm
+      - openjdk-25-default-jvm
       - trino-config
 
 environment:
@@ -25,7 +25,7 @@ environment:
       - go
       - jvmkill
       - maven
-      - openjdk-24-default-jdk
+      - openjdk-25-default-jdk
       - upx
       - wolfi-base
 


### PR DESCRIPTION
OpenJDK 25 is an LTS release; bump packages using 24.
