### PR TITLE
feat(code-server): bump dep to remediate GHSA-vj76-c3g6-qr5v

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.104.2"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0

--- a/code-server/GHSA-pq67-2wwv-3xjx.patch
+++ b/code-server/GHSA-pq67-2wwv-3xjx.patch
@@ -7,7 +7,7 @@
 -      "node-addon-api": "7.1.0"
 +      "node-addon-api": "7.1.0",
 +      "prebuild-install": {
-+        "tar-fs": "2.1.2"
++        "tar-fs": "2.1.4"
 +      }
      }
    },


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump dep to remediate GHSA-625h-95r8-8xpm
<!--ci-cve-scan:fail-any-->
