### PR TITLE
fix conda25.9.0 bump

### DIFF
--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -26,8 +26,7 @@ pipeline:
       conda create --yes --name init
 
       mkdir -p "${{targets.contextdir}}"/root/conda
-      cp -r ${HOME}/conda/* ${HOME}/.conda/envs/init/* \
-        "${{targets.contextdir}}"/root/conda
+      cp -r ${HOME}/.conda/envs/init/* "${{targets.contextdir}}"/root/conda
       echo "root_prefix: /root/conda" > "${{targets.destdir}}"/root/.condarc
 
 update:
@@ -46,6 +45,7 @@ test:
         conda --version
         conda init
         source ${HOME}/.bashrc
+        conda config --add channels defaults
         conda install numpy
         conda create -n foo
         conda install -n foo numpy

--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda-base
   version: "25.9.1"
-  epoch: 0
+  epoch: 1
   description: "Base environment for conda."
   copyright:
     - license: BSD-3-Clause

--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -7,14 +7,14 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - conda=${{package.version}}
+      - conda~${{package.version}}
 
 environment:
   contents:
     packages:
       - bash
       - busybox
-      - conda=${{package.version}}
+      - conda~${{package.version}}
 
 pipeline:
   - runs: |

--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -45,7 +45,7 @@ test:
         conda --version
         conda init
         source ${HOME}/.bashrc
-        conda config --add channels defaults
+        conda config --add channels conda-forge
         conda install numpy
         conda create -n foo
         conda install -n foo numpy

--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -7,14 +7,14 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - conda
+      - conda=${{package.version}}
 
 environment:
   contents:
     packages:
       - bash
       - busybox
-      - conda
+      - conda=${{package.version}}
 
 pipeline:
   - runs: |

--- a/conda.yaml
+++ b/conda.yaml
@@ -113,7 +113,7 @@ subpackages:
         # and do so with a shbang of '/usr/bin/python'.
         - python-${{range.key}}
       provides:
-        - conda=${{package.version}}
+        - conda=${{package.full-version}}
         - py-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
     pipeline:

--- a/conda.yaml
+++ b/conda.yaml
@@ -2,8 +2,8 @@
 # instead you may use the conda-base package in wolfi-dev
 package:
   name: conda
-  version: "25.9.0"
-  epoch: 1
+  version: "25.9.1"
+  epoch: 0
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -60,7 +60,7 @@ pipeline:
     with:
       repository: https://github.com/conda/conda
       tag: ${{package.version}}
-      expected-commit: 0c9e27d0a79686e5ab9ced6bd3193bf1b13e8164
+      expected-commit: ed17a44c1c062d4f827b78a68026fca6b1be9f1e
 
 subpackages:
   - range: py-versions

--- a/conda.yaml
+++ b/conda.yaml
@@ -2,7 +2,7 @@
 # instead you may use the conda-base package in wolfi-dev
 package:
   name: conda
-  version: "25.7.0"
+  version: "25.9.0"
   epoch: 0
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
@@ -59,7 +59,7 @@ pipeline:
     with:
       repository: https://github.com/conda/conda
       tag: ${{package.version}}
-      expected-commit: 6614653b1d9bdbffcef55e338d3220daed70c7f8
+      expected-commit: 0c9e27d0a79686e5ab9ced6bd3193bf1b13e8164
 
 subpackages:
   - range: py-versions

--- a/conda.yaml
+++ b/conda.yaml
@@ -17,7 +17,7 @@ vars:
     conda --version
     conda info
     conda init
-    conda config --add channels defaults
+    conda config --add channels conda-forge
     conda create --quiet -n foo
     conda install --quiet -n foo numpy
     conda install --quiet -n foo --solver=classic requests
@@ -168,7 +168,7 @@ subpackages:
       pipeline:
         - runs: |
             source /etc/profile.d/conda-init.sh
-            conda config --add channels defaults
+            conda config --add channels conda-forge
             conda install -y conda
 
   - name: ${{package.name}}-wrapper
@@ -191,7 +191,7 @@ subpackages:
           HOME: /root
       pipeline:
         - runs: |
-            conda-wrapper config --add channels defaults
+            conda-wrapper config --add channels conda-forge
             conda-wrapper install -y conda
 
 update:

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: "25.9.0"
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -113,7 +113,7 @@ subpackages:
         # and do so with a shbang of '/usr/bin/python'.
         - python-${{range.key}}
       provides:
-        - conda
+        - conda=${{package.version}}
         - py-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
     pipeline:

--- a/conda.yaml
+++ b/conda.yaml
@@ -17,6 +17,7 @@ vars:
     conda --version
     conda info
     conda init
+    conda config --add channels defaults
     conda create --quiet -n foo
     conda install --quiet -n foo numpy
     conda install --quiet -n foo --solver=classic requests
@@ -167,6 +168,7 @@ subpackages:
       pipeline:
         - runs: |
             source /etc/profile.d/conda-init.sh
+            conda config --add channels defaults
             conda install -y conda
 
   - name: ${{package.name}}-wrapper
@@ -189,6 +191,7 @@ subpackages:
           HOME: /root
       pipeline:
         - runs: |
+            conda-wrapper config --add channels defaults
             conda-wrapper install -y conda
 
 update:


### PR DESCRIPTION
fix: add default channels to conda tests
    
Starting in 25.9, conda requires the user to explicitly add channels.

Relates: #67692

See [conda release notes](https://github.com/conda/conda/releases/tag/25.9.0) for details on the deprecation.

<!--ci-cve-scan:fail-any-->