### PR TITLE
kube-arangodb: version stream

### DIFF
--- a/kube-arangodb-1.3.yaml
+++ b/kube-arangodb-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-arangodb-1.3
   version: "1.3.0"
-  epoch: 0
+  epoch: 5
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kube-arangodb-1.3.yaml
+++ b/kube-arangodb-1.3.yaml
@@ -1,10 +1,13 @@
 package:
-  name: kube-arangodb
+  name: kube-arangodb-1.3
   version: "1.3.0"
-  epoch: 4
+  epoch: 0
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kube-arangodb=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout
@@ -38,6 +41,8 @@ subpackages:
     dependencies:
       runtime:
         - envoy
+      provides:
+        - kube-arangodb-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
@@ -103,5 +108,6 @@ update:
   github:
     identifier: arangodb/kube-arangodb
     strip-prefix: v
+    tag-filter: 1.3.
   ignore-regex-patterns:
     - "-preview"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Convert kube-arangodb to kube-arangodb-1.3
<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
    - No, kube-arangodb only supports latest.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
    - Not sure if this is needed in this case but I can draft a PR if so!
