### PR TITLE
Splits curl-static from -dev package

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.16.0"
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -76,6 +76,11 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "curl-static"
+    description: "Statically linked libcurl"
+    pipeline: 
+      - uses: split/static
+ 
   - name: "curl-dev"
     description: "headers for libcurl"
     pipeline:

--- a/curl.yaml
+++ b/curl.yaml
@@ -78,9 +78,9 @@ pipeline:
 subpackages:
   - name: "curl-static"
     description: "Statically linked libcurl"
-    pipeline: 
+    pipeline:
       - uses: split/static
- 
+
   - name: "curl-dev"
     description: "headers for libcurl"
     pipeline:


### PR DESCRIPTION
There's a new package request for [curl-static](https://github.com/chainguard-dev/image-requests/issues/7091).

This PR splits the libcurl.a into a seperate `-static` package.
