### PR TITLE
fix(jenkins-utils): Add openssh-keygen

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.530"
-  epoch: 2
+  epoch: 3
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -96,6 +96,7 @@ subpackages:
         - patch
         - perl
         - openssh-client
+        - openssh-keygen
         - ttf-dejavu
         - sed
         - shadow


### PR DESCRIPTION
Runtime dependency of Jenkins. Missed this