### PR TITLE
rust-1.90: update clang/llvm dependencies to v21

### DIFF
--- a/rust-1.90.yaml
+++ b/rust-1.90.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.90
   version: "1.90.0"
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -10,7 +10,7 @@ package:
     memory: 16Gi
   dependencies:
     runtime:
-      - libLLVM-20
+      - libLLVM-21
     provides:
       - rust=${{package.full-version}}
 
@@ -20,16 +20,16 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-20
+      - clang-21
       - cmake
       - coreutils
       - curl-dev
       - file
-      - libLLVM-20
+      - libLLVM-21
       - libssh2-dev
       - libxml2-dev
-      - llvm-20
-      - llvm-20-dev
+      - llvm-21
+      - llvm-21-dev
       - openssl-dev
       - patch
       - python3
@@ -57,8 +57,8 @@ pipeline:
       TOOLCHAIN_BIN_DIR="$(dirname "$(rustup which cargo)")"
       export PATH="$TOOLCHAIN_BIN_DIR:$PATH"
 
-      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-20/include"
-      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-20/include"
+      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-21/include"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-21/include"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       export ARCH=${{host.triplet.rust}}
@@ -78,8 +78,8 @@ pipeline:
         --release-channel="stable" \
         --enable-local-rust \
         --local-rust-root="/usr" \
-        --llvm-root="/usr/lib/llvm-20" \
-        --llvm-config="/usr/lib/llvm-20/bin/llvm-config" \
+        --llvm-root="/usr/lib/llvm-21" \
+        --llvm-config="/usr/lib/llvm-21/bin/llvm-config" \
         --disable-docs \
         --enable-extended \
         --tools="cargo,src,clippy,rustfmt,rustdoc" \
@@ -113,8 +113,8 @@ pipeline:
       unset CARGO_PROFILE_RELEASE_OPT_LEVEL
       unset CARGO_PROFILE_RELEASE_PANIC
       unset CARGO_PROFILE_RELEASE_CODEGEN_UNITS
-      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-20/include/"
-      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-20/include/"
+      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-21/include/"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-21/include/"
       export OPENSSL_NO_VENDOR=1
       export RUSTC_BOOTSTRAP=1
       export RUST_BACKTRACE=full


### PR DESCRIPTION
We should be building rust-1.90 against clang and llvm 21 as upstream
intended.
https://github.com/rust-lang/rust/pull/143684

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
