### PR TITLE
Pin to required version

### DIFF
--- a/ruby3.2-fluentd-1.19.yaml
+++ b/ruby3.2-fluentd-1.19.yaml
@@ -2,7 +2,7 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.2-fluentd-1.19
   version: "1.19.0"
-  epoch: 1
+  epoch: 2
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ package:
       - ruby${{vars.rubyMM}}-uri
       - ruby${{vars.rubyMM}}-webrick
       - ruby${{vars.rubyMM}}-yajl-ruby
-      - ruby${{vars.rubyMM}}-zstd-ruby
+      - ruby${{vars.rubyMM}}-zstd-ruby~1.5
       - ruby-${{vars.rubyMM}}
       - wolfi-baselayout
     provides:


### PR DESCRIPTION
Currently fluentd requires zstd-ruby~1.5 pinning to match