### PR TITLE
py3-setuptools-scm - add a -bin package.

### DIFF
--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: "9.2.0"
-  epoch: 0
+  epoch: 1
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT
@@ -64,6 +64,20 @@ subpackages:
         - uses: python/import
           with:
             import: ${{vars.module-name}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - uses: split/bin
+    test:
+      pipeline:
+        - runs: |
+            setuptools-scm --help
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
setuptools-scm in version 9 started providing /usr/bin/setuptools-scm. That caused problems, as melange would give the py3.XX-setuptools-scm packages a provides like

    provides = cmd:setuptools-scm=9.2.0-r0

And because that provides has a version it means that py3.X-setuptools-scm cannot be installed allong side py3.Y-setuptools-scm.

That causes a problem as py3-supported packages want to depend on multiple py3.X-setuptools-scm things.
