### PR TITLE
add dnsdist-2.0 nodnscrypt subpackage

### DIFF
--- a/dnsdist-2.0.yaml
+++ b/dnsdist-2.0.yaml
@@ -131,6 +131,14 @@ subpackages:
           - uses: autoconf/make-install
           - runs: make check
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ver-check
+          with:
+            bins: dnsdist
+        - runs: |
+            dnsdist --help
 
   - name: ${{package.name}}-compat
     description: Compatibility package for dnsdist
@@ -197,8 +205,10 @@ test:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/tw/ver-check
+      with:
+        bins: dnsdist
     - runs: |
-        dnsdist --version | grep -q "${{package.version}}"
         dnsdist --help
     - name: "daemon smoke-test for entrypoint"
       uses: test/daemon-check-output

--- a/dnsdist-2.0.yaml
+++ b/dnsdist-2.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnsdist-2.0
   version: "2.0.1"
-  epoch: 0
+  epoch: 1
   description: PowerDNS dnsdist — highly DNS-, DoS- and abuse-aware load-balancer
   copyright:
     - license: GPL-2.0-only
@@ -95,6 +95,43 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-nodnscrypt
+    description: PowerDNS dnsdist without dnscrypt
+    dependencies:
+      provides:
+        - dnsdist-nodnscrypt=${{package.full-version}}
+    pipeline:
+      - working-directory: ./pdns/dnsdistdist
+        pipeline:
+          - runs: make clean
+          - runs: BUILDER_VERSION=${{package.version}} BUILDER_MODULES=dnsdist autoreconf -vfi
+          - uses: autoconf/configure
+            with:
+              opts: |
+                --sysconfdir=/etc/dnsdist \
+                --sbindir=/usr/bin \
+                --enable-dnscrypt=no \
+                --enable-dns-over-tls \
+                --enable-dns-over-https \
+                --enable-dns-over-quic \
+                --enable-dns-over-http3 \
+                --enable-unit-tests \
+                --enable-yaml \
+                --enable-systemd \
+                --enable-dnstap \
+                --with-libsodium=no \
+                --with-gnutls=no \
+                --with-net-snmp \
+                --with-lua=lua${{vars.lua-version}} \
+                --with-h2o \
+                --with-libcap \
+                --with-nghttp2 \
+                --with-re2
+          - uses: autoconf/make
+          - uses: autoconf/make-install
+          - runs: make check
+      - uses: strip
+
   - name: ${{package.name}}-compat
     description: Compatibility package for dnsdist
     dependencies:


### PR DESCRIPTION
Provides a version of dnsdist without dnscrypt support.

### Pre-review Checklist

#### For new package PRs only
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] Functional tests are present.
- [x] Tests fail **and** pass when it's expected.