### PR TITLE
gnupg: Install keyboxd binary

### DIFF
--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.4.8
-  epoch: 0
+  epoch: 1
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -206,18 +206,21 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin "${{targets.subpkgdir}}"/usr/libexec
 
           mv ${{targets.destdir}}/usr/bin/gpg ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/gpg2 ${{targets.subpkgdir}}/usr/bin/
+          mv "${{targets.destdir}}"/usr/libexec/keyboxd "${{targets.subpkgdir}}"/usr/libexec
     test:
       pipeline:
         - uses: test/tw/ver-check
           with:
-            bins: gpg gpg2
+            bins: gpg gpg2 /usr/libexec/keyboxd
         - runs: |
             gpg --help
             gpg2 --help
+            /usr/libexec/keyboxd --help
+            gpg --list-keys
 
   - name: gpg-agent
     dependencies:


### PR DESCRIPTION
gpg now expects to find a keyboxd binary available under /usr/libexec, so let's install it.  Also, extend the test pipeline to make sure "gpg --list-keys" works without problems.