### PR TITLE
py3-pipenv: pip propagation rebuild: 2/3

### DIFF
--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pipenv
   version: "2025.0.4"
-  epoch: 2
+  epoch: 3
   description: Python Development Workflow for Humans.
   copyright:
     - license: MIT


### PR DESCRIPTION
## Context
Following [cherry-pick fix for pip](https://github.com/jamie-albert/os/commit/a246425c45215e18f2a1d4710675e2363d58f606), based off of this [upstream PR](https://github.com/pypa/pip/pull/13550), has been accepted as the remedation path forward and is going to be [included in pip-25.3. ](https://github.com/advisories/GHSA-4xh5-x5gv-qwph#:~:text=The%20fix%2C%20while%20available%20as%20a%20patch%20that%20can%20be%20manually%20applied%2C%20has%20not%20yet%20been%20put%20into%20a%20numbered%20version%20but%20is%20planned%20for%2025.3)

## Action Items
Rebuilding packages in the following order is required to remediate [ansible-operator/GHSA-4xh5-x5gv-qwph](https://github.com/orgs/chainguard-dev/projects/60/views/28?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=131659548&issue=chainguard-dev%7CCVE-Dashboard%7C30814).

Python3-supported-python.yaml **MERGED**-> py3-pipenv.yaml -> ansible-operator -> (images) kiali-operator & request-4952 .... and many many more

## Supporting Evidence
1.  **MERGED** python3-supported-python [depends on](https://apk.chaindag.dev/https/packages.wolfi.dev/os/x86_64/py3-supported-python-1-r5.apk@sha1:1e7532830f7455f5b8bf67485d3526e52a8c5b83/.melange.yaml  ) py3.x-pip-base([fix merged](https://github.com/wolfi-dev/os/pull/67721))
2.  py3-pipenv [depends on the above](https://apk.chaindag.dev/https/packages.wolfi.dev/os/x86_64/py3-pipenv-2025.0.4-r2.apk@sha1:33cd4069d08324729fc4e5ccc6f8ec000b357827/.melange.yaml ) supported python package via supported-pip

3.  ansible-operator [depends on](https://github.com/chainguard-dev/enterprise-packages/blob/de550b40eff4c9130ea2475e7e1df5cbca093df3/ansible-operator.yaml#L21) pipenv-bin, [provided by](https://github.com/jamie-albert/os/blob/4917563bdbe197df1b2974213ab6255191665ede/py3-pipenv.yaml#L25) py3-pipenv and py${{vars.python-version}}-build-base, [provided by](https://github.com/jamie-albert/os/blob/4917563bdbe197df1b2974213ab6255191665ede/py3-supported-python.yaml#L42) python3-supported-python  

## PR Changes Summary
PR 2/3: Epoch bump for py3-pipenv