### PR TITLE
Add JDK as runtime dependency, in place of JRE

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -175,7 +175,7 @@ subpackages:
     dependencies:
       runtime:
         - jenkins-utils
-        - openjdk-${{vars.java-version}}-default-jvm
+        - openjdk-${{vars.java-version}}-default-jdk
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/bin

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.530"
-  epoch: 5
+  epoch: 6
   description: Open-source CI/CD application.
   copyright:
     - license: MIT


### PR DESCRIPTION
Replaces JRE with JDK for the jenkins-docker-agent package. This mirrors upstream:

```
% docker run --rm --entrypoint /bin/sh jenkins/inbound-agent:latest -c "java -version"
openjdk version "17.0.16" 2025-07-15
OpenJDK Runtime Environment Temurin-17.0.16+8 (build 17.0.16+8)
OpenJDK 64-Bit Server VM Temurin-17.0.16+8 (build 17.0.16+8, mixed mode)
```

Without it, you can't compile java applications in Jenkins pipelines with the default tools 