### PR TITLE
datadog-agent, kubeflow-katib, dask-gateway, py3-pip, pypy-3.10, pypy-3.11: bump epoch for GHSA-4xh5-x5gv-qwph

### DIFF
--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: "2025.4.0"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4 # GHSA-4xh5-x5gv-qwph
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.70.2"
-  epoch: 2 # GHSA-jc7w-c686-c4v9
+  epoch: 3 # GHSA-4xh5-x5gv-qwph
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-katib
   version: "0.18.0"
-  epoch: 9 # CVE-2025-47910
+  epoch: 10 # GHSA-4xh5-x5gv-qwph
   description: Kubeflow Katib services
   copyright:
     - license: Apache-2.0

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.2"
-  epoch: 2 # GHSA-4xh5-x5gv-qwph
+  epoch: 1 # CVE-2025-8869
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.2"
-  epoch: 1 # CVE-2025-8869
+  epoch: 2 # GHSA-4xh5-x5gv-qwph
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/pypy-3.10.yaml
+++ b/pypy-3.10.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.10
   description: PyPy is a very fast and compliant implementation of the Python language v 3.10
-  epoch: 12 # GHSA-4xh5-x5gv-qwph
+  epoch: 13 # GHSA-4xh5-x5gv-qwph
   version: "7.3.19"
   copyright:
     - license: Apache-2.0

--- a/pypy-3.11.yaml
+++ b/pypy-3.11.yaml
@@ -4,7 +4,7 @@
 package:
   name: pypy-3.11
   description: PyPy is a very fast and compliant implementation of the Python language v 3.11
-  epoch: 3 # GHSA-4xh5-x5gv-qwph
+  epoch: 4 # GHSA-4xh5-x5gv-qwph
   version: "7.3.20"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump epoch for GHSA-4xh5-x5gv-qwph (pip vulnerability) across OS packages.