### PR TITLE
pdns-nosodium subpackages

### DIFF
--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -144,6 +144,144 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-nosodium
+    description: PowerDNS Authoritative Server without libsodium
+    dependencies:
+      provides:
+        - pdns-nosodium=${{package.full-version}}
+    pipeline:
+      - uses: autoconf/configure
+        with:
+          opts: |
+            --sbindir=/usr/bin \
+            --with-modules="" \
+            --with-dynmodules="bind geoip ldap lmdb lua2 gmysql godbc pipe gpgsql remote gsqlite3" \
+            --enable-tools \
+            --enable-unit-tests \
+            --enable-systemd \
+            --disable-static \
+            --enable-remotebackend-zeromq=no \
+            --with-libcrypto=/usr \
+            --enable-ixfrdist \
+            --enable-reproducible \
+            --with-libsodium=no \
+            --with-gnutls=no
+      - uses: autoconf/make
+      - uses: autoconf/make-install
+      - assertions:
+          required-steps: 1
+        pipeline:
+          - if: ${{build.arch}} == "x86_64"
+            runs: make check
+          - if: ${{build.arch}} == "aarch64"
+            runs: PDNS_TEST_NO_IPV6=1 make check # aarch64 has issues with IPv6 tests on the CI, no error logs available
+      - name: Create necessary directories
+        runs: |
+          mkdir -p ${{targets.contextdir}}/etc/powerdns/pdns.d
+          mkdir -p ${{targets.contextdir}}/var/run/pdns/
+          mkdir -p ${{targets.contextdir}}/var/lib/powerdns
+      - uses: strip
+    test:
+      pipeline:
+        - runs: |
+            # this is dumb, but libmariadb.so.3 is not available here in tests  - apko solves for it at the image level
+            mkdir -p ${{targets.contextdir}}/usr/lib/
+            ln -sf /usr/lib/pdns/libgsqlite3backend.so /usr/lib/libmariadb.so.3
+        - uses: test/tw/ldd-check
+        - runs: |
+            set -euo pipefail
+            pdns_server --help
+            pdnsutil --help
+        - name: "Verify libsodium and gnutls are not loaded"
+          runs: |
+            set -euo pipefail
+            # Check that pdns_server binary does not link to libsodium or gnutls
+            if ldd /usr/bin/pdns_server | grep -E "(libsodium|libgnutls)"; then
+              echo "ERROR: pdns-nosodium should not link to libsodium or gnutls libraries"
+              exit 1
+            fi
+
+  - name: ${{package.name}}-recursor-nosodium
+    description: PowerDNS Recursive Server without libsodium
+    dependencies:
+      provides:
+        - pdns-recursor=${{package.full-version}}
+    pipeline:
+      - runs: BUILDER_VERSION=${{package.version}} BUILDER_MODULES=recursor autoreconf -vfi
+      - working-directory: ./pdns/recursordist
+        pipeline:
+          - uses: autoconf/configure
+            with:
+              opts: |
+                --sysconfdir=/etc/powerdns \
+                --sbindir=/usr/bin \
+                --enable-dns-over-tls \
+                --enable-unit-tests \
+                --enable-snmp \
+                --enable-dnstap \
+                --enable-nod \
+                --with-lua=lua${{vars.lua-version}} \
+                --with-libcrypto=/usr \
+                --with-libcap \
+                --with-libsodium=no \
+                --with-gnutls=no
+          - uses: autoconf/make
+          - uses: autoconf/make-install
+          - assertions:
+              required-steps: 1
+            pipeline:
+              - if: ${{build.arch}} == "x86_64"
+                runs: make check
+              - if: ${{build.arch}} == "aarch64"
+                runs: PDNS_TEST_NO_IPV6=1 make check # aarch64 has issues with IPv6 tests on the CI, no error logs available
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - pdns-recursor-compat
+            - wait-for-it
+        accounts:
+          groups:
+            - groupname: pdns
+              gid: 953
+          users:
+            - username: pdns
+              gid: 953
+              uid: 953
+          run-as: 0 # To bind :53 on the CI
+        environment:
+          TINI_SUBREAPER: 1
+          DEBUG_CONFIG: yes
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: |
+            pdns_recursor --help
+            rec_control --help
+        - name: "Verify libsodium and gnutls are not loaded"
+          runs: |
+            set -euo pipefail
+            # Check that pdns_recursor binary does not link to libsodium or gnutls
+            if ldd /usr/bin/pdns_recursor | grep -E "(libsodium|libgnutls)"; then
+              echo "ERROR: pdns-nosodium should not link to libsodium or gnutls libraries"
+              exit 1
+            fi
+        - name: "start daemon on localhost"
+          uses: test/daemon-check-output
+          with:
+            start: "/usr/bin/tini -- /usr/local/sbin/pdns_recursor-startup"
+            timeout: 30
+            expected_output: |
+              YAML config found and processed
+              Enabled TCP data-ready
+              Listening for queries
+              Launching worker threads
+              Launching tcpworker threads
+              Enabled multiplexer
+            post: |
+              wait-for-it -t 5 --strict localhost:8082
+              wait-for-it -t 5 --strict localhost:53
+
   - name: ${{package.name}}-recursor
     description: PowerDNS Recursive Server
     dependencies:

--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: pdns-5.2
   version: "5.2.5"
-  epoch: 1
+  epoch: 2
   description: PowerDNS Authoritative Server
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
