### PR TITLE
qemu - split edk2 files out to dependent subpackage

### DIFF
--- a/qemu.yaml
+++ b/qemu.yaml
@@ -1,7 +1,7 @@
 package:
   name: qemu
   version: "10.1.0"
-  epoch: 0
+  epoch: 1
   description: "fast processor emulator"
   copyright:
     - license: GPL-2.0
@@ -123,19 +123,12 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}-ipxe
+        - ${{package.name}}-edk2-x86_64
     pipeline:
       - runs: |
           set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/qemu-system-x86_64 "${{targets.subpkgdir}}"/usr/bin/
-
-          # This is the equivalent to QEMU_EFI.fd
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
-          mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
-          mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-secure-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
-
-          # i386 vars are same as format as x86_64, but this is easier for consumer.
-          cp "${{targets.destdir}}"/usr/share/qemu/edk2-i386-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-x86_64-vars.fd
     test:
       environment:
         contents:
@@ -160,23 +153,29 @@ subpackages:
               -kernel /tmp/boot/vmlinuz-virt -m 1G -nographic -append "console=ttyS0 panic=1" \
               -no-reboot | grep -q "Unable to mount root fs"
 
+  - name: ${{package.name}}-edk2-x86_64
+    description: "QEMU built edk2 files for x86_64"
+    pipeline:
+      - runs: |
+          # This is the equivalent to QEMU_EFI.fd
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
+          mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
+          mv "${{targets.destdir}}"/usr/share/qemu/edk2-x86_64-secure-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
+
+          # i386 vars are same as format as x86_64, but this is easier for consumer.
+          cp "${{targets.destdir}}"/usr/share/qemu/edk2-i386-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-x86_64-vars.fd
+
   - name: ${{package.name}}-system-aarch64
     description: "QEMU aarch64 system"
     dependencies:
       runtime:
         - ${{package.name}}-ipxe
+        - ${{package.name}}-edk2-aarch64
     pipeline:
       - runs: |
           set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/qemu-system-aarch64 "${{targets.subpkgdir}}"/usr/bin/
-
-          # This is the equivalent to QEMU_EFI.fd
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
-          mv "${{targets.destdir}}"/usr/share/qemu/edk2-aarch64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
-
-          # arm vars are same as format as aarch64, but this is easier for consumer.
-          cp "${{targets.destdir}}"/usr/share/qemu/edk2-arm-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-aarch64-vars.fd
     test:
       environment:
         contents:
@@ -198,6 +197,17 @@ subpackages:
             # don't reboot, and make sure we get to the step where we're trying to mount a rootfs
             qemu-system-aarch64 -kernel /tmp/boot/vmlinuz-virt -m 1G -cpu max -machine virt \
               -nographic -no-reboot -append "panic=1" | grep -q "Unable to mount root fs"
+
+  - name: ${{package.name}}-edk2-aarch64
+    description: "QEMU built edk2 files for aarch64"
+    pipeline:
+      - runs: |
+          # This is the equivalent to QEMU_EFI.fd
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/qemu
+          mv "${{targets.destdir}}"/usr/share/qemu/edk2-aarch64-code.fd "${{targets.subpkgdir}}"/usr/share/qemu/
+
+          # arm vars are same as format as aarch64, but this is easier for consumer.
+          cp "${{targets.destdir}}"/usr/share/qemu/edk2-arm-vars.fd "${{targets.subpkgdir}}"/usr/share/qemu/edk2-aarch64-vars.fd
 
 test:
   pipeline:


### PR DESCRIPTION
The edk2 files are useful in some scenarios by themselves, so let the user just pull them without all of qemu and deps.
