### PR TITLE
mise-2025.10.6: new package

### DIFF
--- a/mise.yaml
+++ b/mise.yaml
@@ -1,0 +1,49 @@
+package:
+  name: mise
+  version: "2025.11.6"
+  epoch: 0
+  description: dev tools, env vars, task runner
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - clang-18
+      - cmake-3
+      - gcc-13
+      - openssl-dev
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jdx/mise
+      tag: v${{package.version}}
+      expected-commit: a8a96c50ed6044828618247266f70edd700c1ce1
+
+  - name: Configure and build
+    runs: |
+      export AWS_LC_SYS_CFLAGS="-Wno-error=cpp -O2 -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3"
+      CC=clang-18 CXX=clang++-18 cargo build --all-features --release
+      mkdir -p ${{targets.contextdir}}/usr/bin/
+      mv target/release/mise ${{targets.contextdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: jdx/mise
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        mise -v
+        mise doctor
+        mise --help


### PR DESCRIPTION
added version 2025.10.6 of mise

implements #68076

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:
- New package request - #68076 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
