### PR TITLE
llvm-{20,21}: make libLLVM co-installable

### DIFF
--- a/llvm-20.yaml
+++ b/llvm-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-20
   version: "20.1.8"
-  epoch: 4
+  epoch: 5
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -123,9 +123,6 @@ pipeline:
 subpackages:
   - name: libLLVM-${{vars.major-version}}
     description: LLVM ${{vars.major-version}} runtime library
-    dependencies:
-      provides:
-        - libLLVM=${{package.full-version}}
     pipeline:
       - runs: |
           soname="libLLVM.so.${{vars.major-minor-version}}"

--- a/llvm-21.yaml
+++ b/llvm-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-21
   version: "21.1.2"
-  epoch: 0
+  epoch: 1
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -129,9 +129,6 @@ pipeline:
 subpackages:
   - name: libLLVM-${{vars.major-version}}
     description: LLVM ${{vars.major-version}} runtime library
-    dependencies:
-      provides:
-        - libLLVM=${{package.full-version}}
     pipeline:
       - runs: |
           soname="libLLVM.so.${{vars.major-minor-version}}"


### PR DESCRIPTION
libLLVM is always installed to version specific paths so ensure that
different major versions are always co-installable otherwise we end up
with package resolver issues in the archive as different binaries
depend on different versions of libLLVM.
