### PR TITLE
gdal: unpin postgresql-dev

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -73,7 +73,6 @@ environment:
       - pcre2-dev
       - poppler
       - poppler-dev
-      - postgresql
       - postgresql-dev
       - proj-dev
       - py3-supported-numpy-2.2

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: "3.11.4"
-  epoch: 2
+  epoch: 3
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT
@@ -74,7 +74,6 @@ environment:
       - poppler
       - poppler-dev
       - postgresql
-      - postgresql-17-dev
       - postgresql-dev
       - proj-dev
       - py3-supported-numpy-2.2


### PR DESCRIPTION
As postgresql-18 is now in archive, we can't depend on versioned and
unversioned postgresql packages; we need to pin or not-pin.

Unpin gdal so it moves forward.
