### PR TITLE
orthanc-{gdcm,python}: Pin boost-dev~1.88

### DIFF
--- a/orthanc-gdcm.yaml
+++ b/orthanc-gdcm.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-gdcm
   version: 1.8
-  epoch: 2
+  epoch: 3
   description: GDCM plugin for Orthanc DICOM server - advanced DICOM image decoding
   copyright:
     - license: AGPL-3.0-or-later
@@ -12,7 +12,7 @@ package:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - cmake-3

--- a/orthanc-python.yaml
+++ b/orthanc-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-python
   version: "6.0"
-  epoch: 0
+  epoch: 1
   description: Python plugin for Orthanc DICOM server
   copyright:
     - license: AGPL-3.0-or-later
@@ -15,7 +15,7 @@ vars:
 environment:
   contents:
     packages:
-      - boost-dev
+      - boost-dev~1.88
       - build-base
       - busybox
       - cmake-3


### PR DESCRIPTION
Align with core orthanc package and pin boost version to 1.88 until
upstream supports >= 1.89.
