### PR TITLE
added some tests for the aznfs-mount package

### DIFF
--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -1,7 +1,7 @@
 package:
   name: aznfs-mount
   version: "2.0.12"
-  epoch: 3
+  epoch: 4
   description: AZNFS Mount Helper
   copyright:
     - license: Apache-2.0
@@ -67,10 +67,3 @@ update:
   github:
     identifier: Azure/AZNFS-mount
     use-tag: true
-
-# test added by a robot (binary)
-test:
-  pipeline:
-    - runs: |
-        stat /usr/bin/aznfswatchdog
-        stat /usr/bin/mount.aznfs

--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -35,6 +35,32 @@ pipeline:
       install -Dm755 src/mountscript.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/mountscript.sh
       install -Dm755 scripts/aznfs_install.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/aznfs_install.sh
       install -Dm755 lib/common.sh "${{targets.contextdir}}"/opt/microsoft/aznfs/common.sh
+      mkdir -p "${{targets.contextdir}}"/opt/microsoft/aznfs/data
+      touch "${{targets.contextdir}}"/opt/microsoft/aznfs/data/aznfs.log
+
+test:
+  environment:
+    contents:
+      packages:
+        - bash
+  pipeline:
+    - name: Verify binaries are installed
+      runs: |
+        test -f /usr/bin/aznfswatchdog
+        test -x /usr/bin/aznfswatchdog
+        test -f /usr/bin/mount.aznfs
+        test -x /usr/bin/mount.aznfs
+    - name: Verify support scripts are installed
+      runs: |
+        test -f /opt/microsoft/aznfs/mountscript.sh
+        test -f /opt/microsoft/aznfs/aznfs_install.sh
+        test -f /opt/microsoft/aznfs/common.sh
+    - name: Test mount.aznfs binary execution
+      runs: |
+        mount.aznfs --help || true
+    - name: Test aznfswatchdog script syntax
+      runs: |
+        bash -n /usr/bin/aznfswatchdog
 
 update:
   enabled: true


### PR DESCRIPTION
This package was added recently without any tests.

Testing it as best as we can -- check that the critical files are installed, executable, and pass a syntax check.  Try running the command (which previously complained about a missing directory and log file, which we fix with an epoch bump).