### PR TITLE
libxml2: move to shared library soversion naming

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: "2.15.0"
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -13,6 +13,10 @@ var-transforms:
     match: (\d+\.\d+)\.\d+
     replace: $1
     to: mangled-package-version
+
+vars:
+  # NOTE: upstream picked an arbitary version, wire here for package naming.
+  soversion: 16
 
 environment:
   contents:
@@ -56,35 +60,44 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: libxml2-doc
+  - name: ${{package.name}}-${{vars.soversion}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/manpages
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/share/
           mkdir -p ${{targets.subpkgdir}}/usr/share/doc
           mv ${{targets.destdir}}/usr/share/doc/libxml2 ${{targets.subpkgdir}}/usr/share/doc/libxml2
-    description: libxml2 manpages
+    description: ${{package.name}} manpages
     test:
       pipeline:
         - uses: test/docs
 
   # python bindings are getting removed in 2.16.0 remove this subpackage then
-  - name: libxml2-py3
+  - name: ${{package.name}}-py3
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/python3* ${{targets.subpkgdir}}/usr/lib
-    description: libxml2 python3 bindings
+    description: ${{package.name}} python3 bindings
     test:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: libxml2-utils
+  - name: ${{package.name}}-utils
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr
-    description: libxml2 utils
+    description: ${{package.name}} utils
     test:
       pipeline:
         - name: Verify libxml2 installation
@@ -124,16 +137,15 @@ subpackages:
             EOF
             xmllint --noout --dtdvalid example.dtd note.xml || exit 1
 
-  - name: libxml2-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - libxml2=${{package.full-version}}
         - zlib-dev
         - xz-dev
         - libxml2-utils=${{package.full-version}}
-    description: libxml2 dev
+    description: ${{package.name}} dev
     test:
       environment:
         contents:


### PR DESCRIPTION
Update library name to match the soversion (16) so that this version of
the library can be co-installed with older versions of libxml2.
