### PR TITLE
feat(CODEOWNERS): Remove sustaining team as nats* package owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,8 +31,3 @@ openssl.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 perl.yaml                     @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 go-1.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 go-2.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
-
-# Adding sustaining-team as codeowner of nats* packages blocking any 
-# non sustaining-team and automation from merging of nats* package changes. 
-# This is in lieue of a possible move to less open license for nats* packages. 
-nats*.yaml           @wolfi-dev/sustaining-team-write


### PR DESCRIPTION
There is no longer concern regarding nats* packages moving to a less open license.

Sustaining team should no longer block on nats* changes.

This reverts commit e148118ba73319f4a557541116813720563a74e3

Signed-off-by: philroche <phil.roche@chainguard.dev>
