### PR TITLE
abseil-cpp: make libraries co-installable

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -21,8 +21,11 @@ environment:
     # https://github.com/wolfi-dev/os/issues/34075
     CMAKE_CXX_FLAGS: -fdelete-null-pointer-checks
 
-vars:
-  soversion: 2508.0.0
+var-transforms:
+  - from: ${{package.version}}
+    match: ^\d{2}(\d{4}).*$
+    replace: ${1}.0.0
+    to: soversion
 
 pipeline:
   - uses: git-checkout

--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20250814.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,9 @@ environment:
   environment:
     # https://github.com/wolfi-dev/os/issues/34075
     CMAKE_CXX_FLAGS: -fdelete-null-pointer-checks
+
+vars:
+  soversion: 2025.0.0
 
 pipeline:
   - uses: git-checkout
@@ -49,13 +52,19 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: abseil-cpp-dev
+  - name: libabseil${{vars.soversion}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - abseil-cpp
-    description: abseil-cpp dev
+    description: ${{package.name}} dev
     test:
       pipeline:
         - uses: test/pkgconf

--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -52,7 +52,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: libabseil${{vars.soversion}}
+  - name: libabsl${{vars.soversion}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/lib

--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -22,7 +22,7 @@ environment:
     CMAKE_CXX_FLAGS: -fdelete-null-pointer-checks
 
 vars:
-  soversion: 2025.0.0
+  soversion: 2508.0.0
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Move shared libraries to a new soversion'ed subpackage to ensure that
this package is co-installable with the previous version, ensuring
smooth transitions.
