### PR TITLE
glibc: cherry-pick 855bfa256 for openjdk-17 fixes

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.42"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 0
+  epoch: 1
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -53,6 +53,8 @@ pipeline:
       # recommended at https://sourceware.org/glibc/wiki/GlibcGit
       repository: https://repo.or.cz/glibc.git
       tag: glibc-${{package.version}}
+      cherry-picks: |
+        master/855bfa2566bbefefa27c516b344df58a75824a5c: nptl: Fix MADV_GUARD_INSTALL logic for thread without guard page (BZ 33356)
 
   - uses: patch
     with:


### PR DESCRIPTION
#### Fixes:
Adds a cherry pick for https://repo.or.cz/glibc.git/commit/855bfa2566bbefefa27c516b344df58a75824a5c

This commit is associated with a fix for an issue with openjdk-17 where calls to pthread_create() would fail.

I was able to replicate this issue with ubuntu 25.10, using glibc 2.42 (without the patch) and it disappeared after applying the update to 2.42-0ubuntu3

#### Related:
Reported issue on launchpad: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/2121834
ubuntu patch: https://launchpadlibrarian.net/816478266/glibc_2.42-0ubuntu2_2.42-0ubuntu3.diff.gz

#### Issue description:
We first experienced this during a routine update of our base images for `jdk:17`. In that image we install `sbt` and then run it to compile Scala projects. The behavior at the time was simply that sbt would hang after processing the commands, and never finish the process.

Eventually after some debugging we figured a couple of things:
- The issue would show up intermittently
- `sbt` launches `java` with several flags. We could narrow down the issue to the combination of these 3:
```
-Xms1024m -Xmx1024m -Xss4M
```
- The issue happens only with `glibc >= 2.42`
- `sbt` is not uniquely affected. We crafted a java program that simply launches 50 threads and joins them, and running that program with the 3 flags listed above has the same behavior
- When enabling GC debug log messages we see:
```
[0.144s][warning][os,thread   ] Failed to start thread "GC Thread#1" - pthread_create failed (EINVAL) for attributes: stacksize: 1024k, guardsize: 4k, detached.
```
- We first found this issue in our CircleCI runners, and we were able to reproduce them in a kubernetes pod running on EC2 instances. Both of them are using the same `Intel(R) Xeon(R) Platinum 8488C` processor. We also tried GitHub Actions runners (with `AMD EPYC 7763`) and did not see the same behavior.
 
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
