### PR TITLE
DNM - Add Python 3.14 without unversioned "provides"

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,0 +1,329 @@
+package:
+  name: python-3.14
+  version: "3.14.0"
+  epoch: 0
+  description: "the Python programming language"
+  copyright:
+    - license: PSF-2.0
+  resources
+  # We're leaving this out of providing python3; we'll test build critical
+  # packages separately to ensure they're ready for Python 3.14.
+  #
+  # dependencies:
+  #   provides:
+  #     - python3=${{package.full-version}}
+  #     - python-3=${{package.full-version}}
+  #   runtime:
+  #     - ${{package.name}}-base=${{package.full-version}}:
+    cpu: 8
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - expat-dev
+      - gdbm-dev
+      - libcap-utils
+      - libffi-dev
+      - libx11-dev
+      - linux-headers
+      - mpdecimal-dev
+      - ncurses-dev
+      - openssl-dev
+      - readline-dev
+      - sqlite-dev
+      - tcl-dev
+      - tk-dev
+      - xz-dev
+      - zlib-dev
+
+# creates helpful python3.M and 3.M variables
+var-transforms:
+  - from: ${{package.name}}
+    match: '-'
+    replace: ''
+    to: python
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: pyversion
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ebf955df7a89ed0c7968f79faec1de49f61ed7cb
+      repository: https://github.com/python/cpython.git
+      tag: v${{package.version}}
+
+  - name: Force use of system libraries
+    runs: |
+      rm -rf Modules/expat \
+        Modules/_ctypes/darwin* \
+        Modules/_ctypes/libffi*
+
+  - uses: patch
+    with:
+      patches: gh-118224.patch gh-127301.patch
+
+  - name: Configure
+    runs: |
+      ./configure \
+         --host=${{host.triplet.gnu}} \
+         --build=${{host.triplet.gnu}} \
+         --target=${{host.triplet.gnu}} \
+         --prefix=/usr \
+         --enable-ipv6 \
+         --enable-loadable-sqlite-extensions \
+         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
+         --enable-shared \
+         --with-lto \
+         --with-computed-gotos \
+         --with-dbmliborder=gdbm:ndbm \
+         --with-system-expat \
+         --with-system-libmpdec \
+         --without-ensurepip \
+         --with-builtin-hashlib-hashes=blake2 \
+         --with-wheel-pkg-dir=/usr/share/python-wheels
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find ${{targets.destdir}}/usr/lib -type f -name 'libpython*.a' -exec rm -rf '{}' +
+      find ${{targets.destdir}}/usr/lib -type d -name 'test' -exec rm -rf '{}' +
+      find ${{targets.destdir}}/usr/lib -type d -name 'tests' -exec rm -rf '{}' +
+      find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
+
+      cd ${{targets.destdir}}/usr/bin
+      rm -f idle3* 2to3*
+      rm ${{targets.destdir}}/usr/lib/libpython3.so
+
+      # add dubious python -> python3 link
+      ln -s python3 ${{targets.destdir}}/usr/bin/python
+
+      # Drop site-packages README.txt to avoid SCA dep on python3~3.M
+      cd ${{targets.destdir}}/usr/lib/${{vars.python}}
+      rm site-packages/README.txt
+      rmdir site-packages
+
+  - name: "remove idle (python IDE)"
+    runs: |
+      rm -R "${{targets.destdir}}/usr/lib/${{vars.python}}/idlelib"
+
+  - runs: |
+      rm -R ${{targets.destdir}}/usr/lib/${{vars.python}}/ensurepip/_bundled/
+
+  - runs: |
+      find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
+      find ${{targets.destdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
+
+      export LD_LIBRARY_PATH="${{targets.destdir}}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      ${{targets.destdir}}/usr/bin/${{vars.python}} -m compileall --invalidation-mode=unchecked-hash \
+          -r100 ${{targets.destdir}}/usr/lib/
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} without /usr/bin/python3"
+    dependencies:
+      runtime:
+        - py3-pip-wheel
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/bin/${{vars.python}} \
+              ${{targets.destdir}}/usr/bin/pydoc${{vars.pyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/lib/${{vars.python}} \
+             ${{targets.subpkgdir}}/usr/lib
+          mv -v ${{targets.destdir}}/usr/lib/libpython${{vars.pyversion}}.so.* \
+             ${{targets.subpkgdir}}/usr/lib
+
+          # pyconfig.h is needed at runtime... ugh.
+          d=usr/include/${{vars.python}}
+          mkdir -p "${{targets.subpkgdir}}"/$d
+          mv "${{targets.destdir}}"/$d/pyconfig.h "${{targets.subpkgdir}}"/$d/
+
+          # move usr/lib/python3.X/config-3.X-x86_64-linux-gnu
+          # back into main package so the -base-dev can take it below.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.destdir}}/$d"
+          mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
+              "${{targets.destdir}}/$d"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: |
+            ${{vars.python}} version-check.py ${{package.version}}
+        - name: Verify venv installs expected packages
+          runs: |
+            set +x
+            d=$(mktemp -d)
+            echo "$ ${{vars.python}} -m venv $d"
+            ${{vars.python}} -m venv "$d"
+            echo "$ $d/bin/pip list"
+            $d/bin/pip list | tee "$d/list.txt"
+            wd=/usr/share/python-wheels
+            for pkg in pip ; do
+              set -- "$wd"/$pkg-*.whl
+              [ $# -eq 1 ] || {
+                echo "ERROR: found $# wheels in $wd matching $pkg-*.whl";
+                exit 1;
+              }
+              [ -f "$1" ] || {
+                echo "ERROR: $wd/$pkg-*.whl ('$1') was not a file"
+                exit 1
+              }
+              # name is like pip-24.2-py3-none-any.whl. second token is version.
+              wheel=${1}
+              tmp=${wheel##*/}
+              tmp=${tmp#*-}
+              ver=${tmp%%-*}
+              if ! grep -q "${pkg}[ ]\+${ver}$" "$d/list.txt"; then
+                  echo "FAIL: did not find '$pkg==$ver' in venv"
+                  echo "pip list had:"
+                  sed 's,^,>,' "$d/list.txt"
+                  exit 1
+              fi
+              echo "PASS: venv installed '$pkg==$ver'"
+            done
+
+            rm -Rf "$d"
+
+  - name: "${{package.name}}-privileged-netbindservice"
+    description: "Allows Python to bind to ports less than 1024"
+    options:
+      # This replaces the Python binary and depends on base. We don't want
+      # to generate any dependencies or provide anything that would clash
+      # with the rest of Python
+      no-depends: true
+      no-provides: true
+    dependencies:
+      replaces:
+        - ${{package.name}}-base
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/bin"
+          cp "${{targets.outdir}}/${{package.name}}-base/usr/bin/${{vars.python}}" "${{targets.contextdir}}/usr/bin/"
+          # Note this sets the capability the test using getcap fails but the
+          # capability is set in images with this package.
+          setcap cap_net_bind_service=+eip "${{targets.contextdir}}/usr/bin/${{vars.python}}"
+
+  - name: "${{package.name}}-tk"
+    dependencies:
+      provides:
+        - py3-tkinter=${{package.full-version}}
+        - py3.13-tkinter=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+        # 'import _tkinter' will fail with ImportError on 'libtcl9tk9.0.so'
+        # which is provided by tk.  melange SCA does not find this dependency.
+        - tk
+    pipeline:
+      - runs: |
+          # these got moved by python-3.xx-base from ${{targets.destdir}}
+          fromd="${{targets.destdir}}-base"
+          tod=${{targets.contextdir}}
+          d=usr/lib/${{vars.python}}
+
+          mkdir -p "$tod/$d/lib-dynload"
+          mv "$fromd/$d/lib-dynload"/_tkinter.*.so "$tod/$d/lib-dynload/"
+          mv "$fromd/$d/tkinter" "$tod/$d/"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - uses: python/import
+          with:
+            python: python${{vars.pyversion}}
+            import: tkinter
+
+  - name: "${{package.name}}-doc"
+    description: "python3 documentation"
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+  - name: "${{package.name}}-dev"
+    description: "python3 development headers"
+    dependencies:
+      provides:
+        - python3-dev=${{package.full-version}}
+        - python-3-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}=${{package.full-version}}
+        - ${{package.name}}-base-dev=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/bin/python3-config ${{targets.subpkgdir}}/usr/bin
+
+          d="usr/lib/pkgconfig"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v \
+             "${{targets.destdir}}"/$d/python3-embed.pc \
+             "${{targets.destdir}}"/$d/python3.pc \
+             "${{targets.subpkgdir}}/$d/"
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: python3-dev
+            real-pkg-name: ${{subpkg.name}}
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: python-3-dev
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: "${{package.name}}-base-dev"
+    description: "python3 development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # usr/lib/python3.X/config-3.X-x86_64-linux-gnu
+          # split/dev will only move 2 files from it, but we want all of it.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
+             "${{targets.subpkgdir}}"/$d
+      - uses: split/dev
+
+test:
+  pipeline:
+    - runs: |
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
+        pydoc3 --version
+        pydoc3 --help
+        python --version
+        python --help
+        python3 --version
+        python3 --help
+    - name: Verify working python3 -m venv
+      runs: |
+        d=$(mktemp -d)
+        python3 -m venv "$d"
+        $d/bin/pip list
+        $d/bin/pip check
+        rm -Rf "$d"
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: python/cpython
+    strip-prefix: v
+    tag-filter: v3.13
+    use-tag: true

--- a/python-3.14/gh-118224.patch
+++ b/python-3.14/gh-118224.patch
@@ -1,0 +1,82 @@
+Upstream: https://github.com/python/cpython/issues/118224
+
+From 49f920e41aef131f7f11657a65a4a986839ea193 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 14:47:10 +0100
+Subject: [PATCH 1/2] [3.12] gh-118224: Load default OpenSSL provider for
+ nonsecurity algorithms
+
+When OpenSSL is configured to only load "base+fips" providers into the
+Null library context, md5 might not be available at all. In such cases
+currently CPython fallsback to internal hashlib implementation is
+there is one - as there might not be if one compiles python with
+--with-builtin-hashlib-hashes=blake2. With this change "default"
+provider is attempted to be loaded to access nonsecurity hashes.
+---
+ Modules/_hashopenssl.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/Modules/_hashopenssl.c b/Modules/_hashopenssl.c
+index d569b50..cef653f 100644
+--- a/Modules/_hashopenssl.c
++++ b/Modules/_hashopenssl.c
+@@ -57,6 +57,7 @@
+ #endif
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/provider.h>
+ #define PY_EVP_MD EVP_MD
+ #define PY_EVP_MD_fetch(algorithm, properties) EVP_MD_fetch(NULL, algorithm, properties)
+ #define PY_EVP_MD_up_ref(md) EVP_MD_up_ref(md)
+@@ -266,6 +267,17 @@ typedef struct {
+     _Py_hashtable_t *hashtable;
+ } _hashlibstate;
+ 
++static void try_load_default_provider(void) {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    /* Load the default config file, and expected providers */
++    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
++    if (!OSSL_PROVIDER_available(NULL, "default")) {
++	/* System is configured without the default provider */
++        OSSL_PROVIDER_load(NULL, "default");
++    }
++#endif
++}
++
+ static inline _hashlibstate*
+ get_hashlib_state(PyObject *module)
+ {
+@@ -419,6 +431,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+         case Py_ht_evp_nosecurity:
+             digest = FT_ATOMIC_LOAD_PTR_RELAXED(entry->evp_nosecurity);
+             if (digest == NULL) {
++                try_load_default_provider();
+                 digest = PY_EVP_MD_fetch(entry->ossl_name, "-fips");
+ #ifdef Py_GIL_DISABLED
+                 // exchange just in case another thread did same thing at same time
+@@ -445,6 +458,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             digest = PY_EVP_MD_fetch(name, NULL);
+             break;
+         case Py_ht_evp_nosecurity:
++            try_load_default_provider();
+             digest = PY_EVP_MD_fetch(name, "-fips");
+             break;
+         }
+
+From d5e209887d7fa05e46afc1d17dc362cccb0bd53b Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 23:28:53 +0100
+Subject: [PATCH 2/2] Add blurb
+
+---
+ .../next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst    | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+new file mode 100644
+index 00000000000000..c63b71ecbafc58
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+@@ -0,0 +1 @@
++Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.

--- a/python-3.14/gh-127301.patch
+++ b/python-3.14/gh-127301.patch
@@ -1,0 +1,274 @@
+Upstream: https://github.com/python/cpython/pull/127301
+
+diff --git a/Lib/hashlib.py b/Lib/hashlib.py
+index 1b2c30cc32f..b71fe5eb90e 100644
+--- a/Lib/hashlib.py
++++ b/Lib/hashlib.py
+@@ -79,6 +79,23 @@
+     'blake2b', 'blake2s',
+ }
+ 
++# Wrapper that only allows usage when usedforsecurity=False
++# (effectively unapproved service indicator)
++def __usedforsecurity_check(md, name, *args, **kwargs):
++    if kwargs.get("usedforsecurity", True):
++        raise ValueError(name + " is blocked when usedforsecurity=True")
++    return md(*args, **kwargs)
++
++# If the _hashlib OpenSSL wrapper is in FIPS mode, wrap other implementations
++# to check the usedforsecurity kwarg. All builtin implementations are treated
++# as only available for useforsecurity=False purposes in the presence of such
++# a configured and linked OpenSSL.
++def __get_wrapped_builtin(md, name):
++    if __openssl_fips_mode != 0:
++        from functools import partial
++        return partial(__usedforsecurity_check, md, name)
++    return md
++
+ def __get_builtin_constructor(name):
+     cache = __builtin_constructor_cache
+     constructor = cache.get(name)
+@@ -87,32 +104,32 @@ def __get_builtin_constructor(name):
+     try:
+         if name in {'SHA1', 'sha1'}:
+             import _sha1
+-            cache['SHA1'] = cache['sha1'] = _sha1.sha1
++            cache['SHA1'] = cache['sha1'] = __get_wrapped_builtin(_sha1.sha1, name)
+         elif name in {'MD5', 'md5'}:
+             import _md5
+-            cache['MD5'] = cache['md5'] = _md5.md5
++            cache['MD5'] = cache['md5'] = __get_wrapped_builtin(_md5.md5, name)
+         elif name in {'SHA256', 'sha256', 'SHA224', 'sha224'}:
+             import _sha2
+-            cache['SHA224'] = cache['sha224'] = _sha2.sha224
+-            cache['SHA256'] = cache['sha256'] = _sha2.sha256
++            cache['SHA224'] = cache['sha224'] = __get_wrapped_builtin(_sha2.sha224, name)
++            cache['SHA256'] = cache['sha256'] = __get_wrapped_builtin(_sha2.sha256, name)
+         elif name in {'SHA512', 'sha512', 'SHA384', 'sha384'}:
+             import _sha2
+-            cache['SHA384'] = cache['sha384'] = _sha2.sha384
+-            cache['SHA512'] = cache['sha512'] = _sha2.sha512
++            cache['SHA384'] = cache['sha384'] = __get_wrapped_builtin(_sha2.sha384, name)
++            cache['SHA512'] = cache['sha512'] = __get_wrapped_builtin(_sha2.sha512, name)
+         elif name in {'blake2b', 'blake2s'}:
+             import _blake2
+-            cache['blake2b'] = _blake2.blake2b
+-            cache['blake2s'] = _blake2.blake2s
++            cache['blake2b'] = __get_wrapped_builtin(_blake2.blake2b, name)
++            cache['blake2s'] = __get_wrapped_builtin(_blake2.blake2s, name)
+         elif name in {'sha3_224', 'sha3_256', 'sha3_384', 'sha3_512'}:
+             import _sha3
+-            cache['sha3_224'] = _sha3.sha3_224
+-            cache['sha3_256'] = _sha3.sha3_256
+-            cache['sha3_384'] = _sha3.sha3_384
+-            cache['sha3_512'] = _sha3.sha3_512
++            cache['sha3_224'] = __get_wrapped_builtin(_sha3.sha3_224, name)
++            cache['sha3_256'] = __get_wrapped_builtin(_sha3.sha3_256, name)
++            cache['sha3_384'] = __get_wrapped_builtin(_sha3.sha3_384, name)
++            cache['sha3_512'] = __get_wrapped_builtin(_sha3.sha3_512, name)
+         elif name in {'shake_128', 'shake_256'}:
+             import _sha3
+-            cache['shake_128'] = _sha3.shake_128
+-            cache['shake_256'] = _sha3.shake_256
++            cache['shake_128'] = __get_wrapped_builtin(_sha3.shake_128, name)
++            cache['shake_256'] = __get_wrapped_builtin(_sha3.shake_256, name)
+     except ImportError:
+         pass  # no extension module, this hash is unsupported.
+ 
+@@ -172,10 +188,15 @@ def __hash_new(name, data=b'', **kwargs):
+     __get_hash = __get_openssl_constructor
+     algorithms_available = algorithms_available.union(
+             _hashlib.openssl_md_meth_names)
++    try:
++        __openssl_fips_mode = _hashlib.get_fips_mode()
++    except ValueError:
++        __openssl_fips_mode = 0
+ except ImportError:
+     _hashlib = None
+     new = __py_new
+     __get_hash = __get_builtin_constructor
++    __openssl_fips_mode = 0
+ 
+ try:
+     # OpenSSL's PKCS5_PBKDF2_HMAC requires OpenSSL 1.0+ with HMAC and SHA
+diff --git a/Lib/test/_test_hashlib_fips.py b/Lib/test/_test_hashlib_fips.py
+new file mode 100644
+index 00000000000..92537245954
+--- /dev/null
++++ b/Lib/test/_test_hashlib_fips.py
+@@ -0,0 +1,64 @@
++# Test the hashlib module usedforsecurity wrappers under fips.
++#
++#  Copyright (C) 2024   Dimitri John Ledkov (dimitri.ledkov@surgut.co.uk)
++#  Licensed to PSF under a Contributor Agreement.
++#
++
++"""Primarily executed by test_hashlib.py. It can run stand alone by humans."""
++
++import os
++import unittest
++
++OPENSSL_CONF_BACKUP = os.environ.get("OPENSSL_CONF")
++
++
++class HashLibFIPSTestCase(unittest.TestCase):
++    @classmethod
++    def setUpClass(cls):
++        # This openssl.cnf mocks FIPS mode without any digest
++        # loaded. It means all digests must raise ValueError when
++        # usedforsecurity=True via either openssl or builtin
++        # constructors
++        OPENSSL_CONF = os.path.join(os.path.dirname(__file__), "hashlibdata", "openssl.cnf")
++        os.environ["OPENSSL_CONF"] = OPENSSL_CONF
++        # Ensure hashlib is loading a fresh libcrypto with openssl
++        # context affected by the above config file. Check if this can
++        # be folded into test_hashlib.py, specifically if
++        # import_fresh_module() results in a fresh library context
++        import hashlib
++
++    def setUp(self):
++        try:
++            from _hashlib import get_fips_mode
++        except ImportError:
++            self.skipTest('_hashlib not available')
++
++        if get_fips_mode() != 1:
++            self.skipTest('mocking fips mode failed')
++
++    @classmethod
++    def tearDownClass(cls):
++        if OPENSSL_CONF_BACKUP is not None:
++            os.environ["OPENSSL_CONF"] = OPENSSL_CONF_BACKUP
++        else:
++            os.environ.pop("OPENSSL_CONF", None)
++
++    def test_algorithms_available(self):
++        import hashlib
++        self.assertTrue(set(hashlib.algorithms_guaranteed).
++                            issubset(hashlib.algorithms_available))
++        # all available algorithms must be loadable, bpo-47101
++        self.assertNotIn("undefined", hashlib.algorithms_available)
++        for name in hashlib.algorithms_available:
++            with self.subTest(name):
++                digest = hashlib.new(name, usedforsecurity=False)
++
++    def test_usedforsecurity_true(self):
++        import hashlib
++        for name in hashlib.algorithms_available:
++            with self.subTest(name):
++                with self.assertRaises(ValueError):
++                    digest = hashlib.new(name, usedforsecurity=True)
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/Lib/test/hashlibdata/openssl.cnf b/Lib/test/hashlibdata/openssl.cnf
+new file mode 100644
+index 00000000000..9a936ddc5ef
+--- /dev/null
++++ b/Lib/test/hashlibdata/openssl.cnf
+@@ -0,0 +1,19 @@
++# Activate base provider only, with default properties fips=yes. It
++# means that fips mode is on, and no digest implementations are
++# available. Perfect for mock testing builtin FIPS wrappers.
++
++config_diagnostics = 1
++openssl_conf = openssl_init
++
++[openssl_init]
++providers = provider_sect
++alg_section = algorithm_sect
++
++[provider_sect]
++base = base_sect
++
++[base_sect]
++activate = 1
++
++[algorithm_sect]
++default_properties = fips=yes
+diff --git a/Lib/test/support/script_helper.py b/Lib/test/support/script_helper.py
+index 46ce950433d..7b83c8e0632 100644
+--- a/Lib/test/support/script_helper.py
++++ b/Lib/test/support/script_helper.py
+@@ -303,7 +303,14 @@ def make_zip_pkg(zip_dir, zip_basename, pkg_name, script_basename,
+ 
+ 
+ @support.requires_subprocess()
+-def run_test_script(script):
++def run_test_script(script, **kwargs):
++    """Run the file *script* in a child interpreter.
++
++    Keyword arguments are passed on to subprocess.run() within.
++
++    Asserts if the child exits non-zero.  Prints child output after
++    execution when run in verbose mode.
++    """
+     # use -u to try to get the full output if the test hangs or crash
+     if support.verbose:
+         def title(text):
+@@ -315,7 +322,7 @@ def title(text):
+         # In verbose mode, the child process inherit stdout and stdout,
+         # to see output in realtime and reduce the risk of losing output.
+         args = [sys.executable, "-E", "-X", "faulthandler", "-u", script, "-v"]
+-        proc = subprocess.run(args)
++        proc = subprocess.run(args, **kwargs)
+         print(title(f"{name} completed: exit code {proc.returncode}"),
+               flush=True)
+         if proc.returncode:
+diff --git a/Lib/test/test_hashlib.py b/Lib/test/test_hashlib.py
+index 575b2cd0da7..f1ff7c33004 100644
+--- a/Lib/test/test_hashlib.py
++++ b/Lib/test/test_hashlib.py
+@@ -21,6 +21,7 @@
+ from test.support.import_helper import import_fresh_module
+ from test.support import os_helper
+ from test.support import requires_resource
++from test.support import script_helper
+ from test.support import threading_helper
+ from http.client import HTTPException
+ 
+@@ -1196,6 +1197,18 @@ def test_file_digest(self):
+             with open(os_helper.TESTFN, "wb") as f:
+                 hashlib.file_digest(f, "sha256")
+ 
++    def test_builtins_in_openssl_fips_mode(self):
++        try:
++            from _hashlib import get_fips_mode
++        except ImportError:
++            self.skipTest('OpenSSL _hashlib not available')
++        from test import _test_hashlib_fips
++        child_test_path = _test_hashlib_fips.__file__
++        env = os.environ.copy()
++        # A config to mock FIPS mode, see _test_hashlib_fips.py.
++        env["OPENSSL_CONF"] = os.path.join(os.path.dirname(__file__), "hashlibdata", "openssl.cnf")
++        script_helper.run_test_script(child_test_path, env=env)
++
+ 
+ if __name__ == "__main__":
+     unittest.main()
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 8d94ba361fd..908717f1791 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -2447,6 +2447,7 @@ TESTSUBDIRS=	idlelib/idle_test \
+ 		test/decimaltestdata \
+ 		test/dtracedata \
+ 		test/encoded_modules \
++		test/hashlibdata \
+ 		test/leakers \
+ 		test/libregrtest \
+ 		test/mathdata \
+diff --git a/Misc/NEWS.d/next/Library/2024-11-26-16-31-40.gh-issue-127298.jqYJvn.rst b/Misc/NEWS.d/next/Library/2024-11-26-16-31-40.gh-issue-127298.jqYJvn.rst
+new file mode 100644
+index 00000000000..e555661a195
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2024-11-26-16-31-40.gh-issue-127298.jqYJvn.rst
+@@ -0,0 +1,8 @@
++:mod:`hashlib`'s builtin hash implementations now check ``usedforsecurity=False``,
++when the OpenSSL library default provider is in OpenSSL's FIPS mode.  This helps
++ensure that only US FIPS approved implementations are in use by default on systems
++configured as such.
++
++This is only active when :mod:`hashlib` has been built with OpenSSL implementation
++support and said OpenSSL library includes the FIPS mode feature.  Not all variants
++do, and OpenSSL is not a *required* build time dependency of ``hashlib``.

--- a/python-3.14/version-check.py
+++ b/python-3.14/version-check.py
@@ -1,0 +1,12 @@
+import sys
+
+info = sys.version_info
+found = "%s.%s.%s" % (info.major, info.minor, info.micro)
+
+if len(sys.argv) > 1:
+    expected = sys.argv[1]
+    if found != expected:
+        print("ERROR: expected version '%s' found '%s'" % (expected, found))
+        sys.exit(1)
+
+print("python version: " + found)


### PR DESCRIPTION
DNM due to potential need to clean up patches, and we want to provide a GIL-less version as well.