### PR TITLE
bumping fluent-operator version to resolve build failures

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: "3.4.0"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4 # CVE-2025-47907
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -63,7 +63,7 @@ subpackages:
         # When this test fails, that likely means fluent-bit rolled forward to
         # a new version stream anad must be updated in the "replaces" block
         # below
-        - fluent-bit-4.0
+        - fluent-bit-4.1
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/fluent-bit/etc


### PR DESCRIPTION
logs from the fluent-bit container
```
E1007 19:55:32.440894      22 pod_workers.go:1324] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"fluent-bit\" with ImagePullBackOff: \"Back-off pulling image \\\"k3d-k3d.localhost:5005/fluent-bit-watcher:unused@sha256:3e2fef7193bf7d7bcab8fdab7fa7c6e71f106ecb8b7dbf07bc96a729c3cc0eae\\\": ErrImagePull: failed to pull and unpack image \\\"k3d-k3d.localhost:5005/fluent-bit-watcher@sha256:3e2fef7193bf7d7bcab8fdab7fa7c6e71f106ecb8b7dbf07bc96a729c3cc0eae\\\": failed to resolve reference \\\"k3d-k3d.localhost:5005/fluent-bit-watcher@sha256:3e2fef7193bf7d7bcab8fdab7fa7c6e71f106ecb8b7dbf07bc96a729c3cc0eae\\\": failed to do request: Head \\\"https://k3d-k3d.localhost:5005/v2/fluent-bit-watcher/manifests/sha256:3e2fef7193bf7d7bcab8fdab7fa7c6e71f106ecb8b7dbf07bc96a729c3cc0eae\\\": dial tcp: lookup k3d-k3d.localhost: no such host\"" pod="fluent-bit/fluent-bit-xpl66" podUID="79fa1a42-3944-43a4-8241-b589f7a5319b"
```

make image-debug/ output
```
│ Error: failed to test feature: Basic
│ 
│   with module.fluent-bit-watcher.module.test-fluent-watcher-versioned["fluent-watcher"].imagetest_feature.basic,
│   on images/fluent-bit-watcher/tests/main.tf line 84, in resource "imagetest_feature" "basic":
│   84: resource "imagetest_feature" "basic" {
│ 
│ assessment step 'wait for fluent-bit to start' failed:
│ Error executing command (exit code 1)
│ 
│ Command:
│ 	kubectl rollout status daemonset/fluent-bit -n fluent-bit --timeout=120s
│ 
│ Output (stdout/stderr):
│ 	Waiting for daemon set "fluent-bit" rollout to finish: 0 of 1 updated pods are available...
│ 	error: timed out waiting for the condition
│ 
╵
╷
│ Error: failed to test feature: Basic
│ 
│   with module.fluent-bit-watcher.module.test-fluentbit-compliance["fluent-watcher"].imagetest_feature.basic,
│   on images/fluent-bit/tests/main.tf line 119, in resource "imagetest_feature" "basic":
│  119: resource "imagetest_feature" "basic" {
│ 
│ assessment step 'wait until fluent-bit is up and running' failed:
│ Error executing command (exit code 1)
│ 
│ Command:
│ 	kubectl -n fluent-bit rollout status daemonset/fluent-bit --timeout=120s
│ 
│ Output (stdout/stderr):
│ 	Waiting for daemon set "fluent-bit" rollout to finish: 0 of 1 updated pods are available...
│ 	error: timed out waiting for the condition
│ 
```

Likely needs https://github.com/fluent/fluent-operator/pull/1715 patch to chart