### PR TITLE
php-8.*: use external pcre

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.33"
-  epoch: 4
+  epoch: 5
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -50,6 +50,7 @@ environment:
       - openldap-dev
       - openssl-dev
       - patch
+      - pcre2-dev
       - postgresql-dev
       - re2c
       - readline-dev
@@ -99,24 +100,24 @@ pipeline:
         --enable-fpm \
         --with-pear \
         --enable-gd=shared \
-            --with-avif \
-            --with-freetype \
-            --with-jpeg \
-            --with-webp \
-            --with-xpm \
-            --disable-gd-jis-conv \
+        --with-avif \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+        --disable-gd-jis-conv \
         --with-libxml \
         --enable-phar=shared \
         --enable-mbstring=shared \
-      	--with-mysqli=shared \
-            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --with-mysqli=shared \
+        --with-mysql-sock=/run/mysqld/mysqld.sock \
         --enable-mysqlnd=shared \
         --enable-pdo=shared \
-            --with-pdo-mysql=shared,mysqlnd \
-            --with-pdo-sqlite=shared \
-            --with-pdo-dblib=shared \
-            --with-pdo-pgsql=shared \
-            --with-pdo-odbc=shared,unixODBC,/usr \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-pdo-sqlite=shared \
+        --with-pdo-dblib=shared \
+        --with-pdo-pgsql=shared \
+        --with-pdo-odbc=shared,unixODBC,/usr \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -142,7 +143,8 @@ pipeline:
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
         --with-apxs2=/usr/bin/apxs \
-        --enable-phpdbg=shared
+        --enable-phpdbg=shared \
+        --with-external-pcre
 
   - uses: autoconf/make
 

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.29"
-  epoch: 3
+  epoch: 4
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -52,6 +52,7 @@ environment:
       - openldap-dev
       - openssl-dev
       - patch
+      - pcre2-dev
       - postgresql-dev
       - re2c
       - readline-dev
@@ -94,24 +95,24 @@ pipeline:
         --enable-fpm \
         --with-pear \
         --enable-gd=shared \
-            --with-avif \
-            --with-freetype \
-            --with-jpeg \
-            --with-webp \
-            --with-xpm \
-            --disable-gd-jis-conv \
+        --with-avif \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+        --disable-gd-jis-conv \
         --with-libxml \
         --enable-phar=shared \
         --enable-mbstring=shared \
-      	--with-mysqli=shared \
-            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --with-mysqli=shared \
+        --with-mysql-sock=/run/mysqld/mysqld.sock \
         --enable-mysqlnd=shared \
         --enable-pdo=shared \
-            --with-pdo-mysql=shared,mysqlnd \
-            --with-pdo-sqlite=shared \
-            --with-pdo-dblib=shared \
-            --with-pdo-pgsql=shared \
-            --with-pdo-odbc=shared,unixODBC,/usr \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-pdo-sqlite=shared \
+        --with-pdo-dblib=shared \
+        --with-pdo-pgsql=shared \
+        --with-pdo-odbc=shared,unixODBC,/usr \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -137,7 +138,8 @@ pipeline:
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
         --with-apxs2=/usr/bin/apxs \
-        --enable-phpdbg=shared
+        --enable-phpdbg=shared \
+        --with-external-pcre
 
   - uses: autoconf/make
 

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.26"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -57,6 +57,7 @@ environment:
       - oniguruma-dev
       - openldap-dev
       - openssl-dev
+      - pcre2-dev
       - postgresql-dev
       - re2c
       - readline-dev
@@ -99,24 +100,24 @@ pipeline:
         --enable-fpm \
         --with-pear \
         --enable-gd=shared \
-            --with-avif \
-            --with-freetype \
-            --with-jpeg \
-            --with-webp \
-            --with-xpm \
-            --disable-gd-jis-conv \
+        --with-avif \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+        --disable-gd-jis-conv \
         --with-libxml \
         --enable-phar=shared \
         --enable-mbstring=shared \
-      	--with-mysqli=shared \
-            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --with-mysqli=shared \
+        --with-mysql-sock=/run/mysqld/mysqld.sock \
         --enable-mysqlnd=shared \
         --enable-pdo=shared \
-            --with-pdo-mysql=shared,mysqlnd \
-            --with-pdo-sqlite=shared \
-            --with-pdo-dblib=shared \
-            --with-pdo-pgsql=shared \
-            --with-pdo-odbc=shared,unixODBC,/usr \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-pdo-sqlite=shared \
+        --with-pdo-dblib=shared \
+        --with-pdo-pgsql=shared \
+        --with-pdo-odbc=shared,unixODBC,/usr \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -142,7 +143,8 @@ pipeline:
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
         --with-apxs2=/usr/bin/apxs \
-        --enable-phpdbg=shared
+        --enable-phpdbg=shared \
+        --with-external-pcre
 
   - uses: autoconf/make
 

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.13"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -57,6 +57,7 @@ environment:
       - oniguruma-dev
       - openldap-dev
       - openssl-dev
+      - pcre2-dev
       - postgresql-dev
       - re2c
       - readline-dev
@@ -99,24 +100,24 @@ pipeline:
         --enable-fpm \
         --with-pear \
         --enable-gd=shared \
-            --with-avif \
-            --with-freetype \
-            --with-jpeg \
-            --with-webp \
-            --with-xpm \
-            --disable-gd-jis-conv \
+        --with-avif \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+        --disable-gd-jis-conv \
         --with-libxml \
         --enable-phar=shared \
         --enable-mbstring=shared \
-      	--with-mysqli=shared \
-            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --with-mysqli=shared \
+        --with-mysql-sock=/run/mysqld/mysqld.sock \
         --enable-mysqlnd=shared \
         --enable-pdo=shared \
-            --with-pdo-mysql=shared,mysqlnd \
-            --with-pdo-sqlite=shared \
-            --with-pdo-dblib=shared \
-            --with-pdo-pgsql=shared \
-            --with-pdo-odbc=shared,unixODBC,/usr \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-pdo-sqlite=shared \
+        --with-pdo-dblib=shared \
+        --with-pdo-pgsql=shared \
+        --with-pdo-odbc=shared,unixODBC,/usr \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -142,7 +143,8 @@ pipeline:
         --enable-sysvsem=shared \
         --enable-sysvshm=shared \
         --with-apxs2=/usr/bin/apxs \
-        --enable-phpdbg=shared
+        --enable-phpdbg=shared \
+        --with-external-pcre
 
   - uses: autoconf/make
 


### PR DESCRIPTION
This updates our php builds to use the system version of pcre, pcre2 in particular. This should update the package to have a new dep on the pcre2 so. I also indented a few lines to be consistent.