### PR TITLE
libmamba: unpin -dev packages for builds

### DIFF
--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmamba
   version: "2.3.2"
-  epoch: 2
+  epoch: 3
   description: Cross-Platform Package Manager
   copyright:
     - license: BSD-3-Clause
@@ -30,8 +30,7 @@ environment:
       - cmake
       - curl-dev
       - doctest
-      - fmt-dev<11.2.0-r0
-      - fmt<11.2.0-r0
+      - fmt-dev
       - gcc-14-default
       - libarchive-dev
       - libsolv-dev
@@ -48,8 +47,7 @@ environment:
       - reproc++
       - samurai
       - simdjson-dev
-      - spdlog-dev<1.15.3-r2
-      - spdlog<1.15.3-r2
+      - spdlog-dev
       - tl-expected
       - yaml-cpp-dev
       - zstd-dev


### PR DESCRIPTION
These are no longer required and pin old versions of fmt into the
archive.
