### PR TITLE
fmt: use shared library naming policy

### DIFF
--- a/fmt.yaml
+++ b/fmt.yaml
@@ -1,7 +1,7 @@
 package:
   name: fmt
   version: "12.0.0"
-  epoch: 0
+  epoch: 1
   description: Modern formatting library
   copyright:
     - license: MIT
@@ -13,6 +13,12 @@ environment:
       - busybox
       - ca-certificates-bundle
       - make
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\..*$
+    replace: ${1}
+    to: soversion
 
 pipeline:
   - uses: git-checkout
@@ -35,6 +41,15 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: lib${{package.name}}${{vars.soversion}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
@@ -43,7 +58,7 @@ subpackages:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
           with:
-            packages: fmt-dev
+            packages: ${{package.name}}-dev
 
 update:
   enabled: true
@@ -54,7 +69,7 @@ test:
   environment:
     contents:
       packages:
-        - fmt-dev
+        - ${{package.name}}-dev
         - gcc
         - glibc-dev
   pipeline:


### PR DESCRIPTION
fmt: use shared library naming policy
    
Move libraries into a new soversion name lib package to support
co-installation with future new soversions.
    
The soversion for fmt is derived from the major version part of the
package version.
    
This will ease future transitions.
