### PR TITLE
nasm: remove unused sed

### DIFF
--- a/nasm.yaml
+++ b/nasm.yaml
@@ -1,7 +1,7 @@
 package:
   name: nasm
   version: "3.00"
-  epoch: 0
+  epoch: 1
   description: 80x86 assembler designed for portability and modularity
   copyright:
     - license: BSD-2-Clause
@@ -27,10 +27,6 @@ pipeline:
       tag: nasm-${{package.version}}
       cherry-picks: |
         master/a65be7d59b6beeffd1447ae662823e926ee1a45a: bytesex.h fix typo in le32toh function name
-
-  - runs: |
-      # Fix typo in endian helper: l32toh -> le32toh
-      sed -i 's/\<l32toh\>/le32toh/g' include/bytesex.h
 
   - runs: ./autogen.sh
 


### PR DESCRIPTION
I meant to remove the sed in PR https://github.com/wolfi-dev/os/pull/68055
Now I am removing it because the cherry-pick introduced in the PR fixes
the issue.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
