### PR TITLE
py3-gobject3: enable auto updates

### DIFF
--- a/py3-gobject3.yaml
+++ b/py3-gobject3.yaml
@@ -96,4 +96,5 @@ subpackages:
         - uses: test/metapackage
 
 update:
+  enabled: true
   git: {}


### PR DESCRIPTION
There were disabled for unknown reasons.

Checking manually, they seem to work once enabled.

See also: https://github.com/chainguard-dev/internal-dev/issues/13693

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
