### PR TITLE
py3-mwoauth: update to version 0.3.0

### DIFF
--- a/py3-mwoauth.yaml
+++ b/py3-mwoauth.yaml
@@ -1,9 +1,7 @@
 package:
   name: py3-mwoauth
-  # Upstream released v0.4.0 on PyPI, but no source tarball was uploaded. Also repository does not provide neither tags nor releases for 0.4.0.
-  # TODO: Use semver and enable `update`, once the issue is resolved: https://github.com/mediawiki-utilities/python-mwoauth/issues/50
-  version: 0.0_git20231018
-  epoch: 4
+  version: 0.3.0
+  epoch: 0
   description: A generic MediaWiki OAuth handshake helper.
   copyright:
     - license: MIT
@@ -29,11 +27,11 @@ environment:
       - py3-supported-build-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/mediawiki-utilities/python-mwoauth/archive/${{vars.commit}}.tar.gz
-      expected-sha256: de31a42aae05d86fb8d02c0523556281a46da364f19c1b0d4386eb8a14b4b8f5
-      strip-components: 1
+      repository: https://github.com/mediawiki-utilities/python-mwoauth
+      tag: v${{package.version}}
+      expected-commit: bd01c0501e345de62b6623cd112ee04d6a7c934e
 
 subpackages:
   - range: py-versions
@@ -48,6 +46,7 @@ subpackages:
         - py${{range.key}}-oauthlib
         - py${{range.key}}-requests
         - py${{range.key}}-requests-oauthlib
+        - py${{range.key}}-six
     pipeline:
       - uses: py/pip-build-install
         with:
@@ -81,5 +80,7 @@ test:
           import ${{vars.import}}
 
 update:
-  enabled: false
-  exclude-reason: No releases or tags since 2017. But last commit was made in 2023.
+  enabled: true
+  github:
+    identifier: mediawiki-utilities/python-mwoauth
+    strip-prefix: v


### PR DESCRIPTION
And enable auto-updates.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
