### PR TITLE
clang-18-dev -> clang-18

### DIFF
--- a/calico-3.30.yaml
+++ b/calico-3.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.30
   version: "3.30.3"
-  epoch: 3 # GHSA-2464-8j7c-4cjm
+  epoch: 3
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0

--- a/calico-3.30.yaml
+++ b/calico-3.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.30
   version: "3.30.3"
-  epoch: 2 # GHSA-2464-8j7c-4cjm
+  epoch: 3 # GHSA-2464-8j7c-4cjm
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -37,7 +37,6 @@ environment:
       - ca-certificates-bundle
       # - llvm18-tools
       - clang-18
-      - clang-18-dev
       # TODO: Can remove this when cni-plugins are built from source
       - curl
       # for felix

--- a/envoy-1.35.yaml
+++ b/envoy-1.35.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy-1.35
   version: "1.35.3"
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-18
-      - clang-18-dev
       - cmake
       - coreutils
       - git

--- a/istio-envoy-1.27.yaml
+++ b/istio-envoy-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.27
   version: "1.27.1"
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-18
-      - clang-18-dev
       - cmake
       - coreutils
       - git

--- a/uutils.yaml
+++ b/uutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: uutils
   version: "0.2.2"
-  epoch: 0
+  epoch: 1
   description: "Cross-platform Rust rewrite of the GNU coreutils."
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ environment:
       - build-base
       - ca-certificates-bundle
       - cargo-auditable
-      - clang-18-dev
+      - clang-18
       - libselinux-dev
       - rust
       - wolfi-base


### PR DESCRIPTION
clang-18-dev was a provides in older clang-18 package versions; this is
no longer required and is keeping an older clang-18 package version
pinned into the archive.
