### PR TITLE
Switch multiple packages to using tw's help-check

### DIFF
--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -1,7 +1,7 @@
 package:
   name: zeromq
   version: 4.3.5
-  epoch: 6
+  epoch: 7
   description: The ZeroMQ messaging library and tools
   copyright:
     - license: MPL-2.0
@@ -108,5 +108,6 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-    - name: Test help commands
-      runs: curve_keygen --help
+    - uses: test/tw/help-check
+      with:
+        bins: curve_keygen

--- a/zfs.yaml
+++ b/zfs.yaml
@@ -2,7 +2,7 @@
 package:
   name: zfs
   version: "2.3.4"
-  epoch: 0
+  epoch: 1
   description: Advanced filesystem and volume manager
   copyright:
     - license: CDDL-1.0
@@ -157,12 +157,7 @@ test:
       with:
         bins: zed
     - name: Test help commands
-      runs: |-
-        zfs --help
-        zpool --help
-        ztest --help
-        fsck.zfs --help
-        raidz_test -h
-        zed -h
-        zed help
+    - uses: test/tw/help-check
+      with:
+        bins: raidz_test zed zfs zpool ztest
     - uses: test/tw/ldd-check

--- a/zig.yaml
+++ b/zig.yaml
@@ -1,7 +1,7 @@
 package:
   name: zig
   version: "0.15.1"
-  epoch: 0
+  epoch: 1
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
     - license: MIT
@@ -78,9 +78,12 @@ test:
         repository: https://github.com/ziglang/zig
         tag: ${{package.version}}
         expected-commit: 3db960767d12b6214bcf43f1966a037c7a586a12
-    - working-directory: test/
-      runs: |
-        zig --help
-        zig version
+    - uses: test/tw/help-check
+      with:
+        bins: zig
+    - uses: test/tw/ver-check
+      with:
+        bins: zig
+    - runs: |
         # excluding c_import tests for now
         for file in *.zig; do [ "$file" != "c_import.zig" ] && zig test "$file"; done

--- a/zip.yaml
+++ b/zip.yaml
@@ -1,7 +1,7 @@
 package:
   name: zip
   version: 3.0
-  epoch: 7
+  epoch: 8
   description: Creates PKZIP-compatible .zip files
   copyright:
     - license: Info-ZIP
@@ -50,12 +50,9 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zip zipcloak zipnote zipsplit
-    - name: Test help commands
-      runs: |-
-        zip --help
-        zipcloak --help
-        zipnote -h
-        zipsplit -h
+    - uses: test/tw/help-check
+      with:
+        bins: zip zipcloak zipnote zipsplit
     - name: Basic zip creation test
       runs: |
         # Create test files

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,7 +1,7 @@
 package:
   name: zizmor
   version: "1.14.2"
-  epoch: 0 # GHSA-xwfj-jgwm-7wp5
+  epoch: 1 # GHSA-xwfj-jgwm-7wp5
   description: "A static analysis tool for GitHub Actions"
   copyright:
     - license: MIT
@@ -32,5 +32,6 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zizmor
-    - name: Test help commands
-      runs: zizmor --help
+    - uses: test/tw/help-check
+      with:
+        bins: zizmor

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,7 +1,7 @@
 package:
   name: zizmor
   version: "1.14.2"
-  epoch: 1 # GHSA-xwfj-jgwm-7wp5
+  epoch: 1
   description: "A static analysis tool for GitHub Actions"
   copyright:
     - license: MIT

--- a/zola.yaml
+++ b/zola.yaml
@@ -1,7 +1,7 @@
 package:
   name: zola
   version: "0.21.0"
-  epoch: 4 # GHSA-mm7x-qfjj-5g2c
+  epoch: 5 # GHSA-mm7x-qfjj-5g2c
   description: A fast static site generator in a single binary with everything built-in
   copyright:
     - license: MIT
@@ -34,5 +34,6 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zola
-    - name: Test help commands
-      runs: zola --help
+    - uses: test/tw/help-check
+      with:
+        bins: zola

--- a/zola.yaml
+++ b/zola.yaml
@@ -1,7 +1,7 @@
 package:
   name: zola
   version: "0.21.0"
-  epoch: 5 # GHSA-mm7x-qfjj-5g2c
+  epoch: 5
   description: A fast static site generator in a single binary with everything built-in
   copyright:
     - license: MIT

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: "2.1.8"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,6 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zli zot
-    - name: Test help commands
-      runs: |-
-        zli --help
-        zot --help
+    - uses: test/tw/help-check
+      with:
+        bins: zli zot

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: "2.1.8"
-  epoch: 2 # CVE-2025-47910
+  epoch: 2
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0

--- a/zoxide.yaml
+++ b/zoxide.yaml
@@ -1,7 +1,7 @@
 package:
   name: zoxide
   version: "0.9.8"
-  epoch: 1
+  epoch: 2
   description: "A smarter cd command. Supports all major shells."
   copyright:
     - license: MIT
@@ -75,5 +75,6 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zoxide
-    - name: Test help commands
-      runs: zoxide --help
+    - uses: test/tw/help-check
+      with:
+        bins: zoxide

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 31
+  epoch: 32
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only
@@ -152,9 +152,8 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: zsh zsh-5.9
-    - name: Test help commands
-      runs: |-
-        zsh --help
-        zsh-5.9 --help
+    - uses: test/tw/help-check
+      with:
+        bins: zsh zsh-5.9
     - uses: test/tw/ldd-check
     - uses: test/no-docs

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: "1.5.7"
-  epoch: 3
+  epoch: 4
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -84,10 +84,6 @@ test:
     - uses: test/tw/ver-check
       with:
         bins: unzstd zstd zstdcat zstdmt
-    - name: Test help commands
-      runs: |-
-        unzstd --help
-        zstd --help
-        zstdcat --help
-        zstdless --help
-        zstdmt --help
+    - uses: test/tw/help-check
+      with:
+        bins: unzstd zstd zstdcat zstdless zstdmt


### PR DESCRIPTION
`fsck.zfs --help` didn't actually do anything and caused the help-check test to fail, so I dropped it.