### PR TITLE
php-8.*-apcu: build against the new library.

### DIFF
--- a/php-8.1-apcu.yaml
+++ b/php-8.1-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-apcu
   version: "5.1.27"
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -22,6 +22,7 @@ environment:
       - autoconf
       - build-base
       - busybox
+      - pcre2-dev
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-dev
 

--- a/php-8.2-apcu.yaml
+++ b/php-8.2-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-apcu
   version: "5.1.27"
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -22,6 +22,7 @@ environment:
       - autoconf
       - build-base
       - busybox
+      - pcre2-dev
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-dev
 

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-apcu
   version: "5.1.27"
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -22,6 +22,7 @@ environment:
       - autoconf
       - build-base
       - busybox
+      - pcre2-dev
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-dev
 


### PR DESCRIPTION
We updated php-8.* to build against pcre2 in: https://github.com/wolfi-dev/os/pull/68308

This caused a failure for apcu as it tries to use the library that it wasn't built against. This add the new pcre2-dev dep for building apcu.

This is the only package that display this as an immediate issue that i've found that cause displays this issue. The tests do ensure extensions are loaded.  You can quickly run the tests in a repo which something like this:

```
for file in (ag -Ql 'php-${{vars.phpMM}}-dev' php-8.3*.yaml)
    set package (path change-extension '' $file)
    if not make test/$package
        echo $package >> failed
    end
end
```