### PR TITLE
feat(logstash-9.1): bump dep to remediate GHSA-wpv5-97wm-hp9c, GHSA-w9pc-fmgc-vxvw and GHSA-p543-xpfm-54cp

### DIFF
--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -104,6 +104,8 @@ pipeline:
       sed -i "s/rexml (>= 3\.3\.9)/rexml (>= 3.4.2)/" "Gemfile.jruby-3.1.lock.release"
       # Fix GHSA-p543-xpfm-54cp, GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
       sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
+      echo "gem 'rack', '3.1.17'" >> Gemfile.template
+
 
       for plugin in ${{vars.separately-packaged-plugins}}
       do

--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.1
   version: "9.1.5"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -102,6 +102,8 @@ pipeline:
       sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"
       # Fix GHSA-c2f4-jgmc-q2r5
       sed -i "s/rexml (>= 3\.3\.9)/rexml (>= 3.4.2)/" "Gemfile.jruby-3.1.lock.release"
+      # Fix GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
+      sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
 
       for plugin in ${{vars.separately-packaged-plugins}}
       do

--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -102,7 +102,7 @@ pipeline:
       sed -i "s/'date', '>= 3.3.3'/'date', '>= 3.4.1'/" "Gemfile.template"
       # Fix GHSA-c2f4-jgmc-q2r5
       sed -i "s/rexml (>= 3\.3\.9)/rexml (>= 3.4.2)/" "Gemfile.jruby-3.1.lock.release"
-      # Fix GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
+      # Fix GHSA-p543-xpfm-54cp, GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
       sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
 
       for plugin in ${{vars.separately-packaged-plugins}}

--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -221,10 +221,6 @@ subpackages:
         with:
           image: logstash
           version-path: ${{vars.major-minor-version}}/debian-12
-      - uses: patch
-        working-directory: "${{targets.contextdir}}"
-        with:
-          patches: /home/build/bitnami-semantic-version.patch
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/logstash
           mkdir -p ${{targets.contextdir}}/opt/bitnami/logstash/pipeline


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

## Summary

Bump Rack dependency from 3.1.16 to 3.1.17 to remediate three high-severity vulnerabilities in Rack's multipart parser:

- **GHSA-wpv5-97wm-hp9c**: Unbounded memory accumulation when multipart header blocks never terminate
- **GHSA-w9pc-fmgc-vxvw**: Non-file form fields stored entirely in memory as String objects
- **GHSA-p543-xpfm-54cp**: Multipart preamble buffered in memory without size limits

All three vulnerabilities allow attackers to cause denial of service through memory exhaustion. The fix updates Rack to version 3.1.17 which adds proper size limits to multipart parsing operations.

## Changes

- Updated Rack version constraint in `Gemfile.jruby-3.1.lock.release` from `>= 3.1.16` to `>= 3.1.17`
- Added explicit Rack 3.1.17 requirement to `Gemfile.template`
- Incremented epoch to 1

<!--ci-cve-scan:fail-any-->