### PR TITLE
GHSA mm7p fcc7 pg87

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 3 # GHSA-33vc-wfww-vjfv
+  epoch: 4 # GHSA-mm7p-fcc7-pg87
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/consolidated-cve-remedation.patch
+++ b/jitsucom-jitsu/consolidated-cve-remedation.patch
@@ -1,20 +1,8 @@
-From 34a809ac6aca7f8c190c36de1a05a230101a2509 Mon Sep 17 00:00:00 2001
-From: Kyle Steere <kyle.steere@chainguard.dev>
-Date: Thu, 5 Jun 2025 20:29:20 -0500
-Subject: [PATCH] consolidated cve remedation patches: CVE-2025-48387
- CVE-2025-22150 CVE-2025-27152 CVE-2025-27789 CVE-2024-53382 GHSA-fjxv-7rqg-78g4
- GHSA-xv57-4mr9-wg8v GHSA-g5qg-72qw-gw5v GHSA-4342-x723-ch2f
-
-Signed-off-by: Kyle Steere <kyle.steere@chainguard.dev>
----
- package.json | 9 ++++++++-
- 1 file changed, 8 insertions(+), 1 deletion(-)
-
 diff --git a/package.json b/package.json
-index a63735238..f631cd555 100644
+index 061b7fefd..c9cbffdc7 100644
 --- a/package.json
 +++ b/package.json
-@@ -66,5 +66,14 @@
+@@ -86,5 +86,15 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -27,8 +15,7 @@ index a63735238..f631cd555 100644
 +    "tar-fs": "^2.1.3",
 +    "prismjs": "^1.30.0",
 +    "form-data": "^4.0.4",
++    "nodemailer": "^7.0.7",
 +    "next": "^15.4.7"
 +  }
  }
---
-2.43.0


### PR DESCRIPTION
- **neo4j-2025.09: updated**
- **neo4j-2025.09: updated patch directory**
- **Updated commits and tags**
- **Garbage Collection - 9th October 2025**
- **Retain most recent py3-pip 24.2**
- **nasm: remove unused sed**
- **qemu/10.1.1 package update**
- **w3m: withdraw untagged version**
- **dgraph/25.0.0 package update**
- **dgraph: fix make invocation**
- **py3-gobject3: enable auto updates**
- **ncurses: housekeeping**
- **clang-18-dev -> clang-18**
- **freetype-dev-2.13.3-r0.apk: withdraw**
- **rtmpdump/2.6_git20251008 package update**
- **reflex/0.8.14 package update**
- **reflex: remove spurious requirements.txt generation/installation**
- **snyk-cli/1.1300.0 package update (#68346)**
- **openssh/10.1_p1 package update (#68110)**
- **coredns: version stream (#68155)**
- **Retain cassandra-4.1 as well (C3.ai)**
- **Don't purge old libxml2 - Danske Bank**
- **Add cherry-pick for glibc 855bfa256**
- **rancher-kontainer-driver-metadata-2.12/0_git20251008 package update (#68367)**
- **confluent-kafka/8.2.0.313 package update (#68360)**
- **rancher-helm3-charts/0_git20251008 package update (#68358)**
- **ddp-tool/1.0.34.0_git20251008 package update (#68366)**
- **docker/28.5.1 package update (#68365)**
- **renovate/41.142.0 package update (#68364)**
- **fluent-plugin-tag-normaliser/0_git20251008 package update (#68363)**
- **rancher-rke2-charts/0_git20251008 package update (#68356)**
- **docker-cli/28.5.1 package update (#68357)**
- **spire-server/1.13.2 package update (#68354)**
- **rancher-charts-2.12/0_git20251008 package update (#68359)**
- **rancher-system-charts-2.10/0_git20251008 package update (#68361)**
- **go-discover/0_git20251008 package update (#68352)**
- **vim/9.1.1837 package update (#68351)**
- **rancher-partner-charts/0_git20251008 package update (#68362)**
- **fluent-plugin-label-router/0.5.0_git20251008 package update (#68353)**
- **Drop GHSA reference from epoch bump**
- **ruby-3.4/3.4.7 package update**
- **ruby-3.4: update expected-commit**
- **fish/4.1.2 package update**
- **fish: update expected-commit**
- **py3-pydantic/2.12.0 package update**
- **py3-pydantic: bump to compatible py3-pydantic-core version**
- **py3-pydantic: update test expected-commit**
- **Empty withdrawn-packages first**
- **datadog-agent/7.71.1 package update (#68376)**
- **php-8.*: use external pcre (#68308)**
- **terragrunt/0.89.3 package update (#68379)**
- **temporal-ui-server/2.41.0 package update (#68371)**
- **gitlab-kas-18.4/18.4.2 package update (#68377)**
- **gitaly-18.4/18.4.2 package update (#68372)**
- **chart-testing/3.14.0 package update (#68374)**
- **flux-source-controller/1.7.2 package update (#68375)**
- **py3-gobject3/3.54.3 package update (#68373)**
- **gitlab-pages-18.4/18.4.2 package update (#68378)**
- **Restore freetype-dev-2.13.3-r0.apk**
- **Revert "Restore freetype-dev-2.13.3-r0.apk"**
- **flux-image-reflector-controller/1.0.2 package update (#68392)**
- **grafana-rollout-operator/0.30.0 package update (#68387)**
- **flux-notification-controller/1.7.3 package update (#68390)**
- **ruby3.4-rack-protection/4.2.0 package update (#68389)**
- **aws-efs-csi-driver/2.1.13 package update (#68383)**
- **py3-sqlglot/27.24.2 package update (#68386)**
- **ruby3.2-rack-protection/4.2.0 package update (#68384)**
- **checkov/3.2.477 package update (#68391)**
- **ruby3.3-rack-protection/4.2.0 package update (#68385)**
- **ruby3.2-sinatra/4.2.0 package update**
- **ruby3.2-sinatra: emit sinatra output on test exit**
- **bump deps**
- **dataplaneapi/3.2.5 package update (#68399)**
- **flux-helm-controller/1.4.2 package update (#68398)**
- **perl-specio/0.53 package update (#68396)**
- **dagger/0.19.2 package update (#68397)**
- **Updated core-integrations commit**
- **Added check to ensure integrations-core isn't out of date, refreshed patches to work with new version**
- **py3-platformdirs/4.5.0 package update (#68405)**
- **nats-box/0.19.0 package update (#68404)**
- **flux-kustomize-controller/1.7.1 package update (#68403)**
- **tshark-4.4/4.4.10 package update (#68401)**
- **Merge pull request #68381 from wolfi-dev/wolfictl-708e3d61-ad59-4587-85e7-bfd48103c7dd**
- **ruby3.3-sinatra/4.2.0 package update (#68388)**
- **Epoch bump**
- **dagger/0.19.2 package update (#68419)**
- **php-8.2-pecl-mongodb/2.1.4 package update (#68418)**
- **php-8.3-pecl-mongodb/2.1.4 package update (#68408)**
- **php-8.4-pecl-mongodb/2.1.4 package update (#68416)**
- **py3-google-cloud-storage/3.4.1 package update (#68411)**
- **flux/2.7.2 package update (#68412)**
- **py3-filelock/3.20.0 package update (#68410)**
- **librdkafka/2.12.0 package update (#68415)**
- **consul-k8s-1.7/1.7.6 package update (#68417)**
- **flux-2.7/2.7.2 package update (#68409)**
- **terraform-provider-pagerduty/3.30.2 package update (#68414)**
- **Switch multiple packages to using tw's help-check (#68400)**
- **py3-botocore/1.40.48 package update (#68427)**
- **imath/3.2.2 package update (#68426)**
- **openexr/3.4.1 package update (#68424)**
- **aws-cli-2/2.31.11 package update (#68421)**
- **py3-propcache/0.4.1 package update (#68420)**
- **py3-boto3/1.40.48 package update (#68423)**
- **zed/0.207.3 package update (#68425)**
- **npm/11.6.2 package update (#68435)**
- **nats-box/0.19.1 package update (#68434)**
- **coredns-1.13/1.13.1 package update (#68429)**
- **fluent-bit-4.1/4.1.1 package update (#68433)**
- **wasm-tools/1.240.0 package update (#68431)**
- **libdwarf/2.2.0 package update (#68430)**
- **php-8.*-apcu: build against the new library. (#68438)**
- **py3-google-api-core/2.26.0 package update (#68441)**
- **kubo/0.38.1 package update (#68440)**
- **Convert to help check batch3 (#68442)**
- **py3-matplotlib/3.10.7 package update (#68446)**
- **nodejs-24/24.10.0 package update (#68445)**
- **aws-eks-pod-identity-agent/0.1.35 package update (#68444)**
- **kine/0.14.4 package update (#68443)**
- **cluster-autoscaler-1.33/1.33.2 package update (#68449)**
- **nats-box/0.19.2 package update (#68448)**
- **go-tools/0.38.0 package update (#68451)**
- **py3-tomli/2.3.0 package update (#68450)**
- **Switch packages to using help-check (#68437)**
- **mailpit/1.27.10 package update (#68452)**
- **gperftools/tests: ensure tcmalloc libs are linked in to tests (#52897)**
- **jitsucom-jitsu: Remediate CVE**
