### PR TITLE
jitsucom-jitsu: Remediate CVE

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 3 # GHSA-33vc-wfww-vjfv
+  epoch: 4 # GHSA-mm7p-fcc7-pg87
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/consolidated-cve-remedation.patch
+++ b/jitsucom-jitsu/consolidated-cve-remedation.patch
@@ -1,20 +1,8 @@
-From 34a809ac6aca7f8c190c36de1a05a230101a2509 Mon Sep 17 00:00:00 2001
-From: Kyle Steere <kyle.steere@chainguard.dev>
-Date: Thu, 5 Jun 2025 20:29:20 -0500
-Subject: [PATCH] consolidated cve remedation patches: CVE-2025-48387
- CVE-2025-22150 CVE-2025-27152 CVE-2025-27789 CVE-2024-53382 GHSA-fjxv-7rqg-78g4
- GHSA-xv57-4mr9-wg8v GHSA-g5qg-72qw-gw5v GHSA-4342-x723-ch2f
-
-Signed-off-by: Kyle Steere <kyle.steere@chainguard.dev>
----
- package.json | 9 ++++++++-
- 1 file changed, 8 insertions(+), 1 deletion(-)
-
 diff --git a/package.json b/package.json
-index a63735238..f631cd555 100644
+index 061b7fefd..c9cbffdc7 100644
 --- a/package.json
 +++ b/package.json
-@@ -66,5 +66,14 @@
+@@ -86,5 +86,15 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -27,8 +15,7 @@ index a63735238..f631cd555 100644
 +    "tar-fs": "^2.1.3",
 +    "prismjs": "^1.30.0",
 +    "form-data": "^4.0.4",
++    "nodemailer": "^7.0.7",
 +    "next": "^15.4.7"
 +  }
  }
---
-2.43.0


### PR DESCRIPTION
Remediate GHSA-mm7p-fcc7-pg87 by bumping nodemailer

Bump nodemailer dependency to ^7.0.7 to address email parsing
vulnerability where quoted local-parts containing @ are incorrectly
handled, leading to potential email misrouting.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->
