### PR TITLE
fix(flannel): bypass br-netfilter check for aarch64 CI tests

### DIFF
--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,6 +1,6 @@
 package:
   name: flannel
-  version: "0.27.3"
+  version: "0.27.4"
   epoch: 0 # CVE-2025-47907
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
@@ -29,7 +29,11 @@ pipeline:
     with:
       repository: https://github.com/flannel-io/flannel
       tag: v${{package.version}}
-      expected-commit: b243632fbf70280bc46b949d9ea5ace5d91ef105
+      expected-commit: 20bdda0b238784fbfa623a1cf4c469645f531efa
+
+  - uses: patch
+    with:
+      patches: disableBrNetfilterCheck.patch
 
   - uses: go/build
     with:
@@ -112,8 +116,13 @@ test:
         sleep 3
 
         # Run flanneld in background
-        flanneld --etcd-endpoints=$ETCD_ENDPOINTS --iface=$IFACE --iptables-forward-rules=false > /tmp/flannel.log 2>&1 &
-        FLANNEL_PID=$!
+        if [ "${{build.arch}}" = "aarch64" ]; then
+          flanneld --etcd-endpoints=$ETCD_ENDPOINTS --iface=$IFACE --iptables-forward-rules=false --disable-br-netfilter-check > /tmp/flannel.log 2>&1 &
+          FLANNEL_PID=$!
+        else
+          flanneld --etcd-endpoints=$ETCD_ENDPOINTS --iface=$IFACE --iptables-forward-rules=false > /tmp/flannel.log 2>&1 &
+          FLANNEL_PID=$!
+        fi
 
         # Save PID to environment file
         echo "export FLANNEL_PID=$FLANNEL_PID" >> /tmp/env.sh

--- a/flannel/disableBrNetfilterCheck.patch
+++ b/flannel/disableBrNetfilterCheck.patch
@@ -1,0 +1,47 @@
+From b1b4adec167ad515754061b27428449d3c9a39de Mon Sep 17 00:00:00 2001
+From: Debasish Biswas <debasishbsws.dev@gmail.com>
+Date: Thu, 9 Oct 2025 08:41:15 +0000
+Subject: [PATCH] feat: add --disable-br-netfilter-check flag for container
+ environments
+
+This change adds a new command-line flag --disable-br-netfilter-check to address
+compatibility issues in containerized environments, particularly for CI/CD pipelines test
+using Docker runners on aarch64 architecture.
+
+Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>
+---
+ main.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/main.go b/main.go
+index 6f40c4d2..d29ac68b 100644
+--- a/main.go
++++ b/main.go
+@@ -98,6 +98,7 @@ type CmdLineOpts struct {
+ 	blackholeRoute            bool
+ 	netConfPath               string
+ 	setNodeNetworkUnavailable bool
++	disableBrNetfilterCheck   bool
+ }
+ 
+ var (
+@@ -136,6 +137,7 @@ func init() {
+ 	flannelFlags.BoolVar(&opts.blackholeRoute, "ip-blackhole-route", false, "add blackroute route ont the node for the local podCIDR")
+ 	flannelFlags.StringVar(&opts.netConfPath, "net-config-path", "/etc/kube-flannel/net-conf.json", "path to the network configuration file")
+ 	flannelFlags.BoolVar(&opts.setNodeNetworkUnavailable, "set-node-network-unavailable", true, "set NodeNetworkUnavailable after ready")
++	flannelFlags.BoolVar(&opts.disableBrNetfilterCheck, "disable-br-netfilter-check", false, "disable br_netfilter module check (useful for Docker environments)")
+ 
+ 	log.InitFlags(nil)
+ 
+@@ -271,7 +273,7 @@ func main() {
+ 		os.Exit(1)
+ 	}
+ 
+-	if runtime.GOOS != "windows" {
++	if runtime.GOOS != "windows" && !opts.disableBrNetfilterCheck {
+ 		// From Kubernetes 1.30 kubeadm doesn't check if the br_netfilter module is loaded and in case it's missing Flannel wrongly starts
+ 		if config.EnableIPv4 {
+ 			if _, err = os.Stat("/proc/sys/net/bridge/bridge-nf-call-iptables"); os.IsNotExist(err) {
+-- 
+2.51.0
+


### PR DESCRIPTION
This patch adds a fix for the aarch64 test failures by bypassing the upstream br_netfilter check in Flannel's main.go, which causes issues in our CI Docker runner.

Flannel performs a runtime check to verify if the br_netfilter kernel module is loaded: https://github.com/flannel-io/flannel/blob/c2afcd3b6892fe0e08ae0c7631bb752a335472da/main.go#L274-L288

While this check passes on x86 (QEMU-based) runners, it fails on aarch64 where we use Docker-based runners. The log message shows:
  'main.go:278] Failed to check br_netfilter: stat /proc/sys/net/bridge/bridge-nf-call-iptables: no such file or directory'

This seems to be related to kernel config availability, as the /proc/sys/net/bridge directory is missing in aarch64 CI runners. Interestingly, running the same Docker-based build locally on macOS (aarch64) works fine.

Since this issue also exists in the last release (see: https://github.com/wolfi-dev/os/pull/67940), this patch bypasses the check *only* for aarch64 to allow CI to continue and test the rest of the functionality across architectures.

Note: Local testing on aarch64 Mac systems passes, suggesting this is specific to the CI environment with some recent changes.
