### PR TITLE
Epoch bump ruby3.2-rails-8.0, ruby3.3-rails-8.0, ruby3.4-rails-8.0

### DIFF
--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rails-8.0
   version: "8.0.3"
-  epoch: 0
+  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-rails-8.0
   version: "8.0.3"
-  epoch: 0
+  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: "8.0.3"
-  epoch: 0
+  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump epoch to remediate CVEs https://github.com/advisories/GHSA-p543-xpfm-54cp, https://github.com/advisories/GHSA-w9pc-fmgc-vxvw and https://github.com/advisories/GHSA-wpv5-97wm-hp9c.

<!--ci-cve-scan:fail-any-->
