### PR TITLE
chore: add jml dev cve-detection service account to STS policy

### DIFF
--- a/.github/chainguard/lifecycle-cve-detection-dev.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-detection-dev.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://accounts.google.com
+
+# Dev service account for testing
+# - cve-detection-sa@jml-test-chainguard-dev.iam.gserviceaccount.com 117144291088285847777
+subject_pattern: "117144291088285847777"
+
+# Allow CVE detection automation to use Melange package information.
+permissions:
+  contents: read


### PR DESCRIPTION
Grants read access to `cve-detection-sa@jml-test-chainguard-dev.iam.gserviceaccount.com` for testing CVE detection startup probe fix in dev environment.

## What

Adds dev service account `117144291088285847777` to the STS policy.

## Why

Testing a startup probe fix for the CVE detection service. The service needs to clone this repo during startup (~7 minutes) to access Melange package information for CVE patch detection.

## Notes

- Service runs in dry-run mode (no advisories will be created)
- Read-only access (contents: read)
- Service account: cve-detection-sa@jml-test-chainguard-dev.iam.gserviceaccount.com
- Unique ID: 117144291088285847777