### PR TITLE
bump njs for nginx

### DIFF
--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: "0.9.3"
-  epoch: 0
+  epoch: 1
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Getting
nginx: [emerg] module "/var/lib/nginx/modules/ngx_http_js_module.so" version 1029001 instead of 1029002 in /etc/nginx/nginx.conf:8
