### PR TITLE
fix: bump x/crypto to remediate CVE-2025-47913

### DIFF
--- a/argo-workflows-3.7.yaml
+++ b/argo-workflows-3.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows-3.7
   version: "3.7.2"
-  epoch: 1
+  epoch: 2
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/argo-workflows-3.7.yaml
+++ b/argo-workflows-3.7.yaml
@@ -39,6 +39,7 @@ pipeline:
     with:
       deps: |-
         github.com/go-viper/mapstructure/v2@v2.4.0
+        golang.org/x/crypto@v0.43.0
 
   - uses: patch
     with:


### PR DESCRIPTION
Golang have [tagged a release](https://github.com/golang/crypto/releases/tag/v0.43.0) which includes [a fix](https://github.com/golang/crypto/commit/559e062ce8bfd6a39925294620b50906ca2a6f95) for [this issue](https://github.com/golang/go/issues/75178) which (according to the issue comments) has been allocated CVE-2025-47913

This PR bumps `x/crypto` in order to receive the fix