### PR TITLE
use host's http auth credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ dev-container:
 	    -v "${PWD}:${PWD}" \
 	    -w "${PWD}" \
 	    -e SOURCE_DATE_EPOCH=0 \
+	    -e HTTP_AUTH \
 	    ghcr.io/wolfi-dev/sdk:latest
 
 PACKAGES_CONTAINER_FOLDER ?= /work/packages


### PR DESCRIPTION
I use make dev-container all the time.  With the changes to the qemu runner, I now need credentials inside of my dev containers.  Pass through the environment variable.