### PR TITLE
fix(langfuse): GHSA-mm7p-fcc7-pg87 bump nodemailer version

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse
-  version: "3.116.0"
-  epoch: 1
+  version: "3.117.0"
+  epoch: 0
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: 77733d777476e5b2b56257f2ebdc9790213934b9
+      expected-commit: eca06ca08e64dce2627c61e403f91ee075d58b03
 
   - name: "Bump deps and install"
     runs: |

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse
   version: "3.116.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -85,7 +85,8 @@ pipeline:
         "pnpm.overrides.mermaid=^11.10.0" \
         "pnpm.overrides.axios=^1.12.0" \
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
-        "pnpm.overrides.tar-fs=3.1.1"
+        "pnpm.overrides.tar-fs=3.1.1" \
+        "pnpm.overrides.nodemailer=^7.0.7" #GHSA-mm7p-fcc7-pg87
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 


### PR DESCRIPTION
Constrain nodemailer dependency version so that it is not effected by the CVE

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/30977

<!--ci-cve-scan:fail-any-->
