### PR TITLE
Remove Python 3.14 "provides" and update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,3 +31,5 @@ openssl.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 perl.yaml                     @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 go-1.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 go-2.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -9,9 +9,6 @@ package:
     cpu: 8
     memory: 8Gi
   dependencies:
-    provides:
-      - python3=${{package.full-version}}
-      - python-3=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
 
@@ -216,9 +213,6 @@ subpackages:
 
   - name: "${{package.name}}-tk"
     dependencies:
-      provides:
-        - py3-tkinter=${{package.full-version}}
-        - py3.13-tkinter=${{package.full-version}}
       runtime:
         - ${{package.name}}-base=${{package.full-version}}
         # 'import _tkinter' will fail with ImportError on 'libtcl9tk9.0.so'
@@ -243,7 +237,7 @@ subpackages:
             import: tkinter
 
   - name: "${{package.name}}-doc"
-    description: "python3 documentation"
+    description: "python3.14 documentation"
     pipeline:
       - uses: split/manpages
     test:
@@ -251,11 +245,8 @@ subpackages:
         - uses: test/docs
 
   - name: "${{package.name}}-dev"
-    description: "python3 development headers"
+    description: "python3.14 development headers"
     dependencies:
-      provides:
-        - python3-dev=${{package.full-version}}
-        - python-3-dev=${{package.full-version}}
       runtime:
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
@@ -270,16 +261,6 @@ subpackages:
              "${{targets.destdir}}"/$d/python3-embed.pc \
              "${{targets.destdir}}"/$d/python3.pc \
              "${{targets.subpkgdir}}/$d/"
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: python3-dev
-            real-pkg-name: ${{subpkg.name}}
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: python-3-dev
-            real-pkg-name: ${{subpkg.name}}
 
   - name: "${{package.name}}-base-dev"
     description: "python3 development headers"

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,5 +1,7 @@
-ceph-dev-19.2.3-r6.apk
-ceph-doc-19.2.3-r6.apk
-ceph-libs-19.2.3-r6.apk
-ceph-19.2.3-r6.apk
-
+python-3.14-privileged-netbindservice-3.14.0-r0.apk
+python-3.14-doc-3.14.0-r0.apk
+python-3.14-3.14.0-r0.apk
+python-3.14-tk-3.14.0-r0.apk
+python-3.14-dev-3.14.0-r0.apk
+python-3.14-base-3.14.0-r0.apk
+python-3.14-base-dev-3.14.0-r0.apk


### PR DESCRIPTION
Python 3.14 should not be the provider for `python` or `python3` at this time.