### PR TITLE
cassandra: Add entrypoint.sh to compat package.

### DIFF
--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.5"
-  epoch: 5 # GHSA-3p8m-j85q-pgmj
+  epoch: 6
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
@@ -89,12 +89,22 @@ subpackages:
     dependencies:
       provides:
         - cassandra-compat=${{package.full-version}}
+      runtime:
+        - busybox
     pipeline:
+      # Dockerhub entrypoint compatibility.
+      - uses: git-checkout
+        with:
+          repository: https://github.com/docker-library/cassandra
+          expected-commit: 793ea6b2a8097d629252fe77585775443b53e4c3
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc
           ln -sf /opt/cassandra/conf ${{targets.subpkgdir}}/etc/cassandra
           mkdir -p ${{targets.subpkgdir}}/opt
           ln -sf /usr/share/java/cassandra ${{targets.subpkgdir}}/opt/cassandra
+
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          cp ${{vars.major-minor-version}}/docker-entrypoint.sh ${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh
     test:
       pipeline:
         - uses: test/virtualpackage


### PR DESCRIPTION
This adds the optional entrypoint script to the package that configures some default values.

I was not sure what the best practice was here around compat packages (e.g. whether to have multiple, what to name them, etc.), so added to the existing one.

Note: subpackage source missing in sbom. Will be fixed in https://github.com/chainguard-dev/melange/pull/2171

Related: https://github.com/chainguard-dev/customer-issues/issues/2563
