### PR TITLE
Add more testing to py3-termcolor

### DIFF
--- a/py3-termcolor.yaml
+++ b/py3-termcolor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-termcolor
   version: "3.1.0"
-  epoch: 2
+  epoch: 3
   description: ANSI color formatting for output in terminal
   copyright:
     - license: MIT
@@ -23,7 +23,7 @@ data:
 environment:
   contents:
     packages:
-      - py3-supported-build-base
+      - py3-supported-build-base-dev
       - py3-supported-hatch-vcs
       - py3-supported-hatchling
 
@@ -49,11 +49,34 @@ subpackages:
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+        - runs: |
+            python${{range.key}} <<'EOF' 2>&1 | grep -F -e "Attention!"
+            import sys
+
+            from termcolor import colored, cprint
+
+            text = colored("Hello, World!", "red", attrs=["reverse", "blink"])
+            print(text)
+            cprint("Hello, World!", "green", "on_red")
+
+            print_red_on_cyan = lambda x: cprint(x, "red", "on_cyan")
+            print_red_on_cyan("Hello, World!")
+            print_red_on_cyan("Hello, Universe!")
+
+            for i in range(10):
+                cprint(i, "magenta", end=" ")
+
+            cprint("Attention!", "red", attrs=["bold"], file=sys.stderr)
+
+            # You can also specify 0-255 RGB ints via a tuple
+            cprint("Both foreground and background can use tuples", (100, 150, 250), (50, 60, 70))
+            EOF
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -69,6 +92,7 @@ subpackages:
 
 test:
   pipeline:
+    - uses: test/tw/pip-check
     - uses: python/import
       with:
         imports: |


### PR DESCRIPTION
From the enterprise version of the package which was removed as it was not needed.
