### PR TITLE
add py3.14-pip package

### DIFF
--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: pip-zipapp
   version: "25.2"
-  epoch: 1
+  epoch: 2
   description: "Pip as a python zipapp"
   copyright:
     - license: MIT
@@ -56,8 +56,8 @@ pipeline:
 
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/py3/f/flit_core/flit_core-3.9.0-py3-none-any.whl"
-      expected-sha256: "7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301"
+      uri: "https://files.pythonhosted.org/packages/py3/f/flit_core/flit_core-3.12.0-py3-none-any.whl"
+      expected-sha256: "e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c"
       extract: false
 
   - runs: |

--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-build
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: A simple, correct Python build frontend
   copyright:
     - license: MIT
@@ -19,6 +19,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -92,6 +93,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-flit-core.yaml
+++ b/py3-flit-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-flit-core
   version: "3.12.0"
-  epoch: 1
+  epoch: 2
   description: "simple packaging tool for simple packages (core)"
   copyright:
     - license: BSD-3-Clause
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -68,6 +69,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-installer
   version: 0.7.0
-  epoch: 13
+  epoch: 14
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -73,6 +74,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-packaging.yaml
+++ b/py3-packaging.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-packaging
   version: "25.0"
-  epoch: 2
+  epoch: 3
   description: core utilities for python3 packaging
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -61,6 +62,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-packaging.yaml
+++ b/py3-packaging.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-packaging
   version: "25.0"
-  epoch: 3
+  epoch: 4
   description: core utilities for python3 packaging
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.2"
-  epoch: 1 # CVE-2025-8869
+  epoch: 2 # CVE-2025-8869
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -118,6 +118,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}-base
         - py3.12-${{vars.pypi-package}}-base
         - py3.13-${{vars.pypi-package}}-base
+        - py3.14-${{vars.pypi-package}}-base
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-pyparsing.yaml
+++ b/py3-pyparsing.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyparsing
   version: "3.2.5"
-  epoch: 0
+  epoch: 1
   description: pyparsing module - Classes and methods to define and execute parsing grammars
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -71,6 +72,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-hooks
   version: 1.2.0
-  epoch: 3
+  epoch: 4
   description: A low-level library for calling build-backends in `pyproject.toml`-based project
   copyright:
     - license: MIT
@@ -19,6 +19,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -65,6 +66,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: "9.2.0"
-  epoch: 1
+  epoch: 2
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
+      3.14: '314'
 
 environment:
   contents:
@@ -87,6 +88,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setuptools
   version: "80.9.0"
-  epoch: 2
+  epoch: 3
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -19,6 +19,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
+      3.14: '314'
 
 environment:
   contents:
@@ -65,6 +66,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-supported-python
   version: 1
-  epoch: 6
+  epoch: 7
   description: metapackage to install all supported versions of python
   copyright:
     - license: "MIT"
@@ -11,6 +11,7 @@ package:
       - python-3.11-base
       - python-3.12-base
       - python-3.13-base
+      - python-3.14-base
 
 environment:
   contents:
@@ -24,6 +25,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
+      3.14: '314'
 
 subpackages:
   - name: ${{package.name}}-dev
@@ -34,6 +36,7 @@ subpackages:
         - python-3.11-base-dev
         - python-3.12-base-dev
         - python-3.13-base-dev
+        - python-3.14-base-dev
     test:
       pipeline:
         - uses: test/emptypackage
@@ -65,6 +68,7 @@ subpackages:
         - py3.11-build-base
         - py3.12-build-base
         - py3.13-build-base
+        - py3.14-build-base
     test:
       pipeline:
         - uses: test/emptypackage
@@ -93,6 +97,7 @@ subpackages:
         - py3.11-build-base-dev
         - py3.12-build-base-dev
         - py3.13-build-base-dev
+        - py3.14-build-base-dev
         - py3-supported-python-dev
     test:
       pipeline:

--- a/py3-tomli.yaml
+++ b/py3-tomli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli
   version: "2.3.0"
-  epoch: 0
+  epoch: 1
   description: TOML parser
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -62,6 +63,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: "4.15.0"
-  epoch: 0
+  epoch: 1
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: PSF-2.0
@@ -20,6 +20,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -66,6 +67,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.1"
-  epoch: 4
+  epoch: 5
   description: "built-package format for Python"
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "314"
 
 environment:
   contents:
@@ -81,6 +82,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage


### PR DESCRIPTION
this commit appends 3.14 python version to the config of py3-pip
we wanted to release 3.14 image but that image also requires pip
with 3.14 version to be present.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
