### PR TITLE
openjdk: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,4 +34,4 @@ go-2.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 openjdk-*.yaml                @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
-openjdk* /                    @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+openjdk-*/*                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,3 +33,5 @@ go-1.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 go-2.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+openjdk-*.yaml                @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+openjdk* /                    @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write


### PR DESCRIPTION
Ensure that updates to openjdk packages have either OS and VM teams in
the approval path.
