### PR TITLE
python-3.13/python-3.14: cherry-pick CVE remediations from upstream

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.8"
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -55,6 +55,8 @@ pipeline:
       expected-commit: a15ae614deb58f78f9f4aa11ed18a0afc6a9df7d
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: fix CVE-2025-8291
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -52,6 +52,8 @@ pipeline:
       expected-commit: ebf955df7a89ed0c7968f79faec1de49f61ed7cb
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.14/d11e69d6203080e3ec450446bfed0516727b85c3: Fix CVE-2025-8291
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Upstream has not made a point release with the CVE fixes for CVE-2025-8291

We can cherry pick the commits from upstream to remediate until a new release is made.

Python-3.13 from:
https://github.com/python/cpython/commit/333d4a6f4967d3ace91492a39ededbcf3faa76a6

Python-3.14 from:
https://github.com/python/cpython/commit/d11e69d6203080e3ec450446bfed0516727b85c3

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->
