### PR TITLE
abseil-cpp: export cmake targets

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20250814.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 3
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,8 @@ pipeline:
       -DABSL_BUILD_TEST_HELPERS=ON \
       -DABSL_USE_EXTERNAL_GOOGLETEST=ON \
       -DABSL_PROPAGATE_CXX_STD=ON \
-      -DABSL_FIND_GOOGLETEST=ON
+      -DABSL_FIND_GOOGLETEST=ON \
+      -DABSL_ENABLE_INSTALL=ON
       cmake --build build
 
   - runs: |


### PR DESCRIPTION
Use this option to export cmake targets.

These new cmake targets can be used by other dependent packages when building their code.

We have detected the need for this while working on the onnxruntime suite of packages.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
