### PR TITLE
Build Python 3.14 with free-threaded JIT

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -19,6 +19,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      # This is a year old. Hopefully 3.14.x updates will move this to current.
       - clang-19
       - expat-dev
       - gdbm-dev
@@ -26,6 +27,7 @@ environment:
       - libffi-dev
       - libx11-dev
       - linux-headers
+      # This is a year old. Hopefully 3.14.x updates will move this to current.
       - llvm-19
       - mpdecimal-dev
       - ncurses-dev
@@ -162,48 +164,9 @@ subpackages:
         - name: Version check
           runs: |
             ${{vars.python}} version-check.py ${{package.version}}
-        - name: (free-threaded) Version check
-          runs: |
-            export PYTHON_JIT=1
-            ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages
           runs: |
             set +x
-            d=$(mktemp -d)
-            echo "$ ${{vars.python}} -m venv $d"
-            ${{vars.python}} -m venv "$d"
-            echo "$ $d/bin/pip list"
-            $d/bin/pip list | tee "$d/list.txt"
-            wd=/usr/share/python-wheels
-            for pkg in pip ; do
-              set -- "$wd"/$pkg-*.whl
-              [ $# -eq 1 ] || {
-                echo "ERROR: found $# wheels in $wd matching $pkg-*.whl";
-                exit 1;
-              }
-              [ -f "$1" ] || {
-                echo "ERROR: $wd/$pkg-*.whl ('$1') was not a file"
-                exit 1
-              }
-              # name is like pip-24.2-py3-none-any.whl. second token is version.
-              wheel=${1}
-              tmp=${wheel##*/}
-              tmp=${tmp#*-}
-              ver=${tmp%%-*}
-              if ! grep -q "${pkg}[ ]\+${ver}$" "$d/list.txt"; then
-                  echo "FAIL: did not find '$pkg==$ver' in venv"
-                  echo "pip list had:"
-                  sed 's,^,>,' "$d/list.txt"
-                  exit 1
-              fi
-              echo "PASS: venv installed '$pkg==$ver'"
-            done
-
-            rm -Rf "$d"
-        - name: (free-threaded) Verify venv installs expected packages
-          runs: |
-            set +x
-            export PYTHON_JIT=1
             d=$(mktemp -d)
             echo "$ ${{vars.python}} -m venv $d"
             ${{vars.python}} -m venv "$d"
@@ -281,9 +244,6 @@ subpackages:
           with:
             python: python${{vars.pyversion}}
             import: tkinter
-        - runs: |
-            export PYTHON_JIT=1
-            python${{vars.pyversion}} -c "import tkinter"
 
   - name: "${{package.name}}-doc"
     description: "python3.14 documentation"
@@ -333,29 +293,12 @@ test:
         # main package should provide 'python' and 'python3'.
         python version-check.py ${{package.version}}
         python3 version-check.py ${{package.version}}
-    - name: (free-threaded) Verify Python names
-      runs: |
-        export PYTHON_JIT=1
-        # main package should provide 'python' and 'python3'.
-        python version-check.py ${{package.version}}
-        python3 version-check.py ${{package.version}}
     - uses: test/tw/ver-check
       with:
         bins: python python3
     - uses: test/tw/help-check
       with:
         bins: pydoc3 python python3
-    - name: (free-threaded) Verify Python names
-      runs: |
-        export PYTHON_JIT=1
-        # main package should provide 'python' and 'python3'.
-        python version-check.py ${{package.version}}
-        python3 version-check.py ${{package.version}}
-        pydoc3 --help
-        python --version
-        python --help
-        python3 --version
-        python3 --help
     - name: Verify working python3 -m venv
       runs: |
         d=$(mktemp -d)
@@ -371,6 +314,10 @@ test:
         $d/bin/pip list
         $d/bin/pip check
         rm -Rf "$d"
+    - name: Verify functioning JIT
+      runs: |
+        export PYTHON_JIT=1
+        python3 jit-check.py
 
 update:
   enabled: true

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -32,7 +32,10 @@ environment:
       - mpdecimal-dev
       - ncurses-dev
       - openssl-dev
-      - python3
+      # This is required for the JIT-enabled build. Hopefully 3.14.x updates
+      # will remove this requirement, or it will vanish when the JIT version
+      # becomes the default.
+      - python-3.13
       - readline-dev
       - sqlite-dev
       - tcl-dev

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -19,15 +19,18 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      - clang-19
       - expat-dev
       - gdbm-dev
       - libcap-utils
       - libffi-dev
       - libx11-dev
       - linux-headers
+      - llvm-19
       - mpdecimal-dev
       - ncurses-dev
       - openssl-dev
+      - python3
       - readline-dev
       - sqlite-dev
       - tcl-dev
@@ -72,6 +75,7 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=/usr \
+         --enable-experimental-jit=yes-off \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
@@ -155,11 +159,51 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
-        - runs: |
+        - name: Version check
+          runs: |
+            ${{vars.python}} version-check.py ${{package.version}}
+        - name: (free-threaded) Version check
+          runs: |
+            export PYTHON_JIT=1
             ${{vars.python}} version-check.py ${{package.version}}
         - name: Verify venv installs expected packages
           runs: |
             set +x
+            d=$(mktemp -d)
+            echo "$ ${{vars.python}} -m venv $d"
+            ${{vars.python}} -m venv "$d"
+            echo "$ $d/bin/pip list"
+            $d/bin/pip list | tee "$d/list.txt"
+            wd=/usr/share/python-wheels
+            for pkg in pip ; do
+              set -- "$wd"/$pkg-*.whl
+              [ $# -eq 1 ] || {
+                echo "ERROR: found $# wheels in $wd matching $pkg-*.whl";
+                exit 1;
+              }
+              [ -f "$1" ] || {
+                echo "ERROR: $wd/$pkg-*.whl ('$1') was not a file"
+                exit 1
+              }
+              # name is like pip-24.2-py3-none-any.whl. second token is version.
+              wheel=${1}
+              tmp=${wheel##*/}
+              tmp=${tmp#*-}
+              ver=${tmp%%-*}
+              if ! grep -q "${pkg}[ ]\+${ver}$" "$d/list.txt"; then
+                  echo "FAIL: did not find '$pkg==$ver' in venv"
+                  echo "pip list had:"
+                  sed 's,^,>,' "$d/list.txt"
+                  exit 1
+              fi
+              echo "PASS: venv installed '$pkg==$ver'"
+            done
+
+            rm -Rf "$d"
+        - name: (free-threaded) Verify venv installs expected packages
+          runs: |
+            set +x
+            export PYTHON_JIT=1
             d=$(mktemp -d)
             echo "$ ${{vars.python}} -m venv $d"
             ${{vars.python}} -m venv "$d"
@@ -237,6 +281,9 @@ subpackages:
           with:
             python: python${{vars.pyversion}}
             import: tkinter
+        - runs: |
+            export PYTHON_JIT=1
+            python${{vars.pyversion}} -c "import tkinter"
 
   - name: "${{package.name}}-doc"
     description: "python3.14 documentation"
@@ -281,7 +328,20 @@ subpackages:
 
 test:
   pipeline:
-    - runs: |
+    - name: Verify Python names
+      runs: |
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
+        pydoc3 --version
+        pydoc3 --help
+        python --version
+        python --help
+        python3 --version
+        python3 --help
+    - name: (free-threaded) Verify Python names
+      runs: |
+        export PYTHON_JIT=1
         # main package should provide 'python' and 'python3'.
         python version-check.py ${{package.version}}
         python3 version-check.py ${{package.version}}
@@ -293,6 +353,14 @@ test:
         python3 --help
     - name: Verify working python3 -m venv
       runs: |
+        d=$(mktemp -d)
+        python3 -m venv "$d"
+        $d/bin/pip list
+        $d/bin/pip check
+        rm -Rf "$d"
+    - name: (free-threaded) Verify working python3 -m venv
+      runs: |
+        export PYTHON_JIT=1
         d=$(mktemp -d)
         python3 -m venv "$d"
         $d/bin/pip list

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -333,19 +333,24 @@ test:
         # main package should provide 'python' and 'python3'.
         python version-check.py ${{package.version}}
         python3 version-check.py ${{package.version}}
-        pydoc3 --version
-        pydoc3 --help
-        python --version
-        python --help
-        python3 --version
-        python3 --help
     - name: (free-threaded) Verify Python names
       runs: |
         export PYTHON_JIT=1
         # main package should provide 'python' and 'python3'.
         python version-check.py ${{package.version}}
         python3 version-check.py ${{package.version}}
-        pydoc3 --version
+    - uses: test/tw/ver-check
+      with:
+        bins: python python3
+    - uses: test/tw/help-check
+      with:
+        bins: pydoc3 python python3
+    - name: (free-threaded) Verify Python names
+      runs: |
+        export PYTHON_JIT=1
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
         pydoc3 --help
         python --version
         python --help

--- a/python-3.14/jit-check.py
+++ b/python-3.14/jit-check.py
@@ -1,0 +1,5 @@
+import sys
+
+assert sys._jit.is_available
+assert sys._jit.is_enabled
+assert sys._jit.is_active


### PR DESCRIPTION
This adds the experimental free-threaded JIT to Python 3.14. It's off by default; people wanting to use it must export the `PYTHON_JIT=1` environment variable to enable it.
