### PR TITLE
chore(openjdk-25): move to using ga tags

### DIFF
--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -21,13 +21,6 @@ environment:
       - ca-certificates-bundle
       - go-1.20
 
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-25
   version: "25"
-  epoch: 2
+  epoch: 3
   description: OpenJDK 25
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -11,12 +11,6 @@ package:
       - ttf-dejavu
     provides:
       - ${{package.name}}-jmods
-
-var-transforms:
-  - from: ${{package.version}}
-    match: _beta
-    replace: +
-    to: mangled-package-version
 
 environment:
   contents:
@@ -54,7 +48,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openjdk/jdk25u
-      tag: jdk-${{vars.mangled-package-version}}-ga
+      tag: jdk-${{package.version}}-ga
       expected-commit: 6c48f4ed707bf0b15f9b6098de30db8aae6fa40f
 
   - working-directory: /home/build/googletest


### PR DESCRIPTION
we had lots of packages failing with pre-commit lint errors, this
commit moves to using ga tags for openjdk-25

failing lint error looks like 

```bash
2025/10/13 07:37:41 ERRO failed to load configuration: applying variable substitutions: var-transform "mangled-package-version" failed: regex "_beta" does not match input "25" (no substitution will be performed)
```

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
