### PR TITLE
fix(conda): bump epoch to match conda base

### DIFF
--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -2,7 +2,7 @@
 package:
   name: conda-build
   version: "25.9.0"
-  epoch: 0
+  epoch: 1
   description: tools for building conda packages
   copyright:
     - license: BSD-3-Clause

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: "25.9.1"
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
## Explanation

`conda-base` has moved to epoch `1`, this PR bumps rest of conda to match