### PR TITLE
chore(go-1.22): remove mangled-package-version var

### DIFF
--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -21,13 +21,6 @@ environment:
       - ca-certificates-bundle
       - go-1.20
 
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:


### PR DESCRIPTION
we're not using it anywhere

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
