### PR TITLE
chore(rlwrap): remove using var-transforms

### DIFF
--- a/rlwrap.yaml
+++ b/rlwrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: rlwrap
   version: "0.47.1"
-  epoch: 0
+  epoch: 1
   description: A readline wrapper
   copyright:
     - license: GPL-2.0-or-later
@@ -18,17 +18,11 @@ environment:
       - readline-dev
       - wolfi-base
 
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+)\.(\d+)\.0$
-    replace: $1.$2
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/hanslub42/rlwrap
-      tag: v${{vars.mangled-package-version}}
+      tag: v${{package.version}}
       expected-commit: b02a0d1ee0fe589e24078639c13d15e99ae2f65a
 
   - runs: |


### PR DESCRIPTION
https://github.com/hanslub42/rlwrap/tags looks consistent so we don't
need to use mangled-package-version here

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
