### PR TITLE
chore(go): remove var-transforms from config

### DIFF
--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: "1.22.12"
-  epoch: 8 # CVE-2025-47907
+  epoch: 9 # CVE-2025-47907
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -20,13 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go-1.20
-
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
 
 pipeline:
   - uses: git-checkout

--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.23
   version: "1.23.12"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -20,13 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go-1.20
-
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
 
 pipeline:
   - uses: git-checkout

--- a/go-1.24.yaml
+++ b/go-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.24
   version: "1.24.8"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -20,13 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
 
 pipeline:
   - uses: git-checkout

--- a/go-1.25.yaml
+++ b/go-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.25
   version: "1.25.2"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -20,13 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \_
-    replace: ""
-    to: mangled-package-version
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
we're not using it anywhere and in melange 0.31.7 we landed a change
https://github.com/chainguard-dev/melange/commit/0cbbd8bc31b6f44f7d411e7b8e0dc6621cb03d12
which made melange compile stricter.

this commit updates the config so that we don't error out when running
melange compile in CI during linting

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
