### PR TITLE
Keycloak package Fix: Remove duplicate keycloak directory to reduce package size

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.0"
-  epoch: 1 # GHSA-3p8m-j85q-pgmj
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
-      cp -avR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
+      mv ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
       # Create an empty data directory for keycloak. Required by the UI to store some data.
       mkdir -p ${{targets.destdir}}/usr/share/java/keycloak/data
@@ -115,7 +115,6 @@ subpackages:
             # This only runs in k8s but make sure it errors correctly
             java -Djava.util.logging.manager=org.jboss.logmanager.LogManager \
               -jar /usr/share/java/quarkus-app/quarkus-run.jar 2>&1 | grep "Couldn't retrieve the currently connected namespace"
-
   - name: ${{package.name}}-operator-compat
     dependencies:
       provides:
@@ -129,7 +128,6 @@ subpackages:
       pipeline:
         - name: "verify expected link exists"
           runs: readlink /opt/keycloak
-
   - name: ${{package.name}}-compat
     pipeline:
       - runs: |
@@ -147,7 +145,6 @@ subpackages:
           with:
             virtual-pkg-name: keycloak-compat
             real-pkg-name: ${{subpkg.name}}
-
   - name: ${{package.name}}-iamguarded-compat
     description: "compat package with iamguarded/keycloak image"
     dependencies:

--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -115,6 +115,7 @@ subpackages:
             # This only runs in k8s but make sure it errors correctly
             java -Djava.util.logging.manager=org.jboss.logmanager.LogManager \
               -jar /usr/share/java/quarkus-app/quarkus-run.jar 2>&1 | grep "Couldn't retrieve the currently connected namespace"
+
   - name: ${{package.name}}-operator-compat
     dependencies:
       provides:
@@ -128,6 +129,7 @@ subpackages:
       pipeline:
         - name: "verify expected link exists"
           runs: readlink /opt/keycloak
+
   - name: ${{package.name}}-compat
     pipeline:
       - runs: |
@@ -145,6 +147,7 @@ subpackages:
           with:
             virtual-pkg-name: keycloak-compat
             real-pkg-name: ${{subpkg.name}}
+
   - name: ${{package.name}}-iamguarded-compat
     description: "compat package with iamguarded/keycloak image"
     dependencies:


### PR DESCRIPTION
Remove duplicate `keycloak` directory to reduce package size.

Before state:
```
apk manifest --allow-untrusted packages/aarch64/keycloak-26.4-26.4.0-r1.apk 
sha1:4e5e30257ab3f1ee9deeed8dbfa8d02944432011 usr/share/java/keycloak/README.md 
sha1:1699c09393e985ca5e57686a4739b62f72b6b74d usr/share/java/keycloak/bin/client/keycloak-admin-cli-26.4.0.jar 
sha1:d17c094daef57dbd80af71687a475aa6df7cbe54 usr/share/java/keycloak/bin/client/lib/bcprov-jdk18on-1.81.jar 
....
....
sha1:4e5e30257ab3f1ee9deeed8dbfa8d02944432011 usr/share/java/keycloak-26.4.0/README.md 
sha1:1699c09393e985ca5e57686a4739b62f72b6b74d usr/share/java/keycloak-26.4.0/bin/client/keycloak-admin-cli-26.4.0.jar 
sha1:d17c094daef57dbd80af71687a475aa6df7cbe54 usr/share/java/keycloak-26.4.0/bin/client/lib/bcprov-jdk18on-1.81.jar 
....
....
```
Removing `usr/share/java/keycloak-26.4.0` since only `usr/share/java/keycloak` is needed as per upstream.