### PR TITLE
Split the identities we use for elastic builds.

### DIFF
--- a/.github/chainguard/eco-2-28-elastic-build.sts.yaml
+++ b/.github/chainguard/eco-2-28-elastic-build.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://accounts.google.com
+
+# eco-2-28:
+#  presubmit: 109278469796396932019: ebuild-456o8jve9m82pzkyd0rxyya@prod-enforce-fabc.iam.gserviceaccount.com
+#  postsubmit: 116606566869655215545: ebuild-dg05lqlr2tymodkwd5go6a9@prod-enforce-fabc.iam.gserviceaccount.com
+#  world: 115998046588963941434: ebuild-d7lrzt8tuql0tod9242jkco@prod-enforce-fabc.iam.gserviceaccount.com
+subject_pattern: "(109278469796396932019|116606566869655215545|115998046588963941434)"
+
+permissions:
+  contents: read
+  checks: write

--- a/.github/chainguard/staging-elastic-build.sts.yaml
+++ b/.github/chainguard/staging-elastic-build.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://accounts.google.com
+
+# staging:
+#  presubmit: 116478844699827634314: ebuild-tho0c6rsknlo655tnyjlifi@staging-enforce-cd1e.iam.gserviceaccount.com
+#  postsubmit: 115457633213442188328: ebuild-m2wshgog0q6xjkbz7j8swed@staging-enforce-cd1e.iam.gserviceaccount.com
+#  world: 118305965159726888964: ebuild-i74lfrzfboxqsa518b5p3qi@staging-enforce-cd1e.iam.gserviceaccount.com
+subject_pattern: "(116478844699827634314|115457633213442188328|118305965159726888964)"
+
+permissions:
+  contents: read
+  checks: write


### PR DESCRIPTION
This is the first step, once rolled out, we will drop the staging/eco stuff from the prod identity.