### PR TITLE
ruby-3.{2,3,4}: cherry pick OpenSSL 3.6.0 compat

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: "3.2.9"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -57,6 +57,8 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.mangled-package-version}}
       expected-commit: 8f611e0c46012e321b39efd629eb5f4f53976863
+      cherry-picks: |
+        ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
 
   - runs: |
       # Don't bundle the gems we have separate packages for

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -181,5 +181,9 @@ test:
     - name: Validate HTTPS support
       runs: |
         bundle init
-        bundle doctor --ssl
+        OUTPUT=$(bundle doctor --ssl 2>&1)
+        echo "$OUTPUT"
+        if echo "$OUTPUT" | grep -i "failed"; then
+          exit 1
+        fi
     - uses: test/tw/ldd-check

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -150,6 +150,10 @@ update:
     tag-filter-prefix: v3_2_
 
 test:
+  environment:
+    contents:
+      packages:
+        - ruby3.2-bundler
   pipeline:
     - runs: |
         ruby --version | grep ${{package.version}}
@@ -174,4 +178,8 @@ test:
         ri --version
         ri --help
         ruby --help
+    - name: Validate HTTPS support
+      runs: |
+        bundle init
+        bundle doctor --ssl
     - uses: test/tw/ldd-check

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -180,5 +180,9 @@ test:
     - name: Validate HTTPS support
       runs: |
         bundle init
-        bundle doctor --ssl
+        OUTPUT=$(bundle doctor --ssl 2>&1)
+        echo "$OUTPUT"
+        if echo "$OUTPUT" | grep -i "failed"; then
+          exit 1
+        fi
     - uses: test/tw/ldd-check

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: "3.3.9"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -55,6 +55,8 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.mangled-package-version}}
       expected-commit: f5c772fc7cbe9f5b58d962939fcb1c7e3fb1cfa6
+      cherry-picks: |
+        ruby_3_3/ce7aa23f97273fa181be26aec33d3c6998e203c5: Update openssl gem to 3.2.2
 
   - runs: |
       # Don't bundle the gems we have separate packages for

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -148,6 +148,10 @@ update:
     tag-filter-prefix: v3_3_
 
 test:
+  environment:
+    contents:
+      packages:
+        - ruby3.3-bundler
   pipeline:
     - name: Test binaries
       runs: |
@@ -173,4 +177,8 @@ test:
         ri --version
         ri --help
         ruby --help
+    - name: Validate HTTPS support
+      runs: |
+        bundle init
+        bundle doctor --ssl
     - uses: test/tw/ldd-check

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.4
   version: "3.4.7"
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -65,6 +65,8 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.underscore-package-version}}
       expected-commit: 7a5688e2a27668e48f8d6ff4af5b2208b98a2f5e
+      cherry-picks: |
+        ruby_3_4/fce44db5eb7baf1ddd2238254c3cf617fcfd1112: Update openssl gem to 3.3.1 for Ruby 3.4
 
   - uses: patch
     with:

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -189,4 +189,8 @@ test:
     - name: Validate HTTPS support
       runs: |
         bundle init
-        bundle doctor --ssl
+        OUTPUT=$(bundle doctor --ssl 2>&1)
+        echo "$OUTPUT"
+        if echo "$OUTPUT" | grep -i "failed"; then
+          exit 1
+        fi

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -157,6 +157,10 @@ update:
     tag-filter-prefix: v3_4_
 
 test:
+  environment:
+    contents:
+      packages:
+        - ruby3.4-bundler
   pipeline:
     - name: Test binaries
       runs: |
@@ -182,3 +186,7 @@ test:
         ri --version
         ri --help
         ruby --help
+    - name: Validate HTTPS support
+      runs: |
+        bundle init
+        bundle doctor --ssl


### PR DESCRIPTION
Cherry pick fixes for Ruby >= 3.2 to ensure compatibility with a
behavioural change in OpenSSL >= 3.6.0.
