### PR TITLE
ruby-3.{0,1}: cherry pick OpenSSL 3.6.0 compat

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -36,24 +36,16 @@ environment:
 vars:
   prefix: /usr
 
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: _
-    to: underscore-package-version
-
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/ruby/ruby
-      tag: v${{vars.underscore-package-version}}
-      expected-commit: 724a0711752f35478dbccdafbb6718687d983d32
-      cherry-picks: |
-        ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
+      uri: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-${{package.version}}.tar.gz
+      expected-sha256: 2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388
 
   # Adds openssl patch for ruby-3.0.6 and cannot apply just using the patch as it doesnt support binary diffs
   - runs: |
       git apply 0001-ruby-3.0.6-openssl-patch.patch
+      git apply 0002-openssl-3.6.0-compat.patch
 
   - name: Configure
     runs: |
@@ -156,4 +148,6 @@ test:
         ruby --help
         typeprof --version
         typeprof --help
+    - runs: |
+        ruby validate_https.rb
     - uses: test/tw/ldd-check

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -36,11 +36,18 @@ environment:
 vars:
   prefix: /usr
 
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: underscore-package-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-${{package.version}}.tar.gz
-      expected-sha256: 2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388
+      repository: https://github.com/ruby/ruby
+      tag: v${{vars.underscore-package-version}}
+      expected-commit: 724a0711752f35478dbccdafbb6718687d983d32
       cherry-picks: |
         ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
 

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 8
+  epoch: 9
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -41,6 +41,8 @@ pipeline:
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-${{package.version}}.tar.gz
       expected-sha256: 2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388
+      cherry-picks: |
+        ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
 
   # Adds openssl patch for ruby-3.0.6 and cannot apply just using the patch as it doesnt support binary diffs
   - runs: |

--- a/ruby-3.0/0002-openssl-3.6.0-compat.patch
+++ b/ruby-3.0/0002-openssl-3.6.0-compat.patch
@@ -1,0 +1,37 @@
+commit c38243e2c4e874d67b63431f9489f47ddfecdefd
+Author: Kazuki Yamaguchi <k@rhe.jp>
+Date:   Sun Oct 5 19:38:47 2025 +0900
+
+    [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
+    
+    With OpenSSL 3.6.0, it causes nearly every certificate verification to
+    fail with the message "certificate verify failed (unable to get
+    certificate CRL)" because the CRLs are typically unavailable in the
+    default store used by OpenSSL::SSL::SSLContext#set_params.
+    
+    OpenSSL::X509::V_FLAG_CRL_CHECK_ALL is a flag that extends the CRL
+    checking to all certificates in the chain. In OpenSSL < 3.6.0, the flag
+    alone has no effect, and OpenSSL::X509::V_FLAG_CRL_CHECK must also be
+    set to enable CRL checking.
+    
+    In OpenSSL 3.6.0, OpenSSL::X509::V_FLAG_CRL_CHECK_ALL now implies
+    OpenSSL::X509::V_FLAG_CRL_CHECK. This is inconsistent with the man page
+    and may be fixed in a future OpenSSL 3.6.x release, but this flag is not
+    needed and should not be set by default.
+    
+    Fixes https://github.com/ruby/openssl/issues/949
+    
+    https://github.com/ruby/openssl/commit/e8481cd687
+
+diff --git a/ext/openssl/lib/openssl/ssl.rb b/ext/openssl/lib/openssl/ssl.rb
+index ea8bb2a18e..40740a0298 100644
+--- a/ext/openssl/lib/openssl/ssl.rb
++++ b/ext/openssl/lib/openssl/ssl.rb
+@@ -92,7 +92,6 @@ class SSLContext
+ 
+       DEFAULT_CERT_STORE = OpenSSL::X509::Store.new # :nodoc:
+       DEFAULT_CERT_STORE.set_default_paths
+-      DEFAULT_CERT_STORE.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
+ 
+       # A callback invoked when DH parameters are required for ephemeral DH key
+       # exchange.

--- a/ruby-3.0/validate_https.rb
+++ b/ruby-3.0/validate_https.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'uri'
+require 'openssl'
+
+def validate_https_connection(url)
+  uri = URI.parse(url)
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  http.open_timeout = 5
+  http.read_timeout = 5
+
+  begin
+    response = http.start do |h|
+      h.head(uri.path.empty? ? '/' : uri.path)
+    end
+
+    puts "✓ Connection successful"
+    puts "  SSL Certificate: Valid"
+    puts "  Response code: #{response.code}"
+    true
+  rescue OpenSSL::SSL::SSLError => e
+    puts "✗ SSL Error: #{e.message}"
+    false
+  rescue => e
+    puts "✗ Connection failed: #{e.message}"
+    false
+  end
+end
+
+success = validate_https_connection('https://www.example.com') 
+exit(success ? 0 : 1)

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -157,4 +157,6 @@ test:
         ri --version
         ri --help
         ruby --help
+    - runs: |
+        ruby validate_https.rb
     - uses: test/tw/ldd-check

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: "3.1.7"
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -50,6 +50,8 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.underscore-package-version}}
       expected-commit: 0a3704f218f0aec7f92f3a46a2293175b0a7d2b3
+      cherry-picks: |
+        ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
 
   - name: Generate and Configure
     runs: |

--- a/ruby-3.1/validate_https.rb
+++ b/ruby-3.1/validate_https.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'uri'
+require 'openssl'
+
+def validate_https_connection(url)
+  uri = URI.parse(url)
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  http.open_timeout = 5
+  http.read_timeout = 5
+
+  begin
+    response = http.start do |h|
+      h.head(uri.path.empty? ? '/' : uri.path)
+    end
+
+    puts "✓ Connection successful"
+    puts "  SSL Certificate: Valid"
+    puts "  Response code: #{response.code}"
+    true
+  rescue OpenSSL::SSL::SSLError => e
+    puts "✗ SSL Error: #{e.message}"
+    false
+  rescue => e
+    puts "✗ Connection failed: #{e.message}"
+    false
+  end
+end
+
+success = validate_https_connection('https://www.example.com') 
+exit(success ? 0 : 1)


### PR DESCRIPTION
Cherry pick fixes for Ruby < 3.2 to ensure compatibility with a
behavioural change in OpenSSL >= 3.6.0.

There is no specific fix in the upstream branch for each of these
releases but the fix from 3.2 applies cleanly.
