### PR TITLE
ceph: Bump epoch to beat original ceph

### DIFF
--- a/ceph-19.yaml
+++ b/ceph-19.yaml
@@ -2,7 +2,7 @@ package:
   name: ceph-19
   version: "19.2.3"
   description: Distributed object, block, and file storage
-  epoch: 0
+  epoch: 7
   copyright:
     - license: LGPL-2.1
   resources:


### PR DESCRIPTION
We withdrew the latest version of ceph but not all the previous versions. We also reset the epoch to 0, which means that all the old versions of ceph sort greater than ceph-19.

Rather than withdrawing all of the old ceph versions (which I suspect will break something else), I'm just going to bump this epoch for now. We can deal with the other ceph things later.
