### PR TITLE
fix: dex - CVE-2025-47913 - upgrade crypto v0.43.0

### DIFF
--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: "2.44.0"
-  epoch: 2
+  epoch: 3
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,12 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 2dce75009acfcd9df77d57f2d144aae999a4c569
       destination: dex
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.43.0
+      modroot: ./dex
 
   - runs: |
       cd dex


### PR DESCRIPTION
fixed CVE-2025-47913