### PR TITLE
argo-cd-3.1/cve-remediation

### DIFF
--- a/argo-cd-3.1.yaml
+++ b/argo-cd-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-3.1
   version: "3.1.8"
-  epoch: 0 # GHSA-4x4m-3c2p-qppc
+  epoch: 1 # CVE-2025-47913
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,7 @@ pipeline:
     with:
       deps: |-
         k8s.io/kubernetes@v1.33.4
+        golang.org/x/crypto@v0.43.0
 
   - runs: |
       cd ui


### PR DESCRIPTION
fix: CVE-2025-47913 - upgrade crypto to v0.43.0