### PR TITLE
tflint: cleanup package manifest and use go/build pipeline

### DIFF
--- a/tflint.yaml
+++ b/tflint.yaml
@@ -1,31 +1,22 @@
 package:
   name: tflint
   version: "0.59.1"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2
   description: A Pluggable Terraform Linter
   copyright:
     - license: MPL-2.0
 
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
-
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 42f8ce04d9fe24ea0fa22e5b6bff4a0faaca6c3d
-      repository: https://github.com/terraform-linters/tflint
+      repository: https://github.com/terraform-linters/tflint.git
       tag: v${{package.version}}
+      expected-commit: 42f8ce04d9fe24ea0fa22e5b6bff4a0faaca6c3d
 
-  - runs: |
-      make build
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv dist/tflint ${{targets.destdir}}/usr/bin
+  - uses: go/build
+    with:
+      packages: .
+      output: tflint
 
   - uses: strip
 
@@ -36,9 +27,44 @@ update:
     use-tag: true
     strip-prefix: v
 
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility symlink for upstream image
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -s ../../bin/tflint "${{targets.subpkgdir}}/usr/local/bin/tflint"
+    test:
+      pipeline:
+        - uses: test/tw/symlink-check
+
 test:
   pipeline:
-    - name: version check
-      runs: |
-        tflint --version
-        tflint --help
+    - uses: test/tw/help-check
+      with:
+        bins: tflint
+    - uses: test/tw/ver-check
+      with:
+        bins: tflint
+    - runs: |
+        tflint --init
+        touch main.tf
+        # --force flag so it exits with 0
+        tflint --force | grep -F -e "terraform_required_version"
+
+        tee main.tf <<'EOF'
+        terraform {
+          required_version = ">= 1.0"
+        }
+        locals {
+          map   = { a = 0 }
+          value = lookup(local.map, "a")
+        }
+        EOF
+        tflint --force | grep -F -e "terraform_deprecated_lookup"
+        tflint --fix --force
+        sed -n '4p' main.tf | grep -F -e "locals {"
+        sed -n '5p' main.tf | grep -F -e "}"


### PR DESCRIPTION
This also adds a compat subpackage