### PR TITLE
ruby3.x-rails-8.0: bump epoch for rack CVEs

### DIFF
--- a/ruby3.2-rails-8.0.yaml
+++ b/ruby3.2-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rails-8.0
   version: "8.0.3"
-  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
+  epoch: 2 # GHSA-6xw4-3v39-52mm | GHSA-r657-rxjc-j557 | CVE-2025-61770 | CVE-2025-61771 | CVE-2025-61772
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.3-rails-8.0.yaml
+++ b/ruby3.3-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-rails-8.0
   version: "8.0.3"
-  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
+  epoch: 2 # GHSA-6xw4-3v39-52mm | GHSA-r657-rxjc-j557 | CVE-2025-61770 | CVE-2025-61771 | CVE-2025-61772
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: "8.0.3"
-  epoch: 1 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
+  epoch: 2 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT

--- a/ruby3.4-rails-8.0.yaml
+++ b/ruby3.4-rails-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-rails-8.0
   version: "8.0.3"
-  epoch: 2 # GHSA-p543-xpfm-54cp | GHSA-w9pc-fmgc-vxvw | GHSA-wpv5-97wm-hp9c
+  epoch: 2 # GHSA-6xw4-3v39-52mm | GHSA-r657-rxjc-j557 | CVE-2025-61770 | CVE-2025-61771 | CVE-2025-61772
   description: Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
   copyright:
     - license: MIT


### PR DESCRIPTION
Bumps epoch to trigger rebuild with latest rack versions for ruby3.2-rails-8.0, ruby3.3-rails-8.0, and ruby3.4-rails-8.0.

Addresses multiple rack CVEs:
- GHSA-6xw4-3v39-52mm
- GHSA-r657-rxjc-j557  
- CVE-2025-61770
- CVE-2025-61771
- CVE-2025-61772