### PR TITLE
Build xz via git-checkout rather than fetch

### DIFF
--- a/xz.yaml
+++ b/xz.yaml
@@ -1,7 +1,7 @@
 package:
   name: xz
   version: "5.8.1"
-  epoch: 5
+  epoch: 6
   description: "Library and CLI tools for XZ and LZMA compressed files"
   copyright:
     - license: GPL-3.0-or-later
@@ -9,16 +9,25 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gettext-dev
+      - libtool
       - wolfi-baselayout
 
 pipeline:
-  - uses: fetch # use fetch instead of git-checkout else there is a circular dependency with git
+  - uses: git-checkout
     with:
-      uri: https://github.com/tukaani-project/xz/releases/download/v${{package.version}}/xz-${{package.version}}.tar.gz
-      expected-sha256: 507825b599356c10dca1cd720c9d0d0c9d5400b9de300af00e4d1ea150795543
+      repository: https://github.com/tukaani-project/xz
+      tag: v${{package.version}}
+      expected-commit: a522a226545730551f7e7c2685fab27cf567746c
+
+  - name: Generate
+    runs: |
+      ./autogen.sh --no-po4a
 
   - name: Configure
     runs: |


### PR DESCRIPTION
This PR builds `xz` via `git-checkout` instead of `fetch` since the former is our accepted practice when possible. The circular dependency comment is interesting and likely outdated since I was able to build and test locally without issue.

The following languages are excluded when using `--no-po4a`:
```
[po4a_langs] de fr it ko pt_BR ro sr sv uk
```
> code for [reference](https://github.com/tukaani-project/xz/blob/8d26b72915e0d373f898b55935505857c30dbdb3/po4a/po4a.conf#L7)

Which explains the `ci-diff-report` removals:
<img width="498" height="486" alt="image" src="https://github.com/user-attachments/assets/76104bb4-f4ce-490e-9c9c-0373db8457c3" />
