### PR TITLE
Build renovate via git-checkout

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,6 +1,6 @@
 package:
   name: renovate
-  version: "41.148.4"
+  version: "41.148.6"
   epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
@@ -21,16 +21,39 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs-22
-      - npm
+      - pnpm
 
 pipeline:
-  - name: npm install
-    runs: |
-      npm install -g ${{package.name}}@${{package.version}} -prefix ${{targets.contextdir}}/usr/local/
+  - uses: git-checkout
+    with:
+      repository: https://github.com/renovatebot/renovate
+      tag: ${{package.version}}
+      expected-commit: 6fd2b966f086d239562b498d6762430aed1b541a
 
-      # https://github.com/browserify/resolve/issues/288
-      # Mitigates GHSA-2jcg-qqmg-46q6 CVE - malicious monorepo-symlink-test package
-      sed -i 's/monorepo-symlink-test/false-positive/g' ${{targets.contextdir}}/usr/local/lib/node_modules/renovate/node_modules/resolve/test/resolver/multirepo/package.json
+  - runs: |
+      sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json
+
+  - runs: |
+      pnpm i --frozen-lockfile
+      pnpm build
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/usr/bin \
+      ${{targets.contextdir}}/usr/lib/renovate \
+      ${{targets.contextdir}}/usr/local
+
+      cp -a dist ${{targets.contextdir}}/usr/lib/renovate/
+      cp -a node_modules ${{targets.contextdir}}/usr/lib/renovate/
+      cp package.json ${{targets.contextdir}}/usr/lib/renovate/
+
+      # Create executable wrapper
+      printf '#!/bin/sh\nexec node /usr/lib/renovate/dist/renovate.js "$@"\n' > ${{targets.contextdir}}/usr/bin/renovate
+      chmod +x ${{targets.contextdir}}/usr/bin/renovate
+
+      ln -sf ../bin/renovate ${{targets.contextdir}}/usr/local/renovate
+
+      # Clean up musl directories
+      find ${{targets.contextdir}}/usr/lib/renovate/node_modules -type d -name '*musl*' -exec rm -rf {} + 2>/dev/null || true
 
 test:
   pipeline:

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -29,6 +29,7 @@ pipeline:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
       expected-commit: 24a828f8ebbaa3880c4c0684dbdb47979fb114f2
+      depth: 1
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,6 +1,6 @@
 package:
   name: renovate
-  version: "41.148.6"
+  version: "41.149.1"
   epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
@@ -28,7 +28,7 @@ pipeline:
     with:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
-      expected-commit: 6fd2b966f086d239562b498d6762430aed1b541a
+      expected-commit: 24a828f8ebbaa3880c4c0684dbdb47979fb114f2
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -20,6 +20,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - corepack
       - nodejs-22
       - pnpm
 
@@ -29,12 +30,13 @@ pipeline:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
       expected-commit: 24a828f8ebbaa3880c4c0684dbdb47979fb114f2
-      depth: 1
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json
 
   - runs: |
+      corepack enable
+      corepack install
       pnpm i --frozen-lockfile
       pnpm build
 


### PR DESCRIPTION
Similar to #68887 with a bit more of a lift since Renovate is built via `pnpm`.

No CVEs:
```
$ wolfictl scan packages/x86_64/renovate-41.148.6-r0.apk
🔎 Scanning "packages/x86_64/renovate-41.148.6-r0.apk"
✅ No vulnerabilities found
```