### PR TITLE
fix(kube-fluentd-operator): Bump rack to remediate GHSA-r657-rxjc-j557 and GHSA-6xw4-3v39-52mm

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 48 # CVE-2025-47907
+  epoch: 49 # GHSA-r657-rxjc-j557 and GHSA-6xw4-3v39-52mm
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -96,9 +96,11 @@ pipeline:
       # This resolves segmentation faults when reading systemd journal logs (issue #2393)
       sed -i "s/gem 'fluent-plugin-systemd', \"1.0.5\"/gem 'fluent-plugin-systemd', \"~> 1.1.0\"/" Gemfile
 
-      # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
+      # Bump rack to mitigate GHSA-r657-rxjc-j557 and GHSA-6xw4-3v39-52mm
+      echo "gem 'rack', '3.1.18'" >> Gemfile
+
       # bump net-imap to mitigate GHSA-j3g3-5qv5-52mj
-      bundle update rack net-imap --patch
+      bundle update net-imap --patch
 
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'thor', '1.4.0'" >> Gemfile


### PR DESCRIPTION
Bump rack to 3.1.18 and increment epoch.
This remediates GHSA-r657-rxjc-j557 and GHSA-6xw4-3v39-52mm.
<!--ci-cve-scan:fail-any-->
