### PR TITLE
ruby-3.{3.4}: Use self for build

### DIFF
--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: "3.3.9"
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -35,7 +35,7 @@ environment:
       - openssl-dev
       - pkgconf
       - readline-dev
-      - ruby-3.2
+      - ruby-3.3
       - rust
       - yaml-dev
       - zlib-dev

--- a/ruby-3.4.yaml
+++ b/ruby-3.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.4
   version: "3.4.7"
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -44,7 +44,7 @@ environment:
       - openssl-dev
       - pkgconf
       - readline-dev
-      - ruby-3.3
+      - ruby-3.4
       - rust
       - tk-dev
       - yaml-dev


### PR DESCRIPTION
Self depend for package build; past initial bootstrap of a new version
this should always be our default to ease removal of older language
versions as they EOL.
