### PR TITLE
fix(logstash-9.1): Bump rack and sinatra to remediate CVEs

### DIFF
--- a/logstash-9.1.yaml
+++ b/logstash-9.1.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.1
   version: "9.1.5"
-  epoch: 1
+  epoch: 2 # GHSA-6xw4-3v39-52mm, GHSA-mr3q-g2mv-mr4q and GHSA-r657-rxjc-j557
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -104,8 +104,8 @@ pipeline:
       sed -i "s/rexml (>= 3\.3\.9)/rexml (>= 3.4.2)/" "Gemfile.jruby-3.1.lock.release"
       # Fix GHSA-p543-xpfm-54cp, GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
       sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
-      echo "gem 'rack', '3.1.17'" >> Gemfile.template
-
+      echo "gem 'rack', '3.1.18'" >> Gemfile.template
+      echo "gem 'sinatra', '4.2.0'" >> Gemfile.template
 
       for plugin in ${{vars.separately-packaged-plugins}}
       do


### PR DESCRIPTION
Bump rack to 4.1.18 and sinatra to 4.2.0. Also increment epoch.
This remediates GHSA-6xw4-3v39-52mm, GHSA-mr3q-g2mv-mr4q and GHSA-r657-rxjc-j557


<!--ci-cve-scan:fail-any-->

