### PR TITLE
openjdk-{22,23,24}: use self for build

### DIFF
--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.2
-  epoch: 9
+  epoch: 10
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -47,7 +47,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-21-default-jdk
+      - openjdk-22-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
@@ -84,7 +84,7 @@ pipeline:
         --with-extra-cflags="$CFLAGS" \
         --with-extra-cxxflags="$CXXFLAGS" \
         --with-extra-ldflags="$LDFLAGS" \
-        --with-boot-jdk=/usr/lib/jvm/java-21-openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-22-openjdk \
         --prefix=/usr/lib/jvm/java-22-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-23
   version: "23.0.2"
-  epoch: 7
+  epoch: 8
   description: OpenJDK 23
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -47,7 +47,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-22-default-jdk
+      - openjdk-23-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
@@ -82,7 +82,7 @@ pipeline:
         --with-extra-cflags="$CFLAGS" \
         --with-extra-cxxflags="$CXXFLAGS" \
         --with-extra-ldflags="$LDFLAGS" \
-        --with-boot-jdk=/usr/lib/jvm/java-22-openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-23-openjdk \
         --prefix=/usr/lib/jvm/java-23-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 6
+  epoch: 7
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -50,7 +50,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-23-default-jdk
+      - openjdk-24-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
@@ -79,7 +79,7 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --with-boot-jdk=/usr/lib/jvm/java-23-openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-24-openjdk \
         --prefix=/usr/lib/jvm/java-24-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \


### PR DESCRIPTION
Update openjdk-22, openjdk-23, and openjdk-24 to use their own
-default-jdk package in the build environment instead of depending
on the previous version. Also update --with-boot-jdk to point to
the correct self-referencing path.
