### PR TITLE
aws-privateca-issuer: introduce additional tests

### DIFF
--- a/aws-privateca-issuer.yaml
+++ b/aws-privateca-issuer.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-privateca-issuer
   version: "1.7.0"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: Addon for cert-manager that issues certificates using AWS ACM PCA.
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,11 @@ subpackages:
           # Symlink the binary from usr/bin to /
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+    # test added by a robot (compat)
+    test:
+      pipeline:
+        - runs: |
+            readlink -v /manager
 
 update:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
