### PR TITLE
docker: introduce additional tests and drop dockerd subpackage

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.5.1"
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -11,10 +11,11 @@ package:
       # Include busybox because dockerd-oci-entrypoint is a shell script that execs the input params given.
       - busybox
       - ca-certificates
+      - containerd
+      - ctr
       - docker-cli
       - docker-cli-buildx
       - docker-compose
-      - dockerd
       - e2fsprogs
       - e2fsprogs-extra
       - fuse-overlayfs
@@ -28,6 +29,7 @@ package:
       - pigz
       - procps
       - shadow-subids # equivalent of shadow-uidmap in wolfi
+      - tini-static
       - xfsprogs
       - xz
       - zfs
@@ -104,6 +106,13 @@ pipeline:
           unzip -q 7d789f6d3ca9d6cef6c7cbcbbefbd6483ee3d2cd.zip
           mv */** .
 
+  - name: "install additional content"
+    runs: |
+      install -Dm755 bundles/dynbinary-daemon/docker-proxy ${{targets.destdir}}/usr/bin/docker-proxy
+      install -Dm755 bundles/dynbinary-daemon/dockerd ${{targets.destdir}}/usr/bin/dockerd
+      ln -sf /sbin/tini-static ${{targets.destdir}}/usr/bin/docker-init
+      mkdir -p ${{targets.destdir}}/usr/lib/docker/plugins
+
   # Docker is vehemenetly against stripping the resulting binary
   # Ref: https://github.com/moby/moby/blob/d8a51d2887cbc465ab8d76ed98f7a86996ab3c22/project/PACKAGERS.md#stripping-binaries
   # - uses: strip
@@ -111,31 +120,6 @@ pipeline:
       # this exists to appease yam
 
 subpackages:
-  - name: dockerd
-    description: "Docker Engine (dockerd)"
-    dependencies:
-      runtime:
-        # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
-        - btrfs-progs
-        - e2fsprogs
-        - e2fsprogs-extra
-        - ip6tables
-        - iptables
-        - openssl
-        - xfsprogs
-        - xz
-        - pigz
-        - zfs
-        - containerd
-        - ctr
-        - tini-static
-    pipeline:
-      - runs: |
-          install -Dm755 bundles/dynbinary-daemon/docker-proxy ${{targets.destdir}}/usr/bin/docker-proxy
-          install -Dm755 bundles/dynbinary-daemon/dockerd ${{targets.destdir}}/usr/bin/dockerd
-          ln -sf /sbin/tini-static ${{targets.destdir}}/usr/bin/docker-init
-          mkdir -p ${{targets.destdir}}/usr/lib/docker/plugins
-
   - name: docker-oci-entrypoint
     description: "docker OCI entrypoint"
     pipeline:
@@ -182,6 +166,10 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 /home/build/hack/dind "${{targets.subpkgdir}}"/usr/bin/dind
+    test:
+      pipeline:
+        - name: "verify dind binary is in the right place"
+          runs: stat /usr/bin/dind
 
   # ref: https://github.com/docker-library/docker/blob/bce646b7ffd6d126d920a3e06dd59d9192be8d9c/28/dind/dockerd-entrypoint.sh#L229-L231
   - name: docker-dind-compat
@@ -217,7 +205,7 @@ subpackages:
     description: "Systemd services for docker"
     dependencies:
       runtime:
-        - dockerd
+        - docker
         - containerd-service
         - systemd
     pipeline:
@@ -235,6 +223,10 @@ subpackages:
           cat <<EOF >${{targets.contextdir}}/usr/lib/sysusers.d/${{package.name}}.conf
           g docker 125
           EOF
+    test:
+      pipeline:
+        - name: "ensure expected systemd service file exists"
+          runs: stat /usr/lib/systemd/system/docker.service
 
 update:
   enabled: true


### PR DESCRIPTION
Introduce additional tests.

While at it, drop the dockerd subpackage, which is empty. No other
package or image depends on it. The files that were supposed to be
included in the dockerd subpackage are actually in the main docker
package.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
