### PR TITLE
libcap-ng: introduce additional tests

### DIFF
--- a/libcap-ng.yaml
+++ b/libcap-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap-ng
   version: 0.8.5
-  epoch: 3
+  epoch: 4
   description: POSIX capabilities library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -78,6 +78,14 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/bin
     description: posix capabilities utils
+    # test added by a robot (binary)
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/bin/bin/captest
+            stat /usr/bin/bin/filecap
+            stat /usr/bin/bin/netcap
+            stat /usr/bin/bin/pscap
 
 update:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
