### PR TITLE
bind: drop doc package

### DIFF
--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: "9.20.13"
-  epoch: 0
+  epoch: 1
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0
@@ -104,16 +104,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: bind-doc
-    pipeline:
-      - uses: split/manpages
-      - uses: split/infodir
-    description: bind manpages
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
-
   - name: bind-dev
     pipeline:
       - uses: split/dev


### PR DESCRIPTION
The package is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
