### PR TITLE
cargo-audit: drop doc package

### DIFF
--- a/cargo-audit.yaml
+++ b/cargo-audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-audit
   version: "0.21.2"
-  epoch: 7 # GHSA-xwfj-jgwm-7wp5
+  epoch: 8 # GHSA-xwfj-jgwm-7wp5
   description: Audit your dependencies for crates with security vulnerabilities reported to the RustSec Advisory Database.
   copyright:
     - license: MIT OR Apache-2.0
@@ -30,12 +30,6 @@ pipeline:
       install -Dm755 ../target/release/cargo-audit -t "${{targets.destdir}}"/usr/bin/
 
   - uses: strip
-
-subpackages:
-  - name: cargo-audit-doc
-    pipeline:
-      - uses: split/manpages
-    description: cargo-audit manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
