### PR TITLE
avahi: drop doc package

### DIFF
--- a/avahi.yaml
+++ b/avahi.yaml
@@ -1,7 +1,7 @@
 package:
   name: avahi
   version: 0.9_rc1
-  epoch: 43
+  epoch: 44
   description: A multicast/unicast DNS-SD framework
   copyright:
     - license: LGPL-2.1
@@ -74,14 +74,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: avahi-doc
-    pipeline:
-      - uses: split/manpages
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
-
   - name: avahi-dev
     pipeline:
       - uses: split/dev


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
