### PR TITLE
libhtp: drop doc package

### DIFF
--- a/libhtp.yaml
+++ b/libhtp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libhtp
   version: "0.5.52"
-  epoch: 0
+  epoch: 1
   description: LibHTP is a security-aware parser for the HTTP protocol and the related bits and pieces
   copyright:
     - license: BSD-3-Clause
@@ -54,11 +54,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: libhtp-doc
-    pipeline:
-      - uses: split/manpages
-    description: libhtp manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
