### PR TITLE
gst-plugins-bad: drop doc subpackage

### DIFF
--- a/gst-plugins-bad.yaml
+++ b/gst-plugins-bad.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-bad
   version: "1.27.2"
-  epoch: 1
+  epoch: 2
   description: GStreamer streaming media framework bad plug-ins
   copyright:
     - license: LGPL-2.1
@@ -79,11 +79,6 @@ subpackages:
         - uses: test/tw/ldd-check
           with:
             packages: ${{subpkg.name}}
-
-  - name: ${{package.name}}-doc
-    pipeline:
-      - uses: split/manpages
-    description: ${{package.name}} manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
