### PR TITLE
git-crypt: drop doc subpackage

### DIFF
--- a/git-crypt.yaml
+++ b/git-crypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-crypt
   version: "0.8.0"
-  epoch: 0
+  epoch: 1
   description: Transparent file encryption in git
   copyright:
     - license: GPL-3.0-or-later
@@ -29,12 +29,6 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
-
-subpackages:
-  - name: git-crypt-doc
-    pipeline:
-      - uses: split/manpages
-    description: git-crypt manpages
 
 test:
   pipeline:


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
