### PR TITLE
font-misc-cyrillic: drop doc subpackage

### DIFF
--- a/font-misc-cyrillic.yaml
+++ b/font-misc-cyrillic.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-misc-cyrillic
   version: 1.0.4
-  epoch: 2
+  epoch: 3
   description: X.org misc cyrillic fonts
   copyright:
     - license: LicenseRef-xorg-font-misc-cyrillic
@@ -36,12 +36,6 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
-
-subpackages:
-  - name: font-misc-cyrillic-doc
-    pipeline:
-      - uses: split/manpages
-    description: font-misc-cyrillic manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
