### PR TITLE
tomcat-11: Add OpenJDK 25 support

### DIFF
--- a/tomcat-11.0.yaml
+++ b/tomcat-11.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-11.0
   version: "11.0.13"
-  epoch: 0
+  epoch: 1
   description: Apache Tomcat Web Server
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,7 @@ package:
 data:
   - name: openjdk-versions
     items:
+      25: "openjdk-25"
       21: "openjdk-21"
       17: "openjdk-17"
 
@@ -26,8 +27,9 @@ environment:
       - curl
       - openjdk-17
       # Only 17 is used during the build process
-      # 11 and 21 are included for tests
+      # 21 and 25 are included for tests
       - openjdk-21
+      - openjdk-25
       - tomcat-native
 
 pipeline:
@@ -54,7 +56,7 @@ subpackages:
     pipeline:
       - runs: |
           # Only OpenJDK 17 is supported at buildtime
-          # However, we're able to run Tomcat with OpenJDK 17-21
+          # However, we're able to run Tomcat with OpenJDK 17-25
           export JAVA_HOME="/usr/lib/jvm/java-17-openjdk"
 
           ant -Dskip.build.java.version=true


### PR DESCRIPTION
Add OpenJDK 25 to the list of supported java versions and build
dependencies.
