### PR TITLE
meson: drop doc subpackage

### DIFF
--- a/meson.yaml
+++ b/meson.yaml
@@ -1,7 +1,7 @@
 package:
   name: meson
   version: "1.9.1"
-  epoch: 0
+  epoch: 1
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0
@@ -132,11 +132,6 @@ subpackages:
           with:
             python: python3.13
             import: ${{vars.import}}
-
-  - name: meson-doc
-    pipeline:
-      - uses: split/manpages
-    description: meson manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
