### PR TITLE
linux-pam: drop doc subpackage

### DIFF
--- a/linux-pam.yaml
+++ b/linux-pam.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-pam
   version: "1.7.1"
-  epoch: 1
+  epoch: 2
   description: Linux PAM (Pluggable Authentication Modules for Linux)
   copyright:
     - license: BSD-3-Clause
@@ -73,15 +73,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: linux-pam-doc
-    pipeline:
-      - uses: split/manpages
-    description: linux-pam manpages
-    dependencies:
-      runtime:
-        - merged-usrsbin
-        - wolfi-baselayout
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
