### PR TITLE
libxtst: drop doc subpackage

### DIFF
--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxtst
   version: 1.2.5
-  epoch: 3
+  epoch: 4
   description: X11 Testing -- Resource extension library
   copyright:
     - license: XFree86-1.1
@@ -55,11 +55,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: libxtst-doc
-    pipeline:
-      - uses: split/manpages
-    description: libxtst manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
