### PR TITLE
libxi: drop doc subpackage

### DIFF
--- a/libxi.yaml
+++ b/libxi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxi
   version: 1.8.2
-  epoch: 3
+  epoch: 4
   description: X11 Input extension library
   copyright:
     - license: MIT AND X11
@@ -60,11 +60,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: libxi-doc
-    pipeline:
-      - uses: split/manpages
-    description: libxi manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
