### PR TITLE
curl-rustls: fix TLS 1.1 rejection test logic

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -153,21 +153,23 @@ test:
                 return 1;
             }
 
-            // Try to force TLS 1.1 - this should fail with rustls
+            // Try to force TLS 1.1 only - this should fail with rustls
             curl_easy_setopt(curl, CURLOPT_URL, "https://wolfi.dev");
-            curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1);
+            curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1 | CURL_SSLVERSION_MAX_TLSv1_1);
 
             res = curl_easy_perform(curl);
 
             // rustls should reject TLS 1.1
-            if (res != CURLE_SSL_CONNECT_ERROR) {
-                fprintf(stderr, "Expected TLS 1.1 to fail with rustls\n");
+            // CURLE_SSL_CONNECT_ERROR (35) or CURLE_BAD_FUNCTION_ARGUMENT (43) are acceptable
+            // Error 43 means rustls rejected the TLS version before even connecting
+            if (res != CURLE_SSL_CONNECT_ERROR && res != CURLE_BAD_FUNCTION_ARGUMENT) {
+                fprintf(stderr, "Expected TLS 1.1 to fail with rustls, got error code: %d\n", res);
                 curl_easy_cleanup(curl);
-                return 0;
+                return 1;
             }
 
             curl_easy_cleanup(curl);
-            return 1;
+            return 0;
         }
         EOF
         gcc test.c -o test -lcurl


### PR DESCRIPTION
## Summary

Fixed the "Verify rustls backend behavior" test which had inverted logic and was testing the wrong behavior.

## The Bug

The test had two issues:

1. **Inverted return codes**: The test returned 0 (success) when rustls accepted TLS 1.1 and returned 1 (failure) when rustls rejected it - the exact opposite of what should happen.

2. **Incomplete version constraint**: The test only set `CURLOPT_SSLVERSION` to TLS 1.1, which sets the *minimum* version. This allowed rustls to upgrade to TLS 1.2+, causing the connection to succeed with a higher protocol version. The test was passing because rustls was upgrading, not because the test logic was correct.

## The Fix

1. **Swapped return codes**: Now returns 0 (success) when rustls rejects TLS 1.1, and 1 (failure) when it accepts it.

2. **Force TLS 1.1 only**: Set both min and max TLS version using `CURL_SSLVERSION_TLSv1_1 | CURL_SSLVERSION_MAX_TLSv1_1` to prevent version negotiation.

3. **Accept appropriate error codes**: rustls correctly rejects TLS 1.1 and returns `CURLE_BAD_FUNCTION_ARGUMENT` (43), indicating it rejected the unsupported version before attempting connection. The test now accepts both this and `CURLE_SSL_CONNECT_ERROR` (35) as valid rejection codes.

## Test Verification

The test now correctly validates that rustls rejects TLS 1.1 (which only supports TLS 1.2+).