### PR TITLE
fix(mlfow): GHSA-g7f3-828f-7h7m, GHSA-pq5p-34cr-23v9 constrain authlib>1.6.4

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.4.0"
-  epoch: 1
+  epoch: 2
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -71,8 +71,8 @@ pipeline:
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip install --upgrade "requests>=2.32.4"
 
-      # Upgrade requests to fix GHSA-9ggr-2464-2j32
-      pip install --upgrade "authlib>=1.6.4"
+      # Upgrade authlib to fix GHSA-pq5p-34cr-23v9, GHSA-g7f3-828f-7h7m
+      pip install --upgrade "authlib>1.6.4"
 
       # Remove pip
       pip uninstall --yes pip


### PR DESCRIPTION
authlib 1.6.4 has two CVEs against it

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31118, https://github.com/chainguard-dev/CVE-Dashboard/issues/31041

<!--ci-cve-scan:must-fix: GHSA-g7f3-828f-7h7m-->
<!--ci-cve-scan:must-fix: GHSA-pq5p-34cr-23v9-->