### PR TITLE
fix(k8s-sidecar): GHSA-2c2j-9gv5-cj73 unpin specific fastapi version

### DIFF
--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: "1.31.0"
-  epoch: 0
+  epoch: 1
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT
@@ -33,6 +33,7 @@ pipeline:
       # Mitigate CVE-2022-40897 / GHSA-r9hx-vwmv-q579
       pip install --upgrade setuptools
       sed -i 's/requests==2\.32\.3/requests==2.32.4/' /home/build/src/requirements.txt # fix GHSA-9hjg-9r4m-mvj7
+      sed -i 's/fastapi==0\.115\.2/fastapi==0.119.0/' /home/build/src/requirements.txt # fix GHSA-2c2j-9gv5-cj73
       pip install --no-cache-dir -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"
 
       # Patch CVE-2024-3651


### PR DESCRIPTION
Upstream requirements.txt pins fastapi to 0.115.2, which introduces starlette<0.41.0 which includes
this CVE.  Since there is no comment on why the fastapi version is strictly pinned to the one
0.115.2 version, let fastapi upgrade to pick up a newer starlette.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31331

<!--ci-cve-scan:fail-any-->
