### PR TITLE
fix(ruby3.2-elasticsearch): Bump to elasticsearch 9.1.5

### DIFF
--- a/ruby3.2-elasticsearch.yaml
+++ b/ruby3.2-elasticsearch.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.2-elasticsearch
-  version: "9.1.2"
+  version: "9.1.5"
   epoch: 0
   description: |
     Ruby integrations for Elasticsearch (client, API, etc.)
@@ -25,8 +25,14 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/elastic/elasticsearch-ruby.git
-      tag: v${{package.version}}
+      tag: v${{vars.upstream-version}}
       expected-commit: b91799e5f94fb8a949af98ed86102fa6984793a1
+
+  - runs: |
+      # Bump elasticsearch version to 9.1.5 before upstream 9.1.5 release
+      sed -i "s|VERSION = '9.1.2'|VERSION = '9.1.5'|" elasticsearch-api/lib/elasticsearch/api/version.rb
+      sed -i "s|s.add_dependency 'elasticsearch-api', '9.1.2'|s.add_dependency 'elasticsearch-api', '9.1.5'|" elasticsearch/elasticsearch.gemspec
+      sed -i "s|VERSION = '9.1.2'|VERSION = '9.1.5'|" elasticsearch/lib/elasticsearch/version.rb
 
   - working-directory: ${{vars.gem}}
     pipeline:
@@ -41,6 +47,7 @@ pipeline:
 
 vars:
   gem: elasticsearch
+  upstream-version: "9.1.2"
 
 update:
   enabled: true


### PR DESCRIPTION
Remediates CVE-2025-37727


<!--ci-cve-scan:fail-any-->

