### PR TITLE
ldb: drop doc subpackage

### DIFF
--- a/ldb.yaml
+++ b/ldb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ldb
   version: 2.9.1
-  epoch: 6
+  epoch: 7
   description: schema-less, ldap like, API and database
   copyright:
     - license: LGPL-3.0-or-later
@@ -208,11 +208,6 @@ subpackages:
             ldbrename --help
             ldbsearch --help
         - uses: test/tw/ldd-check
-
-  - name: ldb-doc
-    pipeline:
-      - uses: split/manpages
-    description: ldb manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
