### PR TITLE
feat(melange.yaml): Manual bump melange to v0.31.8

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: melange
-  version: "0.31.7"
+  version: "0.31.8"
   epoch: 0
   description: build APKs from source code
   copyright:
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0cbbd8bc31b6f44f7d411e7b8e0dc6621cb03d12
+      expected-commit: e01ce749c30dc120bf147a837831ca799b449b96
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
Due to a bug in v0.31.7 causing auto updates to fail we need to manually bump melange in parallel
to fixing melange and mono so that we can fix the lint checks in the package repos which were also
affected by the v0.31.7 bug.

The v0.31.7 bug was reverted in v0.31.8 with PR https://github.com/chainguard-dev/melange/pull/2185

Signed-off-by: philroche <phil.roche@chainguard.dev>
