### PR TITLE
libxfont: drop doc subpackage

### DIFF
--- a/libxfont.yaml
+++ b/libxfont.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxfont
   version: 2.0.7
-  epoch: 2
+  epoch: 3
   description: "X font handling library for server & utilities"
   copyright:
     - license: BSD-4-Clause
@@ -24,9 +24,6 @@ pipeline:
       expected-sha256: 8b7b82fdeba48769b69433e8e3fbb984a5f6bf368b0d5f47abeec49de3e58efb
 
   - uses: autoconf/configure
-    with:
-      opts: |
-        --mandir=/usr/share/man
 
   - uses: autoconf/make
 
@@ -40,10 +37,6 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
-
-  - name: libxfont-doc
-    pipeline:
-      - uses: split/manpages
 
 update:
   enabled: true


### PR DESCRIPTION
It is empty, and while upstream sources do include documentation, we lack
required dependencies to build the target: such as xorg-fop, etc.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
