### PR TITLE
chore: update pre-commit-config sha

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # See https://eng.inky.wtf/docs/technical/git/pre-commit for info on how to edit this file.
 repos:
   - repo: https://github.com/chainguard-dev/pre-commit-hooks
-    rev: 3ba2c40e8ab2132fe57e79aac2274e911161e6d0
+    rev: a90aaa7f63ec8c376e8bd6cd3460c77bedcfb0ed
     hooks:
       - id: shellcheck-run-steps
         files: '^[^.][^/]*\.yaml$' # matches non-hidden .yaml files at the top level only


### PR DESCRIPTION
    chore: update pre-commit-config sha

    we've reverted melange var-transforms change and post that we updated
    pre-commit-hooks repo to use melange:latest image again and
    now this is updating of commit sha so that we use melange:latest image
    in CI during lint and locally as well.