### PR TITLE
py3-python-pypi-mirror: switch to git update backend

### DIFF
--- a/py3-python-pypi-mirror.yaml
+++ b/py3-python-pypi-mirror.yaml
@@ -58,8 +58,7 @@ subpackages:
 update:
   enabled: true
   manual: false
-  github:
-    identifier: montag451/pypi-mirror
+  git:
     strip-prefix: v
 
 test:


### PR DESCRIPTION
We need to look at tags, not releases.