### PR TITLE
chore: creates symlink to /usr/local/bin

### DIFF
--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.1"
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -290,18 +290,12 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+          ln -sf ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
     test:
       pipeline:
-        - name: "Check symlink /usr/bin/${{range.key}} points to the expected binary /usr/bin/${{range.key}}-${{vars.kubernetes-version}}"
-          runs: |
-            readlink="$(readlink -f /usr/bin/${{range.key}})"
-            expected="/usr/bin/${{range.key}}-${{vars.kubernetes-version}}"
-            if ! echo "$readlink" | grep -q "$expected" ; then
-                echo "FAIL: unexpected link. Expected: [$expected] but got:" >&2
-                echo "$readlink" >&2
-                exit 1
-            fi
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
         - uses: test/virtualpackage
           with:
             virtual-pkg-name: "${{range.key}}-default"
@@ -311,28 +305,45 @@ subpackages:
             virtual-pkg-name: "${{range.key}}"
             real-pkg-name: "${{subpkg.name}}"
 
-  - name: kube-proxy-${{vars.kubernetes-version}}-default-compat
-    description: kube-proxy-default compatibility package
+  - range: components
+    name: "${{range.key}}-${{vars.kubernetes-version}}-default-compat"
+    dependencies:
+      runtime:
+        - ${{range.key}}-${{vars.kubernetes-version}}
+      provides:
+        - ${{range.key}}-default-compat=${{vars.kubernetes-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          ln -sf /usr/bin/kube-proxy-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/local/bin/kube-proxy
+          ln -sf /usr/bin/${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/local/bin/${{range.key}}
     test:
       pipeline:
-        - runs: stat /usr/local/bin/kube-proxy
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: "${{range.key}}-default-compat"
+            real-pkg-name: "${{subpkg.name}}"
 
   - name: kubernetes-${{vars.kubernetes-version}}-default
     description: "Compatibility meta package to set ${{vars.kubernetes-version}} as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
         - kubectl-${{vars.kubernetes-version}}-default
+        - kubectl-${{vars.kubernetes-version}}-default-compat
         - kubeadm-${{vars.kubernetes-version}}-default
+        - kubeadm-${{vars.kubernetes-version}}-default-compat
         - kubelet-${{vars.kubernetes-version}}-default
+        - kubelet-${{vars.kubernetes-version}}-default-compat
         - kube-scheduler-${{vars.kubernetes-version}}-default
+        - kube-scheduler-${{vars.kubernetes-version}}-default-compat
         - kube-proxy-${{vars.kubernetes-version}}-default
         - kube-proxy-${{vars.kubernetes-version}}-default-compat
         - kube-controller-manager-${{vars.kubernetes-version}}-default
+        - kube-controller-manager-${{vars.kubernetes-version}}-default-compat
         - kube-apiserver-${{vars.kubernetes-version}}-default
+        - kube-apiserver-${{vars.kubernetes-version}}-default-compat
     checks:
       disabled:
         - empty


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
