### PR TITLE
ssh-import-id - split into multi-version.

### DIFF
--- a/ssh-import-id.yaml
+++ b/ssh-import-id.yaml
@@ -1,18 +1,22 @@
 package:
   name: ssh-import-id
   version: 5.11
-  epoch: 3
+  epoch: 4
   description: securely retrieve an SSH public key and install it locally
   copyright:
     - license: GPL-3.0-or-later
-  dependencies:
-    runtime:
-      - ca-certificates-bundle
-      - openssh-client
-      - openssh-server
-      - py3-distro
-      - python3
-      - wget
+
+vars:
+  pypi-package: ssh-import-id
+  import: ssh_import_id
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
@@ -20,9 +24,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-distro
-      - py3-setuptools
-      - python3
+      - py3-supported-build-base
       - wolfi-base
 
 pipeline:
@@ -32,24 +34,61 @@ pipeline:
       expected-commit: 4fa6a5f2286b74d1699d49ac887dd8bd332a7cbc
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - ca-certificates-bundle
+        - openssh-keygen
+        - py${{range.key}}-distro
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - ssh-import-id=${{package.full-version}}
+    pipeline:
+      - uses: split/bin
+    test:
+      pipeline:
+        - runs: |
+            ssh-import-id kirkland
+            ssh-import-id-lp kirkland
+            ssh-import-id-gh dustinkirkland
+            ssh-import-id --help
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: test/metapackage
 
 update:
   enabled: true
   git: {}
   ignore-regex-patterns:
     - ^ubuntu/.*
-
-test:
-  pipeline:
-    - runs: |
-        ssh-import-id kirkland
-        ssh-import-id-lp kirkland
-        ssh-import-id-gh dustinkirkland
-        ssh-import-id --help


### PR DESCRIPTION
This was depending on "python3" any old python, but would not work as it used a library outside of stdlib (py3-distro). So if py3-distro came from a different version of python than 'python3' got, the py3-distro would not be available to /usr/bin/ssh-import-id

Also drop wget, which just isnt' used.
