### PR TITLE
chore(Makefile): Add melange compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,15 @@ $(testdbg_targets): test-debug/%: cache $(KEY) $(QEMU_KERNEL_DEP)
 	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"
 	$(MELANGE) test $(yamlfile) $(MELANGE_TEST_OPTS) $(MELANGE_DEBUG_TEST_OPTS) --source-dir ./$(*)/
 
+# Please do not print any additional content via this target
+# so that we can parse output directly with jq
+compile_targets = $(foreach name,$(pkgs),compile/$(name))
+$(compile_targets): compile/%:
+	@$(MAKE) $(KEY) >/dev/null 2>&1
+	@mkdir -p ./$(*)/
+	$(eval yamlfile := $*.yaml)
+	@$(MELANGE) compile $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(*)/
+
 .PHONY: dev-container
 dev-container:
 	docker run --pull=always --privileged --rm -it \


### PR DESCRIPTION
Adds a target for compiling melange manifests. We have a number of pipelines that are used in package manifests so being able to parse everything with jq in a one liner can be very helpful

The limitation being that we can't actually print anything else from this target for it to be helpful so make a note of that