### PR TITLE
fix(celeborn-0.5): Bump netty.version to remediate GHSA-jq43-27x9-3v86

### DIFF
--- a/celeborn-0.5.yaml
+++ b/celeborn-0.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.5
   version: 0.5.4
-  epoch: 7
+  epoch: 8 # GHSA-jq43-27x9-3v86
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0

--- a/celeborn-0.5/pombump-deps.yaml
+++ b/celeborn-0.5/pombump-deps.yaml
@@ -5,3 +5,6 @@ patches:
   - groupId: com.fasterxml.jackson.core
     artifactId: jackson-core
     version: 2.13.0
+  - groupId: io.netty
+    artifactId: netty-codec-smtp
+    version: 4.1.128.Final


### PR DESCRIPTION
Bump netty.version to 4.1.128.Final to remediate GHSA-jq43-27x9-3v86. Also bump epoch.
<!--ci-cve-scan:fail-any-->

