### PR TITLE
libcmis: drop doc subpackage

### DIFF
--- a/libcmis.yaml
+++ b/libcmis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcmis
   version: 0.6.2
-  epoch: 6
+  epoch: 7
   description: C/C++ CMIS client library
   copyright:
     - license: GPL-2.0-or-later
@@ -38,6 +38,7 @@ pipeline:
 
   - uses: autoconf/configure
     with:
+      # bulding docs requires docbook2x which we don't have
       opts: |
         --disable-tests \
         --without-man
@@ -49,10 +50,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: libcmis-doc
-    pipeline:
-      - uses: split/manpages
-
   - name: libcmis-dev
     pipeline:
       - uses: split/dev


### PR DESCRIPTION
It is empty, we don't generate docs on purpose, because we are missing
a dependency.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
