### PR TITLE
Seaweedfs: Install OCI entrypoint at root location and add packages

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,10 +1,13 @@
 package:
   name: seaweedfs
   version: "3.97"
-  epoch: 1 # GHSA-2464-8j7c-4cjm
+  epoch: 2 # GHSA-2464-8j7c-4cjm
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - dash-binsh
 
 environment:
   environment:
@@ -25,23 +28,61 @@ pipeline:
       ldflags: |
         -extldflags -static -X github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(git rev-parse HEAD)
 
-  - name: Add config file and entrypoint script
+  - name: Add config file
     runs: |
       mkdir -p ${{targets.destdir}}/etc/seaweedfs
-      mkdir -p ${{targets.destdir}}/usr/bin
       cp ./docker/filer.toml ${{targets.destdir}}/etc/seaweedfs/filer.toml
-      cp ./docker/entrypoint.sh ${{targets.destdir}}/usr/bin/entrypoint.sh
-      chmod +x ${{targets.destdir}}/usr/bin/entrypoint.sh
+
+subpackages:
+  - name: ${{package.name}}-oci-entrypoint
+    description: Entrypoint for SeaweedFS in OCI containers
+    dependencies:
+      runtime:
+        - dash-binsh
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          cp docker/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
+          chmod +x ${{targets.contextdir}}/entrypoint.sh
+    test:
+      environment:
+        contents:
+          packages:
+            - "${{package.name}}"
+      pipeline:
+        - runs: |
+            test -x /entrypoint.sh
+            /entrypoint.sh help | grep -F "SeaweedFS"
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - jq
+        - wait-for-it
+    environment:
+      MASTER_PORT: "9333"
   pipeline:
-    - uses: test/tw/ver-check
-      with:
-        bins: weed entrypoint.sh
-    - name: "help command"
+    - name: "Version and help commands"
       runs: |
-        entrypoint.sh help
-        weed help
+        weed version |  grep -F "${{package.version}}"
+        weed help | grep -F "SeaweedFS"
+    - name: "Test master server startup and API"
+      uses: test/daemon-check-output
+      with:
+        start: weed master -ip=0.0.0.0 -port="${MASTER_PORT}" -mdir=/tmp/seaweedfs-test
+        timeout: 45
+        expected_output: |
+          Start Seaweed Master
+          No existing leader found!
+          Initializing new cluster
+        post: |
+          wait-for-it "localhost:${MASTER_PORT}" -t 30
+
+          curl -sf "http://localhost:${MASTER_PORT}/cluster/status" | grep -F "Leader"
+          curl -sf "http://localhost:${MASTER_PORT}/dir/assign" | jq -e ".fid and .url"
+          curl -sf "http://localhost:${MASTER_PORT}/dir/status" | jq -e ".Topology"
 
 update:
   enabled: true

--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -5,9 +5,6 @@ package:
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - dash-binsh
 
 environment:
   environment:
@@ -41,9 +38,7 @@ subpackages:
         - dash-binsh
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          cp docker/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
-          chmod +x ${{targets.contextdir}}/entrypoint.sh
+          install -Dm755 docker/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
     test:
       environment:
         contents:


### PR DESCRIPTION
Fixes: 
1. dash-binsh is required on the image level, helm installation is failing without it 
check here : https://github.com/seaweedfs/seaweedfs/blob/master/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml#L124
2. entrypoint is expected at root by the docker file 
check here: https://github.com/seaweedfs/seaweedfs/blob/master/docker/Dockerfile.e2e#L41