### PR TITLE
chore(daemon-check-output): remove leading/trailing quotes from error…

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -203,6 +203,8 @@ pipeline:
           set --
           while read line ; do
               [ "$line" = "" ] && continue
+              # Strip leading and trailing quotes from error patterns
+              line=$(echo "$line" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/")
               set -- "$@" "$line"
           done < "$ERRORS_F"
           num_error_strings=$#

--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -204,7 +204,7 @@ pipeline:
           while read line ; do
               [ "$line" = "" ] && continue
               # Strip leading and trailing quotes from error patterns
-              line=$(echo "$line" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/")
+              line=$(echo "$line" | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")
               set -- "$@" "$line"
           done < "$ERRORS_F"
           num_error_strings=$#


### PR DESCRIPTION
… strings

Some of our package tests have quoted error strings and they need to be removed for proper error detection.
          
