### PR TITLE
fix(pre-commit-config): temporarily disable shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,22 +3,23 @@
 # and can be assumed to be the "source of truth" for our pre-commit rules.
 # See https://eng.inky.wtf/docs/technical/git/pre-commit for info on how to edit this file.
 repos:
-  - repo: https://github.com/chainguard-dev/pre-commit-hooks
-    rev: a90aaa7f63ec8c376e8bd6cd3460c77bedcfb0ed
-    hooks:
-      - id: shellcheck-run-steps
-        files: '^[^.][^/]*\.yaml$' # matches non-hidden .yaml files at the top level only
-        exclude: '^celeborn-0\.5\.yaml$' # for details see https://github.com/chainguard-dev/internal-dev/issues/18336
-        args:
-          - "--" # options to hook before this, options to shellcheck after
-          - "-S"
-          - "error"
-          - "--" # terminates shellcheck options, rest will be filenames
-      - id: check-for-epoch-bump
-        files: |
-          (?x)^(
-              [^/]+\.ya?ml                      # matches .yaml or .yml files at the top level only
-          )$
+  #
+  #- repo: https://github.com/chainguard-dev/pre-commit-hooks
+  #  rev: a90aaa7f63ec8c376e8bd6cd3460c77bedcfb0ed
+  #  hooks:
+  #    - id: shellcheck-run-steps
+  #      files: '^[^.][^/]*\.yaml$' # matches non-hidden .yaml files at the top level only
+  #      exclude: '^celeborn-0\.5\.yaml$' # for details see https://github.com/chainguard-dev/internal-dev/issues/18336
+  #      args:
+  #        - "--" # options to hook before this, options to shellcheck after
+  #        - "-S"
+  #        - "error"
+  #        - "--" # terminates shellcheck options, rest will be filenames
+  #    - id: check-for-epoch-bump
+  #      files: |
+  #        (?x)^(
+  #            [^/]+\.ya?ml                      # matches .yaml or .yml files at the top level only
+  #        )$
   - repo: https://github.com/chainguard-dev/yam
     rev: 768695300c5f663012a77911eb4920c12e5ed2e5 # frozen: v0.2.26
     hooks:


### PR DESCRIPTION
Dockerhub is having service issues and we are unable to download the
docker image.
Temporarily disable the check until services are restored.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
