### PR TITLE
block unapproved hmac

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -44,7 +44,10 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch 0001-baseprovider-add-MD5-and-SHA1.patch
+      patches: |
+        fix-jitter.patch
+        0001-baseprovider-add-MD5-and-SHA1.patch
+        0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,4 +1,3 @@
-#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
   version: "3.6.0"

--- a/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
+++ b/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
@@ -1,0 +1,43 @@
+From 537e05c1d82cac17f28c0b0100f3964115acef9d Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Mon, 20 Oct 2025 16:56:30 +0100
+Subject: [PATCH] fips: block HMAC calculation with unapproved digests
+
+When using legacy HMAC APIs as used by older nodejs, dotnet, and
+python - one can attempt to create HMAC using unapproved digest.
+
+Block such access.
+---
+ crypto/hmac/hmac.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/crypto/hmac/hmac.c b/crypto/hmac/hmac.c
+index 19fc7d3b4f..9eb50dc607 100644
+--- a/crypto/hmac/hmac.c
++++ b/crypto/hmac/hmac.c
+@@ -18,6 +18,7 @@
+ #include <string.h>
+ #include "internal/cryptlib.h"
+ #include <openssl/opensslconf.h>
++#include <openssl/provider.h>
+ #include <openssl/hmac.h>
+ #include <openssl/core_names.h>
+ #include "hmac_local.h"
+@@ -49,6 +50,14 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+     if (EVP_MD_xof(md))
+         return 0;
+ 
++    /*
++     * Block non-fips provider digest in FIPS mode
++     */
++    if (EVP_default_properties_is_fips_enabled(NULL) &&
++        strcmp("fips", OSSL_PROVIDER_get0_name(EVP_MD_get0_provider(md)))) {
++        return 0;
++    }
++
+ #ifdef OPENSSL_HMAC_S390X
+     rv = s390x_HMAC_init(ctx, key, len, impl);
+     if (rv >= 1)
+-- 
+2.51.0
+


### PR DESCRIPTION
- **openssl: drop obsolete nolint**
  Forbidden repositories are no longer used.
  

- **openssl: add patch to block deprecated HMAC API in FIPS mode**
  When using deprecated HMAC API, ensure that digest is from the FIPS
  provider. This should block creating FIPS HMAC with unapproved digests.
  