### PR TITLE
google-cloud-sdk - rework to support any python

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,37 +1,27 @@
 package:
   name: google-cloud-sdk
   version: "543.0.0"
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
   dependencies:
-    provider-priority: 0
     runtime:
-      # Required for cyclic redunancy check (gsutil help crcmod)
-      - py3.11-crcmod
+      - py3.13-${{package.name}}
 
-# Note, application does not support python v3.12, as of today, and fails if attempted:
-# Error: gsutil requires Python version 2.7 or 3.5-3.11, but a different version is installed.
-# You are currently running Python 3.12
-# WARN Follow the steps below to resolve this issue:
-# 1. Switch to Python 3.5-3.11 using your Python version manager or install an appropriate version.
-# 2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.
-# Also see: https://issuetracker.google.com/issues/303737178?pli=1
 data:
   - name: py-versions
     items:
       3.10: "310"
       3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
     packages:
-      - bash
-      - build-base
-      - busybox
       - ca-certificates-bundle
-      - python-3.11
+      - python-3.13
       - wolfi-base
 
 pipeline:
@@ -83,26 +73,41 @@ pipeline:
 
   - uses: strip
 
-# these just force the installation of a specific
-# version of python even though the gcloud tools poke around
-# to find one.  As it is, if you had multiple pythons installed,
-# then you aren't actually guaranteed to have given version run it.
 subpackages:
+  - name: ${{package.name}}-core
+    description: "install files for google-cloud-sdk with no specific python"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"
+          mv "${{targets.destdir}}"/* "${{targets.contextdir}}"/
+
+  # these just force the installation of a specific
+  # version of python even though the gcloud tools poke around
+  # to find one.  As it is, if you had multiple pythons installed,
+  # then you aren't actually guaranteed to have given version run it.
   - range: py-versions
     name: py${{range.key}}-google-cloud-sdk
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
-      provider-priority: ${{range.value}}
       runtime:
-        - google-cloud-sdk
+        - ${{package.name}}-core
         - python-${{range.key}}-base
         - py${{range.key}}-crcmod
-    # test added by a robot. The APK was empty when it was checked,
-    # which may not be true forever. If this test fails in the future, please
-    # replace it with a more accurate test.
     test:
       pipeline:
+        # emptypackage added by a robot. The APK was empty when it was checked,
+        # which may not be true forever. If this test fails in the future, please
+        # replace it with a more accurate test.
         - uses: test/emptypackage
+        - uses: test/tw/ldd-check
+        - uses: test/tw/ver-check
+          with:
+            bins: gcloud
+        - uses: test/tw/help-check
+          with:
+            bins: docker-credential-gcloud gcloud git-credential-gcloud.sh gsutil
+        - runs: |
+            gcloud components list
 
   - name: ${{package.name}}-iamguarded-compat
     description: "compat package with iamguarded/google-cloud-sdk image"
@@ -111,8 +116,7 @@ subpackages:
         - bash
         - busybox
         - merged-usrsbin
-        - python-3.11-base
-        - py3.11-crcmod
+        - py3.11-google-cloud-sdk
         - wolfi-baselayout
     pipeline:
       - uses: iamguarded/build-compat
@@ -162,18 +166,15 @@ subpackages:
 
 test:
   pipeline:
-    - runs: |
-        gcloud --version
-        gsutil --version
-        gcloud components list
-        bq version
-        docker-credential-gcloud version
-        docker-credential-gcloud --help 2>&1 | cat
-        gcloud --help 2>&1 | cat
-        git-credential-gcloud.sh version
-        git-credential-gcloud.sh --help 2>&1 | cat
-        gsutil help 2>&1 | cat
     - uses: test/tw/ldd-check
+    - uses: test/tw/ver-check
+      with:
+        bins: gcloud
+    - uses: test/tw/help-check
+      with:
+        bins: docker-credential-gcloud gcloud git-credential-gcloud.sh gsutil
+    - runs: |
+        gcloud components list
 
 update:
   enabled: true


### PR DESCRIPTION
Things kept the same:
 * iamguarded package will still get you a python-3.11.  I have no idea if this is needed or desired, it can easily be changed to any 3.XX now.

Changes:
 * 'apk add google-cloud-sdk' will now get you python3.13.
 * build for python 3.12 and 3.13 gcloud's gsutil dependency previously only supported python 3.11. That is now fixed https://github.com/GoogleCloudPlatform/gsutil/issues/1776 and google-cloud-sdk tests ok with 3.13.
 * add '-core' package that contains all the content gcloud.
 * make 'google-cloud-sdk' package just a shim that has a dependency on a specific py3.XX-google-cloud-sdk (currently 3.13). So if you install 'google-cloud-sdk', you're going to get python 3.13. Previously this would get you 3.11. Ideally images or user would select the python 'py3.XX-google-cloud-sdk' that matches other packages so they do not end up with multiple pythons.
 * Add tests for subpackages using tw/ver-check and tw/help-check
 * build environment cleanup

Things to note:
 * Installing 'py3.XX-google-cloud-sdk' does not currently guarantee that 'gcloud' will use py3.XX. It really only guarantees that python-3.XX will be installed.  the 'gcloud' shell script pokes around and finds a python version to execute. If there are more than one, it will pick one.
