### PR TITLE
giflib: set cpe for better scanner support

### DIFF
--- a/giflib.yaml
+++ b/giflib.yaml
@@ -1,7 +1,10 @@
 package:
   name: giflib
   version: 5.2.2
-  epoch: 10
+  epoch: 11
+  cpe:
+    vendor: "giflib_project"
+    product: "giflib"
   description: "A library for reading and writing GIF images"
   copyright:
     - license: MIT


### PR DESCRIPTION
Set cpe for better scanner support

This will cause this detection event:

```
$ wolfictl scan giflib-5.2.2-r11.apk 
🔎 Scanning "giflib-5.2.2-r11.apk"
└── 📄 /.PKGINFO
        📦 giflib 5.2.2-r11 (apk)
            Medium CVE-2024-45993
```

https://github.com/wolfi-dev/os/pull/69625/checks?check_run_id=53310723928 is also now accurate