### PR TITLE
thingsboard: fix GHSA-7fch-4f2f-jcgm by updating spring-core to 6.2.12

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "4.2.1"
-  epoch: 3 # GHSA-7fch-4f2f-jcgm
+  epoch: 4 # GHSA-7fch-4f2f-jcgm
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -4,7 +4,7 @@ patches:
     version: 4.9.9
   - groupId: org.springframework.security
     artifactId: spring-core
-    version: 6.2.11
+    version: 6.2.12
   - groupId: org.apache.zookeeper
     artifactId: zookeeper
     version: 3.9.4


### PR DESCRIPTION
## Summary

Completes the fix for GHSA-7fch-4f2f-jcgm affecting spring-websocket by updating spring-core to 6.2.12 for version consistency across Spring Framework components.

**Tracking**: https://github.com/chainguard-dev/CVE-Dashboard/issues/31504

## Changes

### thingsboard/pombump-deps.yaml
- Updated `spring-core` from **6.2.11** → **6.2.12**
- Note: `spring-websocket` was already at 6.2.12
## Rationale

Spring Framework components should maintain version consistency. The pombump-deps.yaml already contained spring-websocket 6.2.12, but spring-core was still at 6.2.11. This update ensures both components are at the same patched version.
