### PR TITLE
fix(zipkin): GHSA-4cx2-fc23-5wg6 bump pulsar

### DIFF
--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -1,7 +1,7 @@
 package:
   name: zipkin
   version: "3.5.1"
-  epoch: 6 # GHSA-jmp9-x22r-554x
+  epoch: 7
   description: Zipkin distributed tracing system
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,12 @@ pipeline:
   - uses: maven/pombump
     with:
       pom: zipkin-server/pom.xml
+
+  # GHSA-4cx2-fc23-5wg6
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-zipkin-collector-pulsar-deps.yaml
+      pom: zipkin-collector/pulsar/pom.xml
 
   - runs: |
       ./mvnw -X -q --batch-mode -DskipTests --also-make -pl zipkin-server clean install

--- a/zipkin/pombump-zipkin-collector-pulsar-deps.yaml
+++ b/zipkin/pombump-zipkin-collector-pulsar-deps.yaml
@@ -1,0 +1,5 @@
+patches:
+  - groupId: org.apache.pulsar
+    artifactId: pulsar-client
+    version: 4.1.0
+    type: pom


### PR DESCRIPTION
bcpkix-jdk18on is brought in my pulsar.  Upstream pulsar fixes this CVE [1], so
bumping pulsar to the version that contains the fix.

[1] https://github.com/apache/pulsar/pull/24650

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31498

<!--ci-cve-scan:must-fix: GHSA-4cx2-fc23-5wg6-->
