### PR TITLE
openssl: stop installing unused engines

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,8 +1,7 @@
-#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -103,18 +102,13 @@ pipeline:
       rm ${{targets.destdir}}/etc/ssl/ct_log_list.cnf
       # Second copy of CT log
       rm ${{targets.destdir}}/etc/ssl/ct_log_list.cnf.dist
+      # Remove engines, deprecated and will be removed in OpenSSL 4
+      rm -r "${{targets.destdir}}"/usr/lib/engines-3
       # Keeping etc/ssl/misc CA.pl & tsget perl scripts
       # without depending on perl, here in openssl package
       # This now makes openssl-config empty package, remove it
       # This also removes the need to have things coupled with
       # openssl-config-fipshardened going forward.
-
-data:
-  - name: engines
-    items:
-      afalg: Linux AF_ALG engine
-      capi: CAPI engine
-      padlock: VIA Padlock engine
 
 subpackages:
   - name: "openssl-dbg"
@@ -170,27 +164,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-        - uses: test/tw/ldd-check
-
-  - range: engines
-    name: "openssl-engine-${{range.key}}"
-    description: "OpenSSL ${{range.value}}"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
-          mv "${{targets.destdir}}"/usr/lib/engines-3/${{range.key}}.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
-    test:
-      pipeline:
-        - uses: test/tw/ldd-check
-
-  - name: "openssl-engine-loader-attic"
-    description: "OpenSSL Loader Attic internal test engine"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
-          mv "${{targets.destdir}}"/usr/lib/engines-3/loader_attic.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
-    test:
-      pipeline:
         - uses: test/tw/ldd-check
 
   - name: "openssl-provider-legacy"


### PR DESCRIPTION
Engines are deprecated, stop installing them.

They will be completely disabled in OpenSSL 4.

They are unused, no reverse depedencies, not included in any images.
