### PR TITLE
apache-arrow: tidy protobuf build dependencies

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -33,11 +33,9 @@ environment:
       - cython
       - gflags-dev
       - glog-dev
-      - grpc
       - grpc-dev
       - icu-dev
       - libevent-dev
-      - libzstd1
       - lz4-dev
       - lz4-static
       - openssl-dev
@@ -51,7 +49,6 @@ environment:
       - snappy-dev
       - systemd-dev
       - thrift-dev
-      - utf8proc
       - utf8proc-dev
       - wolfi-base
       - xsimd-dev

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: "21.0.0"
-  epoch: 6
+  epoch: 7
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -37,13 +37,10 @@ environment:
       - grpc-dev
       - icu-dev
       - libevent-dev
-      - libprotobuf
-      - libprotoc
       - libzstd1
       - lz4-dev
       - lz4-static
       - openssl-dev
-      - protobuf
       - protobuf-dev
       - protoc
       - py3-supported-build-base-dev


### PR DESCRIPTION
Just depend on protobuf-dev and drop libprotobuf and libprotoc; with the
new shared library naming approach the names of these packages will
change over time and the current version of protobuf-dev will always
point to the right versions.
