### PR TITLE
fix(langfuse): GHSA-93m4-6634-74q7, GHSA-7mvr-c777-76hp

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,6 +1,6 @@
 package:
   name: langfuse
-  version: "3.119.1"
+  version: "3.121.0"
   epoch: 0
   description: "Langfuse webapp"
   copyright:
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: 8a80ff13f4ea7474c77c2a3046258e5661c69b16
+      expected-commit: 34309beec3a9f391baaa6a2a43da87643f389904
 
   - name: "Bump deps and install"
     runs: |
@@ -85,7 +85,8 @@ pipeline:
         "pnpm.overrides.mermaid=^11.10.0" \
         "pnpm.overrides.axios=^1.12.0" \
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
-        "pnpm.overrides.tar-fs=3.1.1"
+        "pnpm.overrides.tar-fs=3.1.1" \
+        "pnpm.overrides.playwright=^1.55.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -73,7 +73,7 @@ pipeline:
         "pnpm.overrides.path-to-regexp=^6.3.0" \
         "pnpm.overrides.prismjs=^1.30.0" \
         "pnpm.overrides.undici=^6.21.2" \
-        "pnpm.overrides.vite=^5.4.20" \
+        "pnpm.overrides.vite=^5.4.21" \
         "pnpm.overrides.vitest=^2.1.9" \
         "pnpm.overrides.ws=^8.17.1" \
         "pnpm.overrides.brace-expansion=^4.0.1" \


### PR DESCRIPTION
Bump vite, playwright versions
Also bumped langfuse to most recent version.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31517, https://github.com/chainguard-dev/CVE-Dashboard/issues/31512

<!--ci-cve-scan:must-fix: GHSA-93m4-6634-74q7, GHSA-7mvr-c777-76hp-->
