### PR TITLE
Normalize gnupg, gpgme with FIPS editions

### DIFF
--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.4.8
-  epoch: 2
+  epoch: 3
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -10,6 +10,9 @@ package:
       - merged-lib
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  gpg-package: gpg
 
 environment:
   contents:
@@ -92,7 +95,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: gnupg-doc
+  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/manpages
     description: gnupg manpages
@@ -105,7 +108,7 @@ subpackages:
         - merged-lib
         - wolfi-baselayout
 
-  - name: gnupg-lang
+  - name: ${{package.name}}-lang
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/gnupg
@@ -117,10 +120,10 @@ subpackages:
         - merged-lib
         - wolfi-baselayout
 
-  - name: gnupg-dirmngr
+  - name: ${{package.name}}-dirmngr
     dependencies:
       runtime:
-        - gnupg-gpgconf
+        - ${{package.name}}-gpgconf
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -136,6 +139,7 @@ subpackages:
     description: GNU Privacy Guard 2 - network certificate management service
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: dirmngr dirmngr-client
@@ -143,10 +147,10 @@ subpackages:
           with:
             bins: dirmngr dirmngr-client
 
-  - name: gnupg-gpgconf
+  - name: ${{package.name}}-gpgconf
     dependencies:
       runtime:
-        - gnupg-gpgconf
+        - ${{package.name}}-gpgconf
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -161,6 +165,7 @@ subpackages:
     description: GNU Privacy Guard 2 - core configuration utilities
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpg-connect-agent gpgconf
@@ -168,10 +173,10 @@ subpackages:
           with:
             bins: gpg-connect-agent gpgconf
 
-  - name: gnupg-scdaemon
+  - name: ${{package.name}}-scdaemon
     dependencies:
       runtime:
-        - gpg-agent
+        - ${{vars.gpg-package}}-agent
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -182,11 +187,14 @@ subpackages:
           mv ${{targets.destdir}}/usr/libexec/scdaemon ${{targets.subpkgdir}}/usr/libexec/
           mv ${{targets.destdir}}/usr/lib/udev/rules.d ${{targets.subpkgdir}}/usr/lib/udev/
     description: GNU Privacy Guard 2 - smart card support
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
-  - name: gnupg-wks-client
+  - name: ${{package.name}}-wks-client
     dependencies:
       runtime:
-        - gpg
+        - ${{vars.gpg-package}}
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -195,12 +203,15 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/libexec
           mv ${{targets.destdir}}/usr/libexec/gpg-wks-client ${{targets.subpkgdir}}/usr/libexec/
     description: GNU Privacy Guard 2 - Web Key Service client
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
-  - name: gpg
+  - name: ${{vars.gpg-package}}
     description: GNU Privacy Guard 2 - public key operations only
     dependencies:
       runtime:
-        - gnupg-gpgconf
+        - ${{package.name}}-gpgconf
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -213,6 +224,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/libexec/keyboxd "${{targets.subpkgdir}}"/usr/libexec
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpg gpg2 /usr/libexec/keyboxd
@@ -222,10 +234,10 @@ subpackages:
         - runs: |
             gpg --list-keys
 
-  - name: gpg-agent
+  - name: ${{vars.gpg-package}}-agent
     dependencies:
       runtime:
-        - gnupg-gpgconf
+        - ${{package.name}}-gpgconf
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -243,6 +255,7 @@ subpackages:
     description: GNU Privacy Guard 2 - cryptographic agent
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpg-agent
@@ -250,10 +263,10 @@ subpackages:
           with:
             bins: gpg-agent
 
-  - name: gpg-wks-server
+  - name: ${{vars.gpg-package}}-wks-server
     dependencies:
       runtime:
-        - gpg
+        - ${{vars.gpg-package}}
         - merged-usrsbin
         - merged-lib
         - wolfi-baselayout
@@ -264,6 +277,7 @@ subpackages:
     description: GNU Privacy Guard 2 - Web Key Service server
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpg-wks-server
@@ -271,7 +285,7 @@ subpackages:
           with:
             bins: gpg-wks-server
 
-  - name: gpgsm
+  - name: ${{vars.gpg-package}}sm
     description: GNU Privacy Guard 2 - S/MIME version
     pipeline:
       - runs: |
@@ -279,6 +293,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/gpgsm ${{targets.subpkgdir}}/usr/bin/
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpgsm
@@ -291,7 +306,7 @@ subpackages:
         - merged-lib
         - wolfi-baselayout
 
-  - name: gpgv
+  - name: ${{vars.gpg-package}}v
     description: GNU Privacy Guard 2 - signature verification only
     pipeline:
       - runs: |
@@ -300,6 +315,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/gpgv2 ${{targets.subpkgdir}}/usr/bin/
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpgv gpgv2
@@ -312,7 +328,7 @@ subpackages:
         - merged-lib
         - wolfi-baselayout
 
-  - name: gnupg-utils
+  - name: ${{package.name}}-utils
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr
@@ -320,6 +336,7 @@ subpackages:
     description: GNU Privacy Guard 2 - utility programs
     test:
       pipeline:
+        - uses: test/tw/ldd-check
         - uses: test/tw/ver-check
           with:
             bins: gpgsplit gpgtar kbxutil watchgnupg
@@ -341,9 +358,13 @@ test:
   environment:
     contents:
       packages:
-        - gpg
+        - ${{vars.gpg-package}}
   pipeline:
+    - uses: test/tw/ldd-check
     - uses: test/hardening-check
     - uses: test/tw/ver-check
+      with:
+        bins: gpg
+    - uses: test/tw/help-check
       with:
         bins: gpg

--- a/gnupg/fix-i18n.patch
+++ b/gnupg/fix-i18n.patch
@@ -1,4 +1,12 @@
 # originated from https://git.alpinelinux.org/aports/plain/main/gnupg/fix-i18n.patch
+From: Timo Teräs (https://gitlab.alpinelinux.org/fabled)
+Date: 2015-09-01
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/commit/1997ebdedb85701fd11105a98de22bedf735545d
+Subject: main/gnupg: fix i18n
+
+setlocale() was not called if configured with --disable-nls. fix this
+as setlocale() needs to be set in musl for nl_langinfo to work.
+
 --- gnupg-2.4.8.orig/common/i18n.c
 +++ gnupg-2.4.8/common/i18n.c
 @@ -85,8 +85,8 @@ i18n_init (void)

--- a/gnupg/libassun-version.patch
+++ b/gnupg/libassun-version.patch
@@ -1,3 +1,9 @@
+From: Debasish Biswas (debasish.biswas@chainguard.dev)
+Date: 2024-07-05 07:34:04 +0000
+Subject: use newer libassuan
+
+check if it works with the new Lib version
+
 --- gnupg-2.4.8.orig/configure
 +++ gnupg-2.4.8/configure
 @@ -2921,8 +2921,8 @@ NEED_GPGRT_VERSION=1.46

--- a/gnupg/make-aes-default-for-fips.patch
+++ b/gnupg/make-aes-default-for-fips.patch
@@ -1,4 +1,10 @@
 # When by any chance we're in FIPS mode, use AES256 instead of 3DES by default.
+From: Łukasz 'sil2100' Zemczak (lukasz.zemczak@chainguard.dev)
+Date: 2025-07-25 15:03:08 +0200
+Subject: disable 3DES
+
+gnupg: add patch to not use 3DES in FIPS mode
+
 --- gnupg-2.4.8.orig/g10/main.h
 +++ gnupg-2.4.8/g10/main.h
 @@ -38,7 +38,7 @@

--- a/gpgme.yaml
+++ b/gpgme.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpgme
   version: "2.0.1"
-  epoch: 0
+  epoch: 1
   description: GNU - GnuPG Made Easy
   copyright:
     - license: GPL-3.0-or-later
@@ -50,7 +50,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: gpgme-doc
+  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/manpages
     description: gpgme manpages
@@ -58,12 +58,12 @@ subpackages:
       pipeline:
         - uses: test/docs
 
-  - name: gpgme-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - gpgme
+        - ${{package.name}}
     description: gpgme dev
     test:
       pipeline:
@@ -80,8 +80,9 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-    - runs: |
-        gpgme-json --version
-        gpgme-tool --version
-        gpgme-json --help
-        gpgme-tool --help
+    - uses: test/tw/help-check
+      with:
+        bins: gpgme-json gpgme-tool
+    - uses: test/tw/ver-check
+      with:
+        bins: gpgme-json gpgme-tool


### PR DESCRIPTION
This normalizes the parameterization and tests in the `gnupg.yaml` and `gpgme.yaml` with their FIPS counterparts in `enterprise-packages`.

Also adds some source info to the `gnupg` patches that didn't already have it.