### PR TITLE
semgrep: multiversion cleanup

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,17 +1,25 @@
 package:
   name: semgrep
   version: "1.140.0"
-  epoch: 0
+  epoch: 1
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:
+    provider-priority: 0
     runtime:
-      - py3-semgrep=${{package.full-version}}
+      - py3-${{vars.pypi-package}}-bin
 
 vars:
   # Current ocaml version used by upstream can be found https://github.com/semgrep/semgrep/blob/v${{package.version}}/Dockerfile#L114
   ocaml_version: 5.3.0
+  pypi-package: semgrep
+  import: semgrep
+
+data:
+  - name: py-versions
+    items:
+      3.13: "313"
 
 environment:
   contents:
@@ -39,12 +47,7 @@ environment:
       - pcre2-dev
       - pkgconf-dev
       - posix-libc-utils # ldd
-      - py3-gpep517 # used for py3-semgrep
-      - py3-pip # used in make install
-      - py3-setuptools # used for py3-semgrep
-      - py3-wheel # used for py3-semgrep
-      - python3 # used in make install
-      - python3-dev
+      - py3-supported-build-base-dev
       - rsync
       - wolfi-base
       - zlib-dev
@@ -113,51 +116,66 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: py3-semgrep
-    description: "Python bindings for semgrep"
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-attrs
+        - py${{range.key}}-boltons
+        - py${{range.key}}-click
+        - py${{range.key}}-click-option-group
+        - py${{range.key}}-colorama
+        - py${{range.key}}-defusedxml
+        - py${{range.key}}-exceptiongroup
+        - py${{range.key}}-glom
+        - py${{range.key}}-peewee
+        - py${{range.key}}-requests
+        - py${{range.key}}-rich
+        - py${{range.key}}-ruamel-yaml
+        - py${{range.key}}-ruamel-yaml-clib
+        - py${{range.key}}-tomli
+        - py${{range.key}}-typing-extensions
+        - py${{range.key}}-urllib3
+        - py${{range.key}}-wcmatch
     pipeline:
-      - runs: |
-          cd cli
-          git submodule update --init -- src/semgrep/semgrep_interfaces
-          python3=$(readlink -f `which python3`)
-          $python3 -m gpep517 build-wheel \
-            --wheel-dir dist \
-            --output-fd 3 3>&1 >&2
-          $python3 -m pip install --verbose \
-            --prefix=/usr "--root=${{targets.contextdir}}" dist/*.whl
-          $python3 -m compileall --invalidation-mode=unchecked-hash -r100 "${{targets.contextdir}}"
-      - runs: |
-          # opentelemetry uses pkg_resources but does not declare a dep.
-          python3=$(readlink -f `which python3`)
-          $python3 -m pip install --verbose \
-            --ignore-installed \
-            --prefix=/usr "--root=${{targets.contextdir}}" setuptools packaging
-
-          # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
-          $python3 -m pip install --verbose \
-            --upgrade \
-            --prefix=/usr "--root=${{targets.contextdir}}" "requests>=2.32.4"
-      - runs: |
-          # clean out any bins other than semgrep and pysemgrep.
-          d=$(mktemp -d)
-          cd ${{targets.contextdir}}/usr/bin
-          mv semgrep pysemgrep "$d"
-          # there is a __pycache__ dir here, so -R
-          rm -Rf *
-          mv $d/* .
+      - uses: py/pip-build-install
+        working-directory: cli
+        with:
+          python: python${{range.key}}
       - uses: strip
     test:
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
-            imports: |
-              import semgrep
-        - name: "run pysemgrep --help"
-          runs: |
-            pysemgrep --help
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Commands for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - uses: split/bin
+        working-directory: cli
+    test:
+      pipeline:
+        - runs: |
+            ${{vars.pypi-package}} --version
+            ${{vars.pypi-package}} --help 2>&1 | grep -q "^usage:"
 
 test:
   pipeline:
+    - uses: test/tw/ldd-check
     - name: "run osemgrep --help"
       runs: |
         osemgrep --help


### PR DESCRIPTION
Make the package installable

<details>
<summary>Current situation</summary>

```
bash-5.3# apk add semgrep
(1/4) Installing pcre (8.45-r6)
(2/4) Installing tree-sitter (0.25.9-r0)
(3/4) Installing py3-semgrep (1.139.0-r0)
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/__pycache__/typing_extensions.cpython-313.pyc owned by py3.13-typing-extensions-4.15.0-r0.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/packaging/_elffile.py owned by py3.13-packaging-25.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/pkg_resources/tests/data/my-test-package_zipped-egg/my_test_package-1.0-py3.7.egg owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_distutils/__pycache__/cmd.cpython-313.pyc owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_distutils/command/__pycache__/install_egg_info.cpython-313.pyc owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_distutils/file_util.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_distutils/tests/test_text_file.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_vendor/importlib_metadata/compat/__pycache__/py311.cpython-313.pyc owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_vendor/platformdirs/api.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/_vendor/wheel/cli/unpack.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/command/bdist_rpm.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/setuptools/tests/namespaces.py owned by py3.13-setuptools-80.9.0-r2.
...
ERROR: py3-semgrep-1.139.0-r0: trying to overwrite usr/lib/python3.13/site-packages/urllib3-2.5.0.dist-info/licenses/LICENSE.txt owned by py3.13-urllib3-2.5.0-r2.
(4/4) Installing semgrep (1.139.0-r0)
Executing busybox-1.37.0-r50.trigger
1 error; 5133 MiB in 420 packages
```
</details>

<details>
<summary>Proposed version</summary>

```
bash-5.3# apk add /packages/x86_64/semgrep-1.139.0-r1.apk /packages/x86_64/py3.13-semgrep-1.139.0-r1.apk /packages/x86_64/py3.13-semgrep-bin-1.139.0-r1.apk  --allow-untrusted
(1/5) Installing pcre (8.45-r6)
(2/5) Installing tree-sitter (0.25.9-r0)
(3/5) Installing py3.13-semgrep (1.139.0-r1)
(4/5) Installing py3.13-semgrep-bin (1.139.0-r1)
(5/5) Installing semgrep (1.139.0-r1)
Executing busybox-1.37.0-r50.trigger
OK: 5078 MiB in 421 packages
bash-5.3# apk info --who-owns /usr/bin/semgrep
/usr/bin/semgrep is owned by py3.13-semgrep-bin-1.139.0-r1
bash-5.3# semgrep

┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘
Semgrep CLI scans your code for bugs, security and dependency vulnerabilities.

For more information about Semgrep, visit https://semgrep.dev

Get Started:
  Run `semgrep login && semgrep ci` to enable Pro rules, Semgrep Supply Chain,
  and secrets scanning. Without logging in, Semgrep CLI will only run the free
  open-source rules available at https://semgrep.dev/r.

Commands:
  semgrep login                Enable Pro rules, Supply Chain, and secrets scanning
  semgrep ci                   Run Semgrep on a git diff (for use in CI)
  semgrep scan                 Run Semgrep rules on local folders or files

Help:
  semgrep COMMAND --help       For more information on each command

For the CLI docs visit https://semgrep.dev/docs/cli-reference
```
</details>
