### PR TITLE
ingress-nginx-controller-1.13: build as root

### DIFF
--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.13
   version: "1.13.3"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,9 @@ package:
       - yaml-cpp
 
 environment:
+  accounts:
+    # needed because we run setcap during the build
+    run-as: root
   contents:
     packages:
       - abseil-cpp-dev


### PR DESCRIPTION
ingress-nginx-controller-1.13 needs to build as root because it performs setcap operations.
