### PR TITLE
fix(renovate): Bump package version to remediate GHSA-93m4-6634-74q7

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,6 +1,6 @@
 package:
   name: renovate
-  version: "41.157.0"
+  version: "41.157.1"
   epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
@@ -29,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
-      expected-commit: 0c292aed5843207798c038d1e74be1a3d8e22ff9
+      expected-commit: 63b6a08fd9387e43fbc6aff1d1ffc81e4c3a2b5e
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json


### PR DESCRIPTION
GHSA-93m4-6634-74q7 remediated in upstream commit f4365a2f77a1eb3e253566083502f015554eb8c0
The commit bumps vite to 7.1.11


<!--ci-cve-scan:fail-any-->