### PR TITLE
mountpoint-s3-csi-driver: revert incorrect version bump 2.1 for a 2.0 version stream + withdraw

### DIFF
--- a/mountpoint-s3-csi-driver-2.0.yaml
+++ b/mountpoint-s3-csi-driver-2.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: mountpoint-s3-csi-driver-2.0
-  version: "2.1.0"
-  epoch: 0
+  version: "2.0.0"
+  epoch: 3
   description: Built on Mountpoint for Amazon S3, the Mountpoint CSI driver presents an Amazon S3 bucket as a storage volume accessible by containers in your Kubernetes cluster
   dependencies:
     provides:
@@ -16,7 +16,7 @@ pipeline:
     with:
       repository: https://github.com/awslabs/mountpoint-s3-csi-driver
       tag: v${{package.version}}
-      expected-commit: 83d9ceb6555182811ce0178627530b7bd58b73e9
+      expected-commit: b72b810fb11b5caea59e05df35930d4118afbb77
 
   - uses: go/build
     with:
@@ -50,6 +50,7 @@ update:
   github:
     identifier: awslabs/mountpoint-s3-csi-driver
     strip-prefix: v
+    tag-filter-prefix: "v2.0."
   ignore-regex-patterns:
     - ^helm-chart-aws-mountpoint-s3-csi-driver-.*
 

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,7 +1,1 @@
-python-3.14-privileged-netbindservice-3.14.0-r0.apk
-python-3.14-doc-3.14.0-r0.apk
-python-3.14-3.14.0-r0.apk
-python-3.14-tk-3.14.0-r0.apk
-python-3.14-dev-3.14.0-r0.apk
-python-3.14-base-3.14.0-r0.apk
-python-3.14-base-dev-3.14.0-r0.apk
+mountpoint-s3-csi-driver-2.0-2.1.0-r0.apk


### PR DESCRIPTION
It seems when this package was [converted](https://github.com/wolfi-dev/os/pull/65257) to a version stream there was no tag prefix added to the update config block.

The knock on effect is we then had a automated package bump https://github.com/wolfi-dev/os/pull/68024 of 2.1.0, but the version stream should only be tracking 2.0.x.

This change reverts the version, withdraws the incorrect apks and fixes the update block to avoid this in the future.
