### PR TITLE
airflow-3: remediate CVEs

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.0"
-  epoch: 1
+  epoch: 2
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -127,6 +127,9 @@ pipeline:
 
       # GHSA-847f-9342-265h
       uv pip install --verbose --upgrade h2==4.3.0
+
+      # GHSA-hrfv-mqp8-q5rw, GHSA-f9vj-2wh5-fj8j, GHSA-2g68-c3qc-8985, GHSA-q34m-jh98-gwm2
+      uv pip install --verbose --upgrade Werkzeug==3.0.6
 
       # Build and install the additional provider packages
       # By default, the airflow celery provider is not built, but running the upstream helm chart requires it


### PR DESCRIPTION
Remediate GHSA-hrfv-mqp8-q5rw, GHSA-f9vj-2wh5-fj8j, GHSA-2g68-c3qc-8985
and GHSA-q34m-jh98-gwm2

Bump Werkzeug dependency to v3.0.6

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
