### PR TITLE
akhq: remediate CVE

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.26.0
-  epoch: 2
+  epoch: 3
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0

--- a/akhq/cves-20250714.patch
+++ b/akhq/cves-20250714.patch
@@ -57,7 +57,7 @@ index ae531b3b..707a3a72 100644
 +jacksonVersion=2.17.1
 +lang3Version=3.18.0
 +nimbusJoseJwtVersion=10.0.2
-+logbackVersion=1.5.16
++logbackVersion=1.5.19
 +commonsCompressVersion=1.26.0
 +vertxVersion=4.4.8
 +nettyVersion=4.1.125.Final


### PR DESCRIPTION
Remediate GHSA-25qh-j22f-pwp8
Bump logback to 1.5.19

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->
