### PR TITLE
apache-nifi: remediate CVE

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: "2.6.0"
-  epoch: 0 # GHSA-8v5q-rhf3-jphm
+  epoch: 1 # GHSA-25qh-j22f-pwp8
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0

--- a/apache-nifi/pombump-properties.yaml
+++ b/apache-nifi/pombump-properties.yaml
@@ -7,3 +7,5 @@ properties:
     value: 6.2.11
   - property: spring.security.version
     value: 6.5.4
+  - property: logback.version
+    value: 1.5.19


### PR DESCRIPTION
Remdiate GHSA-25qh-j22f-pwp8
Bump logback.version to 1.5.19

Signed-off-by: David Negreira <david.negreira@chainguard.dev>

<!--ci-cve-scan:fail-any-->
