### PR TITLE
arpack: No-change rebuild for 2.28 toolchain

### DIFF
--- a/arpack.yaml
+++ b/arpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: arpack
   version: 3.9.1
-  epoch: 3
+  epoch: 4
   description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This should work now that `openssf-compiler-options.yaml` has been fixed to add a `gfortran` wrapper.