### PR TITLE
Adds required runtime package fuse to seaweedfs

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -5,6 +5,9 @@ package:
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - fuse2
 
 environment:
   environment:

--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,6 +1,6 @@
 package:
   name: seaweedfs
-  version: "3.97"
+  version: "3.98"
   epoch: 2 # GHSA-2464-8j7c-4cjm
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/seaweedfs/seaweedfs
       tag: ${{package.version}}
-      expected-commit: 76452ab593995ab52b75e681de5b221de1e3f006
+      expected-commit: 76520583c6669f3be56e41a601f550f86911d8fb
 
   - uses: go/build
     with:

--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: seaweedfs
   version: "3.98"
-  epoch: 2 # GHSA-2464-8j7c-4cjm
+  epoch: 3 # GHSA-2464-8j7c-4cjm
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
seaweedfs is missing these three binaries which is present in upstream

1. `fusermount`
2. `mount.fuse`,
3. `ulockmgr_server`

Adding fuse2 as a runtime package here as upstream requires package `fuse-2.9.9`

> docker run -it --entrypoint /bin/sh chrislusf/seaweedfs:latest
> /data # apk info fuse
> fuse-2.9.9-r6 description:
> A library that makes it possible to implement a filesystem in a userspace program.
> 
> fuse-2.9.9-r6 webpage:
> https://github.com/libfuse/libfuse/
> 
> fuse-2.9.9-r6 installed size:
> 521 KiB
> 
> /data #

I am guessing that Dash is required inside the `seaweedfs-oci-entrypoint`
`seaweedfs-oci-entrypoint` subpackage includes dash-binsh as a runtime dependency, which ensures the StatefulSet's shell command will execute successfully in the container.
Here
check here : https://github.com/seaweedfs/seaweedfs/blob/master/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml#L124