### PR TITLE
Better Python 3.14 JIT build options

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -73,17 +73,23 @@ pipeline:
     with:
       patches: gh-118224.patch gh-127301.patch
 
+  # Experimental JIT support
+  #
+  # --enable-optimizations with clang requires PGO support (in particular,
+  # we're missing libclang_rt.profile). This build configuration won't be
+  # optimal and might not produce any performance gains.
   - name: Configure
     runs: |
       ./configure \
+         CC=clang \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=/usr \
          --enable-experimental-jit=yes-off \
+         --with-tail-call-interp \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
-         $([ -d /usr/lib/oldglibc ] || echo --enable-optimizations) \
          --enable-shared \
          --with-lto \
          --with-computed-gotos \


### PR DESCRIPTION
Some tweaks intended to improve experimental JIT performance, although the "real" deal requires some GPO support that we don't have yet.