### PR TITLE
glibc: Update git mirror URL

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.42"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -51,7 +51,7 @@ pipeline:
       expected-commit: d2097651cc57834dbfcaa102ddfacae0d86cfb66
       # sourceware.org often has clone issues, switch to mirror
       # recommended at https://sourceware.org/glibc/wiki/GlibcGit
-      repository: https://repo.or.cz/glibc.git
+      repository: https://gitlab.com/gnutools/glibc.git
       tag: glibc-${{package.version}}
       cherry-picks: |
         master/855bfa2566bbefefa27c516b344df58a75824a5c: nptl: Fix MADV_GUARD_INSTALL logic for thread without guard page (BZ 33356)


### PR DESCRIPTION
Upstream glibc is tightening up their security and reduced the list of recommended mirrors.  Let's use one of their new repos.

Fixes: #69714