### PR TITLE
buck2: add version-transform

### DIFF
--- a/buck2.yaml
+++ b/buck2.yaml
@@ -56,6 +56,9 @@ update:
   ignore-regex-patterns:
     - 'latest'
     - '^androidToolchain/.*'
+  version-transform:
+    - match: '-'
+      replace:
   github:
     identifier: facebook/buck2
     use-tag: true


### PR DESCRIPTION
This should fix automated updates: currently we aren't getting any because our version format will always sort higher than upstream's version format, regardless of the actual date:

```
$ apk version -t 20200101 2020-01-01
>
```