### PR TITLE
nextflow/GHSA-25qh-j22f-pwp8 fix 

### DIFF
--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
-  version: "25.04.8"
-  epoch: 1
+  version: "25.10.0"
+  epoch: 0
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/nextflow-io/nextflow.git
-      expected-commit: c08bd01ab6b17c30c526b03c4923e23ef0db4e10
+      expected-commit: 2db01e6e9cf8fe266e729c424e2d97cff4e43de2
       tag: v${{package.version}}
 
   - uses: patch

--- a/nextflow.yaml
+++ b/nextflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: nextflow
   version: "25.04.8"
-  epoch: 0
+  epoch: 1
   description: A DSL for data-driven computational pipelines.
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       repository: https://github.com/nextflow-io/nextflow.git
       expected-commit: c08bd01ab6b17c30c526b03c4923e23ef0db4e10
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: logback.patch
 
   - runs: |
       # CVE-2025-48924 GHSA-j288-q9x7-2f5v

--- a/nextflow/logback.patch
+++ b/nextflow/logback.patch
@@ -1,0 +1,15 @@
+diff --git a/modules/nextflow/build.gradle b/modules/nextflow/build.gradle
+index ae3dc903f..e83dcfa1b 100644
+--- a/modules/nextflow/build.gradle
++++ b/modules/nextflow/build.gradle
+@@ -34,8 +34,8 @@ dependencies {
+     api "org.slf4j:jcl-over-slf4j:2.0.16"
+     api "org.slf4j:jul-to-slf4j:2.0.16"
+     api "org.slf4j:log4j-over-slf4j:2.0.16"
+-    api "ch.qos.logback:logback-classic:1.5.16"
+-    api "ch.qos.logback:logback-core:1.5.16"
++    api "ch.qos.logback:logback-classic:1.5.19"
++    api "ch.qos.logback:logback-core:1.5.19"
+     api "org.codehaus.gpars:gpars:1.2.1"
+     api("ch.artecat.grengine:grengine:3.0.2") { exclude group: 'org.codehaus.groovy' }
+     api "commons-lang:commons-lang:2.6"

--- a/nextflow/logback.patch
+++ b/nextflow/logback.patch
@@ -1,13 +1,13 @@
 diff --git a/modules/nextflow/build.gradle b/modules/nextflow/build.gradle
-index ae3dc903f..e83dcfa1b 100644
+index 7dac6cece..0204482c2 100644
 --- a/modules/nextflow/build.gradle
 +++ b/modules/nextflow/build.gradle
 @@ -34,8 +34,8 @@ dependencies {
-     api "org.slf4j:jcl-over-slf4j:2.0.16"
-     api "org.slf4j:jul-to-slf4j:2.0.16"
-     api "org.slf4j:log4j-over-slf4j:2.0.16"
--    api "ch.qos.logback:logback-classic:1.5.16"
--    api "ch.qos.logback:logback-core:1.5.16"
+     api "org.slf4j:jcl-over-slf4j:2.0.17"
+     api "org.slf4j:jul-to-slf4j:2.0.17"
+     api "org.slf4j:log4j-over-slf4j:2.0.17"
+-    api "ch.qos.logback:logback-classic:1.5.18"
+-    api "ch.qos.logback:logback-core:1.5.18"
 +    api "ch.qos.logback:logback-classic:1.5.19"
 +    api "ch.qos.logback:logback-core:1.5.19"
      api "org.codehaus.gpars:gpars:1.2.1"


### PR DESCRIPTION
patch added to bump logback-core and classic version, also integrates required changes from automated package version bump pr: https://github.com/wolfi-dev/os/pull/69742

patch is based off this upstream source and extended to fix version 
  * https://github.com/nextflow-io/nextflow/blob/v25.10.0/modules/nextflow/build.gradle#L37-L38
