### PR TITLE
add ruby-protocol-url

### DIFF
--- a/ruby3.2-protocol-url.yaml
+++ b/ruby3.2-protocol-url.yaml
@@ -1,0 +1,86 @@
+package:
+  name: ruby3.2-protocol-url
+  version: 0.4.0
+  epoch: 0
+  description: Provides abstractions for working with URLs.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+vars:
+  gem: protocol-url
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 623d8d9341a64bd7b894a92b0b624a56cd27e93b
+      repository: https://github.com/socketry/protocol-url
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: socketry/protocol-url
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - uses: test/tw/gem-check
+    - name: Verify library loading
+      runs: |
+        ruby -e "require 'protocol/url'; puts 'Successfully loaded gem'"
+    - name: Test URL parsing and manipulation
+      runs: |
+        ruby <<-EOF
+        require 'protocol/url'
+
+        # Test parsing an absolute URL using Protocol::URL[]
+        url = Protocol::URL["https://example.com/path?query=value#fragment"]
+        raise "Failed to parse URL" if url.nil?
+        raise "Expected Absolute URL" unless url.is_a?(Protocol::URL::Absolute)
+
+        # Test parsing a relative URL
+        relative = Protocol::URL["/path/to/resource"]
+        raise "Failed to parse relative URL" if relative.nil?
+        raise "Expected Relative URL" unless relative.is_a?(Protocol::URL::Relative)
+
+        # Test that nil is returned for nil input
+        result = Protocol::URL[nil]
+        raise "Expected nil for nil input" unless result.nil?
+
+        puts "All tests passed!"
+        EOF
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.3-protocol-url.yaml
+++ b/ruby3.3-protocol-url.yaml
@@ -1,0 +1,86 @@
+package:
+  name: ruby3.3-protocol-url
+  version: 0.4.0
+  epoch: 0
+  description: Provides abstractions for working with URLs.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+vars:
+  gem: protocol-url
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 623d8d9341a64bd7b894a92b0b624a56cd27e93b
+      repository: https://github.com/socketry/protocol-url
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: socketry/protocol-url
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - uses: test/tw/gem-check
+    - name: Verify library loading
+      runs: |
+        ruby -e "require 'protocol/url'; puts 'Successfully loaded gem'"
+    - name: Test URL parsing and manipulation
+      runs: |
+        ruby <<-EOF
+        require 'protocol/url'
+
+        # Test parsing an absolute URL using Protocol::URL[]
+        url = Protocol::URL["https://example.com/path?query=value#fragment"]
+        raise "Failed to parse URL" if url.nil?
+        raise "Expected Absolute URL" unless url.is_a?(Protocol::URL::Absolute)
+
+        # Test parsing a relative URL
+        relative = Protocol::URL["/path/to/resource"]
+        raise "Failed to parse relative URL" if relative.nil?
+        raise "Expected Relative URL" unless relative.is_a?(Protocol::URL::Relative)
+
+        # Test that nil is returned for nil input
+        result = Protocol::URL[nil]
+        raise "Expected nil for nil input" unless result.nil?
+
+        puts "All tests passed!"
+        EOF
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.4-protocol-url.yaml
+++ b/ruby3.4-protocol-url.yaml
@@ -1,0 +1,86 @@
+package:
+  name: ruby3.4-protocol-url
+  version: 0.4.0
+  epoch: 0
+  description: Provides abstractions for working with URLs.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+vars:
+  gem: protocol-url
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 623d8d9341a64bd7b894a92b0b624a56cd27e93b
+      repository: https://github.com/socketry/protocol-url
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: socketry/protocol-url
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - uses: test/tw/gem-check
+    - name: Verify library loading
+      runs: |
+        ruby -e "require 'protocol/url'; puts 'Successfully loaded gem'"
+    - name: Test URL parsing and manipulation
+      runs: |
+        ruby <<-EOF
+        require 'protocol/url'
+
+        # Test parsing an absolute URL using Protocol::URL[]
+        url = Protocol::URL["https://example.com/path?query=value#fragment"]
+        raise "Failed to parse URL" if url.nil?
+        raise "Expected Absolute URL" unless url.is_a?(Protocol::URL::Absolute)
+
+        # Test parsing a relative URL
+        relative = Protocol::URL["/path/to/resource"]
+        raise "Failed to parse relative URL" if relative.nil?
+        raise "Expected Relative URL" unless relative.is_a?(Protocol::URL::Relative)
+
+        # Test that nil is returned for nil input
+        result = Protocol::URL[nil]
+        raise "Expected nil for nil input" unless result.nil?
+
+        puts "All tests passed!"
+        EOF
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM


### PR DESCRIPTION
This dependency needed by `ruby3.X-async-http`:

* https://github.com/wolfi-dev/os/pull/69904
* https://github.com/wolfi-dev/os/pull/69895
* https://github.com/wolfi-dev/os/pull/69901

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
