### PR TITLE
fix(airflow-3): Bump aiomysql to 0.3.0 to remediate GHSA-r397-ff8c-wv2g

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.0"
-  epoch: 2
+  epoch: 3 # GHSA-r397-ff8c-wv2g
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -73,6 +73,7 @@ pipeline:
       constraints-file: constraints-${{vars.python-version}}.txt
       packages: |
         cryptography==44.0.1 # GHSA-79v4-65xg-pq4g, GHSA-h4gh-qq45-vh27
+        aiomysql==0.3.0 # GHSA-r397-ff8c-wv2g
 
   - runs: |
       # ZIP doesn't handle the SDE we set correctly, so set it to 1980-01-01


### PR DESCRIPTION

<!--ci-cve-scan:fail-any-->

