### PR TITLE
Fix(CVE): open webui GHSA-jfx9-29x2-rv3j and GHSA-vr63-x8vc-m265

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.34"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -72,7 +72,7 @@ pipeline:
       uv pip install --upgrade starlette==0.47.2
 
       # GHSA-7hfw-26vp-jp8m
-      uv pip install --upgrade pypdf==6.0.0
+      uv pip install --upgrade pypdf==6.1.3
 
       # GHSA-847f-9342-265h
       uv pip install --upgrade h2==4.3.0

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -80,9 +80,6 @@ pipeline:
       # GHSA-9ggr-2464-2j32
       uv pip install --upgrade authlib>=1.6.4
 
-      # GHSA-m42m-m8cr-8m58
-      uv pip install --upgrade langchain-text-splitters>=0.3.9
-
       # GHSA-g8c6-8fjj-2r4m
       uv pip install --upgrade python-socketio>=5.14.0
 


### PR DESCRIPTION
Update the python pypdf module verions from 6.0.0 to 6.1.3


<!--ci-cve-scan:must-fix: GHSA-jfx9-29x2-rv3j-->


<!--ci-cve-scan:must-fix: GHSA-vr63-x8vc-m265-->
