### PR TITLE
fix(keycloak-26.4): Bump vertx-web to remediate GHSA-h5fg-jpgr-rv9c and GHSA-45p5-v273-3qqr

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
-  version: "26.4.0"
-  epoch: 1 # GHSA-3p8m-j85q-pgmj
+  version: "26.4.2"
+  epoch: 0
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -47,12 +47,42 @@ pipeline:
     with:
       repository: https://github.com/keycloak/keycloak
       tag: ${{package.version}}
-      expected-commit: 4e25e47b3c3619b3a0593448e1dfc0dd786cfbe1
+      expected-commit: 60dc235ca35db219c25f4ae601d5b91a9a7d31ee
 
   - uses: maven/pombump
     with:
       patch-file: pombump-deps.yaml
       properties-file: pombump-properties.yaml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
+      properties-file: pombump-properties.yaml
+      pom: distribution/api-docs-dist/pom.xml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
+      properties-file: pombump-properties.yaml
+      pom: quarkus/deployment/pom.xml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
+      properties-file: pombump-properties.yaml
+      pom: quarkus/runtime/pom.xml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
+      properties-file: pombump-properties.yaml
+      pom: services/pom.xml
+
+  - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
+      properties-file: pombump-properties.yaml
+      pom: testsuite/utils/pom.xml
 
   - runs: |
       gcc napi-static-assert.c -o /tmp/preload.so -fPIC -shared -ldl
@@ -66,7 +96,7 @@ pipeline:
       # Gross hack to work around broken NAPI ast-grep module that has
       # undefined symbol: static_assert
       export LD_PRELOAD=/tmp/preload.so
-      ./mvnw clean install -DskipTests -Dmaven.test.skip=true -DskipITs -DskipProtoLock=true -Pdistribution
+      ./mvnw clean install -X -DskipTests -Dmaven.test.skip=true -DskipITs -DskipProtoLock=true -Pdistribution
       unset LD_PRELOAD
 
       mkdir -p ${{targets.destdir}}/usr/share/java

--- a/keycloak-26.4/pombump-deps.yaml
+++ b/keycloak-26.4/pombump-deps.yaml
@@ -34,3 +34,8 @@ patches:
   - groupId: io.netty
     artifactId: netty-codec-http
     version: 4.1.125.Final
+  - groupId: io.vertx
+    artifactId: vertx-web
+    version: 4.5.22
+    scope: import
+    type: pom


### PR DESCRIPTION

<!--ci-cve-scan:fail-any-->

