### PR TITLE
libxml2: align dependency versions

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: "2.15.1"
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -144,7 +144,8 @@ subpackages:
       runtime:
         - zlib-dev
         - xz-dev
-        - libxml2-utils=${{package.full-version}}
+        - ${{package.name}}-utils=${{package.full-version}}
+        - ${{package.name}}-${{vars.soversion}}=${{package.full-version}}
     description: ${{package.name}} dev
     test:
       environment:
@@ -152,7 +153,6 @@ subpackages:
           packages:
             - gcc
             - glibc-dev
-            - libxml2-utils=${{package.full-version}}
       pipeline:
         - name: Verify libxml2-dev installation
           runs: |


### PR DESCRIPTION
Ensure an aligned version of libxml2-16 is installed when installing
libxml2-dev; we should always ensure that the exact version matches
otherwise we risk an older version of the library being used instead.
