### PR TITLE
feat(strimzi-kafka-operator): bump vertx-web to 4.5.22 to remediate GHSA-h5fg-jpgr-rv9c and GHSA-45p5-v273-3qqr

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.48.0"
-  epoch: 0 # GHSA-3p8m-j85q-pgmj
+  epoch: 1
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/strimzi-kafka-operator/pombump-deps-cc.yaml
+++ b/strimzi-kafka-operator/pombump-deps-cc.yaml
@@ -11,6 +11,9 @@ patches:
   - groupId: io.netty
     artifactId: netty-codec-http
     version: 4.1.127.Final
+  - groupId: io.vertx
+    artifactId: vertx-web
+    version: 4.5.22
   - groupId: org.apache.kafka
     artifactId: kafka-clients
     version: 3.9.1


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump vertx-web from 4.5.8 to 4.5.22 to remediate GHSA-h5fg-jpgr-rv9c and GHSA-45p5-v273-3qqr.

**GHSA-h5fg-jpgr-rv9c (CVE-2025-11965)**: Incomplete hidden file protection in Vert.x Web StaticHandler. Files within hidden directories (like `.git`, `.env`, `.aws`, `.ssh`) can be accessed when `setIncludeHidden(false)` is configured, potentially exposing credentials and configuration data.

**GHSA-45p5-v273-3qqr (CVE-2025-11966)**: Stored XSS vulnerability in Vert.x-Web StaticHandlerImpl. File and directory names in HTML directory listings are not properly escaped, allowing attackers with file creation capability to inject malicious HTML/JavaScript.

## Changes
- Added vertx-web 4.5.22 to pombump-deps-cc.yaml (kafka-thirdparty-libs-cc subpackage)
- Incremented epoch to 1

<!--ci-cve-scan:fail-any-->