### PR TITLE
fix(zookeeper): align SLF4J and Logback dependencies

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4.2"
-  epoch: 3 # GHSA-25qh-j22f-pwp8
+  epoch: 4
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0

--- a/zookeeper-3.9/pombump-properties.yaml
+++ b/zookeeper-3.9/pombump-properties.yaml
@@ -1,3 +1,5 @@
 properties:
   - property: "logback-version"
     value: "1.5.19"
+  - property: "slf4j.version"
+    value: "2.0.17"


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

After a previous CVE remediation (https://github.com/wolfi-dev/os/pull/69695) we bumped `logback-version` to 1.5.19.
This is leading Zookeeper to fail on starting up:
```
Exception in thread "main" java.lang.AbstractMethodError: Receiver class ch.qos.logback.classic.PatternLayout does not define or inherit an implementation of the resolved method 'abstract java.util.Map
 getDefaultConverterSupplierMap()' of abstract class ch.qos.logback.core.pattern.PatternLayoutBase.
```

The AbstractMethodError occurs because:
 1. Logback 1.5.19's PatternLayout class expects certain methods to exist in the SLF4J/logback-core API
 2. When running with Zookeeper 3.9.4's SLF4J 2.0.13 (https://github.com/apache/zookeeper/blob/release-3.9.4-2/pom.xml#L553, which is 4 versions behind), some implementation details or internal APIs don't match
 3. The JVM throws AbstractMethodError at runtime when it can't find the method implementation

The issue is that:
 - SLF4J 2.0.13 (ZooKeeper's default) is older than 2.0.17
 - While both are in the 2.0.x series, there may be API differences or the specific getDefaultConverterSupplierMap() method implementation requires newer SLF4J internals

Since it seems that Logback has been built with SLF4J 2.0.17 from v1.5.17: https://logback.qos.ch/news.html#1.5.17, bumping SLF4J to 2.0.17 should fix the problem.

<!--ci-cve-scan:fail-any-->
