### PR TITLE
py3-gevent: allow building with recent gcc version

### DIFF
--- a/py3-gevent.yaml
+++ b/py3-gevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gevent
   version: "25.9.1"
-  epoch: 0
+  epoch: 1
   description: Coroutine-based network library
   copyright:
     - license: MIT
@@ -24,8 +24,6 @@ environment:
   contents:
     packages:
       - file
-      # https://github.com/gevent/gevent/issues/2028
-      - gcc~13
       - py3-supported-build-base-dev
       - py3-supported-cython
 


### PR DESCRIPTION
https://github.com/gevent/gevent/issues/2028 got fixed and py3-gevent builds fine with a recent gcc (tested with 15.2) version.