### PR TITLE
ncurses/6.5_p20251025 package update

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.5_p20250621
-  epoch: 2
+  version: 6.5_p20251025
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
-      expected-sha512: 1b665749b822133e7166c21e44e0cf0d94766a7ed4f96a6138de43c46c8ce85ed0c5d5230c050103de3830e7d2fc35c283262d30990b9de30851d1f999525b85
+      expected-sha512: 0bb6134db470aafa5ace84fb2e7cd2ce859fd3fd2638f6a60d7fb54ab08c1666d230ba1894a5aea4da3efb0d850629cddb2ff48f1a253d0e30c8842d83785ab4
 
   - name: Configure
     runs: |


### PR DESCRIPTION
The current ncurses version we reference was removed from the mirror and now 404s:
```
2025/10/27 14:24:39 WARN --2025-10-27 14:24:39--  https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250621.tgz
2025/10/27 14:24:39 WARN Resolving invisible-mirror.net... 107.180.113.177
2025/10/27 14:24:39 WARN Connecting to invisible-mirror.net|107.180.113.177|:443... connected.
2025/10/27 14:24:39 WARN HTTP request sent, awaiting response... 404 Not Found
2025/10/27 14:24:39 WARN 2025-10-27 14:24:39 ERROR 404: Not Found.
```

This PR bumps to the current version as of 2025/10/25 which builds successfully.