### PR TITLE
chore: move posix-cc-wrappers inline with gcc-<n>

### DIFF
--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -157,37 +157,38 @@ subpackages:
       runtime:
         - gcc=${{package.full-version}}
     pipeline:
-      - working-directory: '${{targets.destdir}}/usr/bin'
-      - runs: |
-          ln -s gcc cc
-      - runs: |
-          cat >c89 <<'EOF'
-          #!/bin/sh
-          _flavor="-std=c89"
-          for opt; do
-            case "$opt" in
-            -ansi|-std=c89|-std=iso9899:1990) _flavor="";;
-            -std=*) echo "$(basename $0) called with non ANSI/ISO C option $opt" >&2
-                    exit 1;;
-            esac
-          done
-          exec cc $_flavor ${1+"$@"}
-          EOF
-      - runs: |
-          cat >c99 <<'EOF'
-          #!/bin/sh
-          _flavor="-std=c99"
-          for opt; do
-            case "$opt" in
-            -std=c99|-std=iso9899:1999) _flavor="";;
-            -std=*) echo "$(basename $0) called with non ISO C99 option $opt" >&2
-                    exit 1;;
-            esac
-          done
-          exec cc $_flavor ${1+"$@"}
-          EOF
-      - runs: |
-          chmod 755 c?9
+      - working-directory: '${{targets.contextdir}}/usr/bin'
+        pipeline:
+          - runs: |
+              ln -s gcc cc
+          - runs: |
+              cat >c89 <<'EOF'
+              #!/bin/sh
+              _flavor="-std=c89"
+              for opt; do
+                case "$opt" in
+                -ansi|-std=c89|-std=iso9899:1990) _flavor="";;
+                -std=*) echo "$(basename $0) called with non ANSI/ISO C option $opt" >&2
+                        exit 1;;
+                esac
+              done
+              exec cc $_flavor ${1+"$@"}
+              EOF
+          - runs: |
+              cat >c99 <<'EOF'
+              #!/bin/sh
+              _flavor="-std=c99"
+              for opt; do
+                case "$opt" in
+                -std=c99|-std=iso9899:1999) _flavor="";;
+                -std=*) echo "$(basename $0) called with non ISO C99 option $opt" >&2
+                        exit 1;;
+                esac
+              done
+              exec cc $_flavor ${1+"$@"}
+              EOF
+          - runs: |
+              chmod 755 c?9
     test:
       pipeline:
         - runs: |

--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -15,7 +15,7 @@ package:
       - libquadmath # This is a temporary workaround for issues with single-arch packages.
       - libstdc++-14-dev
       - openssf-compiler-options
-      - posix-cc-wrappers
+      - posix-cc-wrappers-${{vars.major-version}}=${{package.full-version}}
 
 environment:
   contents:
@@ -150,6 +150,54 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: posix-cc-wrappers-${{vars.major-version}}
+    dependencies:
+      provides:
+        - posix-cc-wrappers=${{package.full-version}} # for backwards compatibility
+      runtime:
+        - gcc=${{package.full-version}}
+    pipeline:
+      - working-directory: '${{targets.destdir}}/usr/bin'
+      - runs: |
+          ln -s gcc cc
+      - runs: |
+          cat >c89 <<'EOF'
+          #!/bin/sh
+          _flavor="-std=c89"
+          for opt; do
+            case "$opt" in
+            -ansi|-std=c89|-std=iso9899:1990) _flavor="";;
+            -std=*) echo "$(basename $0) called with non ANSI/ISO C option $opt" >&2
+                    exit 1;;
+            esac
+          done
+          exec cc $_flavor ${1+"$@"}
+          EOF
+      - runs: |
+          cat >c99 <<'EOF'
+          #!/bin/sh
+          _flavor="-std=c99"
+          for opt; do
+            case "$opt" in
+            -std=c99|-std=iso9899:1999) _flavor="";;
+            -std=*) echo "$(basename $0) called with non ISO C99 option $opt" >&2
+                    exit 1;;
+            esac
+          done
+          exec cc $_flavor ${1+"$@"}
+          EOF
+      - runs: |
+          chmod 755 c?9
+    test:
+      pipeline:
+        - runs: |
+            c89 --version
+            c89 --help
+            c99 --version
+            c99 --help
+            cc --version
+            cc --help
+
   - name: 'gcc-14-doc'
     pipeline:
       - uses: split/manpages


### PR DESCRIPTION
In current state, when we install any `gcc-<n>` package then the latest
gcc comes up as well.

this comes up because we `posix-cc-wrappers` is a runtime dependency
to `gcc-<n>`

and `posix-cc-wrappers` itself depend on latest gcc at runtime.

```yaml
  dependencies:
    runtime:
      - gcc
```
this commit moves posix-cc-wrappers inline with gcc and builds a
subpackage with name `posix-cc-wrappers-<n>` with a provides of
`posix-cc-wrappers` for backwards compatibility.

after building the package inline, we pin the runtime dependency of `gcc-<n>`
like

`- posix-cc-wrappers-${{vars.major-version}}=${{package.full-version}}`

this will always pull in the inline `posix-cc-wrappers-<n>` that we're
building with pinned epoch and revision.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
