### PR TITLE
modsecurity: add yajl support for JSON audit logging

### DIFF
--- a/modsecurity.yaml
+++ b/modsecurity.yaml
@@ -95,3 +95,13 @@ test:
   pipeline:
     - uses: test/tw/ldd-check
     - uses: test/pkgconf
+    - name: Verify yajl support for JSON logging
+      runs: |
+        strings /usr/lib/libmodsecurity.so.3 | grep -q "libyajl"
+
+        if strings /usr/lib/libmodsecurity.so.3 | grep -q "Without YAJL support"; then
+          echo "ERROR: Found 'Without YAJL support' error message in binary"
+          exit 1
+        fi
+
+        echo "ModSecurity compiled with yajl support for JSON logging"

--- a/modsecurity.yaml
+++ b/modsecurity.yaml
@@ -1,7 +1,7 @@
 package:
   name: modsecurity
   version: "3.0.14"
-  epoch: 3
+  epoch: 4
   description: "ModSecurity is an open source, cross platform web application firewall (WAF) engine"
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,7 @@ environment:
       - pcre-dev
       - pkgconf
       - wolfi-base
+      - yajl-dev
 
 pipeline:
   - uses: git-checkout
@@ -53,7 +54,8 @@ pipeline:
       opts: |
         --disable-doxygen-doc \
         --disable-doxygen-html \
-        --disable-examples
+        --disable-examples \
+        --with-yajl
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Adds `yajl-dev` build dependency to enable JSON format audit logging. ModSecurity's configure script auto-detects yajl and compiles with JSON support when available. 

Related:

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
