### PR TITLE
chore: remove runtime deps of posix-cc-wrappers

### DIFF
--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,13 +1,10 @@
 package:
   name: posix-cc-wrappers
-  version: 1
+  version: 2
   epoch: 7
   description: "Wrappers around GCC and Clang for POSIX conformance"
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - gcc
 
 environment:
   contents:
@@ -53,6 +50,10 @@ update:
   manual: true
 
 test:
+  environment:
+    contents:
+      packages:
+        - gcc
   pipeline:
     - runs: |
         c89 --version


### PR DESCRIPTION
    chore: remove runtime deps of posix-cc-wrappers

    we have gcc as runtime dependency to posix-cc-wrappers and each gcc
    includes posix-cc-wrappers as runtime depedency meaning whichever
    gcc-<ver> we pull in, we always bring in latest gcc.

    this commit removes gcc as runtime dependency from posix-cc-wrappers
    and we should be good with this because this package mostly carries a
    symlink and shell scripts.