### PR TITLE
add a qackage pipeline for use with the qackage agent

### DIFF
--- a/pipelines/test/qackage.yaml
+++ b/pipelines/test/qackage.yaml
@@ -1,0 +1,11 @@
+name: qackage
+
+inputs:
+  exception:
+    description: |
+      Justification for requesting qackage evaluation exception.
+    required: false
+    default: ""
+
+pipeline:
+  - name: qackage metadata


### PR DESCRIPTION
this uses a `test/pipeline` as the "interface" for how we plan on providing "exceptions" for the `qackage` agent. in practice this looks something like:

```yaml
test:
  pipeline:
    - uses: test/qackage
      with:
        exception: "Requires GCP Container Analysis API credentials and live service connection not available in hermetic melange test environment"
    - uses: test/tw/ver-check
      with:
        bins: aactl
        version: 0.4.10 # upstream neglected to update the version file before tagging the release see commit 7379407
    - uses: test/tw/help-check
      with:
        bins: aactl
```

we use a pipeline instead of inline comments so that it's preserved through a `melange compile`, and makes it simple/standard for the agent to identify.

the different modes look something like:

without an exception

```yaml
# response
packages:
- name: aactl
  result: FAIL
  suggestions:
  - Fix version check to expect 0.4.12 (currently checks for 0.4.10)
  - Add test that invokes aactl with sample input to validate parsing (e.g., 'aactl
    import --file test.json' and verify meaningful error or success)
  - Test command-line argument validation (e.g., verify aactl rejects invalid flags
    or missing required arguments)
  - If repository contains sample test data, use it to verify the tool can parse vulnerability
    reports, SLSA provenance, or sigstore attestations without requiring cloud credentials
  summary: Version and help checks don't prove the tool can import vulnerability reports,
    SLSA provenance, or sigstore attestations
result: FAIL
summary: Tests only verify binary execution (--version, --help) without validating
  any core data import functionality
```

with a valid exception

```yaml
# exception
  pipeline:
    - uses: test/qackage
      with:
        exception: Too difficult to test
      pipeline:
        - name: qackage metadata

# response
packages:
- name: aactl
  result: EXCEPTION
  suggestions:
  - Test importing OSS vulnerability scanner reports to Container Analysis API
  - Test importing SLSA provenance data to Container Analysis API
  - Test importing sigstore attestations to Container Analysis API
  - Test error handling for invalid credentials or malformed input data
  summary: Basic CLI operations verified (version, help flags). Core functionality
    (importing vulnerability reports, SLSA provenance, and sigstore attestations to
    GCP Container Analysis) requires cloud credentials and live API access.
result: EXCEPTION
summary: Binary CLI functionality (version, help) is tested. Core functionality (GCP
  Container Analysis data import) requires cloud credentials and live service access
  not available in hermetic test environment.
```

with a bogus exception

```yaml
# exception
  pipeline:
    - uses: test/qackage
      with:
        exception: Too difficult to test
      pipeline:
        - name: qackage metadata

# response
# NOTE: suggestions are present such that downstream consumers understand where coverage gaps may be
packages:
- name: aactl
  result: FAIL
  suggestions:
  - Remove or revise the qackage exception - 'too difficult to test' is not a valid
    infrastructure constraint. If cloud credentials are required, cite that specifically
  - Add tests with sample vulnerability scanner reports to verify aactl can parse
    and validate input formats
  - Add tests with sample SLSA provenance documents to verify parsing functionality
  - Add tests with sample sigstore attestation data to verify handling
  - Add tests for error handling with malformed input files
  - If the tool supports dry-run or validation-only modes, use those to test core
    logic without requiring live Google Container Analysis access
  summary: Invalid exception (cites 'difficulty' not infrastructure constraints),
    and actual tests only check version/help output without exercising data import
    functionality
result: FAIL
summary: Tests only verify binary existence and basic execution (--version, --help),
  not core functionality of importing vulnerability reports, SLSA provenance, or sigstore
  attestations
```