### PR TITLE
wolfi-baselayout add compat symlinks

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 25
+  epoch: 26
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -17,6 +17,8 @@ package:
     disabled:
       # fails "usrlocal" linter because it creates /usr/local/lib64
       - usrmerge
+      # fails "tempdir" linter because it creates /run/lock
+      - tempdir
 
 environment:
   contents:
@@ -47,7 +49,7 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in dev etc etc/profile.d etc/secfixes.d home proc root var/log usr/bin usr/local/lib sys tmp var/spool/cron/crontabs opt run usr/lib; do
+      for i in dev etc etc/profile.d etc/secfixes.d home proc root var/log usr/bin usr/local/lib sys tmp var/spool/cron/crontabs opt run usr/lib var/tmp run/lock; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
 
@@ -72,6 +74,8 @@ pipeline:
 
       ln -s /proc/mounts "${{targets.destdir}}"/etc/mtab
       ln -s /var/mail "${{targets.destdir}}"/var/spool/mail
+      ln -s ../var/tmp "${{targets.destdir}}"/usr/tmp
+      ln -s ../run/lock "${{targets.destdir}}"/var/lock
 
       echo 'multi on' > "${{targets.destdir}}"/etc/host.conf
 


### PR DESCRIPTION
/usr/tmp -> /var/tmp
/var/lock -> /run/lock

Note at runtime for VMs, systemd handles /var/lock -> /run/lock, so being overwritten by the /run tmpfs is not a concern.

Justification for doing this: https://github.com/chainguard-dev/internal-dev/issues/21851
