### PR TITLE
Apache-nifi-registry remove jetty-http2-common from pombump to fix TLS startup

### DIFF
--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -120,6 +120,7 @@ subpackages:
 
           ln -sf "${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}" \
                  "${{targets.subpkgdir}}${NIFI_TOOLKIT_HOME}"
+      - uses: strip
     test:
       pipeline:
         - runs: |

--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi-registry
   version: "2.6.0"
-  epoch: 1 # GHSA-25qh-j22f-pwp8
+  epoch: 2 # GHSA-25qh-j22f-pwp8
   description: Apache NiFi Registry is a registry for storing and managing shared resources such as versioned flows across one or more instances of NiFi.
   copyright:
     - license: Apache-2.0
@@ -62,6 +62,8 @@ pipeline:
       patches: patch-registry-web-api-pom.patch
 
   - uses: maven/pombump
+    with:
+      patch-file: pombump-deps.yaml
 
   - runs: |
       MAVEN_THREADS=1
@@ -118,7 +120,6 @@ subpackages:
 
           ln -sf "${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}" \
                  "${{targets.subpkgdir}}${NIFI_TOOLKIT_HOME}"
-      - uses: strip
     test:
       pipeline:
         - runs: |

--- a/apache-nifi-registry/pombump-deps.yaml
+++ b/apache-nifi-registry/pombump-deps.yaml
@@ -11,9 +11,6 @@ patches:
   - groupId: org.springframework
     artifactId: spring-webmvc
     version: 6.2.10
-  - groupId: org.eclipse.jetty.http2
-    artifactId: jetty-http2-common
-    version: 12.0.25
   - groupId: io.netty
     artifactId: netty-codec-compression
     version: 4.2.5.Final


### PR DESCRIPTION
Fixes missing `jetty-http2-common-12.0.27.jar` causing TLS startup failure with NoClassDefFoundError: org/eclipse/jetty/http2/SessionContainer.

Root cause: pombump adds missing dependencies to DependencyManagement section with default scope:import, which interfered with Maven's transitive dependency resolution. Since `jetty-http2-common` is already a transitive dependency of `jetty-http2-server`, the pombump entry prevented natural inclusion.

Verified: r2 APK now contains `jetty-http2-common-12.0.27.jar` and matches upstream `apache/nifi-registry:latest` image 1:1.