### PR TITLE
keycloak-config-cli: revert logback dependency and bump epoch

### DIFF
--- a/keycloak-config-cli.yaml
+++ b/keycloak-config-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-config-cli
   version: 6.4.0
-  epoch: 50 # GHSA-25qh-j22f-pwp8
+  epoch: 51
   description: Import YAML/JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
   copyright:
     - license: Apache-2.0

--- a/keycloak-config-cli/pombump-deps.yaml
+++ b/keycloak-config-cli/pombump-deps.yaml
@@ -20,6 +20,3 @@ patches:
     artifactId: spring-core
     version: 6.2.11
     type: pom
-  - groupId: ch.qos.logback
-    artifactId: logback-core
-    version: 1.5.19


### PR DESCRIPTION
## Summary
Reverts the logback-core dependency addition from https://github.com/wolfi-dev/os/pull/69697 and bumps epoch to 51 instead.

## Changes
- Removed logback-core dependency from pombump-deps.yaml
- Bumped epoch from 50 to 51

## Rationale
This dependency bump breaks the image, reverted and added to [autobump ignore list. ](https://github.com/chainguard-dev/infra-images/pull/2928)

## Verification
- Build: `make package/keycloak-config-cli`
- Scan: `wolfictl scan packages/*/*/keycloak-config-cli-*.apk`