### PR TITLE
curl: add HTTP/3 and QUIC support

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -167,9 +167,11 @@ test:
         - nginx
   pipeline:
     - uses: test/tw/ver-check
-      bins: curl
+      with:
+        bins: curl
     - uses: test/tw/help-check
-      bins: curl
+      with:
+        bins: curl
     - runs: |
         curl --version | grep 'ldap ldaps'
         curl -v https://example.com

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.16.0"
-  epoch: 2
+  epoch: 3
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -27,6 +27,7 @@ environment:
       - libpsl-dev
       - libtool
       - nghttp2-dev
+      - nghttp3-dev
       - openldap-dev
       - openssl-dev
       - perl
@@ -61,6 +62,7 @@ pipeline:
         --without-rustls \
         --with-nghttp2 \
         --with-pic \
+        --with-openssl-quic \
         --enable-ldap \
         --disable-ntlm \
         --without-libssh2 \
@@ -162,11 +164,16 @@ test:
     contents:
       packages:
         - git
+        - nginx
   pipeline:
+    - uses: test/tw/ver-check
+      bins: curl
+    - uses: test/tw/help-check
+      bins: curl
     - runs: |
-        curl --version
         curl --version | grep 'ldap ldaps'
         curl -v https://example.com
         curl -s --output /dev/null --compressed https://aur.archlinux.org
         git clone https://github.com/chainguard-dev/lots-of-refs.git
         curl --help
+        curl --http3 https://example.com

--- a/curl.yaml
+++ b/curl.yaml
@@ -88,9 +88,7 @@ subpackages:
     pipeline:
       - uses: split/dev
       # cd2nroff is needed by trurl
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/bin
-          mv scripts/cd2nroff "${{targets.contextdir}}"/usr/bin
+      - runs: install -Dpm0755 -t "${{targets.contextdir}}"/usr/bin ./scripts/cd2nroff
     dependencies:
       runtime:
         - brotli-dev
@@ -99,11 +97,14 @@ subpackages:
         - openssl-dev
     test:
       pipeline:
-        - runs: |
-            curl-config --version
-            curl-config --help
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+        - uses: test/tw/ver-check
+          with:
+            bins: curl-config
+        - uses: test/tw/help-check
+          with:
+            bins: curl-config
 
   - name: "curl-doc"
     description: "documentation for curl"
@@ -147,10 +148,7 @@ subpackages:
           install -Dm755 etc/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
     test:
       pipeline:
-        - name: Verify entrypoint file
-          runs: |
-            test -s /entrypoint.sh
-            /entrypoint.sh --version | grep -q curl
+        - uses: test/tw/symlink-check
 
 update:
   enabled: true
@@ -161,10 +159,19 @@ update:
 
 test:
   environment:
+    accounts:
+      groups:
+        - groupname: nginx
+          gid: 65532
+      users:
+        - username: nginx
+          gid: 65532
+          uid: 65532
     contents:
       packages:
         - git
         - nginx
+        - wait-for-it
   pipeline:
     - uses: test/tw/ver-check
       with:
@@ -173,9 +180,41 @@ test:
       with:
         bins: curl
     - runs: |
-        curl --version | grep 'ldap ldaps'
-        curl -v https://example.com
-        curl -s --output /dev/null --compressed https://aur.archlinux.org
-        git clone https://github.com/chainguard-dev/lots-of-refs.git
-        curl --help
-        curl --http3 https://example.com
+        curl --version | grep "ldap ldaps"
+        curl --version | grep "HTTP3"
+    - uses: test/daemon-check-output
+      with:
+        setup: |
+          tee /etc/nginx/nginx.conf <<EOF
+          daemon off;
+
+          events {
+              worker_connections 1024;
+          }
+
+          http {
+            server {
+              listen       8080 default_server;
+              listen       [::]:8080 default_server;
+              server_name  _;
+              root         /usr/share/nginx/html;
+              location /hello {
+                add_header Content-Type text/html;
+
+                return 200 "Hello, Linky!";
+              }
+              location /redirect {
+                return 301 /hello;
+              }
+            }
+          }
+          EOF
+
+          nginx -t
+        start: nginx
+        expected_output: " "
+        post: |
+          set -x
+          wait-for-it localhost:8080
+          curl http://localhost:8080/hello | grep -F -e "Hello, Linky!"
+          curl -L http://localhost:8080/redirect | grep -F -e "Hello, Linky!"

--- a/nghttp3.yaml
+++ b/nghttp3.yaml
@@ -1,0 +1,46 @@
+package:
+  name: nghttp3
+  version: 1.12.0
+  epoch: 0
+  description: HTTP/3 library written in C
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - libtool
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ngtcp2/nghttp3.git
+      tag: v${{package.version}}
+      expected-commit: 8e3523d04bec12cc1fbfd6018d2dc0ef4210148d
+      recurse-submodules: true
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: Development dependencies and libraries for ${{package.name}}
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - uses: test/pkgconf
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v

--- a/nghttp3.yaml
+++ b/nghttp3.yaml
@@ -44,3 +44,27 @@ update:
   enabled: true
   git:
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - nghttp3-dev
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        tee ver-check.c <<'EOF'
+        #include <stdio.h>
+        #include <nghttp3/version.h>
+
+        int main() {
+          printf("%s", NGHTTP3_VERSION);
+          return 0;
+        }
+        EOF
+
+        gcc -lnghttp3 ./ver-check.c -o nghttp3-vercheck
+    - uses: test/tw/ver-check
+      with:
+        bins: ./nghttp3-vercheck


### PR DESCRIPTION
Follows instructions from: https://curl.se/docs/http3.html

Helps out a lot with testing these
Also improves tests in the CURL package a bit
