### PR TITLE
datadog-agent: epoch bump to rebuild for CVE fixes

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.71.2"
-  epoch: 2
+  epoch: 3
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
## Summary

Epoch bump to trigger rebuild of datadog-agent which will pick up latest pip dependency versions.