### PR TITLE
feat(mlflow): bump starlette to remediate GHSA-7f5h-v6xp-fcq8

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.5.1"
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -76,6 +76,9 @@ pipeline:
 
       # Upgrade authlib to fix GHSA-pq5p-34cr-23v9, GHSA-g7f3-828f-7h7m
       pip install --upgrade "authlib>1.6.4"
+
+      # Upgrade starlette to fix GHSA-7f5h-v6xp-fcq8
+      pip install --upgrade "starlette>=0.49.1"
 
       # Remove pip
       pip uninstall --yes pip


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump starlette from 0.48.0 to 0.49.1 to remediate GHSA-7f5h-v6xp-fcq8 (CVE-2025-62727).

This vulnerability allows DoS attacks through specially crafted HTTP Range headers that trigger quadratic-time complexity in the parsing and merging logic, exhausting CPU resources.

## Changes
- Added pip upgrade command for starlette>=0.49.1 in mlflow.yaml
- Incremented epoch to 1

<!--ci-cve-scan:must-fix: GHSA-7f5h-v6xp-fcq8 -->