### PR TITLE
feat(open-webui): bump starlette to remediate GHSA-7f5h-v6xp-fcq8

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.34"
-  epoch: 1
+  epoch: 2
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -68,8 +68,8 @@ pipeline:
       uv pip install .
       uv pip install torchvision torchaudio itsdangerous
 
-      # GHSA-2c2j-9gv5-cj73
-      uv pip install --upgrade starlette==0.47.2
+      # GHSA-2c2j-9gv5-cj73, GHSA-7f5h-v6xp-fcq8
+      uv pip install --upgrade starlette==0.49.1
 
       # GHSA-7hfw-26vp-jp8m
       uv pip install --upgrade pypdf==6.1.3


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump starlette from 0.47.2 to 0.49.1 to remediate GHSA-7f5h-v6xp-fcq8 (CVE-2025-62727).

This vulnerability allows DoS attacks through specially crafted HTTP Range headers that trigger quadratic-time complexity in the parsing and merging logic, exhausting CPU resources.

## Changes
- Updated starlette version from 0.47.2 to 0.49.1 in open-webui.yaml
- Added GHSA-7f5h-v6xp-fcq8 to the starlette upgrade comment
- Incremented epoch to 2

<!--ci-cve-scan:fail-any-->