### PR TITLE
feat(kserve): bump starlette to remediate GHSA-7f5h-v6xp-fcq8

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -116,6 +116,10 @@ subpackages:
           poetry add \
             "starlette=^0.49.1"
 
+          # typing-extensions: pydantic-core requires >=4.14.1 (Sentinel added in 4.14.0)
+          poetry add \
+            "typing-extensions>=4.14.1"
+
           poetry run pip freeze | grep -v kserve > requirements.txt
           poetry build
 

--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: "0.15.2"
-  epoch: 5 # CVE-2025-47907
+  epoch: 6
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -112,8 +112,9 @@ subpackages:
           poetry add \
             "urllib3=^2.5.0"
 
+          # starlette: GHSA-7f5h-v6xp-fcq8
           poetry add \
-            "starlette=^0.47.2"
+            "starlette=^0.49.1"
 
           poetry run pip freeze | grep -v kserve > requirements.txt
           poetry build


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump starlette from ^0.47.2 to ^0.49.1 to remediate GHSA-7f5h-v6xp-fcq8 (CVE-2025-62727).

This vulnerability allows DoS attacks through specially crafted HTTP Range headers that trigger quadratic-time complexity in the parsing and merging logic, exhausting CPU resources.

## Changes
- Updated starlette version constraint from ^0.47.2 to ^0.49.1 in kserve.yaml
- Added comment with GHSA ID for the starlette upgrade
- Incremented epoch to 6

<!--ci-cve-scan:fail-any-->