### PR TITLE
feat(k8s-sidecar): bump fastapi to remediate GHSA-7f5h-v6xp-fcq8

### DIFF
--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
-  version: "2.0.2"
-  epoch: 1
+  version: "2.0.3"
+  epoch: 0
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kiwigrid/k8s-sidecar
       tag: ${{package.version}}
-      expected-commit: 323fec2477bf51864e166e74dd57b7be05f01b10
+      expected-commit: 4c31cf7a42c5305beb4ad39969bd731fe36c735c
 
   - runs: |
       cd src

--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: "2.0.2"
-  epoch: 0
+  epoch: 1
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT
@@ -33,7 +33,7 @@ pipeline:
       # Mitigate CVE-2022-40897 / GHSA-r9hx-vwmv-q579
       pip install --upgrade setuptools
       sed -i 's/requests==2\.32\.3/requests==2.32.4/' /home/build/src/requirements.txt # fix GHSA-9hjg-9r4m-mvj7
-      sed -i 's/fastapi==0\.115\.2/fastapi==0.119.0/' /home/build/src/requirements.txt # fix GHSA-2c2j-9gv5-cj73
+      sed -i 's/fastapi==0\.115\.2/fastapi==0.120.2/' /home/build/src/requirements.txt # fix GHSA-2c2j-9gv5-cj73, GHSA-7f5h-v6xp-fcq8
       pip install --no-cache-dir -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"
 
       # Patch CVE-2024-3651
@@ -42,7 +42,6 @@ pipeline:
       pip install urllib3==2.2.2
       # Patch GHSA-248v-346w-9cwc
       pip install certifi==2024.07.04
-      # Patch GHSA-9hjg-9r4m-mvj7
 
   - name: install src/ files to usr/share/app
     runs: |


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump fastapi from 0.115.2 to 0.120.2 to remediate GHSA-7f5h-v6xp-fcq8 (CVE-2025-62727).

This vulnerability exists in Starlette (a dependency of FastAPI) and allows DoS attacks through specially crafted HTTP Range headers that trigger quadratic-time complexity in the parsing and merging logic, exhausting CPU resources. Upgrading FastAPI to 0.120.2 automatically brings in the patched Starlette version (0.49.1+).

## Changes
- Updated fastapi version from 0.115.2 to 0.120.2 in requirements.txt
- Updated comment to include both GHSA-2c2j-9gv5-cj73 and GHSA-7f5h-v6xp-fcq8
- Incremented epoch to 1

<!--ci-cve-scan:fail-any-->