### PR TITLE
systemd: split out udev package

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -243,6 +243,7 @@ subpackages:
         - merged-lib
         - merged-sbin
         - merged-usrsbin
+        - udev-dev
         - wolfi-baselayout
     pipeline:
       - uses: split/dev
@@ -515,6 +516,37 @@ subpackages:
             )
 
             [ "$EXPECTED" = "$(systemd-hwdb query pci:v00001234d00007000sv00001AF4sd00001100bc06sc01i00)" ]
+
+  - name: "udev-dev"
+    description: "udev development files"
+    dependencies:
+      runtime:
+        - libudev
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/include
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+
+          # systemd-dev runs before us and moves all dev files via split/dev
+          # We need to extract the udev-specific files from systemd-dev's staging area
+          SYSTEMD_DEV_DIR="/home/build/melange-out/systemd-dev"
+
+          # Move udev-specific headers from systemd-dev
+          mv $SYSTEMD_DEV_DIR/usr/include/libudev.h ${{targets.subpkgdir}}/usr/include/
+
+          # Move udev pkgconfig file from systemd-dev
+          mv $SYSTEMD_DEV_DIR/usr/lib/pkgconfig/libudev.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+
+          # Move udev development symlink from systemd-dev
+          mv $SYSTEMD_DEV_DIR/usr/lib/libudev.so ${{targets.subpkgdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: "systemd-init"
     description: "Configure systemd for use as an init system"


### PR DESCRIPTION
Not everything needs all of systemd and this is more of a direct replacement for eudev-dev.