### PR TITLE
fix(dotnet-8/9): Set provider priority for .NET host

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.121"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - icu
+    provider-priority: ${{vars.major-version}}
     provides:
       - dotnet=${{package.full-version}}
 

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.111"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - icu
+    provider-priority: ${{vars.major-version}}
     provides:
       - dotnet=${{package.full-version}}
 


### PR DESCRIPTION
Ensures that .NET host 8 won't replace .NET host 9 without explicitly requesting installation of .NET host 8