### PR TITLE
feat: Update libmspack to use git for git-checkout, clean the build file, enable updates.

### DIFF
--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -56,6 +56,7 @@ update:
   github:
     identifier: kyz/libmspack
     strip-prefix: v
+    use-tag: true
 
 test:
   pipeline:

--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -15,18 +15,26 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 70dd1fb2f0aecc36791b71a1e1840e62173079eadaa081192d1c323a0eeea21b
-      uri: https://www.cabextract.org.uk/libmspack/libmspack-0.11alpha.tar.gz
+      repository: https://github.com/kyz/libmspack.git
+      tag: v${{package.version}}
+      expected-commit: 305907723a4e7ab2018e58040059ffb5e77db837
 
   - uses: autoconf/configure
+    with:
+      dir: ./libmspack
 
   - uses: autoconf/make
+    with:
+      dir: ./libmspack
 
   - uses: autoconf/make-install
+    with:
+      dir: ./libmspack
 
   - uses: strip
 
@@ -45,9 +53,9 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # latest version doesn't seem to match what's reported at https://www.cabextract.org.uk/libmspack
-  release-monitor:
-    identifier: 16827
+  github:
+    identifier: kyz/libmspack
+    strip-prefix: v
 
 test:
   pipeline:

--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -1,8 +1,7 @@
-# Generated from https://git.alpinelinux.org/aports/plain/community/libmspack/APKBUILD
 package:
   name: libmspack
-  version: "1.11"
-  epoch: 0
+  version: "0.11_alpha"
+  epoch: 4
   description: Library for Microsoft CAB compression formats
   copyright:
     - license: LGPL-2.1-only
@@ -17,12 +16,20 @@ environment:
       - ca-certificates-bundle
       - libtool
 
+# The upstream does not have `_` in the tags, but it's invalid in semver, so we
+# use a transform to convert it.
+var-transforms:
+  - from: ${{package.version}}
+    match: _alpha
+    replace: alpha
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/kyz/libmspack.git
-      tag: v${{package.version}}
-      expected-commit: 305907723a4e7ab2018e58040059ffb5e77db837
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: 370d41b64230907f7ca16586bcc1cd93304718f9
 
   - uses: autoconf/configure
     with:
@@ -51,12 +58,23 @@ subpackages:
         - libmspack
     description: libmspack dev
 
+# This update section is little wonky because the upstream repo uses two styles
+# of tags for versions. There are two releases, one that is for `cabextract`,
+# and another for `libmspack`.
+# The libmspack are of the form `v0.11alpha` while the cabextract ones are
+# of the form `v1.11`.
+# So, for now we only consider the alpha tags for libmspack itself.
 update:
   enabled: true
+  enable-prerelease-tags: true
+  version-transform:
+    - match: 'alpha'
+      replace: '_alpha'
   github:
     identifier: kyz/libmspack
     strip-prefix: v
     use-tag: true
+    tag-filter-contains: alpha
 
 test:
   pipeline:


### PR DESCRIPTION

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
