### PR TITLE
Enable auto bump headlamp plugin flux

### DIFF
--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -1,7 +1,7 @@
 package:
   name: headlamp-plugin-flux
   version: "0.4.0"
-  epoch: 1
+  epoch: 2
   description: Flux plugin for Headlamp that provides a way to visualize Flux resources.
   copyright:
     - license: Apache-2.0

--- a/headlamp-plugin-flux.yaml
+++ b/headlamp-plugin-flux.yaml
@@ -42,7 +42,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: true
   github:
     identifier: headlamp-k8s/plugins
     strip-prefix: flux-


### PR DESCRIPTION
## Explanation

Remove manual update as its not required for headlamp