### PR TITLE
systemd: split off journal-gatewayd and journal-remote

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "258.1"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -134,6 +134,8 @@ subpackages:
         - merged-sbin
         - systemd
         - systemd-container
+        - systemd-journal-gatewayd
+        - systemd-journal-remote
         - wolfi-baselayout
     pipeline:
       - runs: |
@@ -713,6 +715,38 @@ subpackages:
 
             ukify --help && echo "PASS: ukify --help exited 0" ||
                fail "ukify --help exited $?"
+
+  - name: "systemd-journal-gatewayd"
+    description: "HTTP server for journal events"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system"
+          mv "${{targets.destdir}}/usr/lib/systemd/systemd-journal-gatewayd" "${{targets.subpkgdir}}/usr/lib/systemd/"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-gatewayd.service" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-gatewayd.socket" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
+
+  - name: "systemd-journal-remote"
+    description: "Receive journal messages over the network"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system"
+          mv "${{targets.destdir}}/usr/lib/systemd/systemd-journal-remote" "${{targets.subpkgdir}}/usr/lib/systemd/"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-remote.service" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-remote.socket" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
 
 update:
   enabled: true


### PR DESCRIPTION
Split off the systemd-journal-gatewayd and systemd-journal-remote components into their own optional sub-packages. This is to reduce the dependence on GnuTLS, which both components pull in directly and transitively via libmicrohttpd. Log forwarding to a remote system is still possible by default via the use of systemd-journal-upload.
