### PR TITLE
fix update block of fluxcd-kustomize-mutating-webhook

### DIFF
--- a/fluxcd-kustomize-mutating-webhook.yaml
+++ b/fluxcd-kustomize-mutating-webhook.yaml
@@ -41,7 +41,7 @@ subpackages:
 update:
   enabled: true
   github:
-    tag-filter-prefix: kustomize-mutating-webhook-v
+    tag-filter-prefix: kustomize-mutating-webhook-
     identifier: xunholy/fluxcd-kustomize-mutating-webhook
     strip-prefix: kustomize-mutating-webhook-v
 


### PR DESCRIPTION
we're more consistent and correct if we drop the `v` in there

ref: https://github.com/xunholy/fluxcd-kustomize-mutating-webhook/tags