### PR TITLE
fix(jitsucom-jitsu): GHSA-5jpx-9hw9-2fx4 bump next-auth version

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 5 # GHSA-mm7p-fcc7-pg87
+  epoch: 6
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -46,7 +46,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: consolidated-cve-remedation.patch GHSA-33vc-wfww-vjfv.patch
+      patches: consolidated-cve-remedation.patch GHSA-33vc-wfww-vjfv.patch GHSA-5jpx-9hw9-2fx4.patch
 
   - name: "delete leftover source files"
     runs: |

--- a/jitsucom-jitsu/GHSA-5jpx-9hw9-2fx4.patch
+++ b/jitsucom-jitsu/GHSA-5jpx-9hw9-2fx4.patch
@@ -1,0 +1,23 @@
+From 0a9f65a970fd02c2f931e569143ef4754cfd888d Mon Sep 17 00:00:00 2001
+From: Catherine Redfield <catherine.redfield@chainguard.dev>
+Date: Fri, 31 Oct 2025 18:49:07 +0000
+Subject: [PATCH] fix(console): bump next-auth verison for GHSA-5jpx-9hw9-2fx4
+
+---
+ webapps/console/package.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/webapps/console/package.json b/webapps/console/package.json
+index fdd9088..39583d8 100644
+--- a/webapps/console/package.json
++++ b/webapps/console/package.json
+@@ -78,6 +78,6 @@
+     "mjml-react": "^2.0.8",
+     "monaco-editor": "^0.52.0",
+     "next": "15.3.5",
+-    "next-auth": "^4.24.11",
++    "next-auth": "4.24.12",
+     "node-fetch-commonjs": "^3.3.2",
+     "node-sql-parser": "^5.3.8",
+--
+2.51.2


### PR DESCRIPTION
next-auth is used in the -console subpackage; ensure that it picks up the fixed
4.24.12 version.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31804

<!--ci-cve-scan:fail-any-->
