### PR TITLE
libbpf: add libbpf-private-dev subpackage

### DIFF
--- a/libbpf.yaml
+++ b/libbpf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libbpf
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: GPL-2.0-only
@@ -47,6 +47,24 @@ subpackages:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+
+  - name: libbpf-private-dev
+    description: Header files not usually shipped by libbpf but needed by some software
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/include/bpf
+          for h_file in src/*.h; do
+            if [ ! -e melange-out/libbpf-dev/usr/include/bpf/$(basename $h_file) ]; then
+              cp $h_file ${{targets.subpkgdir}}/usr/include/bpf
+            fi
+          done
+    dependencies:
+      runtime:
+        - libbpf-dev
+    test:
+      pipeline:
+        - runs: |
+            ls /usr/include/bpf/libbpf_internal.h
 
 update:
   enabled: true


### PR DESCRIPTION
This ships the non-public header files from the upstream repo, required for compiling some projects which usually build directly against upstream (e.g. `calico-3.31`).