### PR TITLE
openssl: add patch to block deprecated HMAC API in FIPS mode

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 3
+  epoch: 4
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -44,7 +44,10 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-jitter.patch 0001-baseprovider-add-MD5-and-SHA1.patch
+      patches: |
+        fix-jitter.patch
+        0001-baseprovider-add-MD5-and-SHA1.patch
+        0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
   - name: Create dbg sourcecode
     runs: |

--- a/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
+++ b/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
@@ -1,0 +1,60 @@
+From a4e6eb8707adfb11687bc99af26263d3cdc8916d Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Mon, 20 Oct 2025 16:56:30 +0100
+Subject: [PATCH] fips: block HMAC calculation with unapproved digests
+
+When using legacy HMAC APIs as used by older nodejs, dotnet, and
+python - one can attempt to create HMAC using unapproved digest.
+
+Block such access.
+---
+ crypto/hmac/hmac.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/crypto/hmac/hmac.c b/crypto/hmac/hmac.c
+index 19fc7d3b4f..da9451cb8a 100644
+--- a/crypto/hmac/hmac.c
++++ b/crypto/hmac/hmac.c
+@@ -18,6 +18,7 @@
+ #include <string.h>
+ #include "internal/cryptlib.h"
+ #include <openssl/opensslconf.h>
++#include <openssl/provider.h>
+ #include <openssl/hmac.h>
+ #include <openssl/core_names.h>
+ #include "hmac_local.h"
+@@ -30,6 +31,9 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+     unsigned char pad[HMAC_MAX_MD_CBLOCK_SIZE];
+     unsigned int keytmp_length;
+     unsigned char keytmp[HMAC_MAX_MD_CBLOCK_SIZE];
++    const EVP_MD *checkmd = NULL;
++    const OSSL_PROVIDER *checkprovider = NULL;
++    const char *checkname = NULL;
+ 
+     /* If we are changing MD then we must have a key */
+     if (md != NULL && md != ctx->md && (key == NULL || len < 0))
+@@ -95,6 +99,21 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+     }
+     if (!EVP_MD_CTX_copy_ex(ctx->md_ctx, ctx->i_ctx))
+         goto err;
++
++    /*
++     * Block non-fips provider digest in FIPS mode, note this has to
++     * be done this late, and using fetched MD from MD_CTX, as the
++     * input MD passed to this function can be NULL, or its provider
++     * might be NULL (unfetched). Also check all pointers, to be sure.
++     */
++    if (EVP_default_properties_is_fips_enabled(NULL) &&
++        (checkmd = EVP_MD_CTX_get0_md(ctx->md_ctx)) != NULL &&
++        (checkprovider = EVP_MD_get0_provider(checkmd)) != NULL &&
++        (checkname = OSSL_PROVIDER_get0_name(checkprovider)) != NULL &&
++        strcmp("fips", checkname)) {
++        return 0;
++    }
++
+     rv = 1;
+  err:
+     if (reset) {
+-- 
+2.51.0
+


### PR DESCRIPTION
When using deprecated HMAC API, ensure that digest is from the FIPS
provider. This should block creating FIPS HMAC with unapproved
digests.

Improved implementation over previous attempt, see:
- https://github.com/wolfi-dev/os/pull/70102
- https://github.com/wolfi-dev/os/pull/70351
