### PR TITLE
apache-nifi-registry: add missing shell utilities for script execution

### DIFF
--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -12,7 +12,6 @@ package:
       - curl
       - dash-binsh # Provides /bin/sh -> dash which matches upstream
       - fontconfig
-      - git
       - glibc-locale-en
       - jq
       - net-tools # Provides hostname command needed by common.sh

--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -10,7 +10,7 @@ package:
       - bash
       - coreutils
       - curl
-      - dash-binsh # Provides /bin/sh -> dash (matches upstream Debian)
+      - dash-binsh # Provides /bin/sh -> dash which matches upstream
       - fontconfig
       - git
       - glibc-locale-en
@@ -109,7 +109,9 @@ subpackages:
     description: "Toolkit for Apache NiFi Registry"
     dependencies:
       runtime:
-        - apache-nifi-registry # Provides Java runtime and shell utilities (coreutils, dash) needed by cli.sh
+        - coreutils # Provides readlink, dirname, basename, pwd, uname, expr used by cli.sh
+        - dash-binsh # Provides /bin/sh for script execution
+        - openjdk-${{vars.java-version}}-default-jvm # Provides java command
     pipeline:
       - runs: |
           cd /home/build/nifi-registry/nifi-registry-toolkit

--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -1,17 +1,25 @@
 package:
   name: apache-nifi-registry
   version: "2.6.0"
-  epoch: 2 # GHSA-25qh-j22f-pwp8
+  epoch: 3 # GHSA-25qh-j22f-pwp8
   description: Apache NiFi Registry is a registry for storing and managing shared resources such as versioned flows across one or more instances of NiFi.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - busybox
+      - coreutils
+      - curl
+      - dash-binsh # Provides /bin/sh -> dash (matches upstream Debian)
+      - fontconfig
       - git
-      - java-common-jre
-      - openjdk-${{vars.java-version}}-jre
+      - glibc-locale-en
+      - jq
+      - net-tools # Provides hostname command needed by common.sh
+      - openjdk-${{vars.java-version}}-default-jvm # Creates /usr/bin/java symlink and includes JRE
+      - openssl
+      - sed # Provides sed command needed by scripts
+      - unzip
       - xmlstarlet
 
 vars:
@@ -99,6 +107,9 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-toolkit
     description: "Toolkit for Apache NiFi Registry"
+    dependencies:
+      runtime:
+        - apache-nifi-registry # Provides Java runtime and shell utilities (coreutils, dash) needed by cli.sh
     pipeline:
       - runs: |
           cd /home/build/nifi-registry/nifi-registry-toolkit
@@ -152,7 +163,6 @@ test:
         - ${{package.name}}
         - ${{package.name}}-toolkit
         - java-common-jre
-        - openjdk-${{vars.java-version}}-jre
         - curl
         - grep
         - wait-for-it
@@ -222,6 +232,4 @@ test:
         timeout: 60
         post: |
           wait-for-it localhost:18080 -t 15
-          curl -s http://localhost:18080/nifi-registry-api/access | grep -q "anonymous" || {
-            exit 1
-          }
+          curl -fsS http://localhost:18080/nifi-registry-api/access | grep -q "anonymous"

--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -7,19 +7,15 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - bash
-      - coreutils
-      - curl
-      - dash-binsh # Provides /bin/sh -> dash which matches upstream
-      - fontconfig
-      - glibc-locale-en
-      - jq
-      - net-tools # Provides hostname command needed by common.sh
-      - openjdk-${{vars.java-version}}-default-jvm # Creates /usr/bin/java symlink and includes JRE
-      - openssl
-      - sed # Provides sed command needed by scripts
-      - unzip
-      - xmlstarlet
+      - bash # Required by scripts with #!/bin/bash shebang
+      - coreutils # Provides readlink, dirname, basename, pwd, uname, expr used by nifi-registry.sh and cli.sh
+      - curl # Used in K8s exec-based health probes
+      - dash-binsh # Provides /bin/sh -> dash (matches upstream Debian). All 8 startup scripts use #!/bin/sh
+      - glibc-locale-en # Locale support for Java application
+      - net-tools # Provides hostname command used in common.sh:28 for container identification
+      - openjdk-${{vars.java-version}}-default-jvm # Creates /usr/bin/java symlink. Auto-includes openjdk-21-jre with libfontconfig1
+      - sed # Used by 8 scripts for in-place config editing (common.sh:23, secure.sh:56-57, update_*.sh)
+      - xmlstarlet # RUNTIME: used by update_bundle_provider.sh, update_flow_provider.sh, update_login_providers.sh for XML manipulation
 
 vars:
   # Bump java-version when NiFi’s build baseline moves beyond Java 21


### PR DESCRIPTION
Fixes runtime failures in apache-nifi-registry by adding missing shell utilities that the startup scripts depend on.
Removed `busybox` in favor of individual GNU packages for better compatibility with upstream.
Missing packages were discovered by /pkg-diff tool

> Reference-only packages (apache/nifi-registry:latest) (7 packages):
>   └ curl (1 binaries):
> 	curl
>   └ fontconfig (9 binaries):
> 	fc-cache, fc-cat, fc-conflist, fc-list, fc-match, fc-pattern, fc-query, fc-scan, fc-validate
>   └ jq (1 binaries):
> 	jq
>   └ locales (3 binaries):
> 	locale-gen, update-locale, validlocale
>   └ openssl (1 binaries):
> 	openssl
>   └ unzip (4 binaries):
> 	funzip, unzipsfx, zipgrep, zipinfo
>   └ util-linux (2 binaries):
> 	i386, x86_64
> 
> Reference-only unowned binaries (apache/nifi-registry:latest) (29 binaries):
>   jar, jarsigner, java, javac, javadoc, javap, jcmd, jconsole, jdb, jdeprscan, jdeps, jfr, jhsdb, jimage, jinfo, jlink, jmap, jmod, jpackage, jps, jrunscript, jshell, jstack, jstat, jstatd, jwebserver, keytool, rmiregistry, serialver
> 
> Chainguard-only packages (chainreg.biz/chainguard-private/apache-nifi-registry:latest) (9 packages):
>   └ alsa-lib (1 binaries):
> 	aserver
>   └ busybox (72 binaries):
> 	adjtimex, arping, ash, bbconfig, bc, beep, bunzip2, busybox, bzcat, bzip2, cal, cpio, cryptpw, dc, dos2unix, ed, free, fsync, fuser, getfattr, hd, hexdump, inotifyd, iostat, killall, less, lsof, lzcat, lzma, lzop, lzopcat, microcom, mkpasswd, mpstat, netstat, nmeter, pgrep, ping, ping6, pipe_progress, pkill, pmap, ps, pstree, pwdx, rdev, readahead, resize, setserial, sha3sum, strings, sysctl, top, traceroute, traceroute6, tree, ttysize, tunctl, unix2dos, unlzma, unlzop, unxz, uptime, usleep, uudecode, uuencode, vconfig, vi, vlock, watch, xxd, xzcat
>   └ cyrus-sasl (5 binaries):
> 	pluginviewer, saslauthd, sasldblistusers2, saslpasswd2, testsaslauthd
>   └ gdbm (3 binaries):
> 	gdbm_dump, gdbm_load, gdbmtool
>   └ git (6 binaries):
> 	git, git-cvsserver, git-receive-pack, git-upload-archive, git-upload-pack, scalar
>   └ libxslt (1 binaries):
> 	xsltproc
>   └ p11-kit (1 binaries):
> 	p11-kit
>   └ p11-kit-trust (1 binaries):
> 	trust
>   └ xmlstarlet (1 binaries):
> 	xml
> 