### PR TITLE
New package openssl-hardened-dev

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: "2.14.10"
-  epoch: 8
+  epoch: 9
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only
@@ -20,7 +20,7 @@ environment:
       - lua5.3
       - lua5.3-dev
       - lua5.3-lzlib
-      - openssl-dev
+      - openssl-hardened-dev
       - scdoc
       - zlib-dev
 
@@ -33,7 +33,11 @@ pipeline:
 
   - uses: patch
     with:
-      patches: 292.patch usrmerge-lib.patch 0001-Work-without-fips-sha1.patch
+      patches: |
+        292.patch
+        357.patch
+        0001-Work-without-fips-sha1.patch
+        usrmerge-lib.patch
 
   - runs: |
       sed -i -e 's:-Werror::' Make.rules

--- a/apk-tools/0001-Work-without-fips-sha1.patch
+++ b/apk-tools/0001-Work-without-fips-sha1.patch
@@ -1,26 +1,27 @@
-From e80d57e7756aa119ca161487cad255462ae559c8 Mon Sep 17 00:00:00 2001
+From b5eec48c333fc8841018dfc43bfca87682f37ced Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
 Date: Thu, 21 Aug 2025 12:46:43 +0100
 Subject: [PATCH] Work without fips sha1
 
 ---
- src/apk.c | 3 +++
- 1 file changed, 3 insertions(+)
+ src/apk.c | 4 ++++
+ 1 file changed, 4 insertions(+)
 
 diff --git a/src/apk.c b/src/apk.c
-index 3b4ce40..c9f9202 100644
+index 164acea..6929a80 100644
 --- a/src/apk.c
 +++ b/src/apk.c
-@@ -432,6 +432,9 @@ static void fini_openssl(void)
+@@ -509,6 +509,10 @@ int main(int argc, char **argv)
+ 		if (applet->update_cache) dbopts.cache_max_age = 0;
+ 	}
  
- static void init_openssl(void)
- {
-+	// Preffer, but do not require FIPS algorithms, CRC usage of
++	// Prefer, but do not require FIPS algorithms, CRC usage of
 +	// SHA1 is needed
 +	EVP_set_default_properties(NULL, "?fips=yes");
- 	atexit(fini_openssl);
- 	OpenSSL_add_all_algorithms();
- #ifndef OPENSSL_NO_ENGINE
++
+ 	setup_automatic_flags();
+ 	fetchTimeout = 60;
+ 	fetchRedirectMethod = fetch_redirect;
 -- 
-2.48.1
+2.51.0
 

--- a/apk-tools/357.patch
+++ b/apk-tools/357.patch
@@ -1,0 +1,109 @@
+From https://gitlab.alpinelinux.org/alpine/apk-tools/-/merge_requests/357
+From 3726535965b8c557b60361f88f6873320b0c4299 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+Date: Sun, 2 Nov 2025 13:35:15 +0000
+Subject: [PATCH] openssl: remove deprecated API usage
+
+With this changes apk can be compiled without any deprecated APIs.
+---
+ libfetch/common.c | 12 ++----------
+ src/Makefile      |  4 ++--
+ src/apk.c         | 23 -----------------------
+ 3 files changed, 4 insertions(+), 35 deletions(-)
+
+diff --git a/libfetch/common.c b/libfetch/common.c
+index af064b87..5336ec6a 100644
+--- a/libfetch/common.c
++++ b/libfetch/common.c
+@@ -584,15 +584,7 @@ static int fetch_ssl_setup_client_certificate(SSL_CTX *ctx, int verbose)
+ int
+ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
+ {
+-	/* Init the SSL library and context */
+-	if (!SSL_library_init()){
+-		fprintf(stderr, "SSL library init failed\n");
+-		return (-1);
+-	}
+-
+-	SSL_load_error_strings();
+-
+-	conn->ssl_meth = SSLv23_client_method();
++	conn->ssl_meth = TLS_client_method();
+ 	conn->ssl_ctx = SSL_CTX_new(conn->ssl_meth);
+ 	SSL_CTX_set_mode(conn->ssl_ctx, SSL_MODE_AUTO_RETRY);
+ 
+@@ -620,7 +612,7 @@ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
+ 		return (-1);
+ 	}
+ 
+-	conn->ssl_cert = SSL_get_peer_certificate(conn->ssl);
++	conn->ssl_cert = SSL_get1_peer_certificate(conn->ssl);
+ 	if (!conn->ssl_cert) {
+ 		fprintf(stderr, "No server SSL certificate\n");
+ 		return -1;
+diff --git a/src/Makefile b/src/Makefile
+index a01f5dc6..8a2ec0cb 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -73,8 +73,8 @@ LIBS_apk.so		:= $(libapk_so)
+ 
+ CFLAGS_ALL		+= -D_ATFILE_SOURCE -Ilibfetch
+ CFLAGS_apk.o		:= -DAPK_VERSION=\"$(FULL_VERSION)\"
+-CFLAGS_apk-static.o	:= -DAPK_VERSION=\"$(FULL_VERSION)\" -DOPENSSL_NO_ENGINE
+-CFLAGS_apk-test.o	:= -DAPK_VERSION=\"$(FULL_VERSION)\" -DOPENSSL_NO_ENGINE -DTEST_MODE
++CFLAGS_apk-static.o	:= -DAPK_VERSION=\"$(FULL_VERSION)\"
++CFLAGS_apk-test.o	:= -DAPK_VERSION=\"$(FULL_VERSION)\" -DTEST_MODE
+ 
+ progs-$(STATIC)		+= apk.static
+ apk.static-objs		:= $(filter-out apk.o,$(apk-objs)) apk-static.o
+diff --git a/src/apk.c b/src/apk.c
+index 3b4ce40c..164acea2 100644
+--- a/src/apk.c
++++ b/src/apk.c
+@@ -20,9 +20,6 @@
+ #include <sys/stat.h>
+ 
+ #include <openssl/crypto.h>
+-#ifndef OPENSSL_NO_ENGINE
+-#include <openssl/engine.h>
+-#endif
+ 
+ #include <fetch.h>
+ 
+@@ -421,25 +418,6 @@ static int parse_options(int argc, char **argv, struct apk_applet *applet, void
+ 	return 0;
+ }
+ 
+-static void fini_openssl(void)
+-{
+-	EVP_cleanup();
+-#ifndef OPENSSL_NO_ENGINE
+-	ENGINE_cleanup();
+-#endif
+-	CRYPTO_cleanup_all_ex_data();
+-}
+-
+-static void init_openssl(void)
+-{
+-	atexit(fini_openssl);
+-	OpenSSL_add_all_algorithms();
+-#ifndef OPENSSL_NO_ENGINE
+-	ENGINE_load_builtin_engines();
+-	ENGINE_register_all_complete();
+-#endif
+-}
+-
+ static void on_sigwinch(int s)
+ {
+ 	apk_reset_screen_width();
+@@ -531,7 +509,6 @@ int main(int argc, char **argv)
+ 		if (applet->update_cache) dbopts.cache_max_age = 0;
+ 	}
+ 
+-	init_openssl();
+ 	setup_automatic_flags();
+ 	fetchTimeout = 60;
+ 	fetchRedirectMethod = fetch_redirect;
+-- 
+GitLab
+

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.16.0"
-  epoch: 2
+  epoch: 3
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ environment:
       - libtool
       - nghttp2-dev
       - openldap-dev
-      - openssl-dev
+      - openssl-hardened-dev
       - perl
       - wolfi-base
       - zlib-dev

--- a/openssl-hardened-dev.yaml
+++ b/openssl-hardened-dev.yaml
@@ -1,0 +1,82 @@
+package:
+  name: openssl-hardened-dev
+  version: 3.6.0
+  epoch: 0
+  description: the OpenSSL cryptography suite
+  commit: 6b577e6bf909f4874694aa16659beae6778f42a4
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openssl-dev
+    replaces:
+      - openssl-dev
+
+environment:
+  contents:
+    # NB! accessing historic, but certified build of
+    # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
+    # any version of jitternetropy-library and get an ESV certificate
+    # for it.
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library-dev=3.5.0-r0
+      - jitterentropy-library=3.5.0-r0
+      - perl
+  environment:
+    # To support automatic discovery of source code in debug symbols
+    # packaged in openssl-dbg, build with debug symbols &
+    # file-prefix-map. Also see "Create dbg sourcecode" and
+    # split/debug.
+    CFLAGS: "-g -ffile-prefix-map=/home/build=/usr/src/${{package.name}}"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openssl/openssl
+      tag: openssl-${{package.version}}
+      expected-commit: 7b371d80d959ec9ab4139d09d78e83c090de9779
+
+  - name: Configure and build
+    runs: |
+      perl ./Configure \
+      	linux-x86_64 \
+      	--prefix=/usr \
+      	--libdir=lib \
+      	--openssldir=/etc/ssl \
+      	enable-ktls \
+      	$([ -d /usr/lib/oldglibc ] || echo enable-jitter) \
+      	shared \
+      	enable-pie \
+      	no-zlib \
+      	no-async \
+      	no-comp \
+      	no-idea \
+      	no-mdc2 \
+      	no-rc5 \
+      	no-ec2m \
+      	no-sm2 \
+      	no-sm4 \
+      	no-ssl3 \
+      	no-seed \
+      	no-weak-ssl-ciphers \
+      	no-deprecated \
+      	--debug \
+      	-Wa,--noexecstack
+      perl configdata.pm --dump
+      mkdir -p ${{targets.destdir}}/usr/include/openssl
+      # Configure as closely to the stock build as possible
+      # And install just the configuration header
+      cp include/openssl/configuration.h ${{targets.destdir}}/usr/include/openssl
+
+update:
+  enabled: true
+  manual: false
+  require-sequential: false
+  github:
+    identifier: openssl/openssl
+    strip-prefix: openssl-
+    tag-filter-prefix: openssl-


### PR DESCRIPTION
Add a new package openssl-hardened-dev. It configures an OpenSSL
header that removes access to all deprecated APIs. Allow installing it
as a build-time dependency. This allows to simulate builds against
OpenSSL 3 that is configured with no-deprecated API/ABI, as well as
OpenSSL 4.

Use this new openssl-hardended-dev to compile apk-tools. This shows
all the build-time issues where deprecated APIs are used, and allows
to safely port apk-tools away from them. It remains API/ABI compatible
with the current OpenSSL 3 builds, and will enable to move to OpenSSL
4 ABI with a no-change rebuild.
