### PR TITLE
azuredisk-csi: add blockdev dependency to fix PVC resize failures

### DIFF
--- a/azuredisk-csi-1.33.yaml
+++ b/azuredisk-csi-1.33.yaml
@@ -8,7 +8,7 @@ package:
   dependencies:
     runtime:
       - blkid
-      - blockdev
+      - blockdev # Required by the CSI driver to validate disk size during PVC resize
       - btrfs-progs
       - ca-certificates-bundle
       - device-mapper

--- a/azuredisk-csi-1.33.yaml
+++ b/azuredisk-csi-1.33.yaml
@@ -1,13 +1,14 @@
 package:
   name: azuredisk-csi-1.33
   version: "1.33.5"
-  epoch: 1 # GHSA-4x4m-3c2p-qppc
+  epoch: 2 # GHSA-4x4m-3c2p-qppc
   description: Azure Disk CSI Driver
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - blkid
+      - blockdev
       - btrfs-progs
       - ca-certificates-bundle
       - device-mapper


### PR DESCRIPTION
Fixes: Adds missing `blockdev` runtime dependency required for PVC resize operations. 


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
