### PR TITLE
fix(npm): Bump tar to remediate GHSA-29xp-372q-xqph

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -2,7 +2,7 @@
 package:
   name: npm
   version: "11.6.2"
-  epoch: 0
+  epoch: 1 # GHSA-29xp-372q-xqph
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -11,6 +11,8 @@ environment:
   contents:
     packages:
       - build-base
+      - nodejs-25
+      - npm
       - rsync
       - wolfi-base
 
@@ -20,6 +22,11 @@ pipeline:
       uri: https://registry.npmjs.org/npm/-/npm-${{package.version}}.tgz
       expected-sha512: ee22b335fcbc95662cdf3ab8a053daf045d9cf9c6df6040d28965abb707512b2c16fa6c5eec049d34c74f78f390cebd14f697919eadb97756564d4f9eccc4954
       delete: true
+
+  - name: Bump tar to 7.5.2 to remediate GHSA-29xp-372q-xqph
+    runs: |
+      npm update tar
+      # sed -i 's/"tar": "^7.5.1"/ "tar": "^7.5.2"/' package.json
 
   - runs: |
       # Wrapper scripts written in Bash and CMD.


### PR DESCRIPTION

<!--ci-cve-scan:fail-any-->
