### PR TITLE
fix(ingress-nginx-controller-113): update ngx_http_lua_module version to v0.10.29 and ngx_stream_lua_module to v0.0.17

### DIFF
--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.13
   version: "1.13.3"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 2
+  epoch: 3
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -155,7 +155,7 @@ vars:
   MORE_HEADERS_VERSION: "0.37"
   NGINX_DIGEST_AUTH: "1.0.0"
   OWASP_MODSECURITY_CRS_VERSION: "4.15.0"
-  LUA_NGX_VERSION: "0.10.28"
+  LUA_NGX_VERSION: "0.10.29"
   LUA_STREAM_NGX_VERSION: "0.0.16"
   LUA_UPSTREAM_VERSION: "0.07"
   GEOIP2_VERSION: "445df24ef3781e488cee3dfe8a1e111997fc1dfe"
@@ -309,7 +309,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openresty/lua-nginx-module/archive/v${{vars.LUA_NGX_VERSION}}.tar.gz
-      expected-sha256: 634827d54de6216cb0502d14f76610788b3a3e33160e91d5578d6db0d9a34a20
+      expected-sha256: ca2c2122b909529bf9d1a89e9a5763835a2bd2629def8cb279c550f638f0a78f
       strip-components: 0
 
   - uses: fetch

--- a/ingress-nginx-controller-1.13.yaml
+++ b/ingress-nginx-controller-1.13.yaml
@@ -156,7 +156,7 @@ vars:
   NGINX_DIGEST_AUTH: "1.0.0"
   OWASP_MODSECURITY_CRS_VERSION: "4.15.0"
   LUA_NGX_VERSION: "0.10.29"
-  LUA_STREAM_NGX_VERSION: "0.0.16"
+  LUA_STREAM_NGX_VERSION: "0.0.17"
   LUA_UPSTREAM_VERSION: "0.07"
   GEOIP2_VERSION: "445df24ef3781e488cee3dfe8a1e111997fc1dfe"
   PKG: "k8s.io/ingress-nginx"
@@ -315,7 +315,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openresty/stream-lua-nginx-module/archive/v${{vars.LUA_STREAM_NGX_VERSION}}.tar.gz
-      expected-sha256: 3b1103cf5ee940ea94711eae1a7ccc1a161273ec9a08eb415f1d45ad385f967d
+      expected-sha256: 09cf5b90904a575b90c16d5cf861b978ef2dbe6d5340e5eb3707e2d2a3ac5cdc
       strip-components: 0
 
   - uses: fetch


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

### Reasons

The package in the image is failing at starting up due to:
```
...
2025/11/03 13:37:53 [alert] 25#25: failed to load the 'resty.core' module (https://github.com/openresty/lua-resty-core); ensure you are using an OpenResty release from https://openresty.org/en/download
.html (reason: /usr/lib/lua/resty/core/base.lua:24: ngx_http_lua_module 0.10.29 required) in /etc/nginx/nginx.conf:7
nginx: [alert] failed to load the 'resty.core' module (https://github.com/openresty/lua-resty-core); ensure you are using an OpenResty release from https://openresty.org/en/download.html (reason: /usr/
lib/lua/resty/core/base.lua:24: ngx_http_lua_module 0.10.29 required) in /etc/nginx/nginx.conf:7
W1103 13:37:53.368190       1 nginx.go:37]
-------------------------------------------------------------------------------
NGINX master process died (1): exit status 1
...
```

`lua-rusty-core` was updated to v1.32: https://github.com/wolfi-dev/os/pull/70335
and that particular version wants `ngx_http_lua_module` at version 0.10.29: https://github.com/openresty/lua-resty-core/blob/v0.1.32/lib/resty/core/base.lua#L19-L25

tha `lua-rusty-core`version was also grabbed by ingress-nginx-controller last update to v1.13.3.

----------

We need to upgrade `ngx_stream_lua_module` to `v0.0.17` too:

```
1103 14:48:04.515718       1 event.go:377] Event(v1.ObjectReference{Kind:"Pod", Namespace:"ingress-nginx", Name:"ingress-nginx-controller-9f5df5c87-w5rpv", UID:"d0b8b4ab-d3dc-4293-8b55-aa3451fb06d7",
APIVersion:"v1", ResourceVersion:"571", FieldPath:""}): type: 'Normal' reason: 'RELOAD' NGINX reload triggered due to a change in configuration
2025/11/03 14:48:04 [alert] 27#27: failed to load the 'resty.core' module (https://github.com/openresty/lua-resty-core); ensure you are using an OpenResty release from https://openresty.org/en/download
.html (reason: /usr/lib/lua/resty/core/base.lua:32: ngx_stream_lua_module 0.0.17 required) in /etc/nginx/nginx.conf:454
W1103 14:48:05.517156       1 controller.go:260] Dynamic reconfiguration failed (retrying; 15 retries left): Post "http://127.0.0.1:10246/configuration/backends": dial tcp 127.0.0.1:10246: connect: con
nection refused
...
```

since https://github.com/openresty/lua-resty-core/blob/v0.1.32/lib/resty/core/base.lua#L27-L33

### Changes

Updates:
-  epoch to create a new release
- `ngx_http_lua_module` reference and `ngx_http_lua_module` tar.gz expected sha256sum
- `ngx_stream_lua_module` reference and `ngx_stream_lua_module` tar.gz expected sha256sum

<!--ci-cve-scan:fail-any-->
