### PR TITLE
Updated fluxcd-kustomize-mutating-webhook to 0.7.0 and fixed update config

### DIFF
--- a/fluxcd-kustomize-mutating-webhook.yaml
+++ b/fluxcd-kustomize-mutating-webhook.yaml
@@ -1,6 +1,6 @@
 package:
   name: fluxcd-kustomize-mutating-webhook
-  version: "0.6.0"
+  version: "0.7.0"
   epoch: 0 # CVE-2025-47907
   description: A dynamic solution to patch FluxCD Kustomization resources, seamlessly integrating and federating substitution variables across multiple namespaces.
   copyright:
@@ -11,7 +11,7 @@ pipeline:
     with:
       repository: https://github.com/xunholy/fluxcd-kustomize-mutating-webhook
       tag: kustomize-mutating-webhook-${{package.version}}
-      expected-commit: 3caf097d730f86046d3f1e30fd87a0aa6c6210b1
+      expected-commit: ddaa9339e56941137e739b0fab9797de4c3bcf98
 
   - uses: go/bump
     with:
@@ -43,7 +43,9 @@ update:
   github:
     tag-filter-prefix: kustomize-mutating-webhook-
     identifier: xunholy/fluxcd-kustomize-mutating-webhook
-    strip-prefix: kustomize-mutating-webhook-v
+    strip-prefix: kustomize-mutating-webhook-
+  ignore-regex-patterns:
+    - "chart-" # Not what we want
 
 test:
   environment:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Missing the latest version due to a configuration error

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
