### PR TITLE
fix(kubeflow-pipelines-visualization-server): kubeflow-pipelines-visualization-server epoch bump

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -39,6 +39,9 @@ pipeline:
       cp -r backend/src/apiserver/visualization/* ${{targets.destdir}}/usr/share/app/
       cd ${{targets.destdir}}/usr/share/app/
 
+      # pip-tools is not compatible with pip 25.3
+      pip install -U 'pip!=25.3'
+
       # Reset and regenerate requirements.txt from our modified-requirements.in
       # Necessary to properly (and more easily) patch CVEs and resolve build failures
       rm requirements.txt

--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.14.3"
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Epoch bump to pick up newer keras.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31806

<!--ci-cve-scan:fail-any-->
