### PR TITLE
fix(langfuse): GHSA-5jpx-9hw9-2fx4 bump version

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,6 +1,6 @@
 package:
   name: langfuse
-  version: "3.121.0"
+  version: "3.125.0"
   epoch: 0
   description: "Langfuse webapp"
   copyright:
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: 34309beec3a9f391baaa6a2a43da87643f389904
+      expected-commit: 214ad58bd46e8e97469f9ed6168fd99be1cda3ab
 
   - name: "Bump deps and install"
     runs: |
@@ -217,7 +217,6 @@ subpackages:
           # Copy worker files
           cp -r out/full/package.json "${{targets.contextdir}}"/app/
           cp -r out/full/packages "${{targets.contextdir}}"/app/
-          cp -r out/full/patches "${{targets.contextdir}}"/app/
           cp -r out/full/worker "${{targets.contextdir}}"/app/
           cp -r out/full/turbo.json "${{targets.contextdir}}"/app/
 


### PR DESCRIPTION
Increase langfuse to most recent version to pick up newest next-auth

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31789

<!--ci-cve-scan:fail-any-->
