### PR TITLE
Correcting file structure for apache-nifi-registry-toolkit

### DIFF
--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -9,7 +9,6 @@ package:
     runtime:
       - bash # Required by scripts with #!/bin/bash shebang
       - coreutils # Provides readlink, dirname, basename, pwd, uname, expr used by nifi-registry.sh and cli.sh
-      - curl # Used in K8s exec-based health probes
       - dash-binsh # Provides /bin/sh -> dash (matches upstream Debian). All 8 startup scripts use #!/bin/sh
       - glibc-locale-en # Locale support for Java application
       - net-tools # Provides hostname command used in common.sh:28 for container identification

--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi-registry
   version: "2.6.0"
-  epoch: 3 # GHSA-25qh-j22f-pwp8
+  epoch: 4 # GHSA-25qh-j22f-pwp8
   description: Apache NiFi Registry is a registry for storing and managing shared resources such as versioned flows across one or more instances of NiFi.
   copyright:
     - license: Apache-2.0
@@ -83,11 +83,6 @@ pipeline:
         --strip-components=1 \
         -C "${{targets.contextdir}}${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${{package.version}}"
 
-      for d in bin conf database docs flow_storage lib logs run work; do
-        mkdir -p "${{targets.contextdir}}${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${{package.version}}/$d"
-        chmod 0755 "${{targets.contextdir}}${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${{package.version}}/$d"
-      done
-
       mkdir -p "${{targets.contextdir}}${NIFI_REGISTRY_BASE_DIR}/scripts"
       cp /home/build/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/*.sh \
         "${{targets.contextdir}}${NIFI_REGISTRY_BASE_DIR}/scripts/"
@@ -115,31 +110,21 @@ subpackages:
             -DskipTests
 
           mkdir -p "${{targets.subpkgdir}}/${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}"
-
           cd nifi-registry-toolkit-assembly/target
-          unzip nifi-registry-toolkit-${{package.version}}-bin.zip \
-            -d "${{targets.subpkgdir}}/${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}"
 
-          for d in bin lib; do
-            mkdir -p "${{targets.subpkgdir}}${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}/$d"
-            chmod 0755 "${{targets.subpkgdir}}${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}/$d"
-          done
+          bsdtar -xf nifi-registry-toolkit-${{package.version}}-bin.zip \
+            --strip-components=1 \
+            -C "${{targets.subpkgdir}}/${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}"
 
           ln -sf "${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}" \
                  "${{targets.subpkgdir}}${NIFI_TOOLKIT_HOME}"
       - uses: strip
     test:
       pipeline:
-        - runs: |
-            for dir in \
-              "${NIFI_TOOLKIT_HOME}/bin" \
-              "${NIFI_TOOLKIT_HOME}/lib"; do
-              if [ ! -d "$dir" ] || [ ! -w "$dir" ]; then
-                echo "Error: Directory does not exist or is not writable: $dir"
-                exit 1
-              fi
-              echo "OK: Directory exists and is writable: $dir"
-            done
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
+            packages: ${{package.name}}-toolkit
 
 update:
   enabled: true
@@ -163,6 +148,7 @@ test:
         - grep
         - wait-for-it
     environment:
+      ACCESS_PORT: "18080"
       LANG: "en_US.UTF-8"
       LANGUAGE: "en_US:en"
       JAVA_HOME: "/usr/lib/jvm/java-${{vars.java-version}}-openjdk"
@@ -173,48 +159,9 @@ test:
       NIFI_REGISTRY_LOG_DIR: "/opt/nifi-registry/nifi-registry-current/logs"
       NIFI_REGISTRY_WEB_HTTP_HOST: "0.0.0.0" #for testing
   pipeline:
-    - name: Verify Installation
-      runs: |
-        set -e
-        # Verify symlinks point to correct versioned directories
-        [ "$(readlink -f ${NIFI_REGISTRY_HOME})" = "${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${{package.version}}" ] || exit 1
-        [ "$(readlink -f ${NIFI_TOOLKIT_HOME})" = "${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-registry-${{package.version}}" ] || exit 1
-
-        # Verify binary executables
-        for bin in \
-          "${NIFI_REGISTRY_HOME}/bin/nifi-registry.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/start.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/common.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/secure.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/update_database.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/update_bundle_provider.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/update_flow_provider.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/update_login_providers.sh" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts/update_oidc_properties.sh"; do
-          if [ ! -x "$bin" ]; then
-            echo "Error: Binary is not executable: $bin"
-            exit 1
-          fi
-        done
-
-        # Verify core application directories
-        for dir in \
-          "${NIFI_REGISTRY_HOME}/bin" \
-          "${NIFI_REGISTRY_HOME}/lib" \
-          "${NIFI_REGISTRY_HOME}/docs" \
-          "${NIFI_REGISTRY_BASE_DIR}/scripts" \
-          "${NIFI_REGISTRY_HOME}/conf" \
-          "${NIFI_REGISTRY_HOME}/logs" \
-          "${NIFI_REGISTRY_HOME}/database" \
-          "${NIFI_REGISTRY_HOME}/flow_storage" \
-          "${NIFI_REGISTRY_HOME}/work" \
-          "${NIFI_REGISTRY_HOME}/run"; do
-          if [ ! -d "$dir" ] || [ ! -w "$dir" ]; then
-            echo "Error: Directory does not exist or is not writable: $dir"
-            exit 1
-          fi
-          echo "OK: Directory exists and is writable: $dir"
-        done
+    - uses: test/tw/symlink-check
+      with:
+        allow-absolute: true
     - uses: test/daemon-check-output
       with:
         setup: |
@@ -227,5 +174,5 @@ test:
           Started Application
         timeout: 60
         post: |
-          wait-for-it localhost:18080 -t 15
-          curl -fsS http://localhost:18080/nifi-registry-api/access | grep -q "anonymous"
+          wait-for-it localhost:${ACCESS_PORT} -t 15
+          curl -fsS http://localhost:${ACCESS_PORT}/nifi-registry-api/access | grep -F "anonymous"


### PR DESCRIPTION
Fixes for Toolkit subpackage:
- Fixed nested extraction using `bsdtar --strip-components=1` instead of `unzip`
- Before: `nifi-toolkit-registry-2.6.0/nifi-registry-toolkit-2.6.0/` (nested)
- After: `nifi-toolkit-registry-2.6.0/{bin,classpath,conf,lib}` (flat, matches upstream)

Also removed `curl` package which as added a convenience, [check here there is not runtime usage of curl ](https://github.com/search?q=repo%3Aapache%2Fnifi+path%3A%2F%5Enifi-registry%5C%2F%2F+curl&type=code)

Removed creation of dir's on to the image level for consistency.