### PR TITLE
fix(logstash-9.2): Remediate a few vulnerabilities

### DIFF
--- a/logstash-9.2.yaml
+++ b/logstash-9.2.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.2
   version: "9.2.0"
-  epoch: 0 # GHSA-6xw4-3v39-52mm, GHSA-mr3q-g2mv-mr4q and GHSA-r657-rxjc-j557
+  epoch: 1 # GHSA-22h5-pq3x-2gf2, GHSA-c2f4-jgmc-q2r5, GHSA-gh9q-2xrm-x6qv and GHSA-mhwm-jh88-3gjf
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -103,7 +103,10 @@ pipeline:
       # Fix GHSA-c2f4-jgmc-q2r5
       sed -i "s/rexml (>= 3\.3\.9)/rexml (>= 3.4.2)/" "Gemfile.jruby-3.1.lock.release"
       # Fix GHSA-p543-xpfm-54cp, GHSA-w9pc-fmgc-vxvw and GHSA-wpv5-97wm-hp9c
-      sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
+      sed -i "s/rack (>= 3\.1\.16)/rack (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
+      # Fix GHSA-22h5-pq3x-2gf2
+      sed -i "s/uri (1\.0\.3)/uri (>= 1.0.4)/" "Gemfile.jruby-3.1.lock.release"
+
       echo "gem 'rack', '3.1.18'" >> Gemfile.template
       echo "gem 'sinatra', '4.2.0'" >> Gemfile.template
 


### PR DESCRIPTION
Bump uri to 0.12.4 to remediate GHSA-22h5-pq3x-2gf2
Bump rexml to 3.4.2 to remediate GHSA-c2f4-jgmc-q2r5
Rebuild to bump cgi and remediate GHSA-gh9q-2xrm-x6qv and GHSA-mhwm-jh88-3gjf

<!--ci-cve-scan:fail-any-->

