### PR TITLE
feat(renovate): Bump to latest upstream release 41.169.3 to remediate GHSA-29xp-372q-xqph

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,6 +1,6 @@
 package:
   name: renovate
-  version: "41.158.0"
+  version: "41.169.3"
   epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
@@ -29,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
-      expected-commit: 7e353b9ccabedfd107dfc82ba8a627fb269aac2b
+      expected-commit: c7eabc09c56c48b0c632df36a9cbc89540e2e708
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json


### PR DESCRIPTION
<!--ci-cve-scan:must-fix:GHSA-29xp-372q-xqph-->

