### PR TITLE
dnssec-root: fix missing update backed

### DIFF
--- a/dnssec-root.yaml
+++ b/dnssec-root.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnssec-root
   version: "20190225"
-  epoch: 2
+  epoch: 3
   description: The DNSSEC root key(s)
   copyright:
     - license: CC-PDDC
@@ -33,5 +33,6 @@ pipeline:
       install -Dm644 trusted-key.key ${{targets.destdir}}/usr/share/dnssec-root/trusted-key.key
 
 update:
-  enabled: true
+  enabled: false
   manual: true # no releases or tags, commit sha is used, not auto updatable
+  git: {}


### PR DESCRIPTION
This was creating update errors.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
