### PR TITLE
libfido2: refresh package

### DIFF
--- a/libfido2.yaml
+++ b/libfido2.yaml
@@ -1,14 +1,10 @@
 package:
   name: libfido2
   version: "1.16.0"
-  epoch: 52
+  epoch: 53
   description: library for FIDO 2.0 functionality
   copyright:
     - license: BSD-2-Clause
-  dependencies:
-    runtime:
-      - merged-lib
-      - wolfi-baselayout
 
 environment:
   contents:
@@ -46,25 +42,20 @@ subpackages:
     dependencies:
       runtime:
         - libfido2
-        - merged-lib
-        - wolfi-baselayout
     description: libfido2 dev
     test:
       pipeline:
         - uses: test/pkgconf
         - uses: test/tw/ldd-check
+        - uses: test/tw/no-docs
 
   - name: libfido2-doc
     pipeline:
-      - uses: split/manpages
+      - uses: split/alldocs
     description: libfido2 manpages
     test:
       pipeline:
-        - uses: test/docs
-    dependencies:
-      runtime:
-        - merged-lib
-        - wolfi-baselayout
+        - uses: test/tw/docs
 
   - name: fido2
     pipeline:
@@ -73,14 +64,11 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/* ${{targets.contextdir}}/usr/bin/
     test:
       pipeline:
+        - uses: test/tw/no-docs
         - runs: |
             command -v fido2-assert
             command -v fido2-cred
             fido2-token -V
-    dependencies:
-      runtime:
-        - merged-lib
-        - wolfi-baselayout
 
 update:
   enabled: true
@@ -91,4 +79,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
-    - uses: test/no-docs
+    - uses: test/tw/no-docs


### PR DESCRIPTION
Refresh package, and validate it does not FTBFS.

See also: https://github.com/wolfi-dev/os/issues/62745

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
