### PR TITLE
kubeflow-pipelines-visualization-server: remediate CVE

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.14.3"
-  epoch: 1
+  epoch: 2 # CVE-2025-12058
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0

--- a/kubeflow-pipelines-visualization-server/modified-requirements.in
+++ b/kubeflow-pipelines-visualization-server/modified-requirements.in
@@ -23,3 +23,4 @@ jupyterlab>=4.4.8
 numpy==1.23.5
 pillow>=11.3.0
 pyarrow-hotfix==0.*
+keras>=3.12.0


### PR DESCRIPTION
Remediate CVE-2025-12058 by bumping keras to >= 3.12.0

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->

