### PR TITLE
melange/0.32.0-r1 package update

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.32.0"
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: ffed3df6d619ef0b98d5f010e671c78fa53b4428
+      expected-commit: 5307b483f36d3099f17a1db338779be6a5f0b9cf
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
We had a bad Melange release the other day where GoReleaser failed to run: https://github.com/chainguard-dev/melange/actions/runs/19020362636

The `v0.32.0` tag was cut but we didn't get a full release. It looks like the new tag was picked up here, but I just pushed a corrected `v0.32.0` release after fighting a bit with the auto-bumping logic.

This PR bumps the epoch and uses the release's commit: https://github.com/chainguard-dev/melange/commit/5307b483f36d3099f17a1db338779be6a5f0b9cf