### PR TITLE
Revert "MANUAL libmspack/1.11 package update (#70399)"

### DIFF
--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -1,8 +1,8 @@
 # Generated from https://git.alpinelinux.org/aports/plain/community/libmspack/APKBUILD
 package:
   name: libmspack
-  version: "1.11"
-  epoch: 0
+  version: 0.11_alpha
+  epoch: 4
   description: Library for Microsoft CAB compression formats
   copyright:
     - license: LGPL-2.1-only

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,3 @@
 mountpoint-s3-csi-driver-2.0-2.1.0-r0.apk
+libmspack-dev-1.11-r0.apk
+libmspack-1.11-r0.apk


### PR DESCRIPTION
This reverts commit ac8cfabb35697c2e889db78dc05f76c1dd40550e.

It was incorrectly merged.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
