### PR TITLE
resize Keycloak 26.4 package

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -71,7 +71,7 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
-      mv -avR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
+      mv -vR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
       # Create an empty data directory for keycloak. Required by the UI to store some data.
       mkdir -p ${{targets.destdir}}/usr/share/java/keycloak/data

--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -71,7 +71,7 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
-      mv -vR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
+      mv ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
       # Create an empty data directory for keycloak. Required by the UI to store some data.
       mkdir -p ${{targets.destdir}}/usr/share/java/keycloak/data

--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.2"
-  epoch: 0 # GHSA-3p8m-j85q-pgmj
+  epoch: 1 # GHSA-3p8m-j85q-pgmj
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
-      cp -avR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
+      mv -avR ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
       # Create an empty data directory for keycloak. Required by the UI to store some data.
       mkdir -p ${{targets.destdir}}/usr/share/java/keycloak/data


### PR DESCRIPTION
The keycloak-26.4 package was shipping two copies of the Keycloak distribution. This PR removes the versioned duplicate and keeps the canonical path used by upstream.