### PR TITLE
fix(calico-3.31): replace imagemagick-7 in calico-goldmane-3.31 and harbor-2.9-portal-nginx-config in calico-whisker

### DIFF
--- a/calico-3.31.yaml
+++ b/calico-3.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.31
   version: "3.31.0"
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -652,6 +652,8 @@ subpackages:
     dependencies:
       provides:
         - calico-goldmane=${{package.full-version}}
+      replaces:
+        - imagemagick-7
       runtime:
         - glibc
     pipeline:
@@ -712,6 +714,7 @@ subpackages:
     dependencies:
       replaces:
         - nginx-mainline-config
+        - harbor-2.9-portal-nginx-config
       provides:
         - calico-whisker=${{package.full-version}}
       runtime:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

During image building phase I have:

```
failed to build layer image for "arm64": building filesystem: installing apk packages: installing packages: installing calico-whisker-3.31 (ver:3.31.0-r0 arch:aarch64): unable to install files for
│ pkg calico-whisker-3.31: writing header for "etc/nginx/nginx.conf": packages map[calico-whisker-3.31:calico-3.31 harbor-2.9-portal-nginx-config:harbor-2.9] has conflicting file:
│ "etc/nginx/nginx.conf"
```

the harbor-2.9-portal-nginx-config replace in calico-whisker subpackage should fix it.

During package testing i got:
```
2025/11/05 10:08:32 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/11/05 10:08:32 ERRO failed to test package: unable to build guest: unable to generate image: installing apk packages: installing packages: installing calico-goldmane-3.31 (ver:3.31.0-r0
arch:x86_64): unable to install files for pkg calico-goldmane-3.31: writing header for "usr/bin/stream": packages map[calico-goldmane-3.31:calico-3.31 imagemagick-7:imagemagick-7] has conflicting
file: "usr/bin/stream"
make: *** [Makefile:183: test/calico-3.31] Error 1
```

Replacing imagemagick-7 in calico-goldmane subpackage is letting the package being tested correctly.


<!--ci-cve-scan:fail-any-->
