### PR TITLE
falco-no-driver: fix container plugin path in default configuration

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -94,7 +94,6 @@ pipeline:
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DUSE_BUNDLED_DEPS=Off \
-        -DFALCO_ETC_DIR=/etc/falco \
         -DBUILD_FALCO_MODERN_BPF=ON \
         -DMODERN_BPF_SKEL_DIR=/tmp \
         -DBUILD_DRIVER=Off -DBUILD_BPF=Off \

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: "0.42.0"
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -111,6 +111,9 @@ pipeline:
     runs: |
       install -Dm755 ./userspace/falco/falco \
         ${{targets.destdir}}/usr/bin/falco
+      sed -i \
+        "s|library_path: /home/build/build/container_plugin-prefix/src/container_plugin/libcontainer.so|library_path: libcontainer.so|g" \
+        ./falco.yaml
       install -Dm755 ./falco.yaml \
         "${{targets.destdir}}"/etc/falco/falco.yaml
 
@@ -154,24 +157,6 @@ test:
       uses: test/tw/ver-check
       with:
         bins: falco
-    - name: "Create configuration file"
-      runs: |
-        cat > /etc/falco/falco.yaml << 'EOF'
-        rules_file:
-          - /etc/falco/falco_rules.yaml
-        json_output: false
-        stdout_output:
-          enabled: true
-        log_level: info
-        priority: warning
-
-        # Try to satisfy container plugin requirement
-        plugins:
-          - name: container
-            library_path: libcontainer.so
-            init_config: ""
-        load_plugins: [container]
-        EOF
     - name: "Validate configuration"
       runs: |
         falco -c /etc/falco/falco.yaml --dry-run


### PR DESCRIPTION
  The container plugin path is resolved at build time from
  the workspace, which is obviously invalid at runtime.

  Set it statically to the non absolute shared object name
  path.

  Furthermore, test actual shipped default configuration.