### PR TITLE
Add additional commands to the renovate package

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
-  version: "41.169.3"
-  epoch: 1
+  version: "41.171.6"
+  epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -29,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/renovatebot/renovate
       tag: ${{package.version}}
-      expected-commit: c7eabc09c56c48b0c632df36a9cbc89540e2e708
+      expected-commit: 31b4ceb704ff89ee231697cb9e0c82c0fd2dc11f
 
   - runs: |
       sed -i 's/"version": "0.0.0-semantic-release"/"version": "${{package.version}}"/' package.json

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -50,7 +50,7 @@ pipeline:
       cp package.json ${{targets.contextdir}}/usr/lib/renovate/
 
       # Create executable wrapper
-      for cmd in renovate config-validator proxy; do
+      for cmd in config-validator proxy renovate; do
         [ "$cmd" = "renovate" ] && name=$cmd || name=renovate-$cmd
         printf '#!/bin/sh\nexec node /usr/lib/renovate/dist/%s.js "$@"\n' "$cmd" > ${{targets.contextdir}}/usr/bin/$name
         chmod +x ${{targets.contextdir}}/usr/bin/$name

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
   version: "41.169.3"
-  epoch: 0
+  epoch: 1
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -50,19 +50,27 @@ pipeline:
       cp package.json ${{targets.contextdir}}/usr/lib/renovate/
 
       # Create executable wrapper
-      printf '#!/bin/sh\nexec node /usr/lib/renovate/dist/renovate.js "$@"\n' > ${{targets.contextdir}}/usr/bin/renovate
-      chmod +x ${{targets.contextdir}}/usr/bin/renovate
-
-      ln -sf ../bin/renovate ${{targets.contextdir}}/usr/local/renovate
+      for cmd in renovate config-validator proxy; do
+        [ "$cmd" = "renovate" ] && name=$cmd || name=renovate-$cmd
+        printf '#!/bin/sh\nexec node /usr/lib/renovate/dist/%s.js "$@"\n' "$cmd" > ${{targets.contextdir}}/usr/bin/$name
+        chmod +x ${{targets.contextdir}}/usr/bin/$name
+        ln -sf ../bin/$name ${{targets.contextdir}}/usr/local/$name
+      done
 
       # Clean up musl directories
       find ${{targets.contextdir}}/usr/lib/renovate/node_modules -type d -name '*musl*' -exec rm -rf {} + 2>/dev/null || true
 
 test:
+  environment:
+    contents:
+      packages:
+        - npm
   pipeline:
     - name: Verify renovate version
       runs: |
         renovate --version | grep -i ${{package.version}}
+        npx --yes --package renovate -- renovate-config-validator
+        renovate-proxy --help
     - name: Run with patgithub123
       runs: |
         # work around github push protection GH013


### PR DESCRIPTION
Addresses: #69351/#69352

This PR adds additional commands to the renovate package. The `renovate-config-validator` is the main addition per the aforementioned Issue and PR but there is also a `proxy` command that we can include. The script can easily support additional commands in the future if necessary.