### PR TITLE
pgpool2-4.6: no need to hard-depend on posgresql-17

### DIFF
--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2-4.6
   version: "4.6.3"
-  epoch: 1
+  epoch: 2
   description: Middleware that works between PostgreSQL servers and a PostgreSQL database client.
   copyright:
     - license: BSD-3-Clause AND MIT
@@ -9,8 +9,8 @@ package:
     provides:
       - pgpool2=${{package.full-version}}
     runtime:
-      - postgresql-17
-      - postgresql-17-client
+      - postgresql
+      - postgresql-client
 
 environment:
   contents:
@@ -24,7 +24,7 @@ environment:
       - gcc-14-default
       - libtool
       - openssl-dev
-      - postgresql-17-dev
+      - postgresql-dev
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
The hard requirement for `postgresql-17` was more of a nice-to-have, but it is causing issues in various environments that might depend on `postgresql` only, which will pull in `postgresql-18`.

Addresses https://github.com/chainguard-dev/internal-dev/issues/24324 