### PR TITLE
google-cloud-sdk: add explicit provides for cmd:gcloud.

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,13 +1,15 @@
 package:
   name: google-cloud-sdk
   version: "546.0.0"
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - py3.13-${{package.name}}
+    provides:
+      - cmd:gcloud
 
 data:
   - name: py-versions


### PR DESCRIPTION
bins are symlinks into the google-cloud-sdk install so melange does not automatically generate cmd: provides entries - add the main one for this package.