### PR TITLE
Revert "microvm-init: mount defaultshare read-only, do not chmod moutpoint"

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 13
+  epoch: 14
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
@@ -14,7 +14,6 @@ package:
       - kmod
       - mount
       - openssh-server
-      - umount
       - util-linux-misc
       - xfsprogs
 

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -93,8 +93,10 @@ mount -t 9p \
 	-o security_model=mapped-xattr \
 	-o posixacl=on \
 	-o msize=104857600 \
-	-o ro \
 	defaultshare /mount/mnt/
+
+# Allow the user we are running as to copy things to the shared dir
+chmod 0777 /mount/mnt
 
 mount --rbind /dev /mount/dev
 mount --rbind /proc /mount/proc


### PR DESCRIPTION
This reverts commit bb8213b42f59e2429bfc25efd3fde3a9fca2fbf5.

This causes breakage when builds or tests happen as non root.

Ref: https://github.com/chainguard-dev/melange/pull/2155
