### PR TITLE
fix(jistsucom-bulker): Update to upstream beta release 2.11.913-beta.20251103114200.fb5fbbf

### DIFF
--- a/jitsucom-bulker.yaml
+++ b/jitsucom-bulker.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-bulker
-  version: "2.11.0"
-  epoch: 3 # CVE-2025-47910
+  version: "2.11.913"
+  epoch: 0
   description: Service for bulk-loading data to databases with automatic schema management (Redshift, Snowflake, BigQuery, ClickHouse, Postgres, MySQL)
   copyright:
     - license: MIT
@@ -13,12 +13,15 @@ package:
       - jitsucom-bulker-sidecar
       - jitsucom-bulker-syncctl
 
+vars:
+  upstream_tag_suffix: beta.20251103114200.fb5fbbf
+
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e0bbf23caf7d2e58722318dc90348cf75168235b
+      expected-commit: fb5fbbffa3424e5b797194029c764f8125e3e6c2
       repository: https://github.com/jitsucom/bulker
-      tag: jitsu2-v${{package.version}}
+      tag: jitsu2-v${{package.version}}-${{vars.upstream_tag_suffix}}
 
   - uses: go/bump
     with:
@@ -60,6 +63,8 @@ pipeline:
       modroot: bulkerlib
       work: true
 
+# github.com/marcboeker/go-duckdb/mapping@v0.0.18
+# github.com/marcboeker/go-duckdb/v2@v2.3.8
 data:
   - name: commands
     items:


### PR DESCRIPTION
jistsucom-bulker is currently FTBFS. See failing PR: https://github.com/wolfi-dev/os/pull/70816
Upgrading to latest upstream release fixes the build failure. However, the only concern is that the latest release tag indicates it is meant to be a "beta" release. Though, there doesn't seem to be any documented distinction between non-beta and beta releases upstream.


<!--ci-cve-scan:fail-any-->

