### PR TITLE
chore: add dotnet-sdk provides to dotnet-x

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.121"
-  epoch: 2
+  epoch: 3
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -106,6 +106,8 @@ subpackages:
   - name: dotnet-${{vars.major-version}}-sdk
     description: ".NET ${{vars.major-version}} SDK"
     dependencies:
+      provides:
+        - dotnet-sdk=${{package.version}}
       runtime:
         - aspnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - aspnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.111"
-  epoch: 2
+  epoch: 3
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -97,6 +97,8 @@ subpackages:
   - name: dotnet-${{vars.major-version}}-sdk
     description: ".NET ${{vars.major-version}} SDK"
     dependencies:
+      provides:
+        - dotnet-sdk=${{package.version}}
       runtime:
         - aspnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - aspnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}


### PR DESCRIPTION
dotnet-sdk is used by gdal config and we had that provides till
dotnet-7, but the same is not there for dotnet-{8,9} and new builds
of gdal will use old deps.

this adds dotnet-sdk to new versions of dotnet
