### PR TITLE
fix(jitsucom-bulker): Clean up comments

### DIFF
--- a/jitsucom-bulker.yaml
+++ b/jitsucom-bulker.yaml
@@ -63,8 +63,6 @@ pipeline:
       modroot: bulkerlib
       work: true
 
-# github.com/marcboeker/go-duckdb/mapping@v0.0.18
-# github.com/marcboeker/go-duckdb/v2@v2.3.8
 data:
   - name: commands
     items:


### PR DESCRIPTION
A couple of comments were inadvertently added under https://github.com/wolfi-dev/os/pull/71218, this PR cleans them up.