### PR TITLE
feat(open-webui): bump dep to remediate GHSA-2qfp-q593-8484

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.34"
-  epoch: 2
+  epoch: 3
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -82,6 +82,9 @@ pipeline:
 
       # GHSA-g8c6-8fjj-2r4m
       uv pip install --upgrade python-socketio>=5.14.0
+
+      # GHSA-2qfp-q593-8484
+      uv pip install --upgrade brotli>=1.2.0
 
       uv pip uninstall pip
 


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump Brotli to 1.2.0+ to remediate GHSA-2qfp-q593-8484 (CVE-2025-6176).

This vulnerability allows attackers to trigger denial of service conditions through specially crafted Brotli-compressed data. The issue exploits Brotli's ability to achieve extremely high compression ratios on zero-filled data, causing excessive memory consumption during decompression. Remote servers can crash clients with less than 80GB of available memory.

## Changes
- Added `uv pip install --upgrade brotli>=1.2.0` to upgrade Brotli to version 1.2.0+
- Incremented epoch to 3

<!--ci-cve-scan:fail-any-->