### PR TITLE
trust-manager - clean up build environment.

### DIFF
--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: "0.20.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0
@@ -11,12 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
-      - ca-certificates-bundle
-      - curl
-      - docker
       - go
-      - rsync
-      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version


### PR DESCRIPTION
The dropped packages are no longer needed in the build environment.
