### PR TITLE
chore(crossplane-provider-azure): clean up build time deps

### DIFF
--- a/crossplane-provider-azure.yaml
+++ b/crossplane-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-azure
   version: "2.2.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Official Azure Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -19,12 +19,8 @@ environment:
       - build-base
       - busybox
       - curl
-      - docker
       - go
       - gzip
-      - jq
-  environment:
-    CGO_ENABLED: 0
 
 vars:
   marketplace.version: 1.13.1


### PR DESCRIPTION
docker and jq is not used at build time.
