### PR TITLE
docker - restore missing dependencies.

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.5.2"
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ package:
       - docker-compose
       - docker-init
       - dockerd
+      - openssh-client # used by docker-cli
   checks:
     disabled:
       # docker is a meta package pulling in several subpackages at runtime
@@ -98,6 +99,7 @@ subpackages:
       runtime:
         # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
         - btrfs-progs
+        - ca-certificates
         - containerd
         - ctr
         - e2fsprogs


### PR DESCRIPTION
The previous commit inadvertantly dropped some dependencies from the 'docker' package.

The openssh-client dep would more correctly be put on docker-cli, but in the interest of not having changed things I'm adding it back here in 'docker' as it was before.

The ca-certificates package was also in 'docker', but really is needed for dockerd as it is likely to contact remote systems.
