### PR TITLE
keycloak-26.4: fix CVE-2025-59250

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.2"
-  epoch: 1 # GHSA-3p8m-j85q-pgmj
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak-26.4/pombump-deps.yaml
+++ b/keycloak-26.4/pombump-deps.yaml
@@ -34,3 +34,6 @@ patches:
   - groupId: io.netty
     artifactId: netty-codec-http
     version: 4.1.125.Final
+  - groupId: com.microsoft.sqlserver
+    artifactId: mssql-jdbc
+    version: 10.2.4.jre11


### PR DESCRIPTION
Remediate CVE-2025-59250.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
