### PR TITLE
bento: bump runc to 1.2.8

### DIFF
--- a/bento.yaml
+++ b/bento.yaml
@@ -1,7 +1,7 @@
 package:
   name: bento
   version: "1.12.1"
-  epoch: 0 # GHSA-4vq8-7jfc-9cvp
+  epoch: 1 # GHSA-4vq8-7jfc-9cvp
   description: Bento is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ pipeline:
     with:
       deps: |-
         github.com/ClickHouse/clickhouse-go/v2@v2.32.0
-        github.com/opencontainers/runc@v1.1.14
+        github.com/opencontainers/runc@v1.2.8
         github.com/docker/docker@v28.0.0
 
   - uses: go/build


### PR DESCRIPTION
CVE-2025-31133 GHSA-9493-h29p-rfm2
CVE-2025-52881 GHSA-cgrx-mc8f-2prm
CVE-2025-52565 GHSA-qw9x-cqr3-wc7r