### PR TITLE
buildkitd: bump github.com/opencontainers/selinux to v1.13.0

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: "0.25.2"
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -27,6 +27,11 @@ pipeline:
       repository: https://github.com/moby/buildkit
       tag: v${{package.version}}
       expected-commit: dcc0fe5e96ae78919b30057d0804c52f13a2eb7e
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
CVE-2025-52881 GHSA-cgrx-mc8f-2prm

<!--ci-cve-scan:fail-any-->