### PR TITLE
blob-csi-1.27: fix GHSA-cgrx-mc8f-2prm by updating selinux to v1.13.0

### DIFF
--- a/blob-csi-1.27.yaml
+++ b/blob-csi-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: blob-csi-1.27
   version: "1.27.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # GHSA-cgrx-mc8f-2prm
   description: Azure Blob Storage CSI driver
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,11 @@ pipeline:
       expected-commit: 64c05a906d70db87000b0bfb26f9d2500cd62e5b
       repository: https://github.com/kubernetes-sigs/blob-csi-driver
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
Fixes GHSA-cgrx-mc8f-2prm by adding github.com/opencontainers/selinux@v1.13.0 dependency.

## Changes
- Incremented epoch from 0 to 1
- Added go/bump with github.com/opencontainers/selinux@v1.13.0

## Related Issue
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35428

## References
- GHSA Advisory: https://github.com/advisories/GHSA-cgrx-mc8f-2prm