### PR TITLE
cadvisor GHSA-cgrx-mc8f-2prm/GHSA-qw9x-cqr3-wc7r: update runc to v1.3.3

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: "0.53.0"
-  epoch: 6 # CVE-2025-61725
+  epoch: 7
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -26,12 +26,14 @@ pipeline:
     with:
       deps: |-
         github.com/docker/docker@v28.3.3
+        github.com/opencontainers/runc@v1.3.3
       modroot: cmd
 
   - uses: go/bump
     with:
       deps: |-
         github.com/docker/docker@v28.3.3
+        github.com/opencontainers/runc@v1.3.3
 
   - runs: |
       ./build/build.sh


### PR DESCRIPTION
## Summary
Updates github.com/opencontainers/runc to v1.3.3.

## Changes
- Incremented epoch from 6 to 7
- Added github.com/opencontainers/runc@v1.3.3 to both go/bump sections