### PR TITLE
Remediate GHSA-cgrx-mc8f-2prm in azuredisk-csi-1.33 and azurefile-csi-1.33

### DIFF
--- a/azuredisk-csi-1.33.yaml
+++ b/azuredisk-csi-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: azuredisk-csi-1.33
   version: "1.33.5"
-  epoch: 2 # GHSA-4x4m-3c2p-qppc
+  epoch: 3 # GHSA-cgrx-mc8f-2prm
   description: Azure Disk CSI Driver
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,11 @@ pipeline:
       expected-commit: 2f64b2bb289c6e7580bb377893b09e4922f7547e
       repository: https://github.com/kubernetes-sigs/azuredisk-csi-driver
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:

--- a/azurefile-csi-1.33.yaml
+++ b/azurefile-csi-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: azurefile-csi-1.33
   version: "1.33.5"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # GHSA-cgrx-mc8f-2prm
   description: Azure File CSI Driver
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,11 @@ pipeline:
       expected-commit: 4639b103596bac5b5b1a1988f1973a9a4f55ee04
       repository: https://github.com/kubernetes-sigs/azurefile-csi-driver
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump github.com/opencontainers/selinux to 1.13.0

<!--ci-cve-scan:fail-any-->

