### PR TITLE
cert-manager-csi-driver: fix runc CVEs by updating to v1.3.3

### DIFF
--- a/cert-manager-csi-driver.yaml
+++ b/cert-manager-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-csi-driver
   version: "0.11.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Kubernetes CSI plugin to automatically mount signed certificates to Pods using ephemeral volumes
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,11 @@ pipeline:
       expected-commit: df98a1d9f91c6ab768ea84258dc229208f266e48
       repository: https://github.com/cert-manager/csi-driver
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/runc@v1.3.3
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
Fixes three runc CVEs by updating github.com/opencontainers/runc to v1.3.3.

## Changes
- Incremented epoch from 0 to 1
- Added go/bump with github.com/opencontainers/runc@v1.3.3

## CVEs Fixed
- GHSA-9493-h29p-rfm2 (High) - runc container escape via "masked path" abuse
- GHSA-cgrx-mc8f-2prm (High) - runc vulnerability
- GHSA-qw9x-cqr3-wc7r (High) - runc vulnerability

## Related Issues
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35364
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35344
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35194