### PR TITLE
feat(curl): Replace curl-static with static binary

### DIFF
--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: "1.2.0"
-  epoch: 1
+  epoch: 2
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT
@@ -32,13 +32,38 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-dev
-    description: "headers for brotli"
+  - name: "${{package.name}}-static"
+    description: "${{package.name}} static libraries"
+    pipeline:
+      - runs: |
+          # Build static libraries explicitly
+          # CMake by default builds shared libraries, so we need to rebuild with static
+          mkdir -p build-static
+          cd build-static
+          cmake .. \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+          make -j$(nproc)
+
+          # Install static libraries to subpackage
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          install -Dm644 libbrotlicommon.a "${{targets.subpkgdir}}"/usr/lib/libbrotlicommon.a
+          install -Dm644 libbrotlidec.a "${{targets.subpkgdir}}"/usr/lib/libbrotlidec.a
+          install -Dm644 libbrotlienc.a "${{targets.subpkgdir}}"/usr/lib/libbrotlienc.a
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
+  - name: "${{package.name}}-dev"
+    description: "headers for ${{package.name}}"
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - brotli
+        - "${{package.name}}"
     test:
       pipeline:
         - uses: test/pkgconf

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: "8.17.0"
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -18,21 +18,37 @@ environment:
       - autoconf
       - automake
       - brotli-dev
+      - brotli-static
       - build-base
       - busybox
       - ca-certificates-bundle
       - cyrus-sasl-dev
+      - cyrus-sasl-static
+      - e2fsprogs-static
       - git-bootstrap
+      - jitterentropy-library-dev
+      - keyutils-dev
+      - keyutils-static
       - krb5-dev
+      - krb5-static
+      - libidn2-dev
+      - libidn2-static
       - libpsl-dev
+      - libpsl-static
       - libtool
+      - libunistring-dev
+      - libunistring-static
+      - libverto-static
       - nghttp2-dev
+      - nghttp2-static
       - nghttp3-dev
       - openldap-dev
       - openssl-hardened-dev
+      - openssl-static
       - perl
       - wolfi-base
       - zlib-dev
+      - zlib-static
 
 var-transforms:
   - from: ${{package.version}}
@@ -79,9 +95,66 @@ pipeline:
 
 subpackages:
   - name: "curl-static"
-    description: "Statically linked libcurl"
+    description: "Statically linked curl binary"
     pipeline:
-      - uses: split/static
+      - runs: autoreconf -vif
+      - uses: autoconf/configure
+        with:
+          # Full-featured static build with HTTP2, HTTP3, Kerberos, GSS-API support
+          # Explicitly list all static libraries in LIBS for proper linking order
+          # Note: LDAP is disabled due to symbol conflicts between libsasl2 and libgssapi_krb5
+          # (both define GSS_C_SEC_CONTEXT_SASL_SSF which causes multiple definition errors during static linking)
+          opts: |
+            --enable-ipv6 \
+            --enable-kerberos-auth \
+            --enable-negotiate-auth \
+            --with-gssapi \
+            --enable-unix-sockets \
+            --with-openssl \
+            --without-rustls \
+            --with-nghttp2 \
+            --with-pic \
+            --with-openssl-quic \
+            --disable-ldap \
+            --disable-ntlm \
+            --without-libssh2 \
+            --with-libpsl \
+            --disable-shared \
+            --enable-static \
+            LDFLAGS="-static" \
+            LIBS="-lbrotlidec -lbrotlicommon -lnghttp2 -lpsl -lidn2 -lunistring -lssl -lcrypto -ljitterentropy -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err -lkrb5support -lverto -lkeyutils -lz -lresolv"
+      - uses: autoconf/make
+        with:
+          opts: CPPFLAGS="$CPPFLAGS -DOPENSSL_NO_ENGINE -D_GNU_SOURCE" LDFLAGS="-static -all-static" LIBS="-lbrotlidec -lbrotlicommon -lnghttp2 -lpsl -lidn2 -lunistring -lssl -lcrypto -ljitterentropy -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err -lkrb5support -lverto -lkeyutils -lz -lresolv"
+      - runs: |
+          # Only install the static binary, not libraries
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          install -Dm755 src/curl "${{targets.subpkgdir}}"/usr/bin/curl-static
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - curl-static
+            - busybox
+            - file
+            - ldd-check
+      pipeline:
+        - uses: test/tw/ver-check
+          with:
+            bins: curl-static
+        - name: Verify static binary has HTTP2/HTTP3/brotli support
+          runs: |
+            /usr/bin/curl-static --version | grep "HTTP2"
+            /usr/bin/curl-static --version | grep "HTTP3"
+            /usr/bin/curl-static --version | grep -i "brotli"
+        - name: Verify binary is statically linked
+          runs: |
+            # Check file type shows it's statically linked
+            file /usr/bin/curl-static | grep "statically linked"
+            # Verify ldd shows it's not a dynamic executable
+            # ldd should either say "not a dynamic executable" or fail
+            ! ldd /usr/bin/curl-static 2>&1 | grep -q "=>"
 
   - name: "curl-dev"
     description: "headers for libcurl"

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 45
+  epoch: 46
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -76,6 +76,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "cyrus-sasl-static"
+    description: "cyrus-sasl static libraries"
+    pipeline:
+      - uses: split/static
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
   - name: "cyrus-sasl-dev"
     description: "headers for cyrus-sasl"
     pipeline:

--- a/e2fsprogs.yaml
+++ b/e2fsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: e2fsprogs
   version: "1.47.3"
-  epoch: 1
+  epoch: 2
   description: Standard Ext2/3/4 filesystem utilities
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.0-or-later AND BSD-3-Clause AND MIT

--- a/keyutils.yaml
+++ b/keyutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: keyutils
   version: 1.6.3
-  epoch: 37
+  epoch: 38
   description: Linux Key Management Utilities
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later
@@ -57,6 +57,27 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: keyutils-static
+    description: keyutils static library
+    pipeline:
+      - runs: |
+          # Build static library separately since NO_ARLIB=1 was used in main build
+          make clean
+          make -j1 \
+            LIBDIR=/usr/lib \
+            USRLIBDIR=/usr/lib \
+            VERSION=${{package.version}} \
+            RELEASE=-r${{package.epoch}} \
+            CFLAGS="$CFLAGS" \
+            libkeyutils.a
+
+          # Install with same symlink workaround as main pipeline
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          install -Dm644 libkeyutils.a "${{targets.subpkgdir}}"/usr/lib/libkeyutils.a
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
   - name: keyutils-dev
     pipeline:
       - uses: split/dev

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: "1.22.1"
-  epoch: 1
+  epoch: 2
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
@@ -183,6 +183,45 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+
+  - name: krb5-static
+    description: "krb5 static libraries"
+    pipeline:
+      - working-directory: src
+        runs: |
+          make clean
+      - uses: autoconf/configure
+        with:
+          dir: src
+          opts: |
+            CPPFLAGS="$CPPFLAGS -fPIC -I/usr/include/et" \
+            --localstatedir=/var/lib \
+            --disable-shared \
+            --disable-nls \
+            --enable-static \
+            --disable-rpath \
+            --with-crypto-impl=openssl \
+            --with-tls-impl=openssl \
+            --with-system-et \
+            --with-system-ss \
+            --with-system-verto \
+            --with-ldap \
+            --sbindir=/usr/bin
+      - runs: |
+          # Only build the libraries, not the binaries (which have linking issues with static)
+          cd src
+          make -C util V=1
+          make -C include V=1
+          make -C lib V=1
+          make -C plugins/kdb/db2 V=1
+          make -C plugins/kdb/ldap V=1
+      - runs: |
+          # Install only the static libraries
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          find src -name '*.a' -exec cp {} "${{targets.subpkgdir}}"/usr/lib/ \;
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
 
 update:
   enabled: true

--- a/libverto.yaml
+++ b/libverto.yaml
@@ -1,7 +1,7 @@
 package:
   name: libverto
   version: 0.3.2
-  epoch: 6
+  epoch: 7
   description: Main loop abstraction library
   copyright:
     - license: MIT
@@ -54,6 +54,14 @@ data:
       glib:
 
 subpackages:
+  - name: libverto-static
+    description: "libverto static library"
+    pipeline:
+      - uses: split/static
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
   - name: libverto-dev
     pipeline:
       - uses: split/dev

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: "1.68.0"
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT
@@ -43,6 +43,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "nghttp2-static"
+    description: "nghttp2 static library"
+    pipeline:
+      - uses: split/static
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
   - name: "nghttp2-dev"
     description: "headers for nghttp2"
     pipeline:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 3
+  epoch: 4
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -111,6 +111,14 @@ pipeline:
       # openssl-config-fipshardened going forward.
 
 subpackages:
+  - name: "openssl-static"
+    description: "OpenSSL static libraries"
+    pipeline:
+      - uses: split/static
+    test:
+      pipeline:
+        - uses: test/tw/staticpackage
+
   - name: "openssl-dbg"
     description: "OpenSSL debug symbols"
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/chainguard-dev/image-requests/issues/7091

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
