### PR TITLE
grafana-alloy: bump github.com/opencontainers/runc to v1.2.8

### DIFF
--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -38,7 +38,11 @@ pipeline:
       # 1.2.x which go/bump doesn't understand, so it treats this as a
       # downgrade
       sed -i 's,\(github.com/opencontainers/runc\) v1.2.6,\1 v1.2.8,' go.mod
-      go mod tidy
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - name: Generate UI
     runs: make generate-ui

--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-alloy
   version: "1.11.3"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: OpenTelemetry Collector distribution with programmable pipelines
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,13 @@ pipeline:
       repository: https://github.com/grafana/alloy
       tag: v${{package.version}}
       expected-commit: 091a20eb3eb50a968f129d6094455962e9dd328e
+
+  - runs: |
+      # Upstream already have a `replace` directive downgrading from 1.3.x to
+      # 1.2.x which go/bump doesn't understand, so it treats this as a
+      # downgrade
+      sed -i 's,\(github.com/opencontainers/runc\) v1.2.6,\1 v1.2.8,' go.mod
+      go mod tidy
 
   - name: Generate UI
     runs: make generate-ui


### PR DESCRIPTION
CVE-2025-31133 GHSA-9493-h29p-rfm2
CVE-2025-52881 GHSA-cgrx-mc8f-2prm
CVE-2025-52565 GHSA-qw9x-cqr3-wc7r

<!--ci-cve-scan:fail-any-->