### PR TITLE
keycloak-26.4: fix CVE-2025-59250

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.2"
-  epoch: 2
+  epoch: 3
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak-26.4/pombump-deps.yaml
+++ b/keycloak-26.4/pombump-deps.yaml
@@ -36,4 +36,4 @@ patches:
     version: 4.1.125.Final
   - groupId: com.microsoft.sqlserver
     artifactId: mssql-jdbc
-    version: 10.2.4.jre11
+    version: 13.2.1.jre11


### PR DESCRIPTION
fix: Bump keycloak mssql-jdbc to correct major version

Keycloak 26.4 was carrying version 13 of mssql-jdbc, and was incorrectly bumped to use version 10.

This correctly resolves https://github.com/advisories/GHSA-m494-w24q-6f7w