### PR TITLE
chore(gcc): Add versioned provides

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: "15.2.0"
-  epoch: 3
+  epoch: 4
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -9,6 +9,9 @@ package:
     cpu: 16
     memory: 16Gi
   dependencies:
+    provides:
+      - gcc-${{vars.major-version}}=${{package.full-version}}
+      - gcc-${{vars.major-version}}-default=${{package.full-version}}
     runtime:
       - binutils
       - glibc-dev # Temporary workaround to force build-ordering against new glibc's
@@ -146,6 +149,9 @@ pipeline:
 
 subpackages:
   - name: 'gcc-doc'
+    dependencies:
+      provides:
+        - gcc-${{vars.major-version}}-doc=${{package.full-version}}
     pipeline:
       - uses: split/manpages
     test:
@@ -153,6 +159,9 @@ subpackages:
         - uses: test/docs
 
   - name: 'libstdc++'
+    dependencies:
+      provides:
+        - libstdc++-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -162,6 +171,9 @@ subpackages:
         - uses: test/tw/ldd-check
 
   - name: 'libstdc++-dev'
+    dependencies:
+      provides:
+        - libstdc++-${{vars.major-version}}-dev=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -175,6 +187,9 @@ subpackages:
 
   - name: "libquadmath"
     description: "128-bit math library provided by GCC"
+    dependencies:
+      provides:
+        - libquadmath-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - if: ${{build.arch}} == 'x86_64'
         runs: |
@@ -186,6 +201,9 @@ subpackages:
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"
+    dependencies:
+      provides:
+        - libgfortran-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -196,6 +214,12 @@ subpackages:
 
   - name: "gfortran"
     description: "GNU Fortran Compiler"
+    dependencies:
+      provides:
+        - gfortran-${{vars.major-version}}=${{package.full-version}}
+      runtime:
+        - gcc
+        - libgfortran
     pipeline:
       - runs: |
           _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -213,10 +237,6 @@ subpackages:
 
           mv "${{targets.destdir}}"/$_libdir/finclude "${{targets.subpkgdir}}"/$_libdir
           mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir
-    dependencies:
-      runtime:
-        - gcc
-        - libgfortran
     test:
       pipeline:
         - runs: |
@@ -225,6 +245,9 @@ subpackages:
 
   - name: "libgccjit"
     description: "GCC JIT library"
+    dependencies:
+      provides:
+        - libgccjit-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -235,6 +258,9 @@ subpackages:
 
   - name: "libgccjit-dev"
     description: "GCC JIT library headers"
+    dependencies:
+      provides:
+        - libgccjit-${{vars.major-version}}-dev=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -245,6 +271,9 @@ subpackages:
 
   - name: "libssp"
     description: "GCC stack protection library"
+    dependencies:
+      provides:
+        - libssp-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -252,6 +281,9 @@ subpackages:
 
   - name: "libgomp"
     description: "GNU parallel programming library"
+    dependencies:
+      provides:
+        - libgomp-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -262,6 +294,9 @@ subpackages:
 
   - name: "libgcc"
     description: "GCC runtime library"
+    dependencies:
+      provides:
+        - libgcc-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -272,6 +307,9 @@ subpackages:
 
   - name: "libatomic"
     description: "GCC atomic library"
+    dependencies:
+      provides:
+        - libatomic-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib


### PR DESCRIPTION
There may be situations (such as those where applications are built with the NVCC which supports a limited range of GCC versions) that we may want to pin an application to what is currently the latest version of GCC

This also adds an additional `-default` provider for GCC so that packages that are intentionally pinned to what was the latest version of GCC continue to use that version by default instead of the latest version