### PR TITLE
datadog-agent: bump github.com/opencontainers/selinux to v1.13.0

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.71.2"
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -131,6 +131,8 @@ pipeline:
 
   - uses: go/bump
     with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
       go-version: "1.24.7" # package built w/ go-1.24 - keeps tidy at 1.24.7, otherwise go mod tidy fails
       replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
       show-diff: true


### PR DESCRIPTION
CVE-2025-52881 GHSA-cgrx-mc8f-2prm

<!--ci-cve-scan:fail-any-->