### PR TITLE
fix(docker): GHSA-cgrx-mc8f-2prm

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.5.2"
-  epoch: 1
+  epoch: 2
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -60,6 +60,7 @@ pipeline:
         github.com/opencontainers/runtime-spec@v1.2.1
         github.com/rootless-containers/rootlesskit/v2@v2.3.4
         github.com/golang-jwt/jwt/v5@v5.2.2
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       # setting back to original so we can run moby specific hack


### PR DESCRIPTION
gobump selinux to 1.13

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35303

<!--ci-cve-scan:fail-any-->
