### PR TITLE
fix(cni-plugins): GHSA-cgrx-mc8f-2prm

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: "1.8.0"
-  epoch: 2 # CVE-2025-47910
+  epoch: 3
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,11 @@ pipeline:
       repository: https://github.com/containernetworking/plugins
       tag: v${{package.version}}
       expected-commit: 0e648479e11c2c6d9109b14fc0c9ac64c677861b
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       # Ensure we build statically since CNI plugins often get moved onto the


### PR DESCRIPTION
go bump to newest version of selinux

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35192

<!--ci-cve-scan:fail-any-->
