### PR TITLE
fix(containerd-2): GHSA-cgrx-mc8f-2prm

### DIFF
--- a/containerd-2.yaml
+++ b/containerd-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-2
   version: "2.2.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,11 @@ pipeline:
       expected-commit: 1c4457e00facac03ce1d75f7b6777a7a851e5c41
       repository: https://github.com/containerd/containerd
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/bump
     with:


### PR DESCRIPTION
gobump to most recent version of selinux

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35338

<!--ci-cve-scan:fail-any-->
