### PR TITLE
fix(zot): GHSA-cgrx-mc8f-2prm, GHSA-pwhc-rpq9-4c8w, GHSA-m6hq-p25p-ffr2

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: "2.1.10"
-  epoch: 0
+  epoch: 1
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,11 @@ pipeline:
       expected-commit: dfb5d1df5403186d2359d95cb24c8e2f17ad930c
       repository: https://github.com/project-zot/zot
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       GOARCH=$(go env GOARCH)

--- a/zot.yaml
+++ b/zot.yaml
@@ -28,6 +28,8 @@ pipeline:
     with:
       deps: |-
         github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd@v1.7.29
+        github.com/containerd/containerd/v2@v2.1.5
 
   - runs: |
       GOARCH=$(go env GOARCH)


### PR DESCRIPTION
Bump selinux version and containerd version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35132, https://github.com/chainguard-dev/CVE-Dashboard/issues/35849, https://github.com/chainguard-dev/CVE-Dashboard/issues/35774

<!--ci-cve-scan:fail-any-->
