### PR TITLE
fix(grype): Remediate GHSA-cgrx-mc8f-2prm

### DIFF
--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: "0.103.0"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1 # GHSA-cgrx-mc8f-2prm
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,11 @@ pipeline:
       repository: https://github.com/anchore/grype
       tag: v${{package.version}}
       expected-commit: e96dcd54dec441245735da6d7d6c5d1bbb8f662d
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:

--- a/grype.yaml
+++ b/grype.yaml
@@ -21,6 +21,7 @@ pipeline:
     with:
       deps: |-
         github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd@v1.7.29
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump github.com/opencontainers/selinux to v1.13.0 and github.com/containerd/containerd to v1.7.29

<!--ci-cve-scan:fail-any-->
