### PR TITLE
fix(sonobuoy): wrong host endpoint with brackets

### DIFF
--- a/sonobuoy.yaml
+++ b/sonobuoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonobuoy
   version: "0.57.3"
-  epoch: 9 # CVE-2025-61725
+  epoch: 10
   description: Sonobuoy is a diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of Kubernetes conformance tests and other plugins in an accessible and non-destructive manner.
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,10 @@ pipeline:
       repository: https://github.com/vmware-tanzu/sonobuoy
       expected-commit: a988242e8bbded3ef4602eda48addcfac24a1a91
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: fix-ipv4-brackets.patch
 
   - uses: go/bump
     with:

--- a/sonobuoy/fix-ipv4-brackets.patch
+++ b/sonobuoy/fix-ipv4-brackets.patch
@@ -1,0 +1,19 @@
+diff --git a/pkg/config/loader.go b/pkg/config/loader.go
+index 4d0b5f9a..7b09bb1f 100644
+--- a/pkg/config/loader.go
++++ b/pkg/config/loader.go
+@@ -90,7 +90,13 @@ func (cfg *Config) Resolve() {
+ 	// Figure out what address we will tell pods to dial for aggregation
+ 	if cfg.Aggregation.AdvertiseAddress == "" {
+ 		if ip := os.Getenv("SONOBUOY_ADVERTISE_IP"); ip != "" {
+-			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", ip, cfg.Aggregation.BindPort)
++			if strings.Contains(ip, ":") {
++				// IPv6 address needs brackets
++				cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", ip, cfg.Aggregation.BindPort)
++			} else {
++				// IPv4 address should not have brackets
++				cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("%v:%d", ip, cfg.Aggregation.BindPort)
++			}
+ 		} else {
+ 			hostname, _ := os.Hostname()
+ 			if hostname != "" {


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Fixes sonobuoy IPv4 address formatting in aggregator URL.
The sonobuoy aggregator was unconditionally wrapping all IP addresses in square brackets when constructing the `AGGREGATOR_URL`. This is only valid for IPv6 addresses and causes URL parsing
failures with IPv4 addresses in newer Go versions.

The fix adds proper IPv6 detection using `strings.Contains(ip, ":")` to only apply brackets when the address is actually IPv6.

Error from the pod:
```
# kubectl logs -n sonobuoy sonobuoy-systemd-logs-daemon-set-bd0a5127cde9436a-gqzlq -c sonobuoy-worker
time="2025-11-07T11:29:39Z" level=trace msg="Invoked command single-node with args [] and flags [level=trace logtostderr=true sleep=-1 v=6]"
Error: parsing AggregatorURL: parse "https://[10.42.0.5]:8080": invalid IPv6 host
Usage:
  sonobuoy worker single-node [flags]

Flags:
  -h, --help        help for single-node
      --sleep int   After sending results, keeps the process alive for N seconds to avoid restarting the container. If N<0, Sonobuoy sleeps forever.

Global Flags:
      --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)

time="2025-11-07T11:29:39Z" level=error msg="parsing AggregatorURL: parse \"https://[10.42.0.5]:8080\": invalid IPv6 host" trace="parse \"https://[10.42.0.5]:8080\": invalid IPv6 host\nparsing Aggregat
orURL\ngithub.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app.runGather\n\tgithub.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app/worker.go:169\ngithub.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app.newSingleNodeCmd
.runGatherSingleNode.func1\n\tgithub.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app/worker.go:136\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.6.1/command.go:916\ngithub.com/spf1
3/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.6.1/command.go:1044\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.6.1/command.go:968\nmain.main\n\tgithub.com/vmware-t
anzu/sonobuoy/main.go:27\nruntime.main\n\truntime/proc.go:285\nruntime.goexit\n\truntime/asm_amd64.s:1693"
```

<!--ci-cve-scan:fail-any-->
