### PR TITLE
Rebuild packages for ICU 78 transition (Tranche 0)

### DIFF
--- a/R.yaml
+++ b/R.yaml
@@ -2,7 +2,7 @@
 package:
   name: R
   version: "4.5.2"
-  epoch: 0
+  epoch: 1
   description: Language and environment for statistical computing
   copyright:
     - license: ( GPL-2.0-only OR GPL-3.0-only ) AND LGPL-2.1-or-later

--- a/R.yaml
+++ b/R.yaml
@@ -78,7 +78,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 87a41ce9b50e096dd2c4282f48efea30c9916fcb7b167fa2bc988c9cf3cb6642
+      expected-sha256: 0d71ff7106ec69cd7c67e1e95ed1a3cee355880931f2eb78c530014a9e379f20
       uri: https://cloud.r-project.org/src/base/R-4/R-${{package.version}}.tar.gz
 
   - runs: |

--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.105.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: "3.17.2"
-  epoch: 0
+  epoch: 1
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/libical.yaml
+++ b/libical.yaml
@@ -2,7 +2,7 @@
 package:
   name: libical
   version: 3.0.20
-  epoch: 3
+  epoch: 4
   description: Reference implementation of the iCalendar format
   copyright:
     - license: LGPL-2.1-only OR MPL-2.0

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -1,7 +1,7 @@
 package:
   name: mozjs91
   version: 91.13.0
-  epoch: 8
+  epoch: 9
   description:
   copyright:
     - license: MPL-2.0

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "9129"
-  epoch: 1
+  epoch: 2
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 15
+  epoch: 16
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: "18.20.8"
-  epoch: 4
+  epoch: 5
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: "20.19.5"
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 12
+  epoch: 13
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: "22.21.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: "23.11.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 2
+  epoch: 3
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-24.yaml
+++ b/nodejs-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-24
   version: "24.11.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-25.yaml
+++ b/nodejs-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-25
   version: "25.1.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.1
   version: "9.1.0.1"
-  epoch: 7
+  epoch: 8
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later

--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-xtrabackup-8.4
   version: "8.4.0.4"
-  epoch: 3
+  epoch: 4
   description: Open source hot backup tool for InnoDB and XtraDB databases
   copyright:
     - license: Apache-2.0

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.33"
-  epoch: 7
+  epoch: 8
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.29"
-  epoch: 6
+  epoch: 7
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.27"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.14"
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.10"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.6"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-18.yaml
+++ b/postgresql-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-18
   version: "18.0"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -80,7 +80,7 @@ pipeline:
       # see https://download.qt.io/archive/qt/5.15/5.15.17/submodules/
       # and in the detailis link https://download.qt.io/archive/qt/5.15/5.15.17/submodules/qtbase-everywhere-opensource-src-5.15.17.tar.xz.mirrorlist
       expected-sha256: db1513cbb3f4a5bd2229f759c0839436f7fe681a800ff2bc34c4960b09e756ff
-      uri: https://download.qt.io/official_releases/qt/5.15/${{package.version}}/submodules/qtbase-everywhere-opensource-src-${{package.version}}.tar.xz
+      uri: https://download.qt.io/archive/qt/5.15/${{package.version}}/submodules/qtbase-everywhere-opensource-src-${{package.version}}.tar.xz
 
   - uses: patch
     with:

--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -2,7 +2,7 @@
 package:
   name: qt5-qtbase
   version: "5.15.17"
-  epoch: 4
+  epoch: 5
   description: Qt5 - QtBase components
   copyright:
     - license: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0

--- a/re2.yaml
+++ b/re2.yaml
@@ -1,7 +1,7 @@
 package:
   name: re2
   version: "2025.08.12" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 2
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause

--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -1,7 +1,7 @@
 package:
   name: rspamd
   version: "3.13.2"
-  epoch: 0
+  epoch: 1
   description: "Rapid spam filtering system"
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-charlock_holmes.yaml
+++ b/ruby3.2-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-charlock_holmes
   version: 0.7.9
-  epoch: 3
+  epoch: 4
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/ruby3.3-charlock_holmes.yaml
+++ b/ruby3.3-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-charlock_holmes
   version: 0.7.9
-  epoch: 3
+  epoch: 4
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/ruby3.4-charlock_holmes.yaml
+++ b/ruby3.4-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-charlock_holmes
   version: 0.7.9
-  epoch: 6
+  epoch: 7
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/tesseract.yaml
+++ b/tesseract.yaml
@@ -1,7 +1,7 @@
 package:
   name: tesseract
   version: "5.5.1"
-  epoch: 3
+  epoch: 4
   description: Tesseract Open Source OCR Engine
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This PR rebuilds packages in the first tranche for the ICU 78 shared library transition.

## Packages Rebuilt (31 total)

### Node.js versions
- nodejs-16, nodejs-18, nodejs-20, nodejs-21, nodejs-22, nodejs-23, nodejs-24, nodejs-25

### PHP versions
- php-8.1, php-8.2, php-8.3, php-8.4

### PostgreSQL versions
- postgresql-16, postgresql-17, postgresql-18

### Ruby charlock_holmes gems
- ruby3.2-charlock_holmes, ruby3.3-charlock_holmes, ruby3.4-charlock_holmes

### Database & Server packages
- percona-server-9.1, percona-xtrabackup-8.4

### Other packages
- qt5-qtbase, mozjs91, R, rspamd, neon, tesseract, code-server, re2, libical, freerdp-3

## Details
These packages depend on ICU shared libraries (libicui18n.so, libicuuc.so, libicudata.so) and need to be rebuilt to link against ICU 78 instead of ICU 77.
