### PR TITLE
py3-cryptography: add runtime dependency on typing-extensions

### DIFF
--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -67,6 +67,7 @@ subpackages:
           packages:
             - openssl-provider-legacy
       pipeline:
+        - uses: test/tw/pip-check
         - uses: python/import
           with:
             python: python${{range.key}}

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: "46.0.3"
-  epoch: 0
+  epoch: 1
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -54,6 +54,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-cffi
+        - py${{range.key}}-typing-extensions
         - openssl-provider-legacy
     pipeline:
       - uses: py/pip-build-install


### PR DESCRIPTION
Technically this is only required for Python < 3.11 but as typing-extensions is published for all Pythons, add it as a runtime dependency for all of them.

Add pip-check to the test pipeline to avoid future regressions.
