### PR TITLE
k3s: remediate CVE-2025-52881

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.34.1.1"
-  epoch: 1 # GHSA-47m2-4cr7-mhcw
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -67,6 +67,7 @@ pipeline:
         github.com/quic-go/quic-go@v0.54.1
         github.com/quic-go/webtransport-go@v0.9.0
         github.com/libp2p/go-libp2p@v0.44.0
+        github.com/opencontainers/selinux@v1.13.0
 
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.


### PR DESCRIPTION
Remediate CVE-2025-52881.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
