### PR TITLE
yara-x/1.9.0-r1 build with memory usage fix

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "1.9.0"
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -27,6 +27,9 @@ pipeline:
       repository: https://github.com/VirusTotal/yara-x
       expected-commit: 01ef5e2bc57c112448682ce6a5e6b66c4da6d6c9
       tag: v${{package.version}}
+      # this is temporary until the next release is cut, but we can benefit in the meantime
+      cherry-picks: |
+        main/d6ed5d73cef28704f356a48cdd481793cee72d43: fix: clear module outputs when resetting scan context
 
   - uses: rust/cargobump
 


### PR DESCRIPTION
This PR builds yara-x with my recent commit to prevent individual scan module output messages from continuously building up throughout the lifecycle of a yara-x scanner.

We should no longer see memory usage increase by tens (or more) of gigabytes when scanning larger packages containing hundreds of thousands of files with the same scanner instances.