### PR TITLE
k8s-device-plugin: remediate CVE-2025-52881

### DIFF
--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-device-plugin
   version: "0.18.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: meta package providing all NVIDIA device plugins for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,11 @@ pipeline:
       repository: https://github.com/NVIDIA/k8s-device-plugin
       tag: v${{package.version}}
       expected-commit: 3c9ffca9491f0d2d362a7064138dfcd71bb57592
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"


### PR DESCRIPTION
Remediate CVE-2025-52881.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
