### PR TITLE
Rebuild packages for ICU 78 transition (Tranche 1)

### DIFF
--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 13
+  epoch: 14
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 16
+  epoch: 17
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67 # On update, please check if -fdelete-null-pointer-checks is still required
   version: 1.67.1
-  epoch: 16
+  epoch: 17
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.68.yaml
+++ b/grpc-1.68.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.68
   version: 1.68.2
-  epoch: 14
+  epoch: 15
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.69.yaml
+++ b/grpc-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.69
   version: 1.69.0
-  epoch: 14
+  epoch: 15
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.70.yaml
+++ b/grpc-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.70
   version: "1.70.2"
-  epoch: 9
+  epoch: 10
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.71.yaml
+++ b/grpc-1.71.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.71
   version: "1.71.2"
-  epoch: 8
+  epoch: 9
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.72.yaml
+++ b/grpc-1.72.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.72
   version: "1.72.2"
-  epoch: 5
+  epoch: 6
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.73.yaml
+++ b/grpc-1.73.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.73
   version: "1.73.1"
-  epoch: 5
+  epoch: 6
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.74.yaml
+++ b/grpc-1.74.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.74
   version: "1.74.1"
-  epoch: 4
+  epoch: 5
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.75.yaml
+++ b/grpc-1.75.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.75
   version: "1.75.1"
-  epoch: 2
+  epoch: 3
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.76.yaml
+++ b/grpc-1.76.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.76
   version: "1.76.0"
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: "4.3.1"
-  epoch: 1
+  epoch: 2
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: "4.3.1"
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: "4.3.1"
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.4-pecl-http.yaml
+++ b/php-8.4-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-pecl-http
   version: "4.3.1"
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: "3.10.5"
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 2
+  epoch: 3
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 3
+  epoch: 2
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
This PR rebuilds packages in the second tranche for the ICU 78 shared library transition.

## Packages Rebuilt (18 total)

### gRPC versions
- grpc-1.66, grpc-1.67, grpc-1.68, grpc-1.69, grpc-1.70
- grpc-1.71, grpc-1.72, grpc-1.73, grpc-1.74, grpc-1.75, grpc-1.76

### PHP PECL HTTP extensions
- php-8.1-pecl-http, php-8.2-pecl-http, php-8.3-pecl-http, php-8.4-pecl-http

### Other packages
- postfix, couchdb-3.3

## Details
These packages depend on ICU shared libraries (libicui18n.so, libicuuc.so, libicudata.so) and need to be rebuilt to link against ICU 78 instead of ICU 77.

This tranche includes packages that depend on packages from Tranche 0.