### PR TITLE
kubescape-operator: github.com/opencontainers/selinux to v1.13.0

### DIFF
--- a/kubescape-operator.yaml
+++ b/kubescape-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape-operator
   version: "0.2.111"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Kubescape-Operator is an in-cluster component of the Kubescape security platform.
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,11 @@ pipeline:
       expected-commit: bb4c205ecf15bcb7f756fe1dcaf25f70d2fe9ac3
       repository: https://github.com/kubescape/operator
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
CVE-2025-52881 GHSA-cgrx-mc8f-2prm

<!--ci-cve-scan:fail-any-->