### PR TITLE
k9s: remediate CVE-2025-52881

### DIFF
--- a/k9s.yaml
+++ b/k9s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k9s
   version: "0.50.16"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1
   description: Kubernetes CLI To Manage Your Clusters In Style!
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,11 @@ pipeline:
       expected-commit: 3c37ca2197ca48591566d1f599b7b3a50d54a408
       repository: https://github.com/derailed/k9s
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Remediate CVE-2025-52881.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
