### PR TITLE
kots: remediate CVE-2025-52881

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: "1.128.3"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,11 @@ pipeline:
       repository: https://github.com/replicatedhq/kots
       tag: v${{package.version}}
       expected-commit: 167ead124f6bab482cabf5b37d4fd0505a93c47a
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       set -x


### PR DESCRIPTION
Remediate CVE-2025-52881.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
