### PR TITLE
newrelic-infrastructure-agent: bump github.com/opencontainers/selinux to v1.13.0

### DIFF
--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -16,6 +16,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
+        github.com/containerd/containerd@v1.7.29
         github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: "1.71.0"
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,11 @@ pipeline:
       repository: https://github.com/newrelic/infrastructure-agent
       tag: ${{package.version}}
       expected-commit: a2ce32e5cf2869d3d1abff9e8e29640813e3c034
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
CVE-2025-52881 GHSA-cgrx-mc8f-2prm

<!--ci-cve-scan:fail-any-->