### PR TITLE
skopeo: bump github.com/opencontainers/selinux to v1.13.0

### DIFF
--- a/skopeo.yaml
+++ b/skopeo.yaml
@@ -1,7 +1,7 @@
 package:
   name: skopeo
   version: "1.20.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Work with remote images registries - retrieving information, images, signing content
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
+        github.com/opencontainers/selinux@v1.13.0
         github.com/ulikunitz/xz@v0.5.14
 
   - uses: go/build


### PR DESCRIPTION
CVE-2025-52881 GHSA-cgrx-mc8f-2prm

<!--ci-cve-scan:fail-any-->