### PR TITLE
feat(syft) Remediate CVEs

### DIFF
--- a/syft.yaml
+++ b/syft.yaml
@@ -20,6 +20,11 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
+        github.com/opencontainers/selinux@v1.13.0
+
+  - uses: go/bump
+    with:
+      deps: |-
         github.com/ulikunitz/xz@v0.5.14
       modroot: syft/pkg/cataloger/golang/test-fixtures/image-not-a-module
 

--- a/syft.yaml
+++ b/syft.yaml
@@ -1,7 +1,7 @@
 package:
   name: syft
   version: "1.37.0"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1 # GHSA-rwvp-r38j-9rgg
   description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems
   copyright:
     - license: Apache-2.0

--- a/syft.yaml
+++ b/syft.yaml
@@ -21,6 +21,7 @@ pipeline:
     with:
       deps: |-
         github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd@v1.7.29
 
   - uses: go/bump
     with:


### PR DESCRIPTION
This PR bumps `containerd` and `selinux` to remediate the following CVEs

- GHSA-m6hq-p25p-ffr2
- GHSA-pwhc-rpq9-4c8w
- GHSA-cgrx-mc8f-2prm

