### PR TITLE
fix(docker, docker-cli-buildx): GHSA-m6hq-p25p-ffr2, GHSA-pwhc-rpq9-4c8w

### DIFF
--- a/docker-cli-buildx.yaml
+++ b/docker-cli-buildx.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-cli-buildx
   version: "0.29.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2
   description: buildx is a Docker CLI plugin for extended build capabilities with BuildKit.
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,11 @@ pipeline:
       repository: https://github.com/docker/buildx
       tag: v${{package.version}}
       expected-commit: a32761aeb3debd39be1eca514af3693af0db334b
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/containerd/containerd/v2@v2.1.5
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/libexec/docker/cli-plugins/

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "28.5.2"
-  epoch: 2
+  epoch: 3
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -61,6 +61,7 @@ pipeline:
         github.com/rootless-containers/rootlesskit/v2@v2.3.4
         github.com/golang-jwt/jwt/v5@v5.2.2
         github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd/v2@v2.1.5
 
   - runs: |
       # setting back to original so we can run moby specific hack


### PR DESCRIPTION
Bump containerd

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35827, https://github.com/chainguard-dev/CVE-Dashboard/issues/35851, https://github.com/chainguard-dev/CVE-Dashboard/issues/35668, https://github.com/chainguard-dev/CVE-Dashboard/issues/35673

<!--ci-cve-scan:fail-any-->
