### PR TITLE
fix(spegel): GHSA-cgrx-mc8f-2prm, GHSA-m6hq-p25p-ffr2, GHSA-pwhc-rpq9-4c8w

### DIFF
--- a/spegel.yaml
+++ b/spegel.yaml
@@ -1,7 +1,7 @@
 package:
   name: spegel
   version: "0.5.1"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1
   description: Stateless cluster local OCI registry mirror.
   copyright:
     - license: MIT
@@ -12,6 +12,12 @@ pipeline:
       repository: https://github.com/spegel-org/spegel
       tag: v${{package.version}}
       expected-commit: cd352c73f0755338ef6f6f13125d2491ff981ac6
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd/v2@v2.1.5
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump containerd and selinux

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35223, https://github.com/chainguard-dev/CVE-Dashboard/issues/35813, https://github.com/chainguard-dev/CVE-Dashboard/issues/35771

<!--ci-cve-scan:fail-any-->
