### PR TITLE
fix(gstreamer): enable pulseaudio elements for gst-plugins-good subpackage

### DIFF
--- a/gstreamer.yaml
+++ b/gstreamer.yaml
@@ -149,6 +149,13 @@ subpackages:
             gst-launch-1.0 videotestsrc num-buffers=1 ! videoconvert ! jpegenc ! jpegdec ! fakesink && echo "✓ JPEG pipeline works"
             gst-launch-1.0 audiotestsrc num-buffers=1 ! audioconvert ! fakesink && echo "✓ Audio pipeline works"
             echo "✓ gst-plugins-good test passed"
+        - runs: |
+            echo "Testing pulsaudio plugin elements available..."
+            for element in pulsesrc pulsesink; do
+              gst-inspect-1.0 $element | grep -Eq "$element"
+              echo "✓ $element found"
+            done
+            echo "✓ gst-plugins-good pulseaudio test passed"
         - uses: test/tw/ldd-check
 
   - name: gst-plugins-good-dev

--- a/gstreamer.yaml
+++ b/gstreamer.yaml
@@ -2,7 +2,7 @@
 package:
   name: gstreamer
   version: "1.27.2"
-  epoch: 1
+  epoch: 2
   description: GStreamer streaming media framework
   copyright:
     - license: LGPL-2.1
@@ -50,6 +50,7 @@ environment:
       - orc-compiler
       - orc-dev
       - perl
+      - pulseaudio-dev
       - python3
       - samba-dev
       - speex-dev
@@ -128,7 +129,7 @@ subpackages:
                 -Dqt6=disabled \
                 -Dgtk3=disabled \
                 -Djack=disabled \
-                -Dpulse=disabled \
+                -Dpulse=enabled \
                 -Dsoup=disabled \
                 -Dspeex=enabled \
                 -Dtaglib=disabled \


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
 
 **Notes:**
 livekit-egress tests are failing with the following error:  `could not create element: pulsesrc`
 
 <details>
  <summary>Test harness error logs - click to expand/collapse</summary>
  
**livekit-egress** test failure
  
```
  Egress did not complete as expected
  │ + final_status=$'4\n4\n4'
  │ + echo $'4\n4\n4'
  │ + [[ 4
  │ 4
  │ 4 -eq 3 ]]
  │ ./k8s-test.sh: line 184: [[: 4
  │ 4
  │ 4: arithmetic syntax error in expression (error token is "4
  │ 4")
  │ + echo 'Egress did not complete as expected'
  │ + lk_exec egress list
  │ + local cmd=egress
  │ + shift
  │ + lk egress --url ws://livekit-server.default.svc.cluster.local --api-key devkey --api-secret thisisasecretkeythatislongenoughforlivekit list
  │ Using url from environment
  │ ┌─────────────────┬───────────────┬──────┬──────────────────────────────────────────────────┬─────────────────────────────────────────┬────────────────────────────────────┐
  │ │ EgressID        │ Status        │ Type │ Source                                           │ Started At                              │ Error
  │ │
  │ ├─────────────────┼───────────────┼──────┼──────────────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────────────────┤
  │ │ EG_Lp6QfJVvjzNR │ EGRESS_FAILED │ web  │ http://nginx-demo.default.svc.cluster.local:8080 │ 2025-11-06 22:00:00.732892042 +0000 UTC │ could not create
  │ element: pulsesrc │
  │ │ EG_MNfrkJPFN2pQ │ EGRESS_FAILED │ web  │ http://nginx-demo.default.svc.cluster.local:8080 │ 2025-11-06 22:01:07.466576712 +0000 UTC │ could not create
  │ element: pulsesrc │
  │ │ EG_zk5DXkdVDwo5 │ EGRESS_FAILED │ web  │ http://nginx-demo.default.svc.cluster.local:8080 │ 2025-11-06 22:00:34.119048627 +0000 UTC │ could not create
  │ element: pulsesrc │
  │ └─────────────────┴───────────────┴──────┴──────────────────────────────────────────────────┴─────────────────────────────────────────┴────────────────────────────────────┘
  │ + lk_exec egress list --json
  │ + local cmd=egress
  │ + shift
  │ + lk egress --url ws://livekit-server.default.svc.cluster.local --api-key devkey --api-secret thisisasecretkeythatislongenoughforlivekit list --json
  │ Using url from environment
  │ [
  │   {
  │     "egress_id": "EG_Lp6QfJVvjzNR",
  │     "status": 4,
  │     "started_at": 1762466400732892042,
  │     "ended_at": 1762466401423355417,
  │     "updated_at": 1762466401423355417,
  │     "details": "End reason: Failure",
  │     "error": "could not create element: pulsesrc",
  │     "error_code": 500,
  │     "Request": {
  │       "Web": {
  │         "url": "http://nginx-demo.default.svc.cluster.local:8080",
  │         "Output": null,
  │         "Options": {
  │           "Preset": 0
  │         },
  │         "file_outputs": [
  │           {
  │             "file_type": 1,
  │             "filepath": "/out/egress-smoke-k8s.mp4",
  │             "disable_manifest": true,
  │             "Output": null
  │           }
  │         ]
  │       }
  │     },
  │     "Result": {
  │       "File": {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     },
  │     "file_results": [
  │       {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     ]
  │   },
  │   {
  │     "egress_id": "EG_MNfrkJPFN2pQ",
  │     "status": 4,
  │     "started_at": 1762466467466576712,
  │     "ended_at": 1762466467925812045,
  │     "updated_at": 1762466467925812045,
  │     "details": "End reason: Failure",
  │     "error": "could not create element: pulsesrc",
  │     "error_code": 500,
  │     "Request": {
  │       "Web": {
  │         "url": "http://nginx-demo.default.svc.cluster.local:8080",
  │         "Output": null,
  │         "Options": {
  │           "Preset": 0
  │         },
  │         "file_outputs": [
  │           {
  │             "file_type": 1,
  │             "filepath": "/out/egress-smoke-k8s.mp4",
  │             "disable_manifest": true,
  │             "Output": null
  │           }
  │         ]
  │       }
  │     },
  │     "Result": {
  │       "File": {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     },
  │     "file_results": [
  │       {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     ]
  │   },
  │   {
  │     "egress_id": "EG_zk5DXkdVDwo5",
  │     "status": 4,
  │     "started_at": 1762466434119048627,
  │     "ended_at": 1762466434593006919,
  │     "updated_at": 1762466434593006919,
  │     "details": "End reason: Failure",
  │     "error": "could not create element: pulsesrc",
  │     "error_code": 500,
  │     "Request": {
  │       "Web": {
  │         "url": "http://nginx-demo.default.svc.cluster.local:8080",
  │         "Output": null,
  │         "Options": {
  │           "Preset": 0
  │         },
  │         "file_outputs": [
  │           {
  │             "file_type": 1,
  │             "filepath": "/out/egress-smoke-k8s.mp4",
  │             "disable_manifest": true,
  │             "Output": null
  │           }
  │         ]
  │       }
  │     },
  │     "Result": {
  │       "File": {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     },
  │     "file_results": [
  │       {
  │         "filename": "/out/egress-smoke-k8s.mp4"
  │       }
  │     ]
  │   }
  │ ]
  │ + return 1
  │ + exit_code=1
  │ + current_retry=3
  │ + echo 'Attempt 3 failed with exit code 1. Retrying in 10 seconds...'
  │ + sleep 10
  │ Attempt 3 failed with exit code 1. Retrying in 10 seconds...
  │ + (( current_retry < max_retries ))
  │ + echo 'Failed after 3 attempts.'
  │ + return 1
  │ Failed after 3 attempts.
  │ 2025/11/06 22:01:40 ERROR wrapped process exited with exit code 1
  ```
  </details>

There used to be a gst-plugins-good package in enterprise-packages that had pulsesrc element enabled
- https://github.com/chainguard-dev/enterprise-packages/pull/33086

Looks like gst-plugins-good moved to os as a subpackage for `gstreamer`
- https://github.com/wolfi-dev/os/blob/12335da8388893352a3d44c7140f1320f8567901/gstreamer.yaml#L105

And the pulseaudio plugin is disabled
- https://github.com/wolfi-dev/os/blob/12335da8388893352a3d44c7140f1320f8567901/gstreamer.yaml#L131

Fixes:
- enable pulseaudio elements for `gst-plugins-good` subpackage in `gstreamer`

Related:
- https://github.com/chainguard-dev/internal-dev/issues/24369 
