### PR TITLE
kubernetes-1.34: fix GHSA-cgrx-mc8f-2prm by updating selinux to v1.13.0

### DIFF
--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.1"
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,11 @@ pipeline:
   - runs: |
       go work edit -go=1.25.0
       go work use
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - runs: |
       export GOWORK=off


### PR DESCRIPTION
## Summary
Fixes GHSA-cgrx-mc8f-2prm by adding github.com/opencontainers/selinux@v1.13.0 dependency.

## Changes
- Incremented epoch from 2 to 3
- Added go/bump with github.com/opencontainers/selinux@v1.13.0

## Verification
- Build: make package/kubernetes-1.34 ✅
- Scan: TBD

## Related Issue
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35392