### PR TITLE
kubernetes-csi-driver-nfs: fix GHSA-cgrx-mc8f-2prm by updating selinux to v1.13.0

### DIFF
--- a/kubernetes-csi-driver-nfs.yaml
+++ b/kubernetes-csi-driver-nfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-driver-nfs
   version: "4.12.1"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2
   description: This driver allows Kubernetes to access NFS server on Linux node
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,11 @@ pipeline:
       repository: https://github.com/kubernetes-csi/csi-driver-nfs
       tag: v${{package.version}}
       expected-commit: c220ebec63f171bb2e56b3112f9756e1164e47b2
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
Fixes GHSA-cgrx-mc8f-2prm by adding github.com/opencontainers/selinux@v1.13.0 dependency.

## Changes
- Incremented epoch from 1 to 2
- Added go/bump with github.com/opencontainers/selinux@v1.13.0

## Verification
- Build: make package/kubernetes-csi-driver-nfs ✅
- Scan: TBD

## Related Issue
- https://github.com/chainguard-dev/CVE-Dashboard/issues/35301