### PR TITLE
fix(buildkitd): GHSA-m6hq-p25p-ffr2, GHSA-pwhc-rpq9-4c8w

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: "0.25.2"
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -31,6 +31,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
+        github.com/containerd/containerd/v2@v2.1.5
         github.com/opencontainers/selinux@v1.13.0
 
   - uses: go/build


### PR DESCRIPTION
Bump containerd version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35786, https://github.com/chainguard-dev/CVE-Dashboard/issues/35640

<!--ci-cve-scan:fail-any-->
