### PR TITLE
Go bumps to patch GHSA-m6hq-p25p-ffr2 and GHSA-pwhc-rpq9-4c8w CVEs in teleport-18

### DIFF
--- a/teleport-18.yaml
+++ b/teleport-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: teleport-18
   version: "18.3.1"
-  epoch: 0 # GHSA-47m2-4cr7-mhcw
+  epoch: 1
   description: The easiest, and most secure way to access and protect all of your infrastructure.
   copyright:
     - license: AGPL-3.0-only
@@ -58,6 +58,7 @@ pipeline:
     with:
       deps: |-
         github.com/quic-go/quic-go@v0.54.1
+        github.com/containerd/containerd@v1.7.29
 
   # Fixes build failure introduced with 17.0.5 version:
   # "([wasm-validator error in function fastpathprocessor_process\20externref\20shim]


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
https://github.com/chainguard-dev/CVE-Dashboard/issues/35794
https://github.com/chainguard-dev/CVE-Dashboard/issues/35820

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```
