### PR TITLE
Trivy: Updated containerd and selinux go packages to patch CVES

### DIFF
--- a/trivy-operator.yaml
+++ b/trivy-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy-operator
   version: "0.29.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2
   description: "Kubernetes-native security toolkit that finds and reports vulnerabilities and misconfigurations"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,13 @@ pipeline:
       repository: https://github.com/aquasecurity/trivy-operator
       tag: v${{package.version}}
       expected-commit: c8b31d9428fe730da7f306e43abc45c3de904c94
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd@v1.7.29
+        github.com/containerd/containerd/v2@v2.1.5
 
   - uses: go/build
     with:

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy
   version: "0.67.2"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,13 @@ pipeline:
       expected-commit: 60c57ad5ad7f270cecb51dff2dbf4d680114f6f8
       repository: https://github.com/aquasecurity/trivy
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/opencontainers/selinux@v1.13.0
+        github.com/containerd/containerd@v1.7.29
+        github.com/containerd/containerd/v2@v2.1.5
 
   - uses: go/build
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Relates:
https://github.com/chainguard-dev/CVE-Dashboard/issues/35411
https://github.com/chainguard-dev/CVE-Dashboard/issues/35609
https://github.com/chainguard-dev/CVE-Dashboard/issues/35656
https://github.com/chainguard-dev/CVE-Dashboard/issues/35740
https://github.com/chainguard-dev/CVE-Dashboard/issues/35790

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```
