### PR TITLE
chore(gcc): Create versioned symlinks

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: "15.2.0"
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -145,6 +145,23 @@ pipeline:
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info
 
+  - name: Create versioned symlinks
+    working-directory: ${{targets.destdir}}/usr/bin
+    runs: |
+      for bin in *; do
+        # Skip if binary is already versioned
+        case $bin in
+          *-${{vars.major-version}})
+            continue
+            ;;
+        esac
+
+        # Skip if destination exists
+        [ -e $bin-${{vars.major-version}} ] && continue
+
+        ln -s $bin $bin-${{vars.major-version}}
+      done
+
   - uses: strip
 
 subpackages:
@@ -229,7 +246,7 @@ subpackages:
             mkdir -p "${{targets.subpkgdir}}"/$i
           done
 
-          mv "${{targets.destdir}}"/usr/bin/*fortran "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/*fortran* "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/lib/libgfortran* "${{targets.subpkgdir}}"/usr/lib
           for f in "${{targets.destdir}}"/usr/lib/libquadmath*; do
             [ -f "$f" ] && mv "$f" "${{targets.subpkgdir}}"/usr/lib
@@ -242,6 +259,8 @@ subpackages:
         - runs: |
             gfortran --version
             gfortran --help
+            gfortran-${{vars.major-version}} --version
+            gfortran-${{vars.major-version}} --help
 
   - name: "libgccjit"
     description: "GCC JIT library"
@@ -338,6 +357,8 @@ test:
         rm -f empty.cpp
         : > empty.cpp
         g++ -c empty.cpp
+    - name: Version & help checks
+      runs: |
         c++ --version
         c++ --help
         cpp --version
@@ -358,6 +379,28 @@ test:
         gcov-tool --help
         lto-dump --version
         lto-dump --help
+
+        # Version & help checks with symlinks
+        c++-${{vars.major-version}} --version
+        c++-${{vars.major-version}} --help
+        cpp-${{vars.major-version}} --version
+        cpp-${{vars.major-version}} --help
+        g++-${{vars.major-version}} --help
+        gcc-${{vars.major-version}} --help
+        gcc-ar-${{vars.major-version}} --version
+        gcc-ar-${{vars.major-version}} --help
+        gcc-nm-${{vars.major-version}} --version
+        gcc-nm-${{vars.major-version}} --help
+        gcc-ranlib-${{vars.major-version}} --version
+        gcc-ranlib-${{vars.major-version}} --help
+        gcov-${{vars.major-version}} --version
+        gcov-${{vars.major-version}} --help
+        gcov-dump-${{vars.major-version}} --version
+        gcov-dump-${{vars.major-version}} --help
+        gcov-tool-${{vars.major-version}} --version
+        gcov-tool-${{vars.major-version}} --help
+        lto-dump-${{vars.major-version}} --version
+        lto-dump-${{vars.major-version}} --help
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"
@@ -390,6 +433,12 @@ test:
     - uses: test/compiler/asan
       with:
         cc: gcc
+    - uses: test/compiler/hardening-check
+      with:
+        cc: gcc-${{vars.major-version}}
+    - uses: test/compiler/asan
+      with:
+        cc: gcc-${{vars.major-version}}
     - uses: test/tw/ldd-check
 
 update:


### PR DESCRIPTION
Right now, if we want to use gcc, we have to determine whether or not the version of gcc is latest, then choose whether to invoke gcc or gcc-\<gcc version\> based off of that assumption

Update gcc packaging so that we don't have to do that anymore by creating versioned symlinks