### PR TITLE
pre-commit: bump to get epoch check fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # See https://eng.inky.wtf/docs/technical/git/pre-commit for info on how to edit this file.
 repos:
   - repo: https://github.com/chainguard-dev/pre-commit-hooks
-    rev: a90aaa7f63ec8c376e8bd6cd3460c77bedcfb0ed
+    rev: e4d1134a14c8decd027fb46f6a46b42f79d3fb23
     hooks:
       - id: shellcheck-run-steps
         files: '^[^.][^/]*\.yaml$' # matches non-hidden .yaml files at the top level only


### PR DESCRIPTION
Get latest chaingguard pre-commit hook to pick up the fix to ignore trailing comments after epoch numbers when checking for epoch bumps.

Ref: https://github.com/chainguard-dev/pre-commit-hooks/pull/25
