### PR TITLE
guacamole-server: bump epoch to 2

### DIFF
--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: "1.6.0"
-  epoch: 1
+  epoch: 2
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
## Summary
Bumps epoch for guacamole-server to trigger rebuild.

## Changes
- Incremented epoch from 1 to 2

## Verification
- Build will be tested separately