### PR TITLE
bump the epoch for cert-manager-cmctl

### DIFF
--- a/cert-manager-cmctl.yaml
+++ b/cert-manager-cmctl.yaml
@@ -3,7 +3,7 @@ package:
   # This got pulled from the cert-manager repo in the 1.15 release, prior to
   # that it was in the cert-manager/cert-manager repo.
   version: "2.3.0"
-  epoch: 6 # GHSA-pwhc-rpq9-4c8w
+  epoch: 7 # GHSA-pwhc-rpq9-4c8w
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Fixes: GHSA-m6hq-p25p-ffr2 and GHSA-pwhc-rpq9-4c8w