### PR TITLE
tileserver-gl: target abi-115 binary for maplibre-native

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 2
+  epoch: 3
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -123,7 +123,7 @@ pipeline:
       mkdir -p build
       cd build
       cmake .. -DMLN_WITH_NODE=ON
-      make -j$(nproc)
+      make -j$(nproc) mbgl-node.abi-115
 
       # Print all .node file that were built, for reference
       echo "All for built .node files:"


### PR DESCRIPTION
Fixes failure to build from source and transitions package to ICU 78.