### PR TITLE
add nocaps haproxy

### DIFF
--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.8"
-  epoch: 2
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later

--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.2
   version: "3.2.8"
-  epoch: 0
+  epoch: 2
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -74,6 +74,26 @@ pipeline:
   - runs: setcap cap_net_bind_service=+eip "${{targets.destdir}}/usr/bin/haproxy"
 
 subpackages:
+  - name: "${{package.name}}-nocaps"
+    description: "haproxy without cap_net_bind_service capabilities"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/var/lib/haproxy
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          cp /usr/sbin/haproxy "${{targets.contextdir}}"/usr/bin
+    test:
+      environment:
+        contents:
+          packages:
+            - libcap-utils
+      pipeline:
+        - uses: test/tw/help-check
+          with:
+            bins: /usr/bin/haproxy
+        - name: Test there are no capabilities present
+          runs: |
+            if [ $(getcap /usr/bin/haproxy | wc -l ) -ne 0 ]; then exit 1; fi
+
   - name: "${{package.name}}-doc"
     description: "haproxy documentation"
     pipeline:

--- a/haproxy-3.2.yaml
+++ b/haproxy-3.2.yaml
@@ -78,9 +78,8 @@ subpackages:
     description: "haproxy without cap_net_bind_service capabilities"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/var/lib/haproxy
-          mkdir -p "${{targets.contextdir}}"/usr/bin
-          cp /usr/sbin/haproxy "${{targets.contextdir}}"/usr/bin
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          cp /home/build/melange-out/${{package.name}}/usr/bin/haproxy ${{targets.contextdir}}/usr/bin/
     test:
       environment:
         contents:


### PR DESCRIPTION
Creates an `haproxy-3.2-nocaps` package without net_bind capability on the binary. Doing it this way means not breaking anyone who relies on or has workarounds for the existing binary ***with*** the capability set on it.