### PR TITLE
az: no change rebuild for compatibility with changes in py3-cryptography dependencies.

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.79.0"
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT


### PR DESCRIPTION
py3-cryptography recently added typing-extensions as a dependency - rebuild to ensure that its not re-installed as part of the pip install.

We need to revisit this package - pip installing into /usr is going to be brittle.