### PR TITLE
chore: update py3-cryptography package config

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.79.0"
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: "46.0.3"
-  epoch: 1
+  epoch: 3
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -13,10 +13,13 @@ vars:
   pypi-package: cryptography
 
 data:
-  - name: py-versions
+  - name: py-versions-with-typing-extensions
     items:
       3.10: '310'
       3.11: '311'
+
+  - name: py-versions-without-typing-extensions
+    items:
       3.12: '312'
       3.13: '313'
 
@@ -45,7 +48,7 @@ pipeline:
       expected-commit: c0af4dd7b75921bbe9f1d41a03dbd4b64a9e3403
 
 subpackages:
-  - range: py-versions
+  - range: py-versions-with-typing-extensions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
@@ -55,6 +58,35 @@ subpackages:
       runtime:
         - py${{range.key}}-cffi
         - py${{range.key}}-typing-extensions
+        - openssl-provider-legacy
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - openssl-provider-legacy
+      pipeline:
+        - uses: test/tw/pip-check
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.pypi-package}}
+              import cryptography.hazmat.primitives.ciphers
+
+  - range: py-versions-without-typing-extensions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-cffi
         - openssl-provider-legacy
     pipeline:
       - uses: py/pip-build-install


### PR DESCRIPTION
with https://github.com/wolfi-dev/os/pull/71326/commits/b3cdd290d16ae2e39076f344ab7e1598dc34da61
we added runtime deps of typing-extensions to 3.12 and 3.13 as well.

this commit selectively includes typing-extensions as runtime dep only
for 3.10 and 3.11

also rebuild az again with new build of py3-cryptography 
