### PR TITLE
openjdk: add ldd-checks

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
-  version: "11.0.29" # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 0
+  version: "11.0.29"
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -159,6 +159,9 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: "openjdk-11-jmods"
     description: "OpenJDK 11 jmods"
@@ -266,6 +269,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
-  version: "17.0.17" # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 0
+  version: "17.0.17"
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -182,8 +182,6 @@ subpackages:
               exit 1
             fi
         - uses: test/tw/ldd-check
-          with:
-            extra-library-paths: "/usr/lib/jvm/java-17-openjdk/lib/server/"
 
   - name: "openjdk-17-jmods"
     description: "OpenJDK 17 jmods"
@@ -291,6 +289,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: "21.0.9"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -176,6 +176,9 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: "openjdk-21-jmods"
     description: "OpenJDK 21 jmods"
@@ -283,6 +286,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 7
+  epoch: 8
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -164,6 +164,9 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.
@@ -245,6 +248,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-24-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |


### PR DESCRIPTION
Now that ldd-checks learned to detect and add java specific hotspot
library path, add ldd-checks to all openjdks - both the jre & jdk
packages.

JDK 25 failed to build from source, and will be handled separately
