### PR TITLE
openssh: compile with openssl-hardened-dev

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: "10.2_p1"
-  epoch: 1
+  epoch: 2
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -26,7 +26,7 @@ environment:
       - libedit-dev
       - libselinux-dev
       - linux-pam-dev
-      - openssl-dev
+      - openssl-hardened-dev
       - wolfi-baselayout
       - zlib-dev
 
@@ -45,7 +45,9 @@ pipeline:
   # Patch out checking for OpenSSL version compatibility. This is dangerous and unneeded.
   - uses: patch
     with:
-      patches: no-version-check.patch
+      patches: |
+        no-version-check.patch
+        0001-sshd-auth.c-guard-call-to-OpenSSL_add_all_algorithms.patch
 
   - name: Configure
     runs: |
@@ -67,7 +69,6 @@ pipeline:
          --with-xauth=/usr/bin/xauth \
          --with-default-path='/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' \
          --with-privsep-user=sshd \
-         --with-ssl-engine \
          --with-pam \
          --with-pam-service=sshd \
          --with-libedit \

--- a/openssh/0001-sshd-auth.c-guard-call-to-OpenSSL_add_all_algorithms.patch
+++ b/openssh/0001-sshd-auth.c-guard-call-to-OpenSSL_add_all_algorithms.patch
@@ -1,0 +1,30 @@
+From c23e9d1e05f045b0bfaa435068de68a6340982e2 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Sun, 9 Nov 2025 21:02:43 +0000
+Subject: [PATCH] sshd-auth.c: guard call to OpenSSL_add_all_algorithms
+
+In OpenSSL OpenSSL_add_all_algorithms is deprecated, and can be
+missing when OpenSSL is compiled without deprecated functionality.
+
+There is existing check for presence of this function or macro, thus
+guard the call to it base on the configure time check.
+---
+ sshd-auth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sshd-auth.c b/sshd-auth.c
+index 9c31515de..acfecbdc8 100644
+--- a/sshd-auth.c
++++ b/sshd-auth.c
+@@ -588,7 +588,7 @@ main(int ac, char **av)
+ 	if (!rexeced_flag)
+ 		fatal("sshd-auth should not be executed directly");
+ 
+-#ifdef WITH_OPENSSL
++#if defined(WITH_OPENSSL) && defined(HAVE_OPENSSL_ADD_ALL_ALGORITHMS)
+ 	OpenSSL_add_all_algorithms();
+ #endif
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
Compile openssh with openssl-hardened-dev. This removes usage of
deprecated APIs that will be removed in April 2026 - such as engines,
and empty macros that do nothing.
