### PR TITLE
drop packages wolfi.patch

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: "0.30.20"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
@@ -35,10 +35,8 @@ test:
     - runs: |
         cat <<EOF >> /tmp/wolfi-base.yaml
         contents:
-          keyring:
-            - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
           repositories:
-            - https://packages.wolfi.dev/os
+            - https://apk.cgr.dev/chainguard
           packages:
             - wolfi-base
 

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
-  version: "11.0.29" # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 0
+  version: "11.0.29"
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -159,6 +159,9 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: "openjdk-11-jmods"
     description: "OpenJDK 11 jmods"
@@ -266,6 +269,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
-  version: "17.0.17" # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 0
+  version: "17.0.17"
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -182,8 +182,6 @@ subpackages:
               exit 1
             fi
         - uses: test/tw/ldd-check
-          with:
-            extra-library-paths: "/usr/lib/jvm/java-17-openjdk/lib/server/"
 
   - name: "openjdk-17-jmods"
     description: "OpenJDK 17 jmods"
@@ -291,6 +289,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: "21.0.9"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -176,6 +176,9 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
       - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: "openjdk-21-jmods"
     description: "OpenJDK 21 jmods"
@@ -283,6 +286,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 7
+  epoch: 8
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -164,6 +164,9 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.
@@ -245,6 +248,7 @@ test:
     environment:
       JAVA_HOME: /usr/lib/jvm/java-24-openjdk
   pipeline:
+    - uses: test/tw/ldd-check
     # Test a basic Hello World
     - working-directory: basic
       runs: |

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.3-pg.yaml
+++ b/ruby3.3-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.4-pg.yaml
+++ b/ruby3.4-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev


### PR DESCRIPTION
- **openjdk: add ldd-checks**
  Now that ldd-checks learned to detect and add java specific hotspot
  library path, add ldd-checks to all openjdks - both the jre & jdk
  packages.
  

- **chore: drop using packages.wolfi.dev**
  Prefer implicit repositories, or using apk.cgr.dev over explicit
  packages.wolfi.dev.
  