### PR TITLE
chore: drop using packages.wolfi.dev

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: "0.30.26"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
@@ -35,10 +35,8 @@ test:
     - runs: |
         cat <<EOF >> /tmp/wolfi-base.yaml
         contents:
-          keyring:
-            - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
           repositories:
-            - https://packages.wolfi.dev/os
+            - https://apk.cgr.dev/chainguard
           packages:
             - wolfi-base
 

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.3-pg.yaml
+++ b/ruby3.3-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.4-pg.yaml
+++ b/ruby3.4-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-pg
   version: "1.6.2"
-  epoch: 0
+  epoch: 1
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -50,10 +50,6 @@ update:
 test:
   environment:
     contents:
-      repositories:
-        - https://packages.wolfi.dev/os
-      keyring:
-        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
       packages:
         - shadow
         - ruby-${{vars.rubyMM}}-dev


### PR DESCRIPTION
Prefer implicit repositories, or using apk.cgr.dev over explicit
packages.wolfi.dev.
