### PR TITLE
jemalloc: explicitly depend on libjemalloc

### DIFF
--- a/jemalloc.yaml
+++ b/jemalloc.yaml
@@ -1,10 +1,13 @@
 package:
   name: jemalloc
   version: 5.3.0
-  epoch: 5
+  epoch: 6
   description: general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - libjemalloc${{vars.soversion}}
 
 vars:
   soversion: "2"


### PR DESCRIPTION
The recent automation-driven split into library packages was fine, but it relies on the melange SCA to generate proper so dependencies for the origin package. In case of jemalloc, there are no binaries in the main package, only shell/perl scripts, so no implicit dep has been generated. Let's add one explicit as it is required to run any of those. Also, this is needed for backwards compatibility (or people depending on jemalloc only).