### PR TITLE
fix(falco-no-driver): GHSA-m6hq-p25p-ffr2, GHSA-pwhc-rpq9-4c8w

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
-  version: "0.42.0"
-  epoch: 2
+  version: "0.42.1"
+  epoch: 0
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -59,7 +59,7 @@ pipeline:
     with:
       repository: https://github.com/falcosecurity/falco
       tag: ${{package.version}}
-      expected-commit: d8e430e352396abde7b4309c76039f08042e2512
+      expected-commit: 4ea91437df18290f33ac4dca6414b4bdbcba5892
       recurse-submodules: true
 
   - name: Prepare output dirs


### PR DESCRIPTION
Version bump to most recent

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/35789, https://github.com/chainguard-dev/CVE-Dashboard/issues/35675

<!--ci-cve-scan:fail-any-->
