### PR TITLE
fix(flannel-cni-plugin): add busybox runtime dep and add /flannel symlink

### DIFF
--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,10 +1,14 @@
 package:
   name: flannel-cni-plugin
   version: 1.8.0.2
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      # busybox is required for the cni daemonset to run
+      - busybox
 
 var-transforms:
   - from: ${{package.version}}
@@ -31,6 +35,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/opt/cni/bin
           ln -sf ../../../usr/bin/flannel "${{targets.contextdir}}"/opt/cni/bin/flannel
+          ln -sf usr/bin/flannel "${{targets.contextdir}}"/flannel
     test:
       environment:
         contents:


### PR DESCRIPTION
add busybox as a runtime dependency and add /flannel symlink as both are expected by the upstream helm chart
https://github.com/flannel-io/flannel/blob/97b6771a642511a676f51df17184f6852b425df9/chart/kube-flannel/templates/daemonset.yaml#L40