### PR TITLE
fix(libjxl): add docs package to split off man pages

### DIFF
--- a/libjxl.yaml
+++ b/libjxl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libjxl
   version: "0.10.4_git20251110"
-  epoch: 0
+  epoch: 1
   description: JPEG XL image format reference implementation
   copyright:
     - license: BSD-3-Clause
@@ -85,6 +85,11 @@ subpackages:
             for b in cjxl djxl benchmark_xl cjpegli djpegli jxlinfo jxltran; do
               $b --help
             done
+
+  - name: libjxl-doc
+    description: Documentation for libjxl
+    pipeline:
+      - uses: split/alldocs
 
 update:
   enabled: true

--- a/libjxl.yaml
+++ b/libjxl.yaml
@@ -90,6 +90,9 @@ subpackages:
     description: Documentation for libjxl
     pipeline:
       - uses: split/alldocs
+    test:
+      pipeline:
+        - uses: test/docs
 
 update:
   enabled: true

--- a/libjxl.yaml
+++ b/libjxl.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: libjxl
-  version: "0.10.4_git20251110"
+  version: "0.10.4_git20251111"
   epoch: 1
   description: JPEG XL image format reference implementation
   copyright:


### PR DESCRIPTION
Currently libjxl is failing to install due to some conflicting man pages with brotli. This splits off the man pages into a -docs package.