### PR TITLE
fix(regclient): add functional tests for all binaries

### DIFF
--- a/regclient.yaml
+++ b/regclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: regclient
   version: "0.10.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Docker and OCI Registry Client in Go and tooling using those libraries
   copyright:
     - license: Apache-2.0
@@ -60,3 +60,56 @@ subpackages:
     test:
       pipeline:
         - runs: test "$(readlink /${{range.key}})" = "/usr/bin/${{range.key}}"
+
+test:
+  environment:
+    contents:
+      packages:
+        - jq
+        - regctl
+        - regbot
+        - regsync
+  pipeline:
+    - name: Regctl tests
+      runs: |
+        # pull manifest
+        regctl manifest get cgr.dev/chainguard/static --format raw-body | jq '.schemaVersion' | grep -q '2'
+
+        # fetch image tags
+        regctl tag ls cgr.dev/chainguard/static |  grep -q 'latest'
+
+        # fetch image digest
+        regctl image digest cgr.dev/chainguard/static | grep -q 'sha256:'
+    - name: Regbot tests
+      runs: |
+        cat > regbot.script <<'EOF'
+        version: 1
+        defaults:
+          parallel: 1
+        scripts:
+        - name: static image tags
+          timeout: 30s
+          script: |
+            tags = tag.ls("cgr.dev/chainguard/static")
+            table.sort(tags)
+            for k, t in ipairs(tags) do
+              log("Found tag " .. t)
+            end
+        EOF
+        regbot once -c regbot.script --dry-run 2>&1 | grep -q "Found tag latest"
+    - name: Regsync tests
+      runs: |
+        cat > regsync.conf <<'EOF'
+        version: 1
+        creds:
+          - registry: cgr.dev
+            user: anonymous
+        defaults:
+          parallel: 1
+          interval: 60m
+        sync:
+          - source: cgr.dev/chainguard/static:latest
+            target: localreg.dev/chainguard/static:temp
+            type: image
+        EOF
+        regsync check -c regsync.conf 2>&1 | grep -q "Image sync needed"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Auto-merge on update fails for this package because of missing tests (ref: https://github.com/wolfi-dev/os/pull/71533).
This PR adds some functional tests to avoid manual intervention  