### PR TITLE
apache-nifi-registry: use full JDK instead of JRE

### DIFF
--- a/apache-nifi-registry.yaml
+++ b/apache-nifi-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi-registry
   version: "2.6.0"
-  epoch: 4 # GHSA-25qh-j22f-pwp8
+  epoch: 5 # GHSA-25qh-j22f-pwp8
   description: Apache NiFi Registry is a registry for storing and managing shared resources such as versioned flows across one or more instances of NiFi.
   copyright:
     - license: Apache-2.0
@@ -9,10 +9,10 @@ package:
     runtime:
       - bash # Required by scripts with #!/bin/bash shebang
       - coreutils # Provides readlink, dirname, basename, pwd, uname, expr used by nifi-registry.sh and cli.sh
-      - dash-binsh # Provides /bin/sh -> dash (matches upstream Debian). All 8 startup scripts use #!/bin/sh
+      - dash-binsh # Provides /bin/sh -> dash. All 8 startup scripts use #!/bin/sh
       - glibc-locale-en # Locale support for Java application
       - net-tools # Provides hostname command used in common.sh:28 for container identification
-      - openjdk-${{vars.java-version}}-default-jvm # Creates /usr/bin/java symlink. Auto-includes openjdk-21-jre with libfontconfig1
+      - openjdk-${{vars.java-version}}-default-jdk # Full JDK required, Flyway may need JDK tools
       - sed # Used by 8 scripts for in-place config editing (common.sh:23, secure.sh:56-57, update_*.sh)
       - xmlstarlet # RUNTIME: used by update_bundle_provider.sh, update_flow_provider.sh, update_login_providers.sh for XML manipulation
 
@@ -100,7 +100,7 @@ subpackages:
       runtime:
         - coreutils # Provides readlink, dirname, basename, pwd, uname, expr used by cli.sh
         - dash-binsh # Provides /bin/sh for script execution
-        - openjdk-${{vars.java-version}}-default-jvm # Provides java command
+        - openjdk-${{vars.java-version}}-default-jdk # Full JDK required (matches main package)
     pipeline:
       - runs: |
           cd /home/build/nifi-registry/nifi-registry-toolkit
@@ -143,7 +143,7 @@ test:
       packages:
         - ${{package.name}}
         - ${{package.name}}-toolkit
-        - java-common-jre
+        - java-common
         - curl
         - grep
         - wait-for-it


### PR DESCRIPTION
This change switches from JRE to full JDK to match Apache's official Docker images.
Apache NiFi Registry uses Flyway 11.13.0 for database migrations, and older NiFi Registry documentation explicitly stated that a full JDK is required to avoid runtime errors during Flyway migrations. While modern Flyway versions may be more flexible, using the JDK ensures compatibility with Flyway's requirements and provides JDK tools (javac, jar, jshell) if needed by extensions or plugins.