### PR TITLE
py3-pip/python-3.13: untangle dependencies

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "25.3"
-  epoch: 1 # CVE-2025-8869
+  epoch: 2 # CVE-2025-8869
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.9"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0


### PR DESCRIPTION
python-3.13-base has a build dependency on py3-pip-wheel, and py3-pip
has a dependency on python-3.13-base.

We are trying to bump them together to see if we could have them depend
on their latest revision together, otherwise if we bump py3-pip-wheel we
will get the python-3.13-base old version pulled in which still has the reverse
dependency on py3-pip-wheel which will pull the older version of
python-3.13-base as well.
Related to escalation https://github.com/chainguard-dev/internal-dev/issues/24410

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
