### PR TITLE
py3-{pip,setuptools}: Restore provides + priorities

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,10 +1,12 @@
 package:
   name: py3-pip
   version: "25.3"
-  epoch: 1 # CVE-2025-8869
+  epoch: 2 # CVE-2025-8869
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
+  dependencies:
+    provider-priority: 0
 
 vars:
   pypi-package: pip
@@ -12,11 +14,11 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10:
-      3.11:
-      3.12:
-      3.13:
-      3.14:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+      3.14: '14' # Keep default as 3.13
 
 environment:
   contents:
@@ -54,6 +56,9 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-${{vars.pypi-package}}-base
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/bin

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,10 +1,12 @@
 package:
   name: py3-setuptools
   version: "80.9.0"
-  epoch: 3
+  epoch: 4
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
+  dependencies:
+    provider-priority: 0
 
 vars:
   import: setuptools
@@ -13,11 +15,11 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10:
-      3.11:
-      3.12:
-      3.13:
-      3.14:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+      3.14: '14'
 
 environment:
   contents:
@@ -41,6 +43,10 @@ subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
     pipeline:
       - uses: py/pip-build-install-bootstrap
         with:

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -19,7 +19,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
-      3.14: '14'
+      3.14: '14' # Keep default as 3.13
 
 environment:
   contents:


### PR DESCRIPTION
Restore the provider priorites (but not the py3-<name> provides) to
ensure that apko makes the right choices when picking py3.XX-<name>
pacakges.
