### PR TITLE
Use a more reliable mirror for GNU toolchain packages

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -100,8 +100,12 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 7981
+  version-transform:
+    - match: _
+      replace: .
+  git:
+    tag-filter-prefix: binutils-
+    strip-prefix: binutils-
 
 test:
   pipeline:

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: binutils
   version: "2.45.1"
-  epoch: 0
+  epoch: 1
   cpe:
     vendor: "gnu"
     product: "binutils"
@@ -36,7 +36,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://sourceware.org/git/binutils-gdb.git
+      repository: https://gitlab.com/gnutools/binutils-gdb.git
       tag: binutils-${{vars.mangled-package-version}}
       expected-commit: 48324fde1e284293dd3d570dba597cb644921c92
 

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -444,5 +444,6 @@ test:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 6502
+  git:
+    tag-filter-prefix: releases/gcc-
+    strip-prefix: releases/gcc-

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: "15.2.0"
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -50,10 +50,11 @@ var-transforms:
     to: major-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: 89047a2e07bd9da265b507b516ed3635adb17491c7f4f67cf090f0bd5b3fc7f2ee6e4cc4008beef7ca884b6b71dffe2bb652b21f01a702e17b468cca2d10b2de
+      expected-commit: 5115c7e447fc07457443df874bf57840e8316d5f
+      repository: https://gitlab.com/gnutools/gcc.git
+      tag: releases/gcc-${{package.version}}
 
   - name: 'Set up build directory'
     runs: |

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - expat-dev
+      - flex
       - gmp-dev
       - libtool
       - linux-headers

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -41,6 +41,11 @@ pipeline:
         --disable-nls \
         --disable-werror \
         --disable-sim \
+        --disable-binutils \
+        --disable-ld \
+        --disable-gold \
+        --disable-gas \
+        --disable-gprofng \
         --mandir=/usr/share/man \
         --infodir=/usr/share/info \
         --with-system-readline \

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -64,8 +64,16 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 11798
+  ignore-regex-patterns:
+    # There are old GDB versions that were tagged using underscore.
+    # This confuses the update check algorithm.  Nowadays the GDB tags
+    # never contain underscores, so it's safe to ignore them.
+    - \d+_\d+
+  git:
+    tag-filter-prefix: gdb-
+    tag-filter-contains: -release
+    strip-prefix: gdb-
+    strip-suffix: -release
 
 test:
   pipeline:

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.3"
-  epoch: 4
+  epoch: 5
   description: The GNU Debugger
   copyright:
     - license: GPL-2.0
@@ -28,10 +28,11 @@ environment:
       - zstd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5
-      uri: https://ftpmirror.gnu.org/gnu/gdb/gdb-${{package.version}}.tar.xz
+      expected-commit: 140ba011c003fda0fb2f746cf2bc0f010bf4ac03
+      repository: https://gitlab.com/gnutools/binutils-gdb.git
+      tag: gdb-${{package.version}}-release
 
   - uses: autoconf/configure
     with:

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -776,5 +776,9 @@ test:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 5401
+  ignore-regex-patterns:
+    # glibc creates tags ending with ".9000" for their development
+    # brances.  We have to ignore those.
+    - \.9000$
+  git:
+    strip-prefix: glibc-


### PR DESCRIPTION
We've always had problems fetching source code from ftpmirror.gnu.org or sourceware.org.  The gitlab.com/gnutools mirror is maintained by a GNU toolchain maintainer, and should be more reliable than the alternatives.  Let's switch what we can to it.