### PR TITLE
fix(brotli): include versioned `.so` files on main brotli package (via runtime dependencies)

### DIFF
--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,20 +1,20 @@
 package:
   name: brotli
   version: "1.2.0"
-  epoch: 0
+  epoch: 1
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - libbrotlicommon1
+      - libbrotlidec1
+      - libbrotlienc1
 
 environment:
   contents:
     packages:
       - build-base
-      - busybox
-      - ca-certificates-bundle
-      - cmake
-      - libtool
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -32,7 +32,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "brotli-dev"
+  - name: ${{package.name}}-dev
     description: "headers for brotli"
     pipeline:
       - uses: split/dev
@@ -80,16 +80,14 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - bash
-        - coreutils
-        - findutils
   pipeline:
-    - name: "Verify brotli version"
-      runs: |
-        brotli --version
+    - uses: test/tw/ldd-check
+    - uses: test/tw/help-check
+      with:
+        bins: brotli
+    - uses: test/tw/ver-check
+      with:
+        bins: brotli
     - name: "Basic compression test"
       runs: |
         echo "Hello, Brotli compression test" > original.txt


### PR DESCRIPTION
Not having this makes it so packages that depend on `brotli` at runtime can't load brotli libraries properly