### PR TITLE
chrony: remove hardware reference clocks

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.8"
-  epoch: 0
+  epoch: 1
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -78,7 +78,6 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          install -Dm644 ./conf.d/aws.conf ${{targets.contextdir}}/etc/chrony/conf.d/aws.conf
           install -Dm644 ./sources.d/aws.sources ${{targets.contextdir}}/etc/chrony/sources.d/aws.sources
 
   - name: "${{package.name}}-azure"
@@ -90,7 +89,6 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          install -Dm644 ./conf.d/azure.conf ${{targets.contextdir}}/etc/chrony/conf.d/azure.conf
           install -Dm644 ./sources.d/azure.sources ${{targets.contextdir}}/etc/chrony/sources.d/azure.sources
 
   - name: "${{package.name}}-gcp"

--- a/chrony/conf.d/aws.conf
+++ b/chrony/conf.d/aws.conf
@@ -1,3 +1,0 @@
-# PTP connection on AWS
-# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-ec2-ntp.html#connect-to-the-ptp-hardware-clock
-refclock PHC /dev/ptp0 poll 0 delay 0.000010 prefer

--- a/chrony/conf.d/azure.conf
+++ b/chrony/conf.d/azure.conf
@@ -1,2 +1,0 @@
-# https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2


### PR DESCRIPTION
Hardware reference clocks cannot be enabled by default, as chronyd
fails to start if such devices are not present, which are optional.

Can figure out how to dynamically configure them, or make them
optional in chrony later.
