### PR TITLE
Integrate chrony and timesyncd

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.8"
-  epoch: 0
+  epoch: 1
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -78,7 +78,6 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          install -Dm644 ./conf.d/aws.conf ${{targets.contextdir}}/etc/chrony/conf.d/aws.conf
           install -Dm644 ./sources.d/aws.sources ${{targets.contextdir}}/etc/chrony/sources.d/aws.sources
 
   - name: "${{package.name}}-azure"
@@ -90,7 +89,6 @@ subpackages:
         - wolfi-baselayout
     pipeline:
       - runs: |
-          install -Dm644 ./conf.d/azure.conf ${{targets.contextdir}}/etc/chrony/conf.d/azure.conf
           install -Dm644 ./sources.d/azure.sources ${{targets.contextdir}}/etc/chrony/sources.d/azure.sources
 
   - name: "${{package.name}}-gcp"

--- a/chrony.yaml
+++ b/chrony.yaml
@@ -6,6 +6,8 @@ package:
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
+    provides:
+      - time-daemon
     runtime:
       - merged-usrsbin
       - wolfi-baselayout

--- a/chrony/50-chronyd.list
+++ b/chrony/50-chronyd.list
@@ -1,1 +1,2 @@
 chronyd.service
+chrony-wait.service

--- a/chrony/conf.d/aws.conf
+++ b/chrony/conf.d/aws.conf
@@ -1,3 +1,0 @@
-# PTP connection on AWS
-# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-ec2-ntp.html#connect-to-the-ptp-hardware-clock
-refclock PHC /dev/ptp0 poll 0 delay 0.000010 prefer

--- a/chrony/conf.d/azure.conf
+++ b/chrony/conf.d/azure.conf
@@ -1,2 +1,0 @@
-# https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "258.2"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -748,6 +748,31 @@ subpackages:
           mv "${{targets.destdir}}/usr/lib/systemd/systemd-journal-remote" "${{targets.subpkgdir}}/usr/lib/systemd/"
           mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-remote.service" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
           mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-journal-remote.socket" "${{targets.subpkgdir}}/usr/lib/systemd/system/"
+
+  - name: "systemd-timesyncd"
+    description: "Simple NTP client"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/systemd"
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/ntp-units.d"
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/systemd/system"
+          mkdir -p "${{targets.subpkgdir}}/usr/lib/sysusers.d"
+          mkdir -p "${{targets.subpkgdir}}/usr/share/dbus-1/system-services"
+          mkdir -p "${{targets.subpkgdir}}/usr/share/dbus-1/system.d"
+          mkdir -p "${{targets.subpkgdir}}/usr/share/polkit-1/actions"
+          mv "${{targets.destdir}}/etc/systemd/timesyncd.conf" "${{targets.subpkgdir}}/etc/systemd/timesyncd.conf"
+          mv "${{targets.destdir}}/usr/lib/systemd/systemd-time-wait-sync" "${{targets.subpkgdir}}/usr/lib/systemd/systemd-time-wait-sync"
+          mv "${{targets.destdir}}/usr/lib/systemd/systemd-timesyncd" "${{targets.subpkgdir}}/usr/lib/systemd/systemd-timesyncd"
+          mv "${{targets.destdir}}/usr/lib/systemd/ntp-units.d/80-systemd-timesync.list" "${{targets.subpkgdir}}/usr/lib/systemd/ntp-units.d/80-systemd-timesync.list"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-time-wait-sync.service" "${{targets.subpkgdir}}/usr/lib/systemd/system/systemd-time-wait-sync.service"
+          mv "${{targets.destdir}}/usr/lib/systemd/system/systemd-timesyncd.service" "${{targets.subpkgdir}}/usr/lib/systemd/system/systemd-timesyncd.service"
+          mv "${{targets.destdir}}/usr/lib/sysusers.d/systemd-timesync.conf" "${{targets.subpkgdir}}/usr/lib/sysusers.d/systemd-timesync.conf"
+          mv "${{targets.destdir}}/usr/share/dbus-1/system-services/org.freedesktop.timesync1.service" "${{targets.subpkgdir}}/usr/share/dbus-1/system-services/org.freedesktop.timesync1.service"
+          mv "${{targets.destdir}}/usr/share/dbus-1/system.d/org.freedesktop.timesync1.conf" "${{targets.subpkgdir}}/usr/share/dbus-1/system.d/org.freedesktop.timesync1.conf"
+          mv "${{targets.destdir}}/usr/share/polkit-1/actions/org.freedesktop.timesync1.policy" "${{targets.subpkgdir}}/usr/share/polkit-1/actions/org.freedesktop.timesync1.policy"
 
 update:
   enabled: true

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -531,6 +531,7 @@ subpackages:
         - merged-sbin
         - merged-usrsbin
         - mount
+        - time-daemon
         - tzdata
         - wolfi-baselayout
     pipeline:
@@ -752,6 +753,8 @@ subpackages:
   - name: "systemd-timesyncd"
     description: "Simple NTP client"
     dependencies:
+      provides:
+        - time-daemon
       runtime:
         - ${{package.name}}
     pipeline:


### PR DESCRIPTION
- **chrony: remove hardware reference clocks**
  Hardware reference clocks cannot be enabled by default, as chronyd
  fails to start if such devices are not present, which are optional.
  
  Can figure out how to dynamically configure them, or make them
  optional in chrony later.
  

- **systemd: split timesyncd service**
  Split timesyncd service into a subpackage.
  

- **chrony: integrate with time-sync.target**
  

- **Use virtual provides and depends for time-daemon**
  