### PR TITLE
py3-supported-python - Add python 3.14

### DIFF
--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-build
   version: "1.3.0"
-  epoch: 0
+  epoch: 1
   description: A simple, correct Python build frontend
   copyright:
     - license: MIT
@@ -19,6 +19,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "14"
 
 environment:
   contents:
@@ -92,6 +93,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-installer
   version: 0.7.0
-  epoch: 13
+  epoch: 14
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "14"
 
 environment:
   contents:
@@ -73,6 +74,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: "9.2.2"
-  epoch: 0
+  epoch: 1
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
+      3.14: '14'
 
 environment:
   contents:
@@ -87,6 +88,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-supported-python
   version: 1
-  epoch: 7
+  epoch: 8
   description: metapackage to install all supported versions of python
   copyright:
     - license: "MIT"
@@ -11,6 +11,7 @@ package:
       - python-3.11-base
       - python-3.12-base
       - python-3.13-base
+      - python-3.14-base
 
 environment:
   contents:
@@ -24,6 +25,7 @@ data:
       3.11: '311'
       3.12: '312'
       3.13: '313'
+      3.14: '14'
 
 subpackages:
   - name: ${{package.name}}-dev
@@ -34,6 +36,7 @@ subpackages:
         - python-3.11-base-dev
         - python-3.12-base-dev
         - python-3.13-base-dev
+        - python-3.14-base-dev
     test:
       pipeline:
         - uses: test/emptypackage
@@ -65,6 +68,7 @@ subpackages:
         - py3.11-build-base
         - py3.12-build-base
         - py3.13-build-base
+        - py3.14-build-base
     test:
       pipeline:
         - uses: test/emptypackage
@@ -93,6 +97,7 @@ subpackages:
         - py3.11-build-base-dev
         - py3.12-build-base-dev
         - py3.13-build-base-dev
+        - py3.14-build-base-dev
         - py3-supported-python-dev
     test:
       pipeline:

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.1"
-  epoch: 4
+  epoch: 5
   description: "built-package format for Python"
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ data:
       3.11: "311"
       3.12: "312"
       3.13: "313"
+      3.14: "14"
 
 environment:
   contents:
@@ -81,6 +82,7 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+        - py3.14-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage


### PR DESCRIPTION
Sparked by the addition of 3.14 to py3-pip in
https://github.com/wolfi-dev/os/pull/68550

This seems like the right thing to do.
