### PR TITLE
libxml2: use split/lib pipeline.

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: "2.15.1"
-  epoch: 1
+  epoch: 2
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -62,9 +62,7 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-${{vars.soversion}}
     pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib/
+      - uses: split/lib
     test:
       pipeline:
         - uses: test/tw/ldd-check


### PR DESCRIPTION
Make use of the new split/lib pipeline when building the so-version named lib subpackage.