### PR TITLE
chainguard-security-guide: ca-certs 20251003-r0 update

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -46,9 +46,9 @@ test:
     - name: Verify that the bundle hashes match
       runs: |
         sha256sum /etc/ssl/certs/ca-certificates.crt | awk '{ print $1 }' > /tmp/actual_hash && \
-        yq -p=xml -oy '.["data-stream-collection"]["extended-component"][]
+        yq -p=xml -oy '.["ds:data-stream-collection"]["ds:extended-component"][]
         | select(."+@id" == "scap_org_ecomp_.certaudit")
-        | .oval_definitions.states.["filehash58_state"]["hash"]' \
+        | .oval_definitions.states.["ind:filehash58_state"]["ind:hash"]' \
         /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml > /tmp/expected_hash && \
         diff /tmp/actual_hash /tmp/expected_hash
         rm /tmp/actual_hash /tmp/expected_hash

--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-security-guide
-  version: "3.2.6"
+  version: "3.2.7"
   epoch: 0
   description: Security automation content for Chainguard Images
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/stigs
-      expected-commit: d4bf6bd4e467a220fde7c8a61e844f56bd611efa
+      expected-commit: 20f69a28e697635fcd7c7d8d33fe81c1ea78c9ec
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
- Update GPOS STIG for ca-certificates 20251003-r0 update
- fix yq invocation in the test pipelines to look for the full xml tags (this was causing the tests to fail).