### PR TITLE
remove /opt/cni/bin symlink from flannel-cni-plugin

### DIFF
--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel-cni-plugin
   version: 1.8.0.2
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,6 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/opt/cni/bin
-          ln -sf ../../../usr/bin/flannel "${{targets.contextdir}}"/opt/cni/bin/flannel
           ln -sf usr/bin/flannel "${{targets.contextdir}}"/flannel
     test:
       environment:


### PR DESCRIPTION
remove `/opt/cni/bin` symlink from `flannel-cni-plugin` for helm upstream helm chart compatibility.
upstream's helm chart is trying to cp the flannel binary from `/flannel` to `/opt/cni/bin` 
https://github.com/flannel-io/flannel/blob/97b6771a642511a676f51df17184f6852b425df9/chart/kube-flannel/templates/daemonset.yaml#L47

This cp is failing since the binary already exists over there.
