### PR TITLE
Revert "amazon-k8s-cni/1.20.5 package update (#71252)"

### DIFF
--- a/amazon-k8s-cni.yaml
+++ b/amazon-k8s-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-k8s-cni
-  version: "1.20.5"
-  epoch: 0 # CVE-2025-47907
+  version: "1.20.4"
+  epoch: 1 # CVE-2025-47907
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/aws/amazon-vpc-cni-k8s
       tag: v${{package.version}}
-      expected-commit: 336e73ed6333a6b5611bd7522735523b524c9a92
+      expected-commit: db19d13cd19abed1334112da3c8de9613328aa00
 
   - name: Copy conflist
     runs: |


### PR DESCRIPTION
This reverts commit 7edbab18badba8e90e8dd01ff8503be3f0c9893a.

Tag was deleted by upstream.