### PR TITLE
python-3.10/.11/.12/.13/.14 CVE-2025-6075 fix

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: "3.10.19"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -48,6 +48,8 @@ pipeline:
       expected-commit: f08d3c437bc5f41973ddd11f4cfc3d9fe04010f7
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.10/892747b4cf0f95ba8beb51c0d0658bfaa381ebca: CVE-2025-6075
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -49,7 +49,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.10/892747b4cf0f95ba8beb51c0d0658bfaa381ebca: CVE-2025-6075
+        3.10/892747b4cf0f95ba8beb51c0d0658bfaa381ebca: [CVE-2025-6075]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: "3.11.14"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -48,6 +48,8 @@ pipeline:
       expected-commit: cd1c3a6342869b7346c1b5c27b8de9c6ef9c4e69
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.11/5dceb93486176e6b4a6d9754491005113eb23427: CVE-2025-6075
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -49,7 +49,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.11/5dceb93486176e6b4a6d9754491005113eb23427: CVE-2025-6075
+        3.11/5dceb93486176e6b4a6d9754491005113eb23427: [CVE-2025-6075]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -57,7 +57,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.12/c8a5f3435c342964e0a432cc9fb448b7dbecd1ba: CVE-2025-6075
+        3.12/c8a5f3435c342964e0a432cc9fb448b7dbecd1ba: [CVE-2025-6075]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.12"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -56,6 +56,8 @@ pipeline:
       expected-commit: 4a5632fbf9bf59477c540e3f53fa7cdbeea3e3f5
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.12/c8a5f3435c342964e0a432cc9fb448b7dbecd1ba: CVE-2025-6075
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.9"
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -57,6 +57,7 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: fix CVE-2025-8291
+        3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: CVE-2025-6075
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -56,7 +56,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: fix CVE-2025-8291
+        3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: [CVE-2025-8291]
         3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: [CVE-2025-6075]
 
   - name: Force use of system libraries

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -57,7 +57,7 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: fix CVE-2025-8291
-        3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: CVE-2025-6075
+        3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: [CVE-2025-6075]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -93,7 +93,7 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.14/d11e69d6203080e3ec450446bfed0516727b85c3: Fix CVE-2025-8291
-        3.14/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84: CVE-2025-6075
+        3.14/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84: [CVE-2025-6075]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -92,7 +92,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
-        3.14/d11e69d6203080e3ec450446bfed0516727b85c3: Fix CVE-2025-8291
+        3.14/d11e69d6203080e3ec450446bfed0516727b85c3: [CVE-2025-8291]
         3.14/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84: [CVE-2025-6075]
 
   - name: Force use of system libraries

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 7
+  epoch: 8
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -93,6 +93,7 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.14/d11e69d6203080e3ec450446bfed0516727b85c3: Fix CVE-2025-8291
+        3.14/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84: CVE-2025-6075
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
## Summary
Adds cherry picks to wolfi python packages to remediate CVE-2025-6075 from the following sources:

python-3.10: https://github.com/python/cpython/commit/892747b4cf0f95ba8beb51c0d0658bfaa381ebca
python-3.11: https://github.com/python/cpython/commit/5dceb93486176e6b4a6d9754491005113eb23427
python-3.12: https://github.com/python/cpython/commit/c8a5f3435c342964e0a432cc9fb448b7dbecd1ba
python-3.13: https://github.com/python/cpython/commit/9ab89c026aa9611c4b0b67c288b8303a480fe742
python-3.14: https://github.com/python/cpython/commit/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84