### PR TITLE
Fix installation path for NETStandard.Library.Ref

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.122"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -187,8 +187,8 @@ subpackages:
           fi
 
           # Install .NET Standard targeting pack
-          mkdir -p ${{targets.contextdir}}/usr/share/dotnet
-          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* \
+          mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs/
+          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.Ref \
              ${{targets.contextdir}}/usr/share/dotnet/packs/
 
   - name: dotnet-${{vars.major-version}}-targeting-pack

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.112"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -178,8 +178,8 @@ subpackages:
           fi
 
           # Install .NET Standard targeting pack
-          mkdir -p ${{targets.contextdir}}/usr/share/dotnet
-          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.* \
+          mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs/
+          mv ${{targets.destdir}}/usr/share/dotnet/packs/NETStandard.Library.Ref \
              ${{targets.contextdir}}/usr/share/dotnet/packs/
 
   - name: dotnet-${{vars.major-version}}-targeting-pack


### PR DESCRIPTION
Currently `dotnet-{8,9}` are installing the `NETStandard.Library.Ref` pack under `/usr/share/dotnet/packs/2.1.0/`, i.e., the `NETStandard.Library.Ref/` component of the path is being inadvertently stripped because of globbing rules.  We should fix this by explicitly referring to the NETStandard directory that will be moved to the subpackage.  Let's also take this opportunity to fully create the `/usr/share/dotnet/packs/` directories.