### PR TITLE
fix(clamav): enable TCP port + add clamd-milter defaults

### DIFF
--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -171,8 +171,8 @@ subpackages:
 
           mv "${{targets.destdir}}"/etc/clamav/clamd.conf.sample "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
 
-          # Enable TCPSocket 3310 (required for remote TCP access)
-          sed -i 's/^#TCPSocket.*/TCPSocket 3310/' "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
+          # Enable TCPSocket 3310 and set TCPAddr
+          sed -i 's/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/' "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
     dependencies:
       provides:
         - clamav-daemon=${{package.full-version}}
@@ -292,6 +292,15 @@ subpackages:
 
           mv "${{targets.destdir}}"/etc/clamav/clamav-milter.conf.sample \
             "${{targets.subpkgdir}}"/etc/clamav/clamav-milter.conf
+
+          # Configure milter defaults
+          sed -i -e "s:^\(Example\):\# \1:" \
+            -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
+            -e "s:.*\(User\) .*:\1 clamav:" \
+            -e "s:^\#\(LogFile\) .*:\1 /var/log/clamav/milter.log:" \
+            -e "s:^\#\(LogTime\).*:\1 yes:" \
+            -e "s|.*\(ClamdSocket\) .*|\1 unix:/run/clamav/clamd.sock|" \
+            "${{targets.subpkgdir}}"/etc/clamav/clamav-milter.conf
     description: ClamAV milter
     test:
       pipeline:
@@ -367,10 +376,10 @@ subpackages:
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
       - name: Configure TCP socket
         runs: |
-          # Enable TCPSocket 3310 at runtime to match upstream (required for remote TCP access)
+          # Enable TCPSocket 3310 and set TCPAddr at runtime to match upstream (required for remote TCP access)
           # This ensures TCPSocket is enabled even if config is overridden by ConfigMaps
-          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init
-          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init-unprivileged
+          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init
+          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init-unprivileged
     test:
       environment:
         contents:

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.5
   version: "1.5.1"
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -101,6 +101,15 @@ pipeline:
         -e "s:^\#\(AllowSupplementaryGroups\).*:\1 yes:" \
         "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
 
+      # Configure milter defaults
+      sed -i -e "s:^\(Example\):\# \1:" \
+        -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
+        -e "s:.*\(User\) .*:\1 clamav:" \
+        -e "s:^\#\(LogFile\) .*:\1 /var/log/clamav/milter.log:" \
+        -e "s:^\#\(LogTime\).*:\1 yes:" \
+        -e "s|.*\(ClamdSocket\) .*|\1 unix:/run/clamav/clamd.sock|" \
+        "${{targets.destdir}}"/etc/clamav/clamav-milter.conf.sample
+
       # Enable TCPSocket 3310
       sed -i 's/^#TCPSocket.*/TCPSocket 3310/' "${{targets.destdir}}/etc/clamav/clamd.conf.sample"
 

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -101,6 +101,9 @@ pipeline:
         -e "s:^\#\(AllowSupplementaryGroups\).*:\1 yes:" \
         "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
 
+      # Enable TCPSocket 3310 and set TCPAddr
+      sed -i 's/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/' "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
+
 subpackages:
   - name: ${{package.name}}-doc
     pipeline:
@@ -170,9 +173,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/clamconf "${{targets.subpkgdir}}"/usr/bin/
 
           mv "${{targets.destdir}}"/etc/clamav/clamd.conf.sample "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
-
-          # Enable TCPSocket 3310 and set TCPAddr
-          sed -i 's/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/' "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
     dependencies:
       provides:
         - clamav-daemon=${{package.full-version}}
@@ -291,15 +291,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/clamav-milter "${{targets.subpkgdir}}"/usr/bin/
 
           mv "${{targets.destdir}}"/etc/clamav/clamav-milter.conf.sample \
-            "${{targets.subpkgdir}}"/etc/clamav/clamav-milter.conf
-
-          # Configure milter defaults
-          sed -i -e "s:^\(Example\):\# \1:" \
-            -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
-            -e "s:.*\(User\) .*:\1 clamav:" \
-            -e "s:^\#\(LogFile\) .*:\1 /var/log/clamav/milter.log:" \
-            -e "s:^\#\(LogTime\).*:\1 yes:" \
-            -e "s|.*\(ClamdSocket\) .*|\1 unix:/run/clamav/clamd.sock|" \
             "${{targets.subpkgdir}}"/etc/clamav/clamav-milter.conf
     description: ClamAV milter
     test:

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -98,7 +98,7 @@ pipeline:
         -e "s:.*\(User\) .*:\1 clamav:" \
         -e "s:^\#\(LogFile\) .*:\1 /var/log/clamav/clamd.log:" \
         -e "s:^\#\(LogTime\).*:\1 yes:" \
-            -e "s:^\#\(AllowSupplementaryGroups\).*:\1 yes:" \
+        -e "s:^\#\(AllowSupplementaryGroups\).*:\1 yes:" \
         "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
 
 subpackages:
@@ -170,6 +170,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/clamconf "${{targets.subpkgdir}}"/usr/bin/
 
           mv "${{targets.destdir}}"/etc/clamav/clamd.conf.sample "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
+
+          # Enable TCPSocket 3310 (required for remote TCP access)
+          sed -i 's/^#TCPSocket.*/TCPSocket 3310/' "${{targets.subpkgdir}}"/etc/clamav/clamd.conf
     dependencies:
       provides:
         - clamav-daemon=${{package.full-version}}
@@ -362,6 +365,12 @@ subpackages:
       - name: Patch files
         runs: |
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
+      - name: Configure TCP socket
+        runs: |
+          # Enable TCPSocket 3310 at runtime to match upstream (required for remote TCP access)
+          # This ensures TCPSocket is enabled even if config is overridden by ConfigMaps
+          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init
+          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init-unprivileged
     test:
       environment:
         contents:

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -374,12 +374,6 @@ subpackages:
       - name: Patch files
         runs: |
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
-      - name: Configure TCP socket
-        runs: |
-          # Enable TCPSocket 3310 and set TCPAddr at runtime to match upstream (required for remote TCP access)
-          # This ensures TCPSocket is enabled even if config is overridden by ConfigMaps
-          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init
-          sed -i '/^set -eu/a sed -i "s/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/" /etc/clamav/clamd.conf 2>/dev/null || true' "${{targets.contextdir}}"/init-unprivileged
     test:
       environment:
         contents:

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -374,6 +374,16 @@ subpackages:
       - name: Patch files
         runs: |
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
+          # init scripts process CLAMD_CONF_* env vars which disables TCP socket
+          # append TCP at end of script (after all config processing) to ensure defaults remain enabled
+          for script in "${{targets.contextdir}}"/init "${{targets.contextdir}}"/init-unprivileged; do
+            cat >> "$script" << 'EOFPATCH'
+          # Ensure TCP socket enabled (override any CLAMD_CONF_* env var changes)
+          sed -i "s|.*TCPSocket.*|TCPSocket 3310|" /etc/clamav/clamd.conf 2>/dev/null || true
+          sed -i "s|.*TCPAddr.*|#TCPAddr 0.0.0.0|" /etc/clamav/clamd.conf 2>/dev/null || true
+          sed -i "s|#TCPAddr localhost|#TCPAddr 0.0.0.0|g" /etc/clamav/clamd.conf 2>/dev/null || true
+          EOFPATCH
+          done
     test:
       environment:
         contents:

--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -101,8 +101,8 @@ pipeline:
         -e "s:^\#\(AllowSupplementaryGroups\).*:\1 yes:" \
         "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
 
-      # Enable TCPSocket 3310 and set TCPAddr
-      sed -i 's/^#TCPSocket.*/TCPSocket 3310/; s/^#TCPAddr localhost/#TCPAddr 0.0.0.0/' "${{targets.destdir}}"/etc/clamav/clamd.conf.sample
+      # Enable TCPSocket 3310
+      sed -i 's/^#TCPSocket.*/TCPSocket 3310/' "${{targets.destdir}}/etc/clamav/clamd.conf.sample"
 
 subpackages:
   - name: ${{package.name}}-doc
@@ -365,16 +365,6 @@ subpackages:
       - name: Patch files
         runs: |
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
-          # init scripts process CLAMD_CONF_* env vars which disables TCP socket
-          # append TCP at end of script (after all config processing) to ensure defaults remain enabled
-          for script in "${{targets.contextdir}}"/init "${{targets.contextdir}}"/init-unprivileged; do
-            cat >> "$script" << 'EOFPATCH'
-          # Ensure TCP socket enabled (override any CLAMD_CONF_* env var changes)
-          sed -i "s|.*TCPSocket.*|TCPSocket 3310|" /etc/clamav/clamd.conf 2>/dev/null || true
-          sed -i "s|.*TCPAddr.*|#TCPAddr 0.0.0.0|" /etc/clamav/clamd.conf 2>/dev/null || true
-          sed -i "s|#TCPAddr localhost|#TCPAddr 0.0.0.0|g" /etc/clamav/clamd.conf 2>/dev/null || true
-          EOFPATCH
-          done
     test:
       environment:
         contents:


### PR DESCRIPTION
have updated `TCPSocket` to enable port 3310 and added default configs for `clamav-milter.conf` matching upstream

ref - https://github.com/Cisco-Talos/clamav-docker/blob/main/clamav/1.5/alpine/Dockerfile#L61-L81