### PR TITLE
k3s-1.32: remediate CVE-2024-25621, CVE-2025-64329

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.9.1"
-  epoch: 2 # GHSA-qw9x-cqr3-wc7r
+  epoch: 3 # CVE-2024-25621, CVE-2025-64329
   description:
   copyright:
     - license: Apache-2.0
@@ -181,7 +181,7 @@ subpackages:
     pipeline:
       - runs: |
           sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh
-          sed -i '/VERSION_CONTAINERD=$(get-module-version github.com\/containerd\/containerd\/v2)/a VERSION_CONTAINERD="v2.0.5"' ./scripts/version.sh
+          sed -i '/VERSION_CONTAINERD=$(get-module-version github.com\/containerd\/containerd\/v2)/a VERSION_CONTAINERD="v2.1.5"' ./scripts/version.sh
 
           # Clean up the build directory
           rm -rf bin etc


### PR DESCRIPTION
We remediated CVEs in the k3s-static subpackage by updating the
containerd version from v2.0.5 to v2.1.5.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->
