### PR TITLE
Add `provides` for `dotnet-sdk` versions

### DIFF
--- a/dotnet-10.yaml
+++ b/dotnet-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-10
   version: "10.0.100"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -104,6 +104,8 @@ subpackages:
   - name: dotnet-${{vars.major-version}}-sdk
     description: ".NET ${{vars.major-version}} SDK"
     dependencies:
+      provides:
+        - dotnet-sdk=${{package.full-version}}
       runtime:
         - aspnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - aspnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.122"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -106,6 +106,8 @@ subpackages:
   - name: dotnet-${{vars.major-version}}-sdk
     description: ".NET ${{vars.major-version}} SDK"
     dependencies:
+      provides:
+        - dotnet-sdk=${{package.full-version}}
       runtime:
         - aspnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - aspnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.112"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -97,6 +97,8 @@ subpackages:
   - name: dotnet-${{vars.major-version}}-sdk
     description: ".NET ${{vars.major-version}} SDK"
     dependencies:
+      provides:
+        - dotnet-sdk=${{package.full-version}}
       runtime:
         - aspnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - aspnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}


### PR DESCRIPTION
Currently, doing `apk add dotnet-sdk` will incorrectly install `dotnet-7-sdk`.  This is incorrect and we don't even publish `dotnet-7` anymore.  Fix by adding a virtual `provides` to each `dotnet-X-sdk` version.