### PR TITLE
fix(gdb): Add --disable-gprof to prevent conflict with binutils

### DIFF
--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "16.3"
-  epoch: 5
+  epoch: 6
   description: The GNU Debugger
   copyright:
     - license: GPL-2.0
@@ -47,6 +47,7 @@ pipeline:
         --disable-ld \
         --disable-gold \
         --disable-gas \
+        --disable-gprof \
         --disable-gprofng \
         --mandir=/usr/share/man \
         --infodir=/usr/share/info \


### PR DESCRIPTION
Add --disable-gprof flag to prevent gdb from building gprof, which should only be provided by binutils.
This resolves package conflicts that were blocking tests for packages (e.g openssl) requiring both gdb and binutils dependencies (via hardening-check).

Fixes the following error:
```
2025/11/13 13:53:17 INFO       - uid=1000(build) gid=1000
2025/11/13 13:53:17 INFO     groups:
2025/11/13 13:53:17 INFO       - gid=1000(build) members=[build]
2025/11/13 13:53:18 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/11/13 13:53:18 ERRO failed to test package: unable to build guest: unable to generate image:
installing apk packages: error getting package dependencies: solving "hardening-check" constraint:
resolving "hardening-check-2.25.25-r0.apk" deps:
solving "binutils" constraint:   binutils-2.39-r4.apk disqualified because gdb-16.3-r5.apk already provides
 cmd:gprof
  binutils-2.42-r1.apk disqualified because gdb-16.3-r5.apk already provides cmd:gprof
  binutils-2.44-r0.apk disqualified because gdb-16.3-r5.apk already provides cmd:gprof
  [... all binutils versions disqualified ...]
  binutils-2.45.1-r1.apk disqualified because gdb-16.3-r5.apk already provides cmd:gprof
```