### PR TITLE
dotnet: Remove virtual provides

### DIFF
--- a/dotnet-10.yaml
+++ b/dotnet-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-10
   version: "10.0.100"
-  epoch: 0
+  epoch: 1
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -128,8 +128,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.NETCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - dotnet-runtime=${{package.full-version}}
       runtime:
         - dotnet
     test:
@@ -143,18 +141,10 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.AspNetCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - aspnet-runtime=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - libexpat1
         - libbrotlidec1
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-runtime
-            real-pkg-name: ${{subpkg.name}}
 
   - name: dotnet-${{vars.major-version}}-targeting-pack
     description: "The .NET ${{vars.major-version}} Core targeting pack"
@@ -162,15 +152,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.NETCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
-    dependencies:
-      provides:
-        - dotnet-targeting-pack=${{package.full-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: dotnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
   - name: aspnet-${{vars.major-version}}-targeting-pack
     description: "The ASP.NET ${{vars.major-version}} targeting pack"
@@ -179,16 +160,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.AspNetCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - aspnet-targeting-pack=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
   - name: dotnet-${{vars.major-version}}-aot
     description: "Ahead-of-Time (AOT) support for the .NET ${{vars.major-version}} SDK"
@@ -197,16 +170,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/runtime.*.Microsoft.DotNet.ILCompiler ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - dotnet-aot=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: dotnet-aot
-            real-pkg-name: ${{subpkg.name}}
 
 update:
   enabled: true

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: "8.0.122"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -130,8 +130,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.NETCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - dotnet-runtime=${{package.full-version}}
       runtime:
         - dotnet
     test:
@@ -145,18 +143,10 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.AspNetCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - aspnet-runtime=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - libexpat1
         - libbrotlidec1
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-runtime
-            real-pkg-name: ${{subpkg.name}}
 
   # We separate the .NET Standard targeting pack to allow for
   # co-installation of .NET versions. Different .NET versions
@@ -198,16 +188,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.NETCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - dotnet-targeting-pack=${{package.full-version}}
       runtime:
         - netstandard-targeting-pack-${{vars.netstandard-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: dotnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
   - name: aspnet-${{vars.major-version}}-targeting-pack
     description: "The ASP.NET ${{vars.major-version}} targeting pack"
@@ -216,16 +198,8 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.AspNetCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - aspnet-targeting-pack=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
 update:
   enabled: true

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: "9.0.112"
-  epoch: 1
+  epoch: 2
   description: ".NET ${{vars.major-version}} host"
   copyright:
     - license: MIT
@@ -121,8 +121,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.NETCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - dotnet-runtime=${{package.full-version}}
       runtime:
         - dotnet
     test:
@@ -136,8 +134,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/shared
           mv ${{targets.destdir}}/usr/share/dotnet/shared/Microsoft.AspNetCore.App ${{targets.contextdir}}/usr/share/dotnet/shared/
     dependencies:
-      provides:
-        - aspnet-runtime=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - libexpat1
@@ -189,8 +185,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.NETCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - dotnet-targeting-pack=${{package.full-version}}
       runtime:
         - netstandard-targeting-pack-${{vars.netstandard-version}}
     test:
@@ -207,8 +201,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/Microsoft.AspNetCore.App.* ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - aspnet-targeting-pack=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack
     test:
@@ -225,8 +217,6 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/share/dotnet/packs
           mv ${{targets.destdir}}/usr/share/dotnet/packs/runtime.*.Microsoft.DotNet.ILCompiler ${{targets.contextdir}}/usr/share/dotnet/packs/
     dependencies:
-      provides:
-        - dotnet-aot=${{package.full-version}}
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}
     test:

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -138,12 +138,6 @@ subpackages:
         - dotnet-${{vars.major-version}}-runtime=${{package.full-version}}
         - libexpat1
         - libbrotlidec1
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-runtime
-            real-pkg-name: ${{subpkg.name}}
 
   # We separate the .NET Standard targeting pack to allow for
   # co-installation of .NET versions. Different .NET versions
@@ -187,12 +181,6 @@ subpackages:
     dependencies:
       runtime:
         - netstandard-targeting-pack-${{vars.netstandard-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: dotnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
   - name: aspnet-${{vars.major-version}}-targeting-pack
     description: "The ASP.NET ${{vars.major-version}} targeting pack"
@@ -203,12 +191,6 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: aspnet-targeting-pack
-            real-pkg-name: ${{subpkg.name}}
 
   - name: dotnet-${{vars.major-version}}-aot
     description: "Ahead-of-Time (AOT) support for the .NET ${{vars.major-version}} SDK"
@@ -219,12 +201,6 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-${{vars.major-version}}-targeting-pack=${{package.full-version}}
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: dotnet-aot
-            real-pkg-name: ${{subpkg.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
Now that we've cleaned up the archive (see #71978), we must remove the virtual provides from the dotnet packages so that they don't conflict between themselves.