### PR TITLE
Switch pgpool2 exporter to https

### DIFF
--- a/pgpool2_exporter.yaml
+++ b/pgpool2_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2_exporter
   version: "1.2.2"
-  epoch: 6 # CVE-2025-61725
+  epoch: 7 # CVE-2025-61725
   description: Prometheus exporter for Pgpool-II metrics.
   copyright:
     - license: MIT
@@ -9,7 +9,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/pgpool/pgpool2_exporter
+      repository: https://github.com/pgpool/pgpool2_exporter
       tag: v${{package.version}}
       expected-commit: 06a68dead344308c3346f53aba811c929eff71d5
 


### PR DESCRIPTION
I happened to notice this was on `http://` looking at what schemes we use for cloning.