### PR TITLE
Remove additional symlinks so that kaniko works with Rocky linux base image

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: "1.25.4"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kaniko/remove-usrmerge-symlinks.patch
+++ b/kaniko/remove-usrmerge-symlinks.patch
@@ -1,17 +1,20 @@
 # Fixes: https://github.com/chainguard-dev/customer-issues/issues/2579
 # Internal Issue to investigate long-term fix: https://github.com/chainguard-dev/internal-dev/issues/21302
+diff --git a/pkg/executor/build.go b/pkg/executor/build.go
+index ccdfd17..6992957 100644
 --- a/pkg/executor/build.go
 +++ b/pkg/executor/build.go
-@@ -691,6 +691,8 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
+@@ -691,6 +691,9 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
  // DoBuild executes building the Dockerfile
  func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
  	t := timing.Start("Total Build Time")
 +	fixUsrMergeSymlinks()
++	removeUnusedBaselayoutSymlinks()
 +
  	digestToCacheKey := make(map[string]string)
  	stageIdxToDigest := make(map[string]string)
  
-@@ -827,6 +829,31 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
+@@ -830,6 +833,54 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
  	return nil, err
  }
  
@@ -38,6 +41,29 @@
 +	}
 +
 +	return nil
++}
++
++// removeUnusedBaselayoutSymlinks removes unnecessary symlinks from the base layout.
++// These symlinks are created by wolfi-baselayout but are not needed by kaniko,
++// and their presence can cause issues with kaniko functionality.
++func removeUnusedBaselayoutSymlinks() {
++	// Remove symlinks created by wolfi-baselayout that kaniko doesn't need
++	symlinksToRemove := []string{
++		"/var/spool/cron/crontabs", // symlink to /etc/crontabs
++		"/var/spool/mail",           // symlink to /var/mail
++	}
++
++	for _, symlink := range symlinksToRemove {
++		info, err := os.Lstat(symlink)
++		if err != nil || info.Mode()&os.ModeSymlink == 0 {
++			continue
++		}
++
++		logrus.Infof("Removing unused baselayout symlink: %s", symlink)
++		if err := os.Remove(symlink); err != nil {
++			logrus.Warnf("Failed to remove symlink %s: %v", symlink, err)
++		}
++	}
 +}
 +
  // filesToSave returns all the files matching the given pattern in deps.


### PR DESCRIPTION
ideally, we could remove chainguard-baselayout and wolfi-baselayout from the kaniko image so it would be as barebones as possible, matching the upstream version. but that will require some infra/tooling changes which would likely require a design review first.