### PR TITLE
gdal: Pin to dotnet-10-sdk

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -44,7 +44,7 @@ environment:
       - cmake
       - coreutils
       - curl-dev
-      - dotnet-sdk
+      - dotnet-10-sdk
       - expat-dev
       - geos-dev
       - giflib-dev


### PR DESCRIPTION
We won't be providing a virtual provides for `dotnet-sdk`, so we should explicitly pin the B-D.