### PR TITLE
fix(jellyfin): Don't depend on the .NET host directly

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -1,14 +1,13 @@
 package:
   name: jellyfin
   version: "10.11.2"
-  epoch: 0
+  epoch: 1
   description: The Free Software Media System
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
       - aspnet-${{vars.dotnet-version}}-runtime
-      - dotnet-${{vars.dotnet-version}}
       - ffmpeg
       - fontconfig
       - mesa


### PR DESCRIPTION
The ASPNet runtime already depends on the .NET runtime which depends on the virtual provider for dotnet, which in practice will install the latest version of the host. We don't need to explicitly pin to the host for .NET 9 anymore as later versions of the host are compatible with earlier versions of .NET
