### PR TITLE
argocd-image-updater: Add new symlink

### DIFF
--- a/argocd-image-updater.yaml
+++ b/argocd-image-updater.yaml
@@ -1,7 +1,7 @@
 package:
   name: argocd-image-updater
   version: "1.0.0"
-  epoch: 0 # GHSA-786q-9hcg-v9ff
+  epoch: 1
   description: Automatic container image update for Argo CD
   copyright:
     - license: Apache-2.0
@@ -42,11 +42,12 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
           ln -sf /usr/bin/argocd-image-updater ${{targets.subpkgdir}}/usr/local/bin/argocd-image-updater
-    # test added by a robot (compat)
+          ln -sf /usr/bin/argocd-image-updater ${{targets.subpkgdir}}/manager
     test:
       pipeline:
         - runs: |
             readlink -v /usr/local/bin/argocd-image-updater
+            readlink -v /manager
 
 update:
   enabled: true


### PR DESCRIPTION
The upstream now call their binary manager and put it in the root of the
filesystem.  In order for our image to work with the upstream Helm Chart
we will need to follow suit.

See https://github.com/argoproj-labs/argocd-image-updater/pull/1250
