### PR TITLE
fix(py3-transformers): Pin huggingface hub for now

### DIFF
--- a/py3-transformers.yaml
+++ b/py3-transformers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-transformers
   version: "4.57.1"
-  epoch: 0
+  epoch: 1
   description: State-of-the-art Machine Learning for PyTorch, TensorFlow, and JAX
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,11 @@ subpackages:
         - py${{range.key}}-charset-normalizer
         - py${{range.key}}-filelock
         - py${{range.key}}-fsspec
-        - py${{range.key}}-huggingface-hub
+        # huggingface-hub >=1.0 breaks projects that depend on transformers
+        # Extensive changes have been staged to support 1.0+ in the next
+        # release, but for now pin the version to avoid breaking dependent
+        # projects
+        - py${{range.key}}-huggingface-hub<1.0
         - py${{range.key}}-idna
         - py${{range.key}}-numpy-2.2
         - py${{range.key}}-packaging


### PR DESCRIPTION
huggingface-hub >=1.0 breaks projects that depend on transformers

Extensive changes have been staged to support 1.0+ in the next release, but for now pin the version to avoid breaking dependent projects

We'll know we need to unpin as our pip check test will fail