### PR TITLE
R-sf: bump epoch

### DIFF
--- a/R-sf.yaml
+++ b/R-sf.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-sf
   version: "1.0.22"
-  epoch: 0
+  epoch: 1
   description: Simple Features for R
   copyright:
     - license: GPL-2.0-only AND MIT


### PR DESCRIPTION
Bump in order to build the package against the latest gdal available,
this will fix dependency resolution for certain images.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
