### PR TITLE
docker - restore busybox

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,12 +1,13 @@
 package:
   name: docker
   version: "28.5.2"
-  epoch: 3
+  epoch: 4
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - busybox
       - docker-cli
       - docker-cli-buildx
       - docker-compose


### PR DESCRIPTION
We moved `busybox` to `dockerd-oci-entrypoint` since it wasn’t directly required by `docker` itself and was only needed to satisfy the `dockerd-oci-entrypoint` subpackage. However, our existing packages and images still assume that `busybox` is provided by `docker` package.