### PR TITLE
klipper-helm: Use helm < 4

### DIFF
--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -3,16 +3,16 @@ package:
   version: "0.9.10.20251111"
   # Version format: <base-version>.<build-date> (e.g., 0.9.8.20250709)
   # This gets transformed to upstream tag format: v<base-version>-build<build-date>
-  epoch: 0
+  epoch: 1
   description: Klipper helm integration job image
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - busybox
-      - helm
       - helm-mapkubeapis
       - helm-set-status
+      - helm<4
       - jq
 
 environment:


### PR DESCRIPTION
The upstream does not support Helm v4 yet.  It relies on the `--all`
flag which is not present in v4.

See https://github.com/k3s-io/klipper-helm/blob/ef5dca626551a55624dd731c13edb23e4a4305b6/entry#L4
