### PR TITLE
CODEOWNERS: Add dotnet-* as owned by eng-os

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,3 +34,4 @@ go-2.*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 php-8.5.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+dotnet-*.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write


### PR DESCRIPTION
Arguably, this should have been done before I started working on `dotnet-10`.  Oh, well.  Better late than never.