### PR TITLE
Rollback tree-sitter to stable v0.25.10 and bump epoch (fixes #67928)

### DIFF
--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -1,7 +1,7 @@
 package:
   name: tree-sitter
-  version: "0.26.0"
-  epoch: 0
+  version: "0.25.9"
+  epoch: 1
   description: "Incremental parsing system for programming tools"
   copyright:
     - license: MIT
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/tree-sitter/tree-sitter
       tag: v${{package.version}}
-      expected-commit: 9be3e2bdd8e1e62ad259e3c8ee7de7ebaed0553f
+      expected-commit: a467ea8502d95562171f97953a6dc5b2a8622609
 
   - uses: autoconf/make
 

--- a/tree-sitter.yaml
+++ b/tree-sitter.yaml
@@ -1,6 +1,6 @@
 package:
   name: tree-sitter
-  version: "0.25.9"
+  version: "0.25.10"
   epoch: 1
   description: "Incremental parsing system for programming tools"
   copyright:
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/tree-sitter/tree-sitter
       tag: v${{package.version}}
-      expected-commit: a467ea8502d95562171f97953a6dc5b2a8622609
+      expected-commit: da6fe9beb4f7f67beb75914ca8e0d48ae48d6406
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Upstream has not released 0.26.0. The Wolfi recipe was attempting to use `0.26.0`, which caused the build to fail because that tag does not exist in https://github.com/tree-sitter/tree-sitter.
`fatal: Remote branch v0.26.0 not found in upstream origin`

What I changed
--------------
- Roll back package version to `0.25.10`
- Set `git.tag` to `v0.25.10` and `expected-commit` to `da6fe9beb4f7f67beb75914ca8e0d48ae48d6406`
- Increment `epoch` by 1 so the rollback is treated as an upgrade

Rationale
---------
`v0.25.10` is the latest stable upstream release.


  
Fixes: https://github.com/wolfi-dev/os/issues/67928



