### PR TITLE
amazon-cni: use iptables-wrappers

### DIFF
--- a/amazon-k8s-cni.yaml
+++ b/amazon-k8s-cni.yaml
@@ -1,13 +1,13 @@
 package:
   name: amazon-k8s-cni
   version: "1.20.4"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - iptables
+      - iptables-wrappers
 
 environment:
   contents:


### PR DESCRIPTION
Note that most containers should always install and use
iptables-wrappers. For foreseeable future one cannot assume if the
host is running with nftables or iptables kernel firewall.

This matches upstream dockerfile configuration:
- https://github.com/aws/amazon-vpc-cni-k8s/blob/ad62c7475d0e9a2a2f2843e4973b6394a8920f81/scripts/dockerfiles/Dockerfile.release#L28