### PR TITLE
code-server: fix GHSA-mh29-5h37-fv8m by updating js-yaml to 4.1.1

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.105.1"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -67,7 +67,7 @@ pipeline:
       npm update prebuild-install
 
       # Set npm overrides for security vulnerabilities
-      npm pkg set "overrides.tar-fs=3.1.1" "overrides.node-addon-api=7.1.0"
+      npm pkg set "overrides.tar-fs=3.1.1" "overrides.node-addon-api=7.1.0" "overrides.js-yaml=4.1.1"
 
       # Install modules and build backend/frontend
       npm install


### PR DESCRIPTION
## Summary
Fixes GHSA-mh29-5h37-fv8m (CVE-2025-64718) by updating js-yaml from 4.1.0 to 4.1.1.

## Changes
- Added js-yaml@4.1.1 to existing npm overrides for security vulnerabilities
- Incremented epoch from 1 to 2

## Fix Applied
```yaml
# Set npm overrides for security vulnerabilities
npm pkg set "overrides.tar-fs=3.1.1" "overrides.node-addon-api=7.1.0" "overrides.js-yaml=4.1.1"
```

## References
- GHSA Advisory: https://github.com/advisories/GHSA-mh29-5h37-fv8m
- CVE-Dashboard Issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/41555