### PR TITLE
pipelines/auth/github.yaml - add GITHUB_TOKEN, gh cli support

### DIFF
--- a/pipelines/auth/github.yaml
+++ b/pipelines/auth/github.yaml
@@ -20,16 +20,21 @@ pipeline:
   - runs: |
       set -euo pipefail
 
-      # If .github-token file exists in the source dir, use that.
-      # You can use this for local testing:
-      #
-      #    gh auth token > your-package-name/.github-token
-      #    make package/your-package-name
-      #
-      # THIS IS ONLY FOR LOCAL TESTING -- be careful not to commit your .github-token file!
-      if [ -f .github-token ]; then
+      # Check for authentication in the following order:
+      # 1. GITHUB_TOKEN environment variable
+      # 2. .github-token file (for local testing)
+      # 3. gh CLI tool (if available)
+      # 4. OctoSTS (fallback for CI/CD)
+
+      if [ -n "${GITHUB_TOKEN:-}" ]; then
+        echo "Using GITHUB_TOKEN environment variable for ${{inputs.repo}}"
+        ghtoken="${GITHUB_TOKEN}"
+      elif [ -f .github-token ]; then
         echo "Using .github-token to get a token for ${{inputs.repo}} -- ONLY FOR LOCAL TESTING"
         ghtoken=$(cat .github-token)
+      elif command -v gh >/dev/null 2>&1; then
+        echo "Using gh CLI to get a token for ${{inputs.repo}}"
+        ghtoken=$(gh auth token)
       else
         echo "Using OctoSTS to get a token for ${{inputs.repo}} as ${{inputs.identity}}"
         idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=octo-sts.dev)


### PR DESCRIPTION
Makes it easier to run pipelines locally.
