### PR TITLE
fix(chromium): CVE-2025-13042 version bump

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: "142.0.7444.162"
+  version: "142.0.7444.175"
   epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
@@ -157,7 +157,7 @@ pipeline:
       # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       # which has been automated in https://github.com/chromium-linux-tarballs/chromium-tarballs
       uri: https://github.com/chromium-linux-tarballs/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
-      expected-sha512: 783860211afba502637299c6f5d8ec026f21e4c648472aff920d952423e8e5c053f569d6468d4283a26d027dd6e33266195d520f22f69d5e9e7750d8a4fb9127
+      expected-sha512: c01157d7e0f5b7d6cbc3933d42adca488474414d5d893092e1a108255958aae356e8f997ab5f76b670b3d20044943c3323869741900f6b4e36d30d494f57dfd8
 
   - name: Remove binaries from source tree
     runs: |


### PR DESCRIPTION
Bump chromium to a version >142.0.7444.166.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/41450

<!--ci-cve-scan:fail-any-->
