### PR TITLE
fix(kubeflow-centraldashboard): GHSA-mh29-5h37-fv8m fix version

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 5
+  epoch: 6
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -61,7 +61,8 @@ pipeline:
         "serve-static": "^1.16.0",
         "cookie": "0.7.0",
         "on-headers": "1.1.0",
-        "jsonpath-plus": "10.3.0"
+        "jsonpath-plus": "10.3.0",
+        "js-yaml": "4.1.1"
       }'
 
       # Apply the overrides


### PR DESCRIPTION
Add js-yaml constraint to set it at the fixed version.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/41472

<!--ci-cve-scan:fail-any-->
