### PR TITLE
tomcat-11.0: remove redundant tests and refactor building to use more variables

### DIFF
--- a/tomcat-11.0.yaml
+++ b/tomcat-11.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-11.0
   version: "11.0.14"
-  epoch: 0
+  epoch: 1
   description: Apache Tomcat Web Server
   copyright:
     - license: Apache-2.0
@@ -13,24 +13,20 @@ package:
 data:
   - name: openjdk-versions
     items:
-      25: "openjdk-25"
-      21: "openjdk-21"
-      17: "openjdk-17"
+      25:
+      21:
+      17:
+
+vars:
+  # This is the version of OpenJDK actually used for building
+  target-jdk-version: 25
 
 environment:
   contents:
     packages:
       - ant
-      - build-base
       - busybox
-      - ca-certificates-bundle
-      - curl
-      - openjdk-17
-      # Only 17 is used during the build process
-      # 21 and 25 are included for tests
-      - openjdk-21
-      - openjdk-25
-      - tomcat-native
+      - openjdk-${{vars.target-jdk-version}}
 
 pipeline:
   - uses: git-checkout
@@ -40,7 +36,7 @@ pipeline:
       expected-commit: fb4c518b886e07c9c101b8036eb857f4c7af2510
 
   - runs: |
-      cat <<EOF > build.properties
+      tee build.properties <<EOF
       skip.installer=true
       base.path=$PWD
       compile.debug=false
@@ -48,34 +44,25 @@ pipeline:
 
 subpackages:
   - range: openjdk-versions
-    name: ${{package.name}}-${{range.value}}
+    name: ${{package.name}}-openjdk-${{range.key}}
     dependencies:
       runtime:
-        - ${{range.value}}-default-jvm
+        - openjdk-${{range.key}}-default-jvm
         - tomcat-native
     pipeline:
-      - runs: |
-          # Only OpenJDK 17 is supported at buildtime
-          # However, we're able to run Tomcat with OpenJDK 17-25
-          export JAVA_HOME="/usr/lib/jvm/java-17-openjdk"
-
+      - environment:
+          JAVA_HOME: /usr/lib/jvm/java-${{vars.target-jdk-version}}-openjdk
+        runs: |
           ant -Dskip.build.java.version=true
 
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat
-          cp LICENSE ${{targets.contextdir}}/usr/share/tomcat/
+          install -Dpm0644 -t "${{targets.subpkgdir}}/usr/share/tomcat/" LICENSE
+          install -Dpm0755 -t "${{targets.subpkgdir}}/usr/share/tomcat/bin/" output/build/bin/*
+          install -Dpm0644 -t "${{targets.subpkgdir}}/usr/share/tomcat/conf/" output/build/conf/*
+          install -Dpm0644 -t "${{targets.subpkgdir}}/usr/share/tomcat/lib/" output/build/lib/*
 
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/bin
-          cp output/build/bin/* ${{targets.contextdir}}/usr/share/tomcat/bin
-
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/conf
-          cp output/build/conf/* ${{targets.contextdir}}/usr/share/tomcat/conf
-
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/lib
-          cp output/build/lib/* ${{targets.contextdir}}/usr/share/tomcat/lib
-
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/logs
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/temp
-          mkdir -p ${{targets.contextdir}}/usr/share/tomcat/webapps
+          install -d ${{targets.subpkgdir}}/usr/share/tomcat/logs \
+            ${{targets.subpkgdir}}/usr/share/tomcat/temp \
+            ${{targets.subpkgdir}}/usr/share/tomcat/webapps
 
           # This includes the manager and host-manager apps.
           # The apps are not directly usable without copying into the webapps directory.
@@ -88,116 +75,43 @@ subpackages:
         contents:
           packages:
             - curl
+            - wait-for-it
       pipeline:
-        - name: Verify Tomcat installation
-          runs: |
-            if [[ ! -d "/usr/share/tomcat" ]]; then
-              echo "Tomcat directory not found!"
-              exit 1
-            fi
-            echo "Tomcat installation verified."
-        - name: Check Tomcat version
-          runs: |
-            sh -c "/usr/share/tomcat/bin/version.sh" | grep "Server version: Apache Tomcat/${{package.version}}" || {
-              echo "Tomcat version mismatch!"
-              exit 1
-            }
-            echo "Tomcat version verified."
+        - uses: test/tw/ver-check
+          with:
+            bins: /usr/share/tomcat/bin/version.sh
+            version-flag: " "
+            version: "Server version: Apache Tomcat/${{package.version}}"
         - name: Test Tomcat catalina.sh with OpenJDK ${{range.key}}
+          environment:
+            JAVA_HOME: /usr/lib/jvm/java-${{range.key}}-openjdk
+            LD_LIBRARY_PATH: /usr/lib/tomcat-native
           uses: test/daemon-check-output
           with:
-            setup: |
-              #!/bin/sh -ex
-              cp /usr/share/tomcat/webapps.dist/docs/appdev/sample/sample.war /usr/share/tomcat/webapps/
-            start: |
-              sh -c "
-                if [[ "${{range.key}}" == "8" ]]; then
-                  export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
-                else
-                  export JAVA_HOME=/usr/lib/jvm/java-${{range.key}}-openjdk
-                fi
-                export LD_LIBRARY_PATH=/usr/lib/tomcat-native
-                /usr/share/tomcat/bin/catalina.sh run
-              "
-            timeout: 30
+            setup: cp /usr/share/tomcat/webapps.dist/docs/appdev/sample/sample.war /usr/share/tomcat/webapps/
+            start: /usr/share/tomcat/bin/catalina.sh run
             expected_output: |
               Tomcat/${{package.version}}
               JVM.Version
               Deploying.*sample.war
               Server startup in
             post: |
-              #!/bin/sh -e
-              url=http://localhost:8080/sample/
-              echo "testing $url"
-              response=$(curl -s "$url") || {
-                echo "curl $url failed $?"
-                exit 1
-              }
-              expected="Sample.*Hello.*World.*Application"
-              echo "$response" | grep -q "$expected" || {
-                echo "response from $url did not contain \"$expected\""
-                echo "response: $response"
-                exit 1
-              }
-              echo "found \"$expected\" in output of curl $url"
+              wait-for-it localhost:8080
+              curl "http://localhost:8080/sample/" | grep -F -e "Sample \"Hello, World\" Application"
         - name: Test Tomcat startup.sh with OpenJDK ${{range.key}}
-          runs: |
-            if [[ "${{range.key}}" == "8" ]]; then
-              export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
-            else
-              export JAVA_HOME=/usr/lib/jvm/java-${{range.key}}-openjdk
-            fi
-
-            export CATALINA_HOME="/usr/share/tomcat"
-            export CATALINA_BASE="/usr/share/tomcat"
-            export LD_LIBRARY_PATH="/usr/lib/tomcat-native"
-
-            # Try startup up to 3 times as the startup can be flaky
-            for attempt in 1 2 3; do
-              /usr/share/tomcat/bin/startup.sh
-
-              timeout -k 1 5 sh -x -c 'while true; do
-                sleep 1
-                if ! pgrep -f "org.apache.catalina" >/dev/null; then
-                  echo "tomcat proc not found yet"
-                  continue
-                fi
-                if ! netstat -ln 2>/dev/null | grep -q :8080 && ! ss -ln 2>/dev/null | grep -q :8080; then
-                  echo "port 8080 not open yet"
-                  continue
-                fi
-                echo "Tomcat startup complete"
-                break
-              done' && break
-
-              if [ $attempt -eq 3 ]; then
-                echo "All 3 attempts failed"
-                exit 1
-              fi
-            done
-
-            response=$(curl --silent --retry 5 --retry-delay 2 --retry-connrefused --max-time 10 http://localhost:8080/ 2>&1) || {
-              echo "Curl failed with exit code $?"
-              echo "Response: $response"
-              exit 1
-            }
-            echo "$response" | grep "Apache Tomcat" || {
-              echo "Tomcat did not start correctly on JDK ${{range.key}}"
-              exit 1
-            }
-
-            /usr/share/tomcat/bin/shutdown.sh
-            sleep 3
-        - name: Deploy test application
-          runs: |
-            cp /usr/share/tomcat/webapps.dist/docs/appdev/sample/sample.war /usr/share/tomcat/webapps/
-            /usr/share/tomcat/bin/startup.sh
-            sleep 5
-            curl --silent --retry 3 --retry-connrefused http://localhost:8080/sample/ | grep "This is the home page for a sample application" || {
-              echo "Test application deployment failed!"
-              exit 1
-            }
-            /usr/share/tomcat/bin/shutdown.sh
+          environment:
+            CATALINA_HOME: /usr/share/tomcat
+            CATALINA_BASE: /usr/share/tomcat
+            LD_LIBRARY_PATH: /usr/lib/tomcat-native
+            JAVA_HOME: /usr/lib/jvm/java-${{range.key}}-openjdk
+          uses: test/daemon-check-output
+          with:
+            start: /usr/share/tomcat/bin/startup.sh
+            expected_output: |
+              Tomcat started.
+            post: |
+              wait-for-it localhost:8080
+              curl "http://localhost:8080/" | grep -F -e "Apache Tomcat"
 
 update:
   enabled: true
@@ -208,7 +122,6 @@ update:
     use-tag: true
     tag-filter: 11.0.
 
-# Based on package contents inspection, it was found that this origin package is empty apart from its own SBOM and this test was added to confirm it is empty and will fail if the package is no longer empty (contains more than an SBOM)
 test:
   pipeline:
     - uses: test/emptypackage


### PR DESCRIPTION
This is mostly so that this is easier to maintain in the future, goes with other tomcat versions.
