### PR TITLE
CODEOWNERS: Add ruby-3.5 as owned by OS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,3 +35,4 @@ python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 php-8.5.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 dotnet-*.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+ruby-3.5.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write


### PR DESCRIPTION
Unfortunately we can't use globbing here because it would affect all `ruby-3.*.yaml` packages, which is not what we want.