### PR TITLE
php-8.5: New package

### DIFF
--- a/php-8.5.yaml
+++ b/php-8.5.yaml
@@ -1,0 +1,496 @@
+package:
+  name: php-8.5
+  version: "8.5.0"
+  epoch: 0
+  description: "the PHP programming language"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-config
+      - libxml2
+      - merged-bin
+      - merged-usrsbin
+      - wolfi-baselayout
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d\.\d+)
+    replace: $1
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - aom-dev
+      - apache2-dev
+      - apache2-utils
+      - autoconf
+      - bison
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - curl-dev
+      - dav1d-dev
+      - file
+      - freetds
+      - freetds-dev
+      - freetype-dev
+      - gmp-dev
+      - icu-dev
+      - libavif-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libpsl-dev
+      - libsodium-dev
+      - libtool
+      - libwebp-dev
+      - libx11-dev
+      - libxml2-dev
+      - libxpm-dev
+      - libxslt-dev
+      - libzip
+      - nghttp2-dev
+      - oniguruma-dev
+      - openldap-dev
+      - openssl-dev
+      - pcre2-dev
+      - postgresql-dev
+      - re2c
+      - readline-dev
+      - sqlite-dev
+      - unixodbc-dev
+      - wget
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/php-src
+      tag: php-${{package.version}}
+      expected-commit: 685e99655ae97c667950f7f7d176985958718f56
+
+  # https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/php84/install-pear.patch
+  - uses: patch
+    with:
+      patches: install-pear.patch
+
+  - name: Configure
+    runs: |
+      ./buildconf --force
+      EXTENSION_DIR=/usr/lib/php/modules ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib/php \
+        --sbindir=/usr/bin \
+        --datadir=/usr/share/php \
+        --sysconfdir=/etc/php \
+        --localstatedir=/var \
+        --with-layout=GNU \
+        --with-pic \
+        --with-config-file-path=/etc/php \
+        --with-config-file-scan-dir=/etc/php/conf.d \
+        --enable-cli \
+        --enable-ctype=shared \
+        --enable-bcmath=shared \
+        --with-curl=shared \
+        --enable-dom=shared \
+        --enable-fileinfo=shared \
+        --with-iconv=shared \
+        --with-openssl=shared \
+        --with-readline \
+        --enable-ftp=shared \
+        --with-sodium=shared \
+        --enable-fpm \
+        --with-pear \
+        --enable-gd=shared \
+        --with-avif \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-xpm \
+        --disable-gd-jis-conv \
+        --with-libxml \
+        --enable-phar=shared \
+        --enable-mbstring=shared \
+        --with-mysqli=shared \
+        --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --enable-mysqlnd=shared \
+        --enable-pdo=shared \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-pdo-sqlite=shared \
+        --with-pdo-dblib=shared \
+        --with-pdo-pgsql=shared \
+        --with-pdo-odbc=shared,unixODBC,/usr \
+        --with-unixODBC=shared,/usr \
+        --enable-pcntl=shared \
+        --enable-sockets=shared \
+        --with-bz2=shared \
+        --enable-calendar=shared \
+        --enable-exif=shared  \
+        --with-gettext=shared  \
+        --with-gmp=shared  \
+        --enable-intl=shared  \
+        --with-ldap=shared  \
+        --enable-soap=shared  \
+        --with-xsl=shared \
+        --with-zlib \
+        --enable-xml=shared \
+        --enable-simplexml=shared \
+        --enable-xml=shared \
+        --enable-xmlreader=shared \
+        --enable-xmlwriter=shared \
+        --enable-posix=shared \
+        --with-pgsql=shared \
+        --with-zip=shared \
+        --enable-sysvsem=shared \
+        --enable-sysvshm=shared \
+        --with-apxs2=/usr/bin/apxs \
+        --enable-phpdbg=shared \
+        --with-external-pcre
+
+  - uses: autoconf/make
+
+  - name: Copy httpd.conf before install for apxs
+    runs: |
+      # httpd.conf needs to be in the /home/build/melange-out/php-<VERSION>/etc/apache2/ directory
+      # otherwise `make install` complains that it cannot find it.
+      mkdir -p ${{targets.destdir}}/etc/apache2
+      cp /etc/apache2/httpd.conf ${{targets.destdir}}/etc/apache2/httpd.conf
+
+  - name: Make Install
+    runs: |
+      INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - name: Remove httpd.conf after install for apxs
+    runs: |
+      # After `make install` the httpd.conf file is not needed anymore,
+      # so remove it to avoid conflicts with the apache2 package, as it already provides.
+      rm -f ${{targets.destdir}}/etc/apache2/httpd.conf
+
+  - uses: strip
+
+data:
+  - name: extensions
+    items:
+      bz2: Bzip2
+      curl: cURL
+      gd: GD imaging
+      gmp: GNU GMP support
+      ldap: LDAP
+      mysqlnd: MySQLnd
+      openssl: OpenSSL
+      pdo_mysql: MySQL driver for PDO
+      pdo_sqlite: SQLite 3.x driver for PDO
+      pdo_dblib: PDO driver for Sybase / MS SQL databases
+      pdo_pgsql: PDO driver for pgsql
+      pdo_odbc: PDO driver for ODBC
+      soap: SOAP
+      sodium: Sodium
+      calendar: Calendar
+      exif: EXIF
+      gettext: GetText
+      intl: Internationalization
+      mbstring: Multibyte String Functions
+      pcntl: pcntl
+      pdo: PHP Data Objects
+      phar: PHP Archive
+      sockets: Sockets
+      xsl: XSL
+      bcmath: BC Math
+      ctype: ctype
+      iconv: Iconv
+      dom: DOM
+      pgsql: PostgreSQL
+      posix: Posix
+      simplexml: SimpleXML
+      mysqli: MySQLi
+      xml: XML
+      xmlreader: XMLReader
+      xmlwriter: XMLWriter
+      fileinfo: fileinfo
+      zip: Zip
+      odbc: UnixODBC
+      ftp: FTP
+      sysvsem: System V Semaphores
+      sysvshm: System V Shared Memory
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-config=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          mv php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}"
+    description: "The ${{range.value}} extension"
+    dependencies:
+      runtime:
+        - "${{package.name}}-${{range.key}}-config"
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+      provides:
+        - php-${{range.key}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export EXTENSIONS_DIR=usr/lib/php/modules
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR
+          mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
+            "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}-config"
+    description: "The ${{range.value}} extension configuration"
+    dependencies:
+      provides:
+        - php-${{range.key}}-config=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p $CONF_DIR
+          order=10
+          prefix=
+          # Determine load order based on number of dependencies found in config.w32
+          [ -f "ext/${{range.key}}/config.w32" ] && \
+            deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
+                | tr -d "'," | tr ' ' '\n' \
+                | sort -u \
+                | while read -r dep; do
+                  [ "$dep" = "true" ] || echo $dep
+                done | wc -w`
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP ${{vars.phpMM}} development headers
+    dependencies:
+      provides:
+        - php-dev=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: php-dev
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: ${{package.name}}-doc
+    description: PHP ${{vars.phpMM}} documentation
+    dependencies:
+      provides:
+        - php-doc=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
+
+  - name: "${{package.name}}-apache"
+    description: Apache SAPI for PHP ${{vars.phpMM}}
+    dependencies:
+      provides:
+        - php-apache=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/apache2/modules
+          mv /home/build/libs/libphp.so ${{targets.subpkgdir}}/usr/lib/apache2/modules/
+          install -Dm644 apache.conf ${{targets.subpkgdir}}/etc/apache2/extra/php_module.conf
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - apache2 # Ensure that we properly install the subpackage along with the main package and apache2
+            - apache2-compat
+      pipeline:
+        - uses: test/tw/ldd-check
+        - runs: stat /usr/lib/apache2/modules/libphp.so
+
+  - name: "${{package.name}}-cgi"
+    description: PHP ${{vars.phpMM}} CGI
+    dependencies:
+      provides:
+        - php-cgi=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: php-cgi
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: "${{package.name}}-dbg"
+    description: Interactive PHP Debugger
+    dependencies:
+      provides:
+        - php-dbg=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: php-dbg
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: "${{package.name}}-fpm"
+    description: PHP ${{vars.phpMM}} FastCGI Process Manager (FPM)
+    dependencies:
+      runtime:
+        - "${{package.name}}-fpm-config"
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+      provides:
+        - php-fpm=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-fpm ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: php-fpm
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: ${{package.name}}-fpm-config
+    description: PHP ${{vars.phpMM}} FastCGI Process Manager (FPM) configuration
+    dependencies:
+      provides:
+        - php-fpm-config=${{package.full-version}}
+      runtime:
+        - merged-bin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
+          mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
+          && { \
+            echo '[global]'; \
+            echo 'error_log = /proc/self/fd/2'; \
+            echo 'daemonize = no'; \
+            echo; \
+            echo '[www]'; \
+            echo 'listen = [::]:9000'; \
+            echo 'access.log = /proc/self/fd/2'; \
+            echo; \
+            echo 'clear_env = no'; \
+            echo; \
+            echo 'catch_workers_output = yes'; \
+            echo; \
+            echo 'decorate_workers_output = no'; \
+          } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: php-fpm-config
+            real-pkg-name: ${{subpkg.name}}
+
+  - name: ${{package.name}}-pear
+    description: PHP ${{vars.phpMM}} PEAR package manager
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - ${{package.name}}-xml
+        - ${{package.name}}-openssl
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mkdir -p ${{targets.subpkgdir}}/usr/share/php
+
+          # Move PEAR executables
+          mv ${{targets.destdir}}/usr/bin/pear ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/peardev ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pecl ${{targets.subpkgdir}}/usr/bin/
+
+          # Move PEAR libraries
+          if [ -d "${{targets.destdir}}/usr/share/php/pear" ]; then
+            mv ${{targets.destdir}}/usr/share/php/pear ${{targets.subpkgdir}}/usr/share/php/
+          fi
+    test:
+      pipeline:
+        - runs: |
+            pear version
+        - runs: |
+            echo "Available channels:"
+            echo "Available channels:"
+            pear list-channels
+            pear install Cache_Lite
+            # Verify PEAR functionality by checking if we have core packages
+            if pear list | grep -q "PEAR"; then
+                echo "PEAR core packages are installed"
+            else
+                echo "No PEAR packages found"
+                exit 1
+            fi
+
+update:
+  enabled: true
+  github:
+    identifier: php/php-src
+    strip-prefix: php-
+    tag-filter: php-8.5
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        php --version
+        php --help
+    - runs: |
+        cat <<'EOF' >> /tmp/hello.php
+        <?php
+        echo 'Hello, Wolfi!';
+        EOF
+
+        php /tmp/hello.php

--- a/php-8.5/apache.conf
+++ b/php-8.5/apache.conf
@@ -1,0 +1,13 @@
+# Required modules: dir_module, php_module
+
+<IfModule dir_module>
+	<IfModule php_module>
+		DirectoryIndex index.php index.html
+		<FilesMatch "\.php$">
+			SetHandler application/x-httpd-php
+		</FilesMatch>
+		<FilesMatch "\.phps$">
+			SetHandler application/x-httpd-php-source
+		</FilesMatch>
+	</IfModule>
+</IfModule>

--- a/php-8.5/install-pear.patch
+++ b/php-8.5/install-pear.patch
@@ -1,0 +1,16 @@
+diff --git a/pear/Makefile.frag b/pear/Makefile.frag
+index 9408757a..53f98762 100644
+--- a/pear/Makefile.frag
++++ b/pear/Makefile.frag
+@@ -1,7 +1,8 @@
+ peardir=$(PEAR_INSTALLDIR)
+
+ # Skip all php.ini files altogether
+-PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1
++PEAR_INSTALL_XML_FLAGS = -d extension="$(top_builddir)/modules/xml.so" -d extension="$(top_builddir)/modules/phar.so"
++PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 $(PEAR_INSTALL_XML_FLAGS)
+
+ WGET = `which wget 2>/dev/null`
+ FETCH = `which fetch 2>/dev/null`
+
+


### PR DESCRIPTION
The main change here is that upstream made opcache built-in, which means that we no longer have to build it as a shared library.