### PR TITLE
celeborn-0.6: Remediate CVE

### DIFF
--- a/celeborn-0.6.yaml
+++ b/celeborn-0.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.6
   version: "0.6.1"
-  epoch: 0 # GHSA-jq43-27x9-3v86
+  epoch: 1 # GHSA-7p63-w6x9-6gr7
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0

--- a/celeborn-0.6/pombump-properties.yaml
+++ b/celeborn-0.6/pombump-properties.yaml
@@ -21,3 +21,5 @@ properties:
     value: 2.13.17
   - property: spark.version
     value: 3.5.5
+  - property: jersey.version
+    value: 2.46


### PR DESCRIPTION
Remediate GHSA-7p63-w6x9-6gr7

Bump jersey.version to 2.46

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
<!--ci-cve-scan:fail-any-->
