### PR TITLE
add systemd runtime dependency from fluent-watcher package

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -25,6 +25,9 @@ pipeline:
 
 subpackages:
   - name: fluent-watcher
+    dependencies:
+      runtime:
+        - fluent-plugin-systemd
     pipeline:
       - uses: go/build
         with:

--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: "3.5.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/21951