### PR TITLE
neo4j-2025.10.1: remediate CVE

### DIFF
--- a/neo4j-2025.10.yaml
+++ b/neo4j-2025.10.yaml
@@ -144,6 +144,7 @@ subpackages:
               Bolt enabled on localhost
             post: |-
               #!/bin/sh -e
+              sleep 5
               curl -fsSL localhost:7474/browser | grep "<title>Neo4j Browser</title>"
 
 update:
@@ -175,4 +176,5 @@ test:
           #!/bin/sh -e
           neo4j status | grep -i "Neo4j is running"
           neo4j-admin server status | grep -i "Neo4j is running"
+          sleep 5
           curl -fsSL localhost:7474/browser | grep "<title>Neo4j Browser</title>"

--- a/neo4j-2025.10.yaml
+++ b/neo4j-2025.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-2025.10
   version: "2025.10.1"
-  epoch: 0
+  epoch: 1 # GHSA-7p63-w6x9-6gr7
   description:
   copyright:
     - license: GPL-3.0-or-later
@@ -43,6 +43,8 @@ pipeline:
       repository: https://github.com/neo4j/neo4j
       tag: ${{package.version}}
       expected-commit: 503a3228c34cb48495838fb7866b46d1a7a49640
+
+  - uses: maven/pombump
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/neo4j-2025.10/pombump-properties.yaml
+++ b/neo4j-2025.10/pombump-properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: jersey.version
+    value: 2.46


### PR DESCRIPTION
Remediate GHSA-7p63-w6x9-6gr7

Bump jersey.version to 2.46

Signed-off-by: David Negreira <david.negreira@chainguard.dev>

<!--ci-cve-scan:fail-any-->
