### PR TITLE
fix: resolve dependency issues in checkov

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -5,9 +5,15 @@ package:
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT
+  options: 
+    no-depends: true
+    no-provides: true
   dependencies:
     runtime:
+      - bash
       - python-${{vars.python-version}}
+      - py${{vars.python-version}}-pyyaml
+      - ca-certificates-bundle
 
 vars:
   python-version: '3.12'
@@ -25,6 +31,7 @@ environment:
       - py${{vars.python-version}}-setuptools
       - py${{vars.python-version}}-wheel
       - python-${{vars.python-version}}
+      - py${{vars.python-version}}-packaging
       - wolfi-base
       - wolfi-baselayout
 
@@ -35,9 +42,33 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: b1114135b5f9a33922ec290826c744e048c8d770
 
-  - uses: py/pip-build-install
-    with:
-      python: python${{vars.python-version}}
+  - runs: | 
+      # Create virtual environment
+      python3 -m venv venv --system-site-packages
+      source venv/bin/activate
+
+      # Remediate CVE-2025-8869
+      pip install --upgrade 'pip>=25.3'
+
+      # Install dependencies
+      pip install bc-jsonpath-ng junit-xml lark bc-detect-secrets dpath rustworkx bc-python-hcl2
+
+      # Install checkov
+      pip install .
+
+      # Remove pip and virtualenv
+      pip uninstall --yes pip virtualenv
+
+      # Use Python in virtual environment
+      find venv/pyvenv.cfg venv/bin/ -type f | xargs sed -i 's|/home/build/venv|/usr/share/checkov|g'
+
+      # Install virtual environment
+      mkdir -p ${{targets.destdir}}/usr/share/checkov
+      cp -r venv/* ${{targets.destdir}}/usr/share/checkov/
+
+      # Create symlink so checkov is available in PATH
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /usr/share/checkov/bin/checkov ${{targets.destdir}}/usr/bin/checkov
 
   - uses: strip
 


### PR DESCRIPTION
Resolves the various dependency issues faced during runtime

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->



Fixes:

Previously, `checkov` was installed directly into the system site-packages
using `py/pip-build-install` and only declared a runtime dependency on
`python-3.12`. On a minimal image this resulted in repeated runtime failures
when running `checkov`:

- `ModuleNotFoundError: No module named 'argcomplete'`
- `ModuleNotFoundError: No module named 'configargparse'`
- (and additional missing Python modules as they were imported)

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
