### PR TITLE
protobuf: Pin required libraies so we don't mix and match

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: "33.1" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -63,11 +63,11 @@ subpackages:
     dependencies:
       runtime:
         - abseil-cpp-dev
-        - libprotoc${{vars.soversion}}
-        - libprotobuf${{vars.soversion}}
-        - libprotobuf-lite${{vars.soversion}}
-        - protobuf
-        - protoc
+        - libprotobuf${{vars.soversion}}=${{package.full-version}}
+        - libprotobuf-lite${{vars.soversion}}=${{package.full-version}}
+        - libprotoc${{vars.soversion}}=${{package.full-version}}
+        - protobuf=${{package.full-version}}
+        - protoc=${{package.full-version}}
         - zlib-dev
     test:
       pipeline:


### PR DESCRIPTION
This prevents installing mis matched versions of the libraries.