### PR TITLE
kaniko: Improve baselayout patch for better compatibility

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: "1.25.5"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -20,7 +20,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 0a913af7e0b3e84a90f53e234c18cae6cd00a1a8
 
-  # patch to fix customer escalation: https://github.com/chainguard-dev/customer-issues/issues/2579
+  # patch to make kaniko more compatible with wolfi-baselayout.
   - uses: patch
     with:
       patches: remove-usrmerge-symlinks.patch

--- a/kaniko/remove-usrmerge-symlinks.patch
+++ b/kaniko/remove-usrmerge-symlinks.patch
@@ -1,7 +1,7 @@
 # Fixes: https://github.com/chainguard-dev/customer-issues/issues/2579
 # Internal Issue to investigate long-term fix: https://github.com/chainguard-dev/internal-dev/issues/21302
 diff --git a/pkg/executor/build.go b/pkg/executor/build.go
-index ccdfd17..9531c78 100644
+index ccdfd17e..1756a6b6 100644
 --- a/pkg/executor/build.go
 +++ b/pkg/executor/build.go
 @@ -691,6 +691,9 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
@@ -9,82 +9,85 @@ index ccdfd17..9531c78 100644
  func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
  	t := timing.Start("Total Build Time")
 +	fixUsrMergeSymlinks()
-+	removeUnusedBaselayoutSymlinks()
++	removeUnusedBaselayoutFiles()
 +
  	digestToCacheKey := make(map[string]string)
  	stageIdxToDigest := make(map[string]string)
  
-@@ -830,6 +833,75 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
+@@ -830,6 +833,78 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
  	return nil, err
  }
  
 +// remove usrmerge symlinks to avoid circular dependencies
-+func fixUsrMergeSymlinks() error {
++func fixUsrMergeSymlinks() {
 +	logrus.Info("Fixing usrmerge symlinks")
 +
-+	linksToFix := []string{"/bin", "/lib", "/sbin", "/lib64", "/usr/sbin"}
-+
 +	// Remove symlinks and recreate as directories
-+	for _, link := range linksToFix {
-+		info, err := os.Lstat(link)
-+		if err != nil {
-+			logrus.Debugf("Path %s does not exist, skipping", link)
++	for _, link := range []string{"/bin", "/lib", "/sbin", "/lib64", "/usr/sbin"} {
++		if !removeSymlinkIfExists(link) {
 +			continue
-+		}
-+		if info.Mode()&os.ModeSymlink == 0 {
-+			logrus.Debugf("%s is not a symlink, skipping removal", link)
-+			continue
-+		}
-+
-+		logrus.Infof("Removing usrmerge symlink: %s", link)
-+		if err := os.Remove(link); err != nil {
-+			return err
 +		}
 +
 +		// Recreate as directory after removing symlink
 +		logrus.Infof("Creating directory: %s", link)
 +		if err := os.MkdirAll(link, 0755); err != nil {
-+			return err
++			logrus.Warnf("Failed to create directory %s: %v", link, err)
 +		}
 +	}
 +
 +	// Recreate /bin/sh symlink needed by kaniko
 +	logrus.Info("Creating /bin/sh symlink to /busybox/sh")
 +	if err := os.Symlink("/busybox/sh", "/bin/sh"); err != nil {
-+		return err
++		logrus.Warnf("Failed to create /bin/sh symlink: %v", err)
 +	}
-+
-+	return nil
 +}
 +
-+// removeUnusedBaselayoutSymlinks removes unnecessary symlinks from the base layout.
-+// These symlinks are created by wolfi-baselayout but are not needed by kaniko,
++// removeUnusedBaselayoutFiles removes unnecessary files and symlinks from the
++// base layout.
++// These are created by wolfi-baselayout but are not needed by kaniko,
 +// and their presence can cause issues with kaniko functionality.
-+func removeUnusedBaselayoutSymlinks() {
-+	logrus.Info("Checking for unused baselayout symlinks to remove")
++func removeUnusedBaselayoutFiles() {
++	logrus.Info("Checking for unused baselayout files to remove")
 +
-+	// Remove symlinks created by wolfi-baselayout that kaniko doesn't need
-+	symlinksToRemove := []string{
++	// Remove files created by wolfi-baselayout that kaniko doesn't need.
++	for _, file := range []string{
++		"/etc/protocols",
++		"/etc/services",
++		"/etc/shells",
++	} {
++		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
++			logrus.Warnf("Failed to remove unused baselayout file %s: %v", file, err)
++		}
++	}
++
++	// Remove symlinks created by wolfi-baselayout that kaniko doesn't need.
++	for _, symlink := range []string{
 +		"/var/spool/cron/crontabs", // symlink to /etc/crontabs
-+		"/var/spool/mail",           // symlink to /var/mail
++		"/var/spool/mail",          // symlink to /var/mail
++	} {
++		removeSymlinkIfExists(symlink)
++	}
++}
++
++// removeSymlinkIfExists removes the symlink at the given path if it exists.
++// It returns true if the symlink was removed, false otherwise.
++func removeSymlinkIfExists(path string) bool {
++	info, err := os.Lstat(path)
++	if err != nil {
++		logrus.Debugf("Symlink %s does not exist, skipping", path)
++		return false
++	}
++	if info.Mode()&os.ModeSymlink == 0 {
++		logrus.Debugf("%s is not a symlink, skipping", path)
++		return false
 +	}
 +
-+	for _, symlink := range symlinksToRemove {
-+		info, err := os.Lstat(symlink)
-+		if err != nil {
-+			logrus.Debugf("Symlink %s does not exist, skipping", symlink)
-+			continue
-+		}
-+		if info.Mode()&os.ModeSymlink == 0 {
-+			logrus.Debugf("%s is not a symlink, skipping", symlink)
-+			continue
-+		}
-+
-+		logrus.Infof("Removing unused baselayout symlink: %s", symlink)
-+		if err := os.Remove(symlink); err != nil {
-+			logrus.Warnf("Failed to remove symlink %s: %v", symlink, err)
-+		}
++	logrus.Infof("Removing unused baselayout symlink: %s", path)
++	if err := os.Remove(path); err != nil {
++		logrus.Warnf("Failed to remove symlink %s: %v", path, err)
++		return false
 +	}
++	return true
 +}
 +
  // filesToSave returns all the files matching the given pattern in deps.

--- a/kaniko/remove-usrmerge-symlinks.patch
+++ b/kaniko/remove-usrmerge-symlinks.patch
@@ -1,5 +1,3 @@
-# Fixes: https://github.com/chainguard-dev/customer-issues/issues/2579
-# Internal Issue to investigate long-term fix: https://github.com/chainguard-dev/internal-dev/issues/21302
 diff --git a/pkg/executor/build.go b/pkg/executor/build.go
 index ccdfd17e..1756a6b6 100644
 --- a/pkg/executor/build.go


### PR DESCRIPTION
This adds a couple of more files to remove to the existing patch fixing usrmerge and baselayout for improves kaniko compatibility. In particular, it removes /etc/protocols, /etc/services and /etc/shells to avoid potential conflicts on those files.

It also slightly reworks the patch to surface any failure during those operations as warnings properly and deduplicates some of the code.