### PR TITLE
cortex: fix golang tags

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -1,19 +1,10 @@
 package:
   name: cortex
   version: "1.20.0"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: A horizontally scalable, highly available, multi-tenant, long term Prometheus.
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -26,10 +17,13 @@ pipeline:
     with:
       packages: ./cmd/cortex
       output: cortex
+      tags: netgo,slicelabels
       ldflags: |
         -X main.Branch=$(git rev-parse --abbrev-ref HEAD) \
         -X main.Revision=$(git rev-parse --short HEAD) \
         -X main.Version=$(cat ./VERSION)
+
+  - uses: strip
 
 update:
   enabled: true
@@ -39,6 +33,9 @@ update:
 
 test:
   pipeline:
-    - runs: |
-        /usr/bin/cortex --version
-        cortex --version
+    - uses: test/tw/help-check
+      with:
+        bins: cortex
+    - uses: test/tw/ver-check
+      with:
+        bins: cortex

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -13,6 +13,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 4e5684803ed82fd804b6589af03d39ea97c38c5c
 
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.45.0
+
   - uses: go/build
     with:
       packages: ./cmd/cortex


### PR DESCRIPTION
Upstream seems to be building cortex with these tags by default.
Prevents crashes on runtime
