### PR TITLE
Add PHP 8.5 modules

### DIFF
--- a/php-8.5-amqp.yaml
+++ b/php-8.5-amqp.yaml
@@ -1,0 +1,73 @@
+package:
+  name: php-8.5-amqp
+  version: 2.1.2
+  epoch: 0
+  description: "PHP extension to communicate with any AMQP compliant server"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+      - rabbitmq-c
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - rabbitmq-c-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-amqp/php-amqp
+      tag: "v${{package.version}}"
+      expected-commit: 82424ed50eb10cd97777e2aabf0f2a0887faf447
+
+  - uses: patch
+    with:
+      patches: fix-build-with-php-8.5.patch
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=amqp.so" > "${{targets.subpkgdir}}/etc/php/conf.d/amqp.ini"
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: php-amqp/php-amqp
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.5-amqp/fix-build-with-php-8.5.patch
+++ b/php-8.5-amqp/fix-build-with-php-8.5.patch
@@ -1,0 +1,136 @@
+From 789de276603ca54cf85c958bf996c4faedf73223 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Fri, 4 Jul 2025 12:13:08 +0200
+Subject: [PATCH 1/3] Use php_format_date instead of php_std_date
+
+- php_format_date exists in 7.4+
+- php_std_date removed in 8.5
+
+x
+---
+ amqp_connection_resource.c | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/amqp_connection_resource.c b/amqp_connection_resource.c
+index 8809a20b..eaf857e7 100644
+--- a/amqp_connection_resource.c
++++ b/amqp_connection_resource.c
+@@ -26,7 +26,7 @@
+ #endif
+ 
+ #include "php.h"
+-#include "ext/standard/datetime.h"
++#include "ext/date/php_date.h"
+ #include "zend_exceptions.h"
+ 
+ #ifdef PHP_WIN32
+@@ -470,8 +470,8 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
+ {
+     struct timeval tv = {0};
+     struct timeval *tv_ptr = &tv;
++    zend_string *std_datetime;
+ 
+-    char *std_datetime;
+     amqp_table_entry_t client_properties_entries[4];
+     amqp_table_t client_properties_table;
+ 
+@@ -581,8 +581,6 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
+         return NULL;
+     }
+ 
+-    std_datetime = php_std_date(time(NULL));
+-
+     client_properties_entries[0].key = amqp_cstring_bytes("type");
+     client_properties_entries[0].value.kind = AMQP_FIELD_KIND_UTF8;
+     client_properties_entries[0].value.value.bytes = amqp_cstring_bytes("php-amqp extension");
+@@ -597,7 +595,8 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
+ 
+     client_properties_entries[3].key = amqp_cstring_bytes("connection started");
+     client_properties_entries[3].value.kind = AMQP_FIELD_KIND_UTF8;
+-    client_properties_entries[3].value.value.bytes = amqp_cstring_bytes(std_datetime);
++    std_datetime = php_format_date("D, d M Y H:i:s \\G\\M\\T", sizeof("D, d M Y H:i:s \\G\\M\\T")-1, time(NULL), 0);
++    client_properties_entries[3].value.value.bytes = amqp_cstring_bytes(ZSTR_VAL(std_datetime));
+ 
+     client_properties_table.entries = client_properties_entries;
+     client_properties_table.num_entries = sizeof(client_properties_entries) / sizeof(amqp_table_entry_t);
+@@ -632,7 +631,7 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
+         params->password
+     );
+ 
+-    efree(std_datetime);
++    zend_string_release(std_datetime);
+ 
+     if (AMQP_RESPONSE_NORMAL != res.reply_type) {
+         char *message = NULL, *long_message = NULL;
+
+From 32c799b2f4182e4d7f2ef99cdbd9df3d6f0c2678 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Tue, 15 Jul 2025 14:50:40 +0200
+Subject: [PATCH 2/3] use zend_ce_exception
+
+---
+ amqp.c       | 2 +-
+ amqp_queue.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/amqp.c b/amqp.c
+index ef04488d..84a87b7b 100644
+--- a/amqp.c
++++ b/amqp.c
+@@ -276,7 +276,7 @@ static PHP_MINIT_FUNCTION(amqp) /* {{{ */
+ 
+     /* Exceptions */
+     INIT_CLASS_ENTRY(ce, "AMQPException", NULL);
+-    amqp_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default());
++    amqp_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
+ 
+     INIT_CLASS_ENTRY(ce, "AMQPConnectionException", NULL);
+     amqp_connection_exception_class_entry = zend_register_internal_class_ex(&ce, amqp_exception_class_entry);
+diff --git a/amqp_queue.c b/amqp_queue.c
+index eeeec3df..48287fa1 100644
+--- a/amqp_queue.c
++++ b/amqp_queue.c
+@@ -754,7 +754,7 @@ static PHP_METHOD(amqp_queue_class, consume)
+             ZVAL_UNDEF(&exception);
+             object_init_ex(&exception, amqp_envelope_exception_class_entry);
+             zend_update_property_string(
+-                zend_exception_get_default(),
++                zend_ce_exception,
+                 PHP_AMQP_COMPAT_OBJ_P(&exception),
+                 ZEND_STRL("message"),
+                 "Orphaned envelope"
+
+From 977449987412a3d5c59a036dbab8b6d67764bb3e Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Mon, 29 Sep 2025 07:49:28 +0200
+Subject: [PATCH 3/3] Silent the "not representable as an int" warning
+
+---
+ tests/amqpconnection_validation.phpt | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/tests/amqpconnection_validation.phpt b/tests/amqpconnection_validation.phpt
+index 9f67cf67..bb1790c0 100644
+--- a/tests/amqpconnection_validation.phpt
++++ b/tests/amqpconnection_validation.phpt
+@@ -26,7 +26,12 @@ foreach ($parameters as $args) {
+     list($prop, $setter, $getter, $values) = $args;
+     foreach ($values as $value) {
+         try {
+-            $con1 = new AMQPConnection([$prop => $value]);
++            if (in_array($prop, ['frame_max', 'heartbeat'])) {
++                // Silent the "not representable as an int" warning
++                $con1 = @new AMQPConnection([$prop => $value]);
++            } else {
++                $con1 = new AMQPConnection([$prop => $value]);
++            }
+             echo $getter . " after constructor: ";
+             echo $con1->{$getter}();
+             echo PHP_EOL;
+@@ -109,4 +114,4 @@ AMQPConnectionException: Parameter 'heartbeat' is out of range.
+ AMQPConnectionException: Parameter 'heartbeat' is out of range.
+ getHeartbeatInterval after constructor: 250
+ getHeartbeatInterval after constructor: 0
+-==DONE==
+\ No newline at end of file
++==DONE==

--- a/php-8.5-apcu.yaml
+++ b/php-8.5-apcu.yaml
@@ -1,0 +1,120 @@
+package:
+  name: php-8.5-apcu
+  version: "5.1.27"
+  epoch: 0
+  description: "PHP extension for User Cache"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - pcre2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/apcu
+      tag: "v${{package.version}}"
+      expected-commit: 36e51f020a3f798286d990cb8857b22e501ef523
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=apcu.so" > "${{targets.subpkgdir}}/etc/php/conf.d/apcu.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/apcu
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true
+
+test:
+  pipeline:
+    - name: "Check if extension is loaded"
+      runs: |
+        php -m | grep -i "apcu"
+    - name: "Verify extension version"
+      runs: |
+        php -r 'echo phpversion("apcu");'
+    - name: "Test basic cache storage and retrieval"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!apcu_store("test_key", "test_value")) exit(1);
+          $value = apcu_fetch("test_key");
+          if ($value !== "test_value") exit(1);
+          echo "Success";
+        '
+    - name: "Test cache exists functionality"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!apcu_store("check_key", "check_value")) exit(1);
+          if (!apcu_exists("check_key")) exit(1);
+          if (apcu_exists("nonexistent_key")) exit(1);
+          echo "Success";
+        '
+    - name: "Test cache deletion"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!apcu_store("delete_key", "delete_value")) exit(1);
+          if (!apcu_delete("delete_key")) exit(1);
+          if (apcu_exists("delete_key")) exit(1);
+          echo "Success";
+        '
+    - name: "Test cache clearing"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!apcu_store("clear_key", "clear_value")) exit(1);
+          if (!apcu_clear_cache()) exit(1);
+          if (apcu_exists("clear_key")) exit(1);
+          echo "Success";
+        '
+    - name: "Test increment/decrement operations"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!apcu_store("counter", 5)) exit(1);
+          if (apcu_inc("counter") !== 6) exit(1);
+          if (apcu_dec("counter") !== 5) exit(1);
+          echo "Success";
+        '
+    - name: "Verify configuration file"
+      runs: |
+        grep -q "^extension=apcu.so" /etc/php/conf.d/apcu.ini
+    - name: "Verify APCu is enabled in CLI"
+      runs: |
+        php -d apc.enable_cli=1 -r '
+          if (!ini_get("apc.enable_cli")) exit(1);
+          echo "APCu CLI mode enabled";
+        '
+    - uses: test/tw/ldd-check

--- a/php-8.5-ddtrace.yaml
+++ b/php-8.5-ddtrace.yaml
@@ -1,0 +1,125 @@
+package:
+  name: php-8.5-ddtrace
+  version: "1.14.0"
+  epoch: 0
+  description: "Datadog PHP Clients"
+  copyright:
+    - license: Apache-2.0 OR BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - ${{package.name}}-src
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - curl-dev
+      - pcre2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - posix-libc-utils
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DataDog/dd-trace-php
+      tag: "${{package.version}}"
+      expected-commit: 12004d34feca5a24ed1bd002362446c78a6361ee
+
+  - name: Clone submodules
+    runs: git submodule update --init --recursive
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ddtrace.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ddtrace.ini"
+          echo "datadog.trace.sources_path=\"/usr/share/dd-trace-php/src\"" >> "${{targets.subpkgdir}}/etc/php/conf.d/ddtrace.ini"
+
+  - name: ${{package.name}}-src
+    description: "Datadog PHP tracer source files"
+    dependencies:
+      runtime:
+        - php-${{vars.phpMM}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/dd-trace-php"
+          cp -r src "${{targets.subpkgdir}}/usr/share/dd-trace-php/"
+
+test:
+  environment:
+    contents:
+      packages:
+        - php-${{vars.phpMM}}
+        - ${{package.name}}-config
+        - ${{package.name}}-src
+  pipeline:
+    - name: Verify Extension is Loaded
+      runs: |
+        php -m | grep -i 'ddtrace'
+        if [ $? -ne 0 ]; then
+          echo "Test failed: ddtrace extension is not loaded."
+          exit 1
+        else
+          echo "Test passed: ddtrace extension is loaded."
+        fi
+    - name: Test Basic ddtrace Functionality
+      runs: |
+        echo "<?php
+        use function DDTrace\trace_method;
+        use function DDTrace\trace_function;
+
+        \DDTrace\trace_method('App', 'get', function () {
+          echo \"Datadog tracer is running and trace method was created.\n\";
+        });
+
+        \DDTrace\trace_function('App\some_utility_function', function () {
+          echo \"Datadog tracer is running and trace function was created.\n\";
+        });
+        ?>" > test.php
+
+        php test.php
+
+        if [ $? -ne 0 ]; then
+          echo "Test failed: Unable to use ddtrace extension."
+          exit 1
+        else
+          echo "Test passed: ddtrace extension is functional."
+        fi
+    - name: Test PHP Class Availability
+      runs: |
+        php -r 'if (!class_exists("DDTrace\\GlobalTracer")) exit(1);'
+        if [ $? -ne 0 ]; then
+          echo "Test failed: DDTrace\\GlobalTracer class is not available."
+          exit 1
+        else
+          echo "Test passed: DDTrace\\GlobalTracer class is available."
+        fi
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: DataDog/dd-trace-php
+    use-tag: true

--- a/php-8.5-decimal.yaml
+++ b/php-8.5-decimal.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.5-decimal
+  version: 1.5.0
+  epoch: 0
+  description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - mpdecimal-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-decimal/ext-decimal
+      tag: "v${{package.version}}"
+      expected-commit: 9b4d6f4cf282230a0949ef4204e0b6bfe29b2c51
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=decimal.so" > "${{targets.subpkgdir}}/etc/php/conf.d/decimal.ini"
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: php-decimal/ext-decimal
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.5-ds.yaml
+++ b/php-8.5-ds.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.5-ds
+  version: "1.6.0"
+  epoch: 0
+  description: "An extension providing efficient data structures for PHP"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-ds/ext-ds
+      tag: "v${{package.version}}"
+      expected-commit: 118c06b8863386ceada4238f3cec18ab84c9efb7
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ds.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ds.ini"
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: php-ds/ext-ds
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.5-excimer.yaml
+++ b/php-8.5-excimer.yaml
@@ -1,0 +1,65 @@
+package:
+  name: php-8.5-excimer
+  version: "1.2.5"
+  epoch: 0
+  description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/wikimedia/mediawiki-php-excimer
+      tag: "${{package.version}}"
+      expected-commit: 72ac819677db895df4914e3388df7f394c0b61af
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=excimer.so" > "${{targets.subpkgdir}}/etc/php/conf.d/excimer.ini"
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: wikimedia/mediawiki-php-excimer
+    use-tag: true

--- a/php-8.5-grpc.yaml
+++ b/php-8.5-grpc.yaml
@@ -1,0 +1,93 @@
+package:
+  name: php-8.5-grpc
+  version: "1.76.0"
+  epoch: 0
+  description: "A PHP extension for gRPC"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - grpc
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - grpc-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grpc/grpc
+      tag: "v${{package.version}}"
+      expected-commit: f5ffb68d8a2fd603dff16287e90a4ac571e1fec6
+
+  - uses: patch
+    with:
+      patches: fix-build-with-php-8.5.patch
+
+  - name: Prepare build
+    runs: cd src/php/ext/grpc && phpize
+
+  - name: Configure
+    runs: cd src/php/ext/grpc && ./configure
+
+  - name: Make install
+    runs: |
+      cd src/php/ext/grpc
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=grpc.so" > "${{targets.subpkgdir}}/etc/php/conf.d/grpc.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: grpc/grpc
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - php-${{vars.phpMM}}
+        - php-${{vars.phpMM}}-grpc
+        - php-${{vars.phpMM}}-grpc-config
+        - grpc
+  pipeline:
+    - name: Verify gRPC Extension
+      runs: |
+        php -m | grep -q grpc || (echo "gRPC extension not loaded" && exit 1)
+    - name: Test gRPC Functionality
+      runs: |
+        PHP_SCRIPT=$(cat <<'EOF'
+        <?php
+        // Simple script to test grpc
+        if (extension_loaded("grpc")) {
+            echo "gRPC extension loaded successfully.\n";
+            echo "gRPC version: " . phpversion("grpc") . "\n";
+        } else {
+            echo "gRPC extension is not loaded.\n";
+        }
+        ?>
+        EOF
+        )
+            echo "$PHP_SCRIPT" | php
+    - uses: test/tw/ldd-check

--- a/php-8.5-grpc/fix-build-with-php-8.5.patch
+++ b/php-8.5-grpc/fix-build-with-php-8.5.patch
@@ -1,0 +1,26 @@
+From 4134a5ac820c07a10c62428eaefa55eba64a2030 Mon Sep 17 00:00:00 2001
+From: Heena Bansal <heena.bansal20@ibm.com>
+Date: Mon, 29 Sep 2025 10:41:41 -0400
+Subject: [PATCH] Fix runtime error with PHp8.5 alpha because
+ zend_exception_get_default is removed
+
+---
+ src/php/ext/grpc/call.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/php/ext/grpc/call.c b/src/php/ext/grpc/call.c
+index 7bc711be67d23..a9f4c0bbb52e5 100644
+--- a/src/php/ext/grpc/call.c
++++ b/src/php/ext/grpc/call.c
+@@ -84,7 +84,11 @@ zval *grpc_parse_metadata_array(grpc_metadata_array
+     if (php_grpc_zend_hash_find(array_hash, str_key, key_len, (void **)&data)
+         == SUCCESS) {
+       if (Z_TYPE_P(data) != IS_ARRAY) {
++#if PHP_VERSION_ID >= 80500
++        zend_throw_exception(zend_ce_exception,
++#else
+         zend_throw_exception(zend_exception_get_default(TSRMLS_C),
++#endif
+                              "Metadata hash somehow contains wrong types.",
+                              1 TSRMLS_CC);
+         efree(str_key);

--- a/php-8.5-igbinary.yaml
+++ b/php-8.5-igbinary.yaml
@@ -1,0 +1,72 @@
+package:
+  name: php-8.5-igbinary
+  version: 3.2.16
+  epoch: 0
+  description: "Igbinary is a drop in replacement for the standard php serializer."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/igbinary/igbinary
+      tag: ${{package.version}}
+      expected-commit: 8326f6a69ebb30dd6258dd536eb0914454fbf146
+      cherry-picks: |
+        master/c7fe8aad3d7894bb85f5a189eba60dec9203950d: use Zend/zend_smart_string.h
+        master/d28f7e6e5a2e7f73225bdf9b619920a7986ff885: fix tests for 8.5.0beta2
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure CFLAGS="-O2 -g" --enable-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP ${{vars.phpMM}} igbinary development headers
+    pipeline:
+      - uses: split/dev
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  github:
+    identifier: igbinary/igbinary

--- a/php-8.5-imagick.yaml
+++ b/php-8.5-imagick.yaml
@@ -1,0 +1,72 @@
+package:
+  name: php-8.5-imagick
+  version: "3.8.0"
+  epoch: 0
+  description: "PHP extension for ImageMagick"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - imagemagick
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - imagemagick-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Imagick/imagick
+      tag: "${{package.version}}"
+      expected-commit: 555bf68b592a8d9d0a0a2f37d1256a8b6cf2d39e
+      cherry-picks: |
+        master/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e: Use Zend/zend_smart_string.h
+
+  # Apply package version template as `package.xml` does not seem to apply this automatically
+  - runs: sed -i "s/@PACKAGE_VERSION@/${{package.version}}/g" ./*.h
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=imagick.so" > "${{targets.subpkgdir}}/etc/php/conf.d/imagick.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: Imagick/imagick
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+    - name: Ensure versioning got passed to module
+      runs: |
+        php --info | grep -F -e imagick | grep -E -e "${{package.version}}"

--- a/php-8.5-memcached.yaml
+++ b/php-8.5-memcached.yaml
@@ -1,0 +1,71 @@
+package:
+  name: php-8.5-memcached
+  version: "3.4.0"
+  epoch: 0
+  description: "A PHP extension for Memcached"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libmemcached-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-memcached-dev/php-memcached
+      tag: v${{package.version}}
+      expected-commit: ce37962769fc7b25f9905c4b23fa53df92447a32
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP ${{vars.phpMM}} memcached development headers
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: php-memcached-dev/php-memcached
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-msgpack.yaml
+++ b/php-8.5-msgpack.yaml
@@ -1,0 +1,69 @@
+package:
+  name: php-8.5-msgpack
+  version: 3.0.0
+  epoch: 0
+  description: "A PHP extension for msgpack"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/msgpack/msgpack-php
+      # The tag has a msgpack- prefix, but the version does not.
+      tag: msgpack-${{package.version}}
+      expected-commit: a934abefac024c02e78c930a4702026dd08459cc
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --with-msgpack
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP ${{vars.phpMM}} msgpack development headers
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: msgpack/msgpack-php
+    tag-filter-prefix: msgpack-
+    strip-prefix: msgpack-
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-opentelemetry.yaml
+++ b/php-8.5-opentelemetry.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.5-opentelemetry
+  version: "1.2.1"
+  epoch: 0
+  description: "OpenTelemetry PHP auto-instrumentation extension"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-telemetry/opentelemetry-php-instrumentation
+      tag: ${{package.version}}
+      expected-commit: c5ebd70d50d9d25a0628c2ae0bfb6e516b551838
+
+  - name: Prepare build
+    runs: cd ext && phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      cd ext
+      ./configure
+
+  - name: Make install
+    runs: |
+      set -x
+      cd ext
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=opentelemetry.so" > "${{targets.subpkgdir}}/etc/php/conf.d/opentelemetry.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: open-telemetry/opentelemetry-php-instrumentation
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-pecl-http.yaml
+++ b/php-8.5-pecl-http.yaml
@@ -1,0 +1,61 @@
+package:
+  name: php-8.5-pecl-http
+  version: "4.3.1"
+  epoch: 0
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - curl-dev
+      - gcc
+      - gcc-14-default
+      - icu-dev
+      - libtool
+      - openssl-dev
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pecl-raphf
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/pecl_http-${{package.version}}.tgz
+      expected-sha256: 1512dc02fea2356c4df50113e00943b0b7fc99bb22d34d9f624b4662f1dad263
+
+  - uses: pecl/phpize
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: "http"
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 371919
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-pecl-mcrypt.yaml
+++ b/php-8.5-pecl-mcrypt.yaml
@@ -1,0 +1,65 @@
+package:
+  name: php-8.5-pecl-mcrypt
+  version: "1.0.9"
+  epoch: 0
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libmcrypt-dev
+      - libtool
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/pecl-encryption-mcrypt
+      tag: ${{package.version}}
+      expected-commit: ee7378051c1776414ee6a459d16942e3f9acdbfc
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mcrypt.so" > ${{targets.destdir}}/etc/php/conf.d/mcrypt.ini
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: php/pecl-encryption-mcrypt
+    use-tag: true
+    # ignore version 2.x.y tags, 1.x.y is the only mentioned version on https://pecl.php.net/package/mcrypt
+    tag-filter: "1."
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-pecl-mongodb.yaml
+++ b/php-8.5-pecl-mongodb.yaml
@@ -1,0 +1,83 @@
+package:
+  name: php-8.5-pecl-mongodb
+  version: "2.1.4"
+  epoch: 0
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - cyrus-sasl-dev
+      - gcc
+      - icu-dev
+      - libtool
+      - openssl-dev>3
+      - php-${{vars.phpMM}}-dev
+      - snappy-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/mongodb-${{package.version}}.tgz
+      expected-sha512: af5ede6c0c13a168cb741aee1d503e13e13b1ca925cda2a155d6b50a51d35cfe832f4b7d266617c6a65d82d4507be0b109bdd4cf92939715b23ba6248b238236
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mongodb.so" > ${{targets.destdir}}/etc/php/conf.d/mongodb.ini
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - php-${{vars.phpMM}}
+  pipeline:
+    - name: Verify Extension is Loaded
+      runs: |
+        echo "<?php
+        if (!extension_loaded('mongodb')) {
+            die('The MongoDB PHP extension is not loaded. Please install or enable it.\n');
+        }
+        ?>" > test.php
+        php test.php
+        if [ $? -ne 0 ]; then
+          echo "Test failed: Unable to use mongodb extension."
+          exit 1
+        else
+          echo "Test passed: mongodb extension is functional."
+        fi
+    - uses: test/tw/ldd-check
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11158

--- a/php-8.5-pecl-raphf.yaml
+++ b/php-8.5-pecl-raphf.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.5-pecl-raphf
+  version: 2.0.1
+  epoch: 0
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/m6w6/ext-raphf
+      tag: "release-${{package.version}}"
+      expected-commit: f52e2bcd62aa733f00454bb61933b83443d3e7cb
+
+  - uses: pecl/phpize
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: "raphf"
+
+  - runs: |
+      # PHP initialization is order dependent. So we will explicitly
+      # load this by prefixing the file with 10- so it runs before
+      # other modules which start with letters starts.
+      mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: m6w6/ext-raphf
+    strip-prefix: release-
+    tag-filter: release-
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-pecl-sqlsrv.yaml
+++ b/php-8.5-pecl-sqlsrv.yaml
@@ -1,0 +1,67 @@
+package:
+  name: php-8.5-pecl-sqlsrv
+  version: 5.12.0
+  epoch: 0
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - php-${{vars.phpMM}}-dev
+      - unixodbc-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/microsoft/msphpsql
+      tag: "v${{package.version}}"
+      expected-commit: 98ff5a8bd4c022cc15664f1478fab2d7629262da
+
+  - runs: |
+      cd source
+      bash ./packagize.sh
+
+  - working-directory: source/sqlsrv
+    uses: pecl/phpize
+
+  - working-directory: source/sqlsrv
+    uses: autoconf/make
+
+  - working-directory: source/sqlsrv
+    uses: pecl/install
+    with:
+      extension: "sqlsrv"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: microsoft/msphpsql
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-protobuf.yaml
+++ b/php-8.5-protobuf.yaml
@@ -1,0 +1,111 @@
+package:
+  name: php-8.5-protobuf
+  version: "4.33.1"
+  epoch: 0
+  description: "Protocol Buffers - Google's data interchange format"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - protobuf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/protobuf-${{package.version}}.tgz
+      expected-sha512: 88c86270584fbd06c5399f53b48b16a6951bfb2a5f2f91bfa554aa3b2e9d1c65b5cb0f0dadfbf0ccd795389d3d07a2f9dd852b8a03ae8d9226755c14e4d95fe5
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure build
+    runs: ./configure
+
+  # The upstream code enables aarch64-specific optimizations, which later will segfault in our tests
+  # because illegal CPU instructions are being used. I guess this is because different arm64 instructions extensions are
+  # embedded in the code compared to what most arm64 CPU could run.
+  # Disable the arm64-optimized ASM, and hope the non-optimized version can run just fine and not cause other problems.
+  # Before this change, functions call would be:
+  #   encode_varint() --> encode_longvarint_arm64()
+  # After this change, it would be:
+  #   encode_varint() --> encode_longvarint()
+  - if: ${{build.arch}} == "aarch64"
+    name: Disable aarch64 ASM optimizations
+    runs: |
+      find . -type f -name "*.c" -o -name "*.h" | xargs sed -i 's/#ifdef UPB_ARM64_ASM/#if 0/g'
+
+  - name: Build and install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=protobuf.so" > "${{targets.subpkgdir}}/etc/php/conf.d/protobuf.ini"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 141406
+
+test:
+  environment:
+    contents:
+      packages:
+        - protobuf
+        - protoc
+  pipeline:
+    - name: "Verify PHP extension is loaded"
+      runs: |
+        php -m | grep -q protobuf
+    - name: "Check extension information"
+      runs: |
+        php --ri protobuf
+    - name: "Test with generated protobuf class"
+      runs: |
+        cat > message.proto << 'EOF'
+        syntax = "proto3";
+        package test;
+        message SimpleMessage {
+          string name = 1;
+          int32 id = 2;
+        }
+        EOF
+        protoc --php_out=. message.proto
+
+        cat > test.php << 'EOF'
+        <?php
+        require_once('GPBMetadata/Message.php');
+        require_once('Test/SimpleMessage.php');
+
+        $message = new Test\SimpleMessage();
+        $message->setName("test");
+        $message->setId(123);
+
+        $data = $message->serializeToString();
+        $newMessage = new Test\SimpleMessage();
+        $newMessage->mergeFromString($data);
+
+        echo ($newMessage->getName() === "test" && $newMessage->getId() === 123) ? "OK" : "FAIL";
+        EOF
+        php test.php | grep -q "OK"
+    - uses: test/tw/ldd-check

--- a/php-8.5-redis.yaml
+++ b/php-8.5-redis.yaml
@@ -1,0 +1,109 @@
+package:
+  name: php-8.5-redis
+  version: "6.3.0"
+  epoch: 0
+  description: "A PHP extension for Redis"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-igbinary
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/phpredis/phpredis
+      tag: ${{package.version}}
+      expected-commit: df4fab2de7fc327c54c94a13af2b9542e4fbd720
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-redis-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP ${{vars.phpMM}} redis development headers
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: phpredis/phpredis
+
+test:
+  environment:
+    contents:
+      packages:
+        - php-${{vars.phpMM}}
+  pipeline:
+    - name: Verify Extension is Loaded
+      runs: |
+        # Ensure the extension configuration is in place
+        if [ ! -f /etc/php/conf.d/redis.ini ]; then
+          echo "extension=redis.so" > /etc/php/conf.d/redis.ini
+        fi
+
+        # List loaded PHP modules and check for 'redis'
+        php -m | grep -i 'redis'
+        if [ $? -ne 0 ]; then
+          echo "Test failed: Redis extension is not loaded."
+          exit 1
+        else
+          echo "Test passed: Redis extension is loaded."
+        fi
+    - name: Test Basic Redis Functionality
+      runs: |
+        # Create a PHP script to test the extension
+        echo "<?php
+        \$redis = new Redis();
+        if (!\$redis) {
+          echo 'Failed to create Redis instance';
+          exit(1);
+        }
+        echo 'Redis extension is functional';
+        ?>" > test.php
+
+        # Run the PHP script
+        php test.php
+
+        # Check the output
+        if [ $? -ne 0 ]; then
+          echo "Test failed: Unable to use Redis extension."
+          exit 1
+        else
+          echo "Test passed: Redis extension is functional."
+        fi
+    - uses: test/tw/ldd-check

--- a/php-8.5-ssh2.yaml
+++ b/php-8.5-ssh2.yaml
@@ -1,0 +1,62 @@
+package:
+  name: php-8.5-ssh2
+  version: 1.4.1
+  epoch: 0
+  description: "Bindings for the libssh2 library"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libssh2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/pecl-networking-ssh2
+      tag: "${{package.version}}"
+      expected-commit: 65c0da1b18373e2286d1569a176101583225a2c0
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ssh2.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ssh2.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php/pecl-networking-ssh2
+    use-tag: true
+    tag-filter-prefix: 1.
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check

--- a/php-8.5-zstd.yaml
+++ b/php-8.5-zstd.yaml
@@ -1,0 +1,65 @@
+package:
+  name: php-8.5-zstd
+  version: "0.15.2"
+  epoch: 0
+  description: Zstd Extension for PHP
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - file
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - zstd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kjdev/php-ext-zstd
+      tag: "${{package.version}}"
+      expected-commit: 666c9fe4840fa7d3e7958ccca345895a6a7f8881
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --with-libzstd
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=zstd.so" > "${{targets.subpkgdir}}/etc/php/conf.d/zstd.ini"
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - pie$
+  github:
+    identifier: kjdev/php-ext-zstd
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check


### PR DESCRIPTION
Created the module packages using:

```
for p in php-8.4-*.yaml; do
    sed -e 's,epoch: .*,epoch: 0,'  -e 's,name: php-8.4-,name: php-8.5-,' "$p" > php-8.5${p#php-8.4};
done
```

Some adjustments were needed:

- `php-8.5-amqp`: Adopt upstream patch from https://github.com/php-amqp/php-amqp/pull/595
- `php-8.5-grpc`: Adopt upstream patch from https://github.com/grpc/grpc/pull/40337
- `php-8.5-igbinary`: Cherry-pick https://github.com/igbinary/igbinary/commit/c7fe8aad3d7894bb85f5a189eba60dec9203950d and https://github.com/igbinary/igbinary/commit/d28f7e6e5a2e7f73225bdf9b619920a7986ff885
- `php-8.5-imagick`: Cherry-pick https://github.com/Imagick/imagick/commit/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e

The following modules aren't ready for PHP 8.5 yet:

- `php-8.5-pdo_snowflake`
- `php-8.5-pecl-pdosqlsrv`
- `php-8.5-swoole`
- `php-8.5-xdebug`