### PR TITLE
Action for final approver-bot stage

### DIFF
--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -5,19 +5,20 @@ on:
     types:
       - labeled
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   approve:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.label.name == 'approver-bot/approve'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
       - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
       - name: Approve PR
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve --body "Approved by approver-bot"

--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -1,0 +1,24 @@
+name: Approve PR from approver-bot
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.event.label.name == 'approver-bot/approve'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+      - name: Approve PR
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} --approve --body "Approved by approver-bot"

--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -2,7 +2,8 @@ name: Approve PR from approver-bot
 
 on:
   pull_request:
-    types: [labeled]
+    types:
+      - labeled
 
 permissions:
   contents: read


### PR DESCRIPTION
Now that we've moved from the cron approver-bot to the event based bot, let's also replace

https://github.com/wolfi-dev/os/blob/main/scripts/auto-approve-pr.sh and https://github.com/wolfi-dev/os/blob/main/.github/workflows/auto-approve.yaml

with an event driven final step.

Once this is validated, we can cleanup the old infra.