### PR TITLE
chrony: include hyper-v configs

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -90,6 +90,7 @@ subpackages:
         - ${{package.name}}
         - merged-usrsbin
         - wolfi-baselayout
+        - ${{package.name}}-hyperv
     pipeline:
       - runs: |
           install -Dm644 ./sources.d/azure.sources ${{targets.contextdir}}/etc/chrony/sources.d/azure.sources
@@ -104,6 +105,15 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm644 ./sources.d/gcp.sources ${{targets.contextdir}}/etc/chrony/sources.d/gcp.sources
+
+  - name: "${{package.name}}-hyperv"
+    description: "${{package.name}} configuration for Hyper-V"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          install -Dm644 ./conf.d/hyperv.conf ${{targets.contextdir}}/etc/chrony/conf.d/hyperv.conf
 
 update:
   enabled: true

--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.8"
-  epoch: 1
+  epoch: 2
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later

--- a/chrony/conf.d/hyperv.conf
+++ b/chrony/conf.d/hyperv.conf
@@ -1,0 +1,3 @@
+# See https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2
+makestep 1.0 -1


### PR DESCRIPTION
Use Hyper-V configs on Azure, and ship them separately for standalone Hyper-V.

This configures chrony to use the Hyper-V timesource device.

Fixes: VMS-58