### PR TITLE
sudo: Add tmpfiles.d snippet

### DIFF
--- a/sudo.yaml
+++ b/sudo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo
   version: 1.9.17_p2
-  epoch: 1
+  epoch: 2
   description: Give certain users the ability to run some commands as root
   copyright:
     - license: BSD-2-Clause AND BSD-2-Clause-NetBSD AND Zlib AND BSD-3-Clause AND BSD-2-Clause AND ISC
@@ -48,7 +48,8 @@ pipeline:
         --with-sendmail=/usr/bin/sendmail \
         --with-passprompt="[sudo] password for %p: " \
         --sbindir=/usr/bin \
-        --with-selinux
+        --with-selinux \
+        --enable-tmpfiles.d=/usr/lib/tmpfiles.d
 
   - uses: autoconf/make
 


### PR DESCRIPTION
In a VM, `/run` will be a fresh tmpfs, so include matching `systemd-tmpfiles` configuration as well as the `/run/sudo` directory.

Related: https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw