### PR TITLE
fix(lerna): Bump glob and js-yaml to remediate GHSA-5j98-mcp5-4vw2 and GHSA-mh29-5h37-fv8m

### DIFF
--- a/lerna.yaml
+++ b/lerna.yaml
@@ -1,7 +1,7 @@
 package:
   name: lerna
   version: "9.0.1"
-  epoch: 0
+  epoch: 1 # GHSA-5j98-mcp5-4vw2 and GHSA-mh29-5h37-fv8m
   description: "Lerna is a fast, modern build system for managing and publishing multiple JavaScript/TypeScript packages from the same repository."
   copyright:
     - license: MIT
@@ -27,6 +27,9 @@ pipeline:
     runs: |
       npm install -g ${{package.name}}@${{package.version}} -prefix ${{targets.destdir}}/usr/local/
 
+      # GHSA-5j98-mcp5-4vw2
+      npm install glob@11.1.0 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/lerna/
+
       # CVE-2025-27152 GHSA-jr5f-v2jv-69x6 GHSA-rm8p-cx58-hcvx
       npm install axios@1.12.0 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/lerna/
 
@@ -35,6 +38,10 @@ pipeline:
 
       # Fix tmp CVE GHSA-52f5-9888-hmc6
       npm install tmp@0.2.4 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/lerna/
+
+      # GHSA-mh29-5h37-fv8m
+      npm install js-yaml@4.1.1 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/lerna/
+      npm install js-yaml@4.1.1 -prefix ${{targets.destdir}}/usr/local/lib/node_modules/lerna/node_modules/@lerna/create/
 
       # https://github.com/browserify/resolve/issues/288
       sed -i 's/monorepo-symlink-test/false-positive/g' ${{targets.destdir}}/usr/local/lib/node_modules/lerna/node_modules/resolve/test/resolver/multirepo/package.json


### PR DESCRIPTION
<!--ci-cve-scan:fail-any-->
