### PR TITLE
fix(kubeflow-pipelines): GHSA-mh29-5h37-fv8m patch

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.14.4"
-  epoch: 0 # GHSA-p84v-gxvw-73pf
+  epoch: 1
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -200,10 +200,14 @@ subpackages:
           patches: |
             GHSA-952p-6rrq-rcjv.patch
             GHSA-4hjh-wcwx-xvwj.patch
+            GHSA-mh29-5h37-fv8m.patch
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/server
           mkdir -p ${{targets.subpkgdir}}/client
           cd frontend/
+          # Update package lock in frontend
+          #npm i
+          #npm audit fix --package-lock-only --legacy-peer-deps || true
 
           # Update package lock in server
           cd server/

--- a/kubeflow-pipelines/GHSA-mh29-5h37-fv8m.patch
+++ b/kubeflow-pipelines/GHSA-mh29-5h37-fv8m.patch
@@ -1,0 +1,12 @@
+diff --git a/frontend/server/package.json b/frontend/server/package.json
+index 86c1cd7..31c275e 100644
+--- a/frontend/server/package.json
++++ b/frontend/server/package.json
+@@ -10,6 +10,7 @@
+     "express": "^4.21.0",
+     "gunzip-maybe": "^1.4.1",
+     "http-proxy-middleware": "^0.18.0",
++    "js-yaml": "3.14.2",
+     "lodash": ">=4.17.21",
+     "minio": "~8.0.3",
+     "node-fetch": "^2.6.7",


### PR DESCRIPTION
Set frontend/server js-yaml to fixed 3.14.2 version.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/42345

<!--ci-cve-scan:fail-any-->
