### PR TITLE
fix(langfuse): GHSA-mh29-5h37-fv8m

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,6 +1,6 @@
 package:
   name: langfuse
-  version: "3.132.0"
+  version: "3.134.0"
   epoch: 0
   description: "Langfuse webapp"
   copyright:
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: b925120e0ebfce6685ac91ebd12ad6d5d5921fd3
+      expected-commit: d2aaddb6e0b7e99dd703040680dc3b8c2ed97777
 
   - name: "Bump deps and install"
     runs: |


### PR DESCRIPTION
Version bump pulls in fixed glob

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/42429

<!--ci-cve-scan:fail-any-->
