### PR TITLE
chrony hardening

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.8"
-  epoch: 2
+  epoch: 3
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later

--- a/chrony/chrony.conf
+++ b/chrony/chrony.conf
@@ -29,6 +29,15 @@ rtcsync
 # Allow NTP client access from local network.
 #allow 192.168.0.0/16
 
+# Port to serve NTP on, set to zero to operate in client only mode by
+# default. Comment out, or set to 123, at the same time as enabling
+# allow directives to enable server mode
+port 0
+
+# Port for remote management commands, set to zero to disable by
+# default. Comment out, or set to 323 to enable management access.
+cmdport 0
+
 # Serve time even if not synchronized to a time source.
 #local stratum 10
 

--- a/chrony/sources.d/aws.sources
+++ b/chrony/sources.d/aws.sources
@@ -3,4 +3,4 @@ server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-ec2-ntp.html#configure-amazon-time-service-IPv6
 server fd00:ec2::123 prefer iburst minpoll 4 maxpoll 4
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-time-sync.html
-pool time.aws.com iburst
+pool time.aws.com iburst maxpoll 16

--- a/chrony/sources.d/azure.sources
+++ b/chrony/sources.d/azure.sources
@@ -1,1 +1,1 @@
-pool time.windows.com iburst
+pool time.windows.com iburst maxpoll 16

--- a/chrony/sources.d/gcp.sources
+++ b/chrony/sources.d/gcp.sources
@@ -1,7 +1,7 @@
 # https://cloud.google.com/compute/docs/instances/configure-ntp
 server metadata.google.internal prefer iburst minpoll 4 maxpoll 4
 # https://developers.google.com/time/guides#ntpd_or_chrony
-server time1.google.com iburst
-server time2.google.com iburst
-server time3.google.com iburst
-server time4.google.com iburst
+server time1.google.com iburst maxpoll 16
+server time2.google.com iburst maxpoll 16
+server time3.google.com iburst maxpoll 16
+server time4.google.com iburst maxpoll 16


### PR DESCRIPTION
Operate in client mode only, without remote server or management
access by default. Note this is a no-op change, as no allow list was
specified.

Also explicitely set maxpoll settings, to cap out max poll to a
reasonable value of 18.2 hours.
