### PR TITLE
opentelemetry: re-add shared libraries

### DIFF
--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: "1.23.0"
-  epoch: 3
+  epoch: 4
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ pipeline:
         -DWITH_EXAMPLES=OFF \
         -DWITH_FUNC_TESTS=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_ABSEIL=ON
 
@@ -75,6 +75,10 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
These were removed inadvertantly in https://github.com/wolfi-dev/os/pull/35855/

No one is actually using them (I can see nothing depending on their .so files) but it is super weird they're not there.   