### PR TITLE
kaniko: Delete /etc/rpc on startup as well

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: "1.25.5"
-  epoch: 1 # GHSA-pwhc-rpq9-4c8w
+  epoch: 2 # GHSA-pwhc-rpq9-4c8w
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kaniko/remove-usrmerge-symlinks.patch
+++ b/kaniko/remove-usrmerge-symlinks.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/executor/build.go b/pkg/executor/build.go
-index ccdfd17e..1756a6b6 100644
+index ccdfd17e..ff67eca8 100644
 --- a/pkg/executor/build.go
 +++ b/pkg/executor/build.go
 @@ -691,6 +691,9 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
@@ -12,7 +12,7 @@ index ccdfd17e..1756a6b6 100644
  	digestToCacheKey := make(map[string]string)
  	stageIdxToDigest := make(map[string]string)
  
-@@ -830,6 +833,78 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
+@@ -830,6 +833,79 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
  	return nil, err
  }
  
@@ -52,6 +52,7 @@ index ccdfd17e..1756a6b6 100644
 +		"/etc/protocols",
 +		"/etc/services",
 +		"/etc/shells",
++		"/etc/rpc",
 +	} {
 +		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 +			logrus.Warnf("Failed to remove unused baselayout file %s: %v", file, err)


### PR DESCRIPTION
Another file that kaniko doesn't need, but that causes conflicts unnecessarily.