### PR TITLE
test(flux): test that the manager and workers start

### DIFF
--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: "1.4.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -71,22 +71,19 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - name: "start ${{package.name}} and test"
+    - name: Launch controller with kwok cluster
       uses: test/daemon-check-output
       with:
         setup: |
           kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
           kubectl wait --for=condition=Ready nodes --all
-        start: helm-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
+        start: helm-controller --health-addr :8080 --metrics-addr :8081
         timeout: 30
         expected_output: |
-          starting manager
-          Serving metrics server
-          helm.toolkit.fluxcd.io
           Starting Controller
           Starting workers
         post: |
           #!/bin/sh -e
           set -o pipefail
           curl -s localhost:8081/metrics  | grep rest_client_requests_total
-          curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"
+          curl -v localhost:8080/healthz 2>&1 | grep -i "200 OK"

--- a/flux-image-automation-controller.yaml
+++ b/flux-image-automation-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-automation-controller
   version: "1.0.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: GitOps Toolkit controller that patches container image tags in Git
   copyright:
     - license: Apache-2.0
@@ -96,5 +96,21 @@ test:
     contents:
       packages:
         - ${{package.name}}-compat
+        - curl
   pipeline:
     - runs: image-automation-controller -h
+    - uses: test/kwok/cluster
+    - name: Launch controller with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+          kubectl wait --for=condition=Ready nodes --all
+        start: image-automation-controller --metrics-addr :8080 --health-addr :8081
+        timeout: 30
+        expected_output: |
+          Starting Controller
+          Starting workers
+        post: |
+          curl --silent --fail localhost:8080/metrics
+          curl --silent --fail localhost:8081/healthz

--- a/flux-image-reflector-controller.yaml
+++ b/flux-image-reflector-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-reflector-controller
   version: "1.0.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: GitOps Toolkit controller that scans container registries
   copyright:
     - license: Apache-2.0
@@ -82,6 +82,22 @@ test:
     contents:
       packages:
         - ${{package.name}}
+        - curl
   pipeline:
     - runs: |
         image-reflector-controller -h
+    - uses: test/kwok/cluster
+    - name: Launch controller with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://github.com/fluxcd/image-reflector-controller/releases/download/v${{package.version}}/image-reflector-controller.crds.yaml
+          kubectl wait --for=condition=Ready nodes --all
+        start: image-reflector-controller --health-addr :8081 --metrics-addr :8080
+        timeout: 30
+        expected_output: |
+          Starting Controller
+          Starting workers
+        post: |
+          curl --silent --fail localhost:8080/metrics
+          curl --silent --fail localhost:8081/healthz

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: "1.7.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -87,8 +87,26 @@ update:
     tag-filter: v
     use-tag: true
 
-# test added by a robot (binary)
 test:
+  environment:
+    contents:
+      packages:
+        - curl
   pipeline:
     - runs: |
         stat /usr/bin/kustomize-controller
+    - uses: test/kwok/cluster
+    - name: Launch controller with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+          kubectl wait --for=condition=Ready nodes --all
+        start: kustomize-controller --health-addr :9441 --metrics-addr :8081
+        timeout: 30
+        expected_output: |
+          Starting Controller
+          Starting workers
+        post: |
+          curl --silent --fail localhost:8081/metrics
+          curl --silent --fail localhost:9441/healthz

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: "1.7.5"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
@@ -61,7 +61,6 @@ update:
     strip-prefix: v
     tag-filter: v
 
-# only passes with docker runner: `MELANGE_EXTRA_OPTS="--runner docker" make test/flux-notification-controller`
 test:
   environment:
     contents:
@@ -69,23 +68,19 @@ test:
         - curl
   pipeline:
     - uses: test/kwok/cluster
-    - name: "start ${{package.name}} and test"
+    - name: Launch controller with kwok cluster
       uses: test/daemon-check-output
       with:
         setup: |
-          kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+          kubectl apply -f https://github.com/fluxcd/notification-controller/releases/download/v${{package.version}}/notification-controller.crds.yaml
           kubectl wait --for=condition=Ready nodes --all
-        start: notification-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
+        start: notification-controller --health-addr :8080 --metrics-addr :8081
         timeout: 30
         expected_output: |
-          starting event server
-          starting webhook receiver server
-          starting manager
-          notification.toolkit.fluxcd.io
           Starting Controller
           Starting workers
         post: |
           #!/bin/sh -e
           set -o pipefail
           curl -s localhost:8081/metrics  | grep rest_client_requests_total
-          curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"
+          curl -v localhost:8080/healthz 2>&1 | grep -i "200 OK"

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: "1.7.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0
@@ -82,9 +82,6 @@ update:
 
 test:
   environment:
-    environment:
-      KUBERNETES_SERVICE_HOST: "127.0.0.1"
-      KUBERNETES_SERVICE_PORT: 32764
     contents:
       packages:
         - ${{package.name}}
@@ -93,25 +90,20 @@ test:
     - runs: |
         source-controller -h > output.txt 2>&1
         cat output.txt | grep "Usage of source-controller"
-    # only passes with docker runner: `MELANGE_EXTRA_OPTS="--runner docker" make test/flux-notification-controller`
     - uses: test/kwok/cluster
-    - name: "start ${{package.name}} and test"
+    - name: Launch controller with kwok cluster
       uses: test/daemon-check-output
       with:
         setup: |
           kubectl apply -f https://github.com/fluxcd/source-controller/releases/download/v${{package.version}}/source-controller.crds.yaml
           kubectl wait --for=condition=Ready nodes --all
-        start: source-controller --storage-adv-addr=source-controller.default.svc.cluster.local --storage-path=/ --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1
+        start: source-controller --storage-path=/tmp --health-addr :9441 --metrics-addr :8081
         timeout: 30
         expected_output: |
-          starting manager
-          source.toolkit.fluxcd.io
           Starting Controller
           Starting workers
         post: |
-          #!/bin/sh -e
           set -o pipefail
           curl -s localhost:8081/metrics  | grep rest_client_requests_total
           curl -v localhost:9441/healthz 2>&1 | grep -i "200 OK"
-          # Test the file server is up
           curl -s localhost:9090 | grep 'pre'


### PR DESCRIPTION
This commit adds tests of the operators to ensure that the manager and possibly also the worker reconcilers start as expected. The tests run against kwok, so since there is no kubelet running tests run as further as possible.

See also:
* #73072
* #73097
* #73098
* #73099