### PR TITLE
test(grafana-operators): test that the manager and workers start

### DIFF
--- a/grafana-operator.yaml
+++ b/grafana-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-operator
   version: "5.20.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: An operator for Grafana that installs and manages Grafana instances, Dashboards and Datasources through Kubernetes/OpenShift CRs
   copyright:
     - license: Apache-2.0
@@ -52,16 +52,12 @@ test:
         grafana-operator --help
         grafana-operator -h
     - uses: test/kwok/cluster
-    - name: "Fetch and deploy operator manifests"
-      runs: |
-        git clone --depth=1 --branch v${{package.version}} https://github.com/grafana-operator/grafana-operator.git
-        kubectl create -f grafana-operator/deploy/kustomize/base/crds.yaml
-        # Give k8s some time to fully apply the CRDs
-        sleep 5
     - name: "Start and verify operator"
       uses: test/daemon-check-output
       with:
         setup: |
+          git clone --depth=1 --branch v${{package.version}} https://github.com/grafana-operator/grafana-operator.git
+          kubectl create -f grafana-operator/deploy/kustomize/base/crds.yaml
           kubectl create namespace grafana-operator-system
         start: |
           grafana-operator manager \
@@ -74,12 +70,6 @@ test:
           starting server
           Starting Controller
           Starting workers
-        # exception for a known limitation with kwok
-        error_strings: |
-          controller-runtime.source.EventHandler
         post: |
-          # Verify metrics endpoint is working
-          curl -s http://localhost:8080/metrics
-
-          # Verify health endpoint
-          curl -s http://localhost:8081/healthz
+          curl --silent --fail http://localhost:8080/metrics
+          curl --silent --fail http://localhost:8081/healthz

--- a/grafana-rollout-operator.yaml
+++ b/grafana-rollout-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-rollout-operator
   version: "0.32.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Kubernetes Rollout Operator
   copyright:
     - license: Apache-2.0
@@ -26,9 +26,35 @@ pipeline:
       output: rollout-operator
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
+    environment:
+      KUBERNETES_SERVICE_HOST: "127.0.0.1"
+      KUBERNETES_SERVICE_PORT: "32764"
   pipeline:
     - runs: |
         rollout-operator --help
+    - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
+    - name: Launch operator with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl apply -f https://raw.githubusercontent.com/grafana/rollout-operator/refs/tags/v${{package.version}}/operations/rollout-operator/crds/replica-templates.yaml
+          kubectl apply -f https://raw.githubusercontent.com/grafana/rollout-operator/refs/tags/v${{package.version}}/operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
+          kubectl create clusterrolebinding default --clusterrole=cluster-admin --serviceaccount=default:default
+        start: rollout-operator -kubernetes.namespace=default -server.port 8080
+        timeout: 30
+        expected_output: |
+          zpdb config informer caches have synced
+          zpdb pod informer caches have synced
+          informer caches have synced
+        post: |
+          curl --fail --silent http://127.0.0.1:8080/metrics
+          curl --fail --silent http://127.0.0.1:8080/ready
 
 update:
   enabled: true


### PR DESCRIPTION
This commit adds tests of the operators to ensure that the manager and possibly also the worker reconcilers start as expected. The tests run against kwok, so since there is no kubelet running tests run as further as possible.

See also
* #73072
* #73096
* #73098
* #73099