### PR TITLE
test(aws-operators): test that the manager and workers start

### DIFF
--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: "2.16.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0
@@ -62,21 +62,18 @@ test:
   environment:
     contents:
       packages:
-        - bash
-        - coreutils
-        - grep
+        - curl
   pipeline:
-    - name: "Verify binary exists and is executable"
-      runs: |
-        test -x /usr/bin/controller
-    - name: "Check basic controller initialization"
-      runs: |
-        # Should fail gracefully without AWS credentials
-        if controller --cluster-name=test 2>&1 | grep -q "error"; then
-          exit 0
-        else
-          exit 1
-        fi
-    - name: "Verify controller metrics endpoint configuration"
-      runs: |
-        controller --metrics-bind-addr=":8080" --help 2>&1 | grep -q "metrics-bind-addr"
+    - uses: test/tw/ldd-check
+    - uses: test/kwok/cluster
+      with:
+        serviceaccount: true
+    - name: Launch controller with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          kubectl config view --minify --raw > /tmp/kubeconfig.yaml
+        start: controller --cluster-name=test-cluster --aws-region=us-east-1 --metrics-bind-addr ":8080" --health-probe-bind-addr ":8081"
+        timeout: 30
+        expected_output: |
+          unable to initialize AWS cloud

--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -1,6 +1,6 @@
 package:
   name: aws-s3-controller
-  version: "1.1.3"
+  version: "1.1.2"
   epoch: 0 # CVE-2025-61725
   description: ACK service controller for Amazon Simple Storage Service (S3)
   copyright:
@@ -47,3 +47,11 @@ test:
         stat /usr/bin/controller
         controller --help 2>&1 | grep webhook
         controller --aws-region us-east-1 2>&1 | grep -E 'credentials'
+    - uses: test/kwok/cluster
+    - name: Launch controller with kwok cluster
+      uses: test/daemon-check-output
+      with:
+        start: controller --aws-region=us-east-1 --log-level=info
+        timeout: 30
+        expected_output: |
+          Unable to create controller manager


### PR DESCRIPTION
This commit adds tests of the operators to ensure that the manager and possibly also the worker reconcilers start as expected. The tests run against kwok, so since there is no kubelet running tests run as further as possible.

See also:
* #73072
* #73096
* #73097
* #73098