### PR TITLE
Revert "py3-xet-core/1.2.1 package update (#72751)"

### DIFF
--- a/py3-xet-core.yaml
+++ b/py3-xet-core.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-xet-core
-  version: "1.2.1"
+  version: "1.2.0"
   epoch: 0 # GHSA-xwfj-jgwm-7wp5
   description: Run your *raw* PyTorch training script on any kind of device
   copyright:
@@ -35,7 +35,7 @@ pipeline:
     with:
       repository: https://github.com/huggingface/xet-core
       tag: v${{package.version}}
-      expected-commit: 76fd5dab6e63e91d45f35bab0c264f3d81106edd
+      expected-commit: 50c69409c507ec8e9436da314c8434f57f6769bc
 
   - name: fix py03 API compatibility issues
     working-directory: hf_xet


### PR DESCRIPTION
This reverts commit a9ebe8e17fa6a5aca6b1caabd327e1e6610d13cd.

The tag was withdrawn.

Builds are failing with:

> fatal: Remote branch v1.2.1 not found in upstream origin