### PR TITLE
fix(tileserver-gl): Remediate GHSA-mh29-5h37-fv8m

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 3
+  epoch: 4 # GHSA-mh29-5h37-fv8m
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -58,6 +58,8 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: d18d5c483bdc184ee0444331d068f09ab1d6a432
       destination: app
+      cherry-picks: |
+        master/a568498c4953c27a482ad881036d556c85c6704c: GHSA-mh29-5h37-fv8m
 
   - working-directory: app
     pipeline:


### PR DESCRIPTION
Remediate GHSA-mh29-5h37-fv8m by bumping js-yaml to 4.1.1
Bumped through an upstream cherry pick.


<!--ci-cve-scan:must-fix: GHSA-mh29-5h37-fv8m-->

