### PR TITLE
always init jitter DNM break test

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -49,6 +49,7 @@ pipeline:
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
         0001-seed_src_jitter-always-init-jitter.patch
+        0001-DNM-test-build.patch
 
   - name: Configure and build
     runs: |
@@ -244,6 +245,7 @@ test:
         grep -q 'Breakpoint 2,' gdb.log || exit 1
     - name: Verify jitter entropy source opt-in works
       runs: |
+        set -x
         cat <<EOF >openssl.cnf
         openssl_conf = openssl_init
         [openssl_init]

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -49,17 +49,6 @@ pipeline:
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
-  - name: Create dbg sourcecode
-    runs: |
-      SRCDIR=$(mktemp -d)
-      cp -r . $SRCDIR/
-      mkdir -p ${{targets.destdir}}-dbg/usr/src/
-      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-      # Note that mktemp -d created it as 700, whilst the contents
-      # inside is 644 for files and 755 for dirs, without this gdb
-      # doesn't work for non-root user, fix this up.
-      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-
   - name: Configure and build
     runs: |
       perl ./Configure \
@@ -85,6 +74,21 @@ pipeline:
          no-weak-ssl-ciphers \
          -Wa,--noexecstack
       perl configdata.pm --dump
+
+      # Create generated .c from .c.in
+      make build_all_generated
+
+      # Create debug sources after creating all the generated .c from .c.in
+      SRCDIR=$(mktemp -d)
+      cp -r . $SRCDIR/
+      mkdir -p ${{targets.destdir}}-dbg/usr/src/
+      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+      # Note that mktemp -d created it as 700, whilst the contents
+      # inside is 644 for files and 755 for dirs, without this gdb
+      # doesn't work for non-root user, fix this up.
+      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+
+      # Continue building everything
       make -j$(nproc)
       make tests HARNESS_JOBS=10
 

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -272,9 +272,9 @@ test:
         run genrsa -out /dev/null
         EOF
         gdb --batch --command ./openssl.gdb openssl
-        # Assert that jitter entropy was not used
+        # Assert that jitter entropy was used
         grep -q 'Breakpoint 1,' jitter.log || exit 1
-        # Assert that getrandom syscall wrapper was used
+        # Assert that getrandom syscall wrapper was not used
         grep -q 'Breakpoint 2,' jitter.log && exit 1
     - name: docker-dind certificate generation
       runs: |

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -48,6 +48,7 @@ pipeline:
         fix-jitter.patch
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
+        0001-seed_src_jitter-always-init-jitter.patch
 
   - name: Configure and build
     runs: |

--- a/openssl/0001-DNM-test-build.patch
+++ b/openssl/0001-DNM-test-build.patch
@@ -1,0 +1,29 @@
+From 8d9879dd8402d8f775370117b21dd93fc59f5626 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 25 Nov 2025 05:41:28 +0000
+Subject: [PATCH] DNM: test build
+
+---
+ providers/implementations/rands/seed_src_jitter.c.in | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/providers/implementations/rands/seed_src_jitter.c.in b/providers/implementations/rands/seed_src_jitter.c.in
+index 4d73f07574..e3065a9d98 100644
+--- a/providers/implementations/rands/seed_src_jitter.c.in
++++ b/providers/implementations/rands/seed_src_jitter.c.in
+@@ -156,12 +156,10 @@ static int jitter_instantiate(void *vseed, unsigned int strength,
+     PROV_JITTER *s = (PROV_JITTER *)vseed;
+     int ret;
+ 
+-    if ((ret = jent_entropy_init_ex(0, JENT_FORCE_FIPS)) != 0) {
+         ERR_raise_data(ERR_LIB_RAND, RAND_R_ERROR_RETRIEVING_ENTROPY,
+                        "jent_entropy_init_ex (%d)", ret);
+         s->state = EVP_RAND_STATE_ERROR;
+         return 1;
+-    }
+ 
+     s->state = EVP_RAND_STATE_READY;
+     return 1;
+-- 
+2.51.0
+

--- a/openssl/0001-seed_src_jitter-always-init-jitter.patch
+++ b/openssl/0001-seed_src_jitter-always-init-jitter.patch
@@ -1,0 +1,32 @@
+From b5ac03001b66c409a37d8ed18379ffbd84e8323b Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 25 Nov 2025 13:52:19 +0000
+Subject: [PATCH] seed_src_jitter: always init jitter
+
+Always init jitter entropy source, even when in error state. This
+ensures that when primary DRBG is configured to use Jitter seed
+source, jitter seed source remains in use.
+
+Since, in the rare case that initialize fails, NULL is returned, and
+the FIPS provider crng is initialised with NULL seed source, which
+means default is used, which for now is OS-specific getrandom source.
+---
+ providers/implementations/rands/seed_src_jitter.c.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/providers/implementations/rands/seed_src_jitter.c.in b/providers/implementations/rands/seed_src_jitter.c.in
+index 4d73f07574..3868bec48f 100644
+--- a/providers/implementations/rands/seed_src_jitter.c.in
++++ b/providers/implementations/rands/seed_src_jitter.c.in
+@@ -160,7 +160,7 @@ static int jitter_instantiate(void *vseed, unsigned int strength,
+         ERR_raise_data(ERR_LIB_RAND, RAND_R_ERROR_RETRIEVING_ENTROPY,
+                        "jent_entropy_init_ex (%d)", ret);
+         s->state = EVP_RAND_STATE_ERROR;
+-        return 0;
++        return 1;
+     }
+ 
+     s->state = EVP_RAND_STATE_READY;
+-- 
+2.51.0
+


### PR DESCRIPTION
- **openssl: correct comments in tests**
  During jitter testing the grep asserts are correct, but comments were
  left unchanged from the earlier getrandom testing. Update the comments
  to match the implementation and the test-case name / intention.
  

- **openssl-dbg: fixup source code snapshot for generated code**
  fixup source code snapshot for all the generated code
  

- **bump epoch**
  

- **Always init jitter seed source**
  

- **DNM: test build**
  