### PR TITLE
flip default sources

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -57,7 +57,7 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
-         $([ -d /usr/lib/oldglibc ] || echo enable-jitter) \
+         $([ -d /usr/lib/oldglibc ] || echo enable-jitter -DOPENSSL_DEFAULT_SEED_SRC=JITTER) \
          shared \
          enable-pie \
          no-zlib \

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -49,17 +49,6 @@ pipeline:
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
-  - name: Create dbg sourcecode
-    runs: |
-      SRCDIR=$(mktemp -d)
-      cp -r . $SRCDIR/
-      mkdir -p ${{targets.destdir}}-dbg/usr/src/
-      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-      # Note that mktemp -d created it as 700, whilst the contents
-      # inside is 644 for files and 755 for dirs, without this gdb
-      # doesn't work for non-root user, fix this up.
-      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-
   - name: Configure and build
     runs: |
       perl ./Configure \
@@ -85,6 +74,21 @@ pipeline:
          no-weak-ssl-ciphers \
          -Wa,--noexecstack
       perl configdata.pm --dump
+
+      # Create generated .c from .c.in
+      make build_all_generated
+
+      # Create debug sources after creating all the generated .c from .c.in
+      SRCDIR=$(mktemp -d)
+      cp -r . $SRCDIR/
+      mkdir -p ${{targets.destdir}}-dbg/usr/src/
+      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+      # Note that mktemp -d created it as 700, whilst the contents
+      # inside is 644 for files and 755 for dirs, without this gdb
+      # doesn't work for non-root user, fix this up.
+      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+
+      # Continue building everything
       make -j$(nproc)
       make tests HARNESS_JOBS=10
 

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -272,9 +272,9 @@ test:
         run genrsa -out /dev/null
         EOF
         gdb --batch --command ./openssl.gdb openssl
-        # Assert that jitter entropy was not used
+        # Assert that jitter entropy was used
         grep -q 'Breakpoint 1,' jitter.log || exit 1
-        # Assert that getrandom syscall wrapper was used
+        # Assert that getrandom syscall wrapper was not used
         grep -q 'Breakpoint 2,' jitter.log && exit 1
     - name: docker-dind certificate generation
       runs: |

--- a/openssl/openssl.cnf
+++ b/openssl/openssl.cnf
@@ -1,5 +1,13 @@
 # Comment out the next line to ignore configuration errors
 config_diagnostics = 1
 
+openssl_conf = openssl_init
+
 # Include hardened configuration for ca & req apps
 .include /etc/ssl/ca.cnf
+
+[openssl_init]
+random = random
+
+[random]
+seed = SEED-SRC


### PR DESCRIPTION
- **openssl: correct comments in tests**
  During jitter testing the grep asserts are correct, but comments were
  left unchanged from the earlier getrandom testing. Update the comments
  to match the implementation and the test-case name / intention.
  

- **openssl-dbg: fixup source code snapshot for generated code**
  fixup source code snapshot for all the generated code
  

- **bump epoch**
  

- **openssl: flip default/fallback and opt-in seed sources**
  Make Jitter the default/fallback seed-source, and make the os-specific
  SEED-SRC an opt-in one.
  