### PR TITLE
keycloak: add packages.json, pnpm-lock.yaml to apk

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.5"
-  epoch: 0
+  epoch: 1
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,16 @@ pipeline:
       repository: https://github.com/keycloak/keycloak
       tag: ${{package.version}}
       expected-commit: f8ffb1b9a361d3ba2df48ab23145c4dc80c7839f
+
+  - uses: patch
+    with:
+      # Include package.json in order to get scanners to pick up on npm
+      # dependencies.
+      # Note: This over-matches the dependencies, since this also picks up
+      # everything in package.json, including dev dependencies.
+      # See https://github.com/keycloak/keycloak/issues/36747 for upstream
+      # discussion for how to fix this.
+      patches: npm-packages.patch
 
   - uses: maven/pombump
     with:

--- a/keycloak-26.4/npm-packages.patch
+++ b/keycloak-26.4/npm-packages.patch
@@ -1,0 +1,93 @@
+diff --git a/js/apps/account-ui/pom.xml b/js/apps/account-ui/pom.xml
+index 855adaa460..dff328bd8e 100644
+--- a/js/apps/account-ui/pom.xml
++++ b/js/apps/account-ui/pom.xml
+@@ -71,6 +71,18 @@
+             <resource>
+                 <directory>maven-resources</directory>
+             </resource>
++            <resource>
++                <directory>.</directory>
++                <includes>
++                    <include>package.json</include>
++                </includes>
++            </resource>
++            <resource>
++                <directory>../..</directory>
++                <includes>
++                    <include>pnpm-lock.yaml</include>
++                </includes>
++            </resource>
+         </resources>
+         <plugins>
+             <plugin>
+diff --git a/js/apps/admin-ui/pom.xml b/js/apps/admin-ui/pom.xml
+index c595c33f8e..d18e229dfb 100644
+--- a/js/apps/admin-ui/pom.xml
++++ b/js/apps/admin-ui/pom.xml
+@@ -71,6 +71,18 @@
+             <resource>
+                 <directory>maven-resources</directory>
+             </resource>
++            <resource>
++                <directory>.</directory>
++                <includes>
++                    <include>package.json</include>
++                </includes>
++            </resource>
++            <resource>
++                <directory>../..</directory>
++                <includes>
++                    <include>pnpm-lock.yaml</include>
++                </includes>
++            </resource>
+         </resources>
+         <plugins>
+             <plugin>
+diff --git a/js/themes-vendor/pom.xml b/js/themes-vendor/pom.xml
+index 98e72f13ae..28ded1cd0c 100755
+--- a/js/themes-vendor/pom.xml
++++ b/js/themes-vendor/pom.xml
+@@ -106,6 +106,42 @@
+                             </resources>
+                         </configuration>
+                     </execution>
++                    <execution>
++                        <id>copy-package-json</id>
++                        <phase>generate-resources</phase>
++                        <goals>
++                            <goal>copy-resources</goal>
++                        </goals>
++                        <configuration>
++                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
++                            <resources>
++                                <resource>
++                                    <directory>${project.basedir}</directory>
++                                    <includes>
++                                        <include>package.json</include>
++                                    </includes>
++                                </resource>
++                            </resources>
++                        </configuration>
++                    </execution>
++                    <execution>
++                        <id>copy-pnpm-lock</id>
++                        <phase>generate-resources</phase>
++                        <goals>
++                            <goal>copy-resources</goal>
++                        </goals>
++                        <configuration>
++                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
++                            <resources>
++                                <resource>
++                                    <directory>${project.basedir}/..</directory>
++                                    <includes>
++                                        <include>pnpm-lock.yaml</include>
++                                    </includes>
++                                </resource>
++                            </resources>
++                        </configuration>
++                    </execution>
+                 </executions>
+             </plugin>
+         </plugins>


### PR DESCRIPTION
This adds [Keycloak javascript](https://github.com/keycloak/keycloak/tree/main/js) package.json and lock files to the apk, to help scanners pick up on javascript dependencies embedded in the jars. For each js app, we include the per-folder package.json, as well as the top level pnpm-lock.yaml.

NOTE: the packages and lock file will likely over-report on js packages, since not all of them appear in each jar. We're optimizing for completeness over accuracy here in order to make sure these can be included.

See https://github.com/keycloak/keycloak/issues/36747 for related discussion for generating more accurate JS SBOMs in the upstream build configs.

### Pre-review Checklist

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
