### PR TITLE
openjdk-8/8.472.08: update to icedtea 3.37.0

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
-  version: 8.452.09 # this corresponds to same release as jdk8u452-ga / jdk8u452-b09
-  epoch: 9
+  version: 8.472.08 # this corresponds to same release as jdk8u472-ga / jdk8u472-b08
+  epoch: 0
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -71,15 +71,15 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://icedtea.classpath.org/download/source/icedtea-3.35.0.tar.xz
-      expected-sha512: 3e997c8d2aa414fab1929c0dd8ff586950bc653a574b929e5c34b6e01bea1af9259b2c9548e9187dc2b2e3e0358ffe991c460cff7a2efc33c7aa66a6812c0804
+      uri: https://icedtea.classpath.org/download/source/icedtea-3.37.0.tar.xz
+      expected-sha512: 196d4bd0a56d8788033ac629baf370dcd5624363b4bdf6640887514660410b57a9e5b48202954d2d9046951004e15ef98bc321024b4453ec9d742ab9e0813b87
 
   - working-directory: /home/build/icedtea-drops
     pipeline:
       - uses: fetch
         with:
-          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.35.0/openjdk-git.tar.xz
-          expected-sha512: a57081a2fdfcd7fff2203d82d5c4edd6e3fd7b2fcfd5ef5471173073b93bd75dfdf67b20b2cece6c4b3a249f911ba74fbdf5e08c53ef5501cf1600c54208d7ce
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.37.0/openjdk-git.tar.xz
+          expected-sha512: ab258a8fff6ed7752fa8915d5bf5c58eb79bca28d792f65d90b33e003f7e0147801d245cff80a438e4b47add159801ac97b9c0d6ae9e28c2e4bda23b4f995652
           extract: false
       - uses: fetch
         with:


### PR DESCRIPTION
## Summary
- Update openjdk-8 from version 8.452.09 to 8.472.08
- Update icedtea from 3.35.0 to 3.37.0
- Corresponds to OpenJDK 8u472-b08
- Reset epoch from 9 to 0 for new version
- Includes security fixes for CVE-2025-53057 and CVE-2025-53066