### PR TITLE
confluent-kafka: migrate ub to cp-docker-utils

### DIFF
--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-common-docker
   version: 7.6.0
-  epoch: 20 # CVE-2025-47906
+  epoch: 21
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0
@@ -44,21 +44,6 @@ subpackages:
           cp -r base/include/etc/confluent/docker/* "${{targets.subpkgdir}}"/etc/confluent/docker/
           chmod -R 755 ${{targets.subpkgdir}}/etc/confluent/docker
 
-  # https://github.com/confluentinc/common-docker/tree/master/base-lite/ub
-  - name: ${{package.name}}-ub
-    description: "ub tool for base-lite"
-    pipeline:
-      - uses: go/build
-        with:
-          modroot: ./base-lite/ub
-          packages: .
-          output: ub
-    # test added by a robot (binary)
-    test:
-      pipeline:
-        - runs: |
-            stat /usr/bin/ub
-
 update:
   enabled: false
   exclude-reason: >
@@ -66,11 +51,5 @@ update:
 
 
 test:
-  environment:
-    contents:
-      packages:
-        - confluent-common-docker-ub
   pipeline:
-    - runs: |
-        ub -h
     - uses: test/no-docs

--- a/confluent-cp-docker-utils.yaml
+++ b/confluent-cp-docker-utils.yaml
@@ -1,0 +1,43 @@
+package:
+  name: confluent-cp-docker-utils
+  version: "1.0.2"
+  epoch: 2
+  description: confluent cp-docker-utils
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6371f07e78ba06cea43770d8416964b8242ada6e
+      repository: https://github.com/confluentinc/cp-docker-utils
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/ub
+      output: ub
+
+  - uses: go/build
+    with:
+      packages: ./cmd/package_dedupe
+      output: package_dedupe
+
+test:
+  pipeline:
+    - name: "verify binaries are in place"
+      runs: |
+        stat /usr/bin/ub
+        stat /usr/bin/package_dedupe
+    - name: "verify ub can render some basic template"
+      runs: |
+        echo '{{- $test := stringSlice "xyz" -}}{{$test}}' > test.tmpl
+        if ! ub render-template test.tmpl | grep -q "xyz" ; then
+          echo "FAIL: ub did not render the template as expected." >&2
+          exit 1
+        fi
+
+update:
+  enabled: true
+  git:
+    strip-prefix: v

--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -9,7 +9,7 @@ package:
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
   version: "8.2.0.522"
-  epoch: 0
+  epoch: 1
   description: Community edition of Confluent Kafka.
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ package:
       - busybox
       - confluent-common-docker
       - confluent-common-docker-base
-      - confluent-common-docker-ub
+      - confluent-cp-docker-utils
       - confluent-docker-utils
       - confluent-kafka-images-kafka
       - openjdk-17-default-jvm


### PR DESCRIPTION
The ub tool has been moved to the confluent-cp-docker-utils package.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
