### PR TITLE
Need to run checkout before using gh cli

### DIFF
--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -19,6 +19,8 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To fix the 

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

failures.