### PR TITLE
Go back to using Curl for approvals

### DIFF
--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -21,9 +21,7 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - name: Approve PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Review PR
         run: |
           curl \
             -o review_output.json \
@@ -31,11 +29,12 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               https://api.github.com/repos/"${{ github.repository }}"/pulls/"${{ github.event.pull_request.number}}"/reviews
-
-          REVIEW_ID=$(jq -r '.id' review_output.json)
-
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-              /repos/"${{ github.repository }}"/pulls/"${{ github.event.pull_request.number}}"/reviews/"${REVIEW_ID}"/events \
+              /repos/"${{ github.repository }}"/pulls/"${{ github.event.pull_request.number}}"/reviews/"$(jq -r '.id' review_output.json)"/events \
             -f event='APPROVE'

--- a/.github/workflows/approve-from-label.yaml
+++ b/.github/workflows/approve-from-label.yaml
@@ -25,4 +25,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr review ${{ github.event.pull_request.number }} --approve --body "Approved by approver-bot"
+          curl \
+            -o review_output.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/"${{ github.repository }}"/pulls/"${{ github.event.pull_request.number}}"/reviews
+
+          REVIEW_ID=$(jq -r '.id' review_output.json)
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+              /repos/"${{ github.repository }}"/pulls/"${{ github.event.pull_request.number}}"/reviews/"${REVIEW_ID}"/events \
+            -f event='APPROVE'


### PR DESCRIPTION
We tried to do this with just the `gh` CLI but it's seemingly blocked from being allowed https://github.com/wolfi-dev/os/actions/runs/19677894815/job/56364057107.

Have copied the flow from https://github.com/wolfi-dev/os/blob/main/scripts/auto-approve-pr.sh and put it into here.