### PR TITLE
feat(victoriametrics): build package without nethttpomithttp2 go build tag

### DIFF
--- a/victoriametrics-cluster.yaml
+++ b/victoriametrics-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-cluster
   version: "1.130.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0
@@ -36,7 +36,6 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          tags: nethttpomithttp2
           packages: ./app/${{range.key}}
           output: ${{range.key}}
           ldflags: -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${{range.key}}-$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")-$(git rev-parse HEAD)

--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics
   version: "1.130.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,6 @@ pipeline:
 
   - uses: go/build
     with:
-      tags: nethttpomithttp2
       packages: ./app/victoria-metrics
       output: victoria-metrics
       ldflags: -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=victoria-metrics-$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")-$(git rev-parse HEAD)

--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -51,7 +51,6 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          tags: nethttpomithttp2
           packages: ./app/${{range.key}}
           output: ${{range.key}}
           ldflags: -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${{range.key}}-$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")-$(git rev-parse HEAD)


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

The `nethttpomithttp2` build tag was causing vmauth to crash at startup with a nil pointer dereference in v1.130.0:
```
# k -n victoriametrics logs vmauth-f5fc9ff79-jcp2n
2025-11-25T17:07:56.544Z        info    VictoriaMetrics/lib/logger/flag.go:12   build version: vmauth-2025-11-17T23:22:25Z-04c24fc8312eaf5c0287cd1962afe7e66ce7593c
2025-11-25T17:07:56.544Z        info    VictoriaMetrics/lib/logger/flag.go:13   command-line flags
2025-11-25T17:07:56.544Z        info    VictoriaMetrics/lib/logger/flag.go:20     -auth.config="/config/auth.yml"
2025-11-25T17:07:56.544Z        info    VictoriaMetrics/app/vmauth/main.go:96   starting vmauth at "[:8427]"...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x74279d]

goroutine 1 [running]:
github.com/VictoriaMetrics/VictoriaMetrics/lib/httputil.NewTransport(0x0, {0x8720ec, 0xe})
        github.com/VictoriaMetrics/VictoriaMetrics/lib/httputil/transport.go:35 +0x13d
main.newRoundTripper({0x0?, 0x888b62?}, {0x0?, 0x97cb20?}, {0x0?, 0x5?}, {0x0, 0x0}, 0x0)
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/main.go:553 +0x267
main.parseAuthConfig({0xc000170c00?, 0x48bc24?, 0xc00014a240?})
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/auth_config.go:792 +0x765
main.reloadAuthConfigData({0xc000170c00, 0xeb, 0x200})
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/auth_config.go:723 +0xb7
main.reloadAuthConfig()
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/auth_config.go:703 +0xdb
main.initAuthConfig()
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/auth_config.go:620 +0x99
main.main()
        github.com/VictoriaMetrics/VictoriaMetrics/app/vmauth/main.go:98 +0x265
/ #
```

When this build tag is set, Go's HTTP/2 initialization is skipped, leaving `TLSClientConfig` uninitialized. VictoriaMetrics v1.130.0 code tries to access `TLSClientConfig.NextProtos` without a nil check, causing the crash.

Upstream VictoriaMetrics doesn't use this tag in their builds (their Makefile doesn't seem to show any of this). Removing it aligns with upstream and fixes the crash.

Some links related: 
  - Go issue https://github.com/golang/go/issues/35082 about nethttpomithttp2 tag 
  - VictoriaMetrics PR https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10003

<!--ci-cve-scan:fail-any-->
