### PR TITLE
clamav-1.5: Ignore tempdir check

### DIFF
--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.5
   version: "1.5.1"
-  epoch: 1
+  epoch: 2
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -374,6 +374,12 @@ subpackages:
       - name: Patch files
         runs: |
           sed -i '/^set -eu/a sleep 20' ${{targets.contextdir}}/usr/local/bin/clamdcheck.sh
+    checks:
+      disabled:
+        # Ships /run/clamav without corresponding tmpfiles.d snippet, but
+        # this is only used in Docker and the entry point creates the
+        # directory if it doesn't exist, so it doesn't matter.
+        - tempdir
     test:
       environment:
         contents:


### PR DESCRIPTION
melange is soon going to make it an error to ship a directory under `/run` without a corresponding `/usr/lib/tmpfiles.d` snippet as part of the project to merge `/var/run` into `/run`, but in this case it doesn't actually matter.

Related: https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw