### PR TITLE
mysql-9.5, percona-server-9.1: Add tmpfiles.d snippet

### DIFF
--- a/mysql-9.5.yaml
+++ b/mysql-9.5.yaml
@@ -94,11 +94,6 @@ pipeline:
         runs: |
           mv "${{targets.destdir}}"/usr/usr/lib/* "${{targets.destdir}}"/usr/lib/
           rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/usr/lib
-      # We don't currently use the systemd services, but we configure with
-      # systemd support in order to install a suitable tmpfiles.d snippet.
-      - name: "Remove systemd services"
-        runs: |
-          rm -r "${{targets.destdir}}"/usr/lib/systemd/
       - name: "Remove extras"
         runs: |
           rm -r "${{targets.destdir}}"/usr/mysql-test/
@@ -178,6 +173,17 @@ subpackages:
         - runs: |
             test /entrypoint.sh
             test /usr/local/bin/docker-entrypoint.sh
+
+  - name: "${{package.name}}-systemd-units"
+    description: "systemd units for MySQL"
+    dependencies:
+      runtime:
+        - mysql=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          mv "${{targets.destdir}}"/usr/lib/systemd/system/* "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/lib/systemd/system
 
   - name: ${{package.name}}-iamguarded-compat
     dependencies:

--- a/mysql-9.5.yaml
+++ b/mysql-9.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-9.5
   version: "9.5.0"
-  epoch: 0
+  epoch: 1
   description: "The MySQL open source relational database"
   copyright:
     - license: GPL-2.0-only # https://downloads.mysql.com/docs/licenses/mysqld-9.0-gpl-en.pdf
@@ -40,8 +40,10 @@ environment:
       - ncurses-dev
       - openssl-dev
       - pcre2-dev
+      - pkgconf
       - readline-dev
       - rpcsvc-proto
+      - systemd-dev
       - wolfi-baselayout
       - xz-dev
       - zlib-dev
@@ -76,15 +78,27 @@ pipeline:
             -DINSTALL_SUPPORTFILESDIR=share/support/${{package.name}} \
             -DINSTALL_MYSQLSHAREDIR=share/${{package.name}} \
             -DINSTALL_DOCDIR=share/doc/${{package.name}} \
+            -DSYSTEMD_SERVICES_DIR=lib/systemd/system \
+            -DSYSTEMD_TMPFILES_DIR=lib/tmpfiles.d \
             -DWITH_ASAN=OFF \
             -DWITH_JEMALLOC=OFF \
             -DWITH_LIBWRAP=OFF \
-            -DWITH_SYSTEMD=OFF \
+            -DWITH_SYSTEMD=ON \
             -DWITH_SSL=system \
             -DWITH_VALGRIND=OFF \
             -DWITH_ZLIB=system
       - uses: cmake/build
       - uses: cmake/install
+      # CMAKE_INSTALL_PREFIX=/usr confuses this.
+      - name: "Fix installation path of systemd components"
+        runs: |
+          mv "${{targets.destdir}}"/usr/usr/lib/* "${{targets.destdir}}"/usr/lib/
+          rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/usr/lib
+      # We don't currently use the systemd services, but we configure with
+      # systemd support in order to install a suitable tmpfiles.d snippet.
+      - name: "Remove systemd services"
+        runs: |
+          rm -r "${{targets.destdir}}"/usr/lib/systemd/
       - name: "Remove extras"
         runs: |
           rm -r "${{targets.destdir}}"/usr/mysql-test/

--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.1
   version: "9.1.0.1"
-  epoch: 8
+  epoch: 9
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later
@@ -49,11 +49,13 @@ environment:
       - openssl-dev
       - pcre2-dev
       - perl
+      - pkgconf
       - readline-dev
       - reflex
       - rpcgen
       - samurai
       - sed
+      - systemd-dev
       - wolfi-baselayout
       - xz-dev
       - zlib-dev
@@ -101,10 +103,12 @@ pipeline:
         -DINSTALL_DOCREADMEDIR=share/doc/${{package.name}} \
         -DINSTALL_SUPPORTFILESDIR=share/${{package.name}} \
         -DINSTALL_DOCDIR=share/doc/${{package.name}} \
+        -DSYSTEMD_SERVICES_DIR=lib/systemd/system \
+        -DSYSTEMD_TMPFILES_DIR=lib/tmpfiles.d \
         -DWITH_ROCKSDB=YES \
         -DWITH_ASAN=OFF \
         -DWITH_EXTRA_CHARSETS=complex \
-        -DWITH_SYSTEMD=no \
+        -DWITH_SYSTEMD=ON \
         -DWITH_SSL=system \
         -DWITH_LZ4=system \
         -DWITH_ICU=system \
@@ -119,6 +123,18 @@ pipeline:
     runs: |
       cd build
       DESTDIR="${{targets.destdir}}" ninja install
+
+  # CMAKE_INSTALL_PREFIX=/usr confuses this.
+  - name: "Fix installation path of systemd components"
+    runs: |
+      mv "${{targets.destdir}}"/usr/usr/lib/* "${{targets.destdir}}"/usr/lib/
+      rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/usr/lib
+
+  # We don't currently use the systemd services, but we configure with
+  # systemd support in order to install a suitable tmpfiles.d snippet.
+  - name: "Remove systemd services"
+    runs: |
+      rm -r "${{targets.destdir}}"/usr/lib/systemd/
 
   - name: "Remove extras"
     runs: |

--- a/percona-server-9.1.yaml
+++ b/percona-server-9.1.yaml
@@ -130,12 +130,6 @@ pipeline:
       mv "${{targets.destdir}}"/usr/usr/lib/* "${{targets.destdir}}"/usr/lib/
       rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/usr/lib
 
-  # We don't currently use the systemd services, but we configure with
-  # systemd support in order to install a suitable tmpfiles.d snippet.
-  - name: "Remove systemd services"
-    runs: |
-      rm -r "${{targets.destdir}}"/usr/lib/systemd/
-
   - name: "Remove extras"
     runs: |
       rm -rf "${{targets.destdir}}"/usr/mysql-test
@@ -167,6 +161,14 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           cp docker-entrypoint.sh ${{targets.contextdir}}/docker-entrypoint.sh
           chmod +x ${{targets.contextdir}}/docker-entrypoint.sh
+
+  - name: "${{package.name}}-systemd-units"
+    description: "systemd units for Percona Server"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          mv "${{targets.destdir}}"/usr/lib/systemd/system/* "${{targets.subpkgdir}}"/usr/lib/systemd/system
+          rmdir -p --ignore-fail-on-non-empty "${{targets.destdir}}"/usr/lib/systemd/system
 
 update:
   enabled: true


### PR DESCRIPTION
This ensures that the appropriate subdirectory of `/run` exists when running in a VM, where `/run` is a tmpfs.

Related: https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw