### PR TITLE
openldap-2.6: Add tmpfiles.d snippet

### DIFF
--- a/openldap-2.6.yaml
+++ b/openldap-2.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap-2.6
   version: "2.6.10"
-  epoch: 6
+  epoch: 7
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8
@@ -169,9 +169,11 @@ pipeline:
 
       install -d -m 700 \
         run/openldap \
+        usr/lib/tmpfiles.d \
         var/lib/openldap \
         var/lib/openldap/openldap-data \
         var/lib/openldap/openldap-lloadd
+      echo 'd /run/openldap 0700 root root -' >usr/lib/tmpfiles.d/"${{package.name}}".conf
 
   - runs: |
       install -D -m 640 lloadd.conf -t ${{targets.destdir}}/etc/openldap/


### PR DESCRIPTION
This ensures that the appropriate subdirectory of `/run` exists when running in a VM, where `/run` is a tmpfs.

Related: https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw