### PR TITLE
withdraw kafka-bitnami-compat packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -2,3 +2,5 @@ pango-1.90-r0.apk
 pango-dev-1.90-r0.apk
 pango-doc-1.90-r0.apk
 pango-tools-1.90-r0.apk
+kafka-bitnami-compat-3.9
+kafka-bitnami-compat-4.0


### PR DESCRIPTION
these are the packages in the apkindex [right now](https://apk.dag.dev/https/packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz@etag:60861722ab539b5367e6841a9c4a2758/APKINDEX?full=false&search=kafka-bitnami-compat&depend=&provide=)