### PR TITLE
chore: apply patch to pipenv for FIPS compatibility

### DIFF
--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -85,10 +85,99 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/
           mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
     test:
+      environment:
+        contents:
+          packages:
+            - python-${{range.key}}
+            - git
+            - py${{range.key}}-pip
       pipeline:
         - runs: |
+            set -euo pipefail
+
+            # Basic version checks
             pipenv --version
-            pipenv-resolver --help
+            pipenv --version | grep -F "pipenv, version"
+
+            # Verify pipenv-resolver is functional
+            pipenv-resolver --help | grep -F "resolver"
+        - runs: |
+            set -euo pipefail
+
+            # Create a test project directory
+            TEST_DIR=$(mktemp -d)
+            cd "$TEST_DIR"
+
+            # Initialize a new pipenv project with this Python version
+            pipenv --python python${{range.key}}
+
+            # Verify Pipfile was created
+            test -f Pipfile
+            cat Pipfile | grep -F "[packages]"
+            cat Pipfile | grep -F "[dev-packages]"
+
+            # Verify environment path commands return valid paths
+            pipenv --where | grep -F "$TEST_DIR"
+            test -d "$(pipenv --venv)"
+            test -x "$(pipenv --py)"
+
+            # Install a simple package
+            pipenv install six
+
+            # Verify Pipfile.lock was created
+            test -f Pipfile.lock
+            cat Pipfile.lock | grep -F '"six"'
+
+            # Verify the package appears in Pipfile
+            cat Pipfile | grep -F "six"
+
+            # Verify lock file integrity passes with valid lock
+            pipenv verify
+
+            # Corrupt the lock file hash and verify it fails
+            cp Pipfile.lock Pipfile.lock.bak
+            sed -i 's/"sha256:/"sha256:corrupted/' Pipfile.lock
+            ! pipenv verify
+            mv Pipfile.lock.bak Pipfile.lock
+
+            # Run a command inside the virtual environment
+            pipenv run python -c "import six; print('six version:', six.__version__)"
+
+            # Test the graph command
+            pipenv graph | grep -F "six"
+
+            # Test lock command with verification
+            pipenv lock
+            test -f Pipfile.lock
+
+            # Test sync by deleting venv and recreating from lock file
+            rm -rf "$(pipenv --venv)"
+
+            pipenv sync
+            # Verify package is importable after sync recreated venv
+            pipenv run python -c "import six"
+
+            # Test requirements export
+            pipenv requirements > requirements.txt
+            cat requirements.txt | grep -F "six"
+
+            # Test dev dependencies
+            pipenv install --dev pytest
+
+            # Verify dev dependency in Pipfile
+            cat Pipfile | grep -F "pytest"
+
+            # Verify dev dependency can be run
+            pipenv run pytest --version
+
+            # Test uninstall
+            pipenv uninstall six
+
+            # Verify six is removed from Pipfile (should not match)
+            ! grep -F 'six = ' Pipfile
+
+            # Verify six is no longer importable - expect ModuleNotFoundError
+            ! pipenv run python -c "import six"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -114,5 +203,10 @@ update:
 test:
   pipeline:
     - runs: |
-        pipenv --help
-        pipenv-resolver --version
+        set -euo pipefail
+
+        # Basic smoke test. Functional tests tests are in per-version
+        # subpackages, which ensures we run tests across all python versions.
+        pipenv --version
+        pipenv --version | grep -F "pipenv, version"
+        pipenv-resolver --help

--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pipenv
   version: "2025.0.4"
-  epoch: 3
+  epoch: 4
   description: Python Development Workflow for Humans.
   copyright:
     - license: MIT
@@ -38,6 +38,10 @@ pipeline:
       repository: https://github.com/pypa/pipenv
       tag: v${{package.version}}
       expected-commit: 4e5f9a79839f0e6701422341dcdf8edebb5063eb
+
+  - uses: patch
+    with:
+      patches: fips-md5-usedforsecurity.patch
 
 subpackages:
   - range: py-versions

--- a/py3-pipenv/fips-md5-usedforsecurity.patch
+++ b/py3-pipenv/fips-md5-usedforsecurity.patch
@@ -1,0 +1,22 @@
+From b070e6956827f0a6d3c6b7dc10dc577f2d0544de Mon Sep 17 00:00:00 2001
+From: Aditya Tirmanwar <aditya.tirmanwar@chainguard.dev>
+Date: Tue, 25 Nov 2025 22:11:58 +0000
+Subject: [PATCH] Fix MD5 usage for FIPS compatibility
+
+---
+ pipenv/utils/resolver.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pipenv/utils/resolver.py b/pipenv/utils/resolver.py
+index 57545113..be93f5e1 100644
+--- a/pipenv/utils/resolver.py
++++ b/pipenv/utils/resolver.py
+@@ -753,7 +753,7 @@ def _generate_resolution_cache_key(
+     ]
+ 
+     key_string = "|".join(key_components)
+-    return hashlib.md5(key_string.encode()).hexdigest()
++    return hashlib.md5(key_string.encode(), usedforsecurity=False).hexdigest()
+ 
+ 
+ def _should_use_resolution_cache(cache_key, clear):


### PR DESCRIPTION
pipenv fails in FIPS mode with `_hashlib.UnsupportedDigestmodError` when generating resolution cache keys. Python 3.12's
[gh-127301](https://github.com/wolfi-dev/os/blob/main/python-3.12/gh-127301.patch) patch ensures that when _hashlib/OpenSSL is available and OpenSSL is in FIPS mode, builtin hash implementations require `usedforsecurity=False` for MD5/SHA1 usage.