### PR TITLE
docker-credential-acr-env: Cherry pick bump commit

### DIFF
--- a/docker-credential-acr-env.yaml
+++ b/docker-credential-acr-env.yaml
@@ -30,6 +30,7 @@ pipeline:
         golang.org/x/sys@v0.13.0
         golang.org/x/text@v0.9.0
         golang.org/x/crypto@v0.45.0
+        github.com/golang-jwt/jwt/v4@v4.5.2
 
   - runs: |
       make build

--- a/docker-credential-acr-env.yaml
+++ b/docker-credential-acr-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-acr-env
   version: 0.7.0
-  epoch: 25 # GHSA-j5w8-q4qc-rx2x
+  epoch: 26
   description: ACR Docker Credential Helper
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,8 @@ pipeline:
       repository: https://github.com/chrismellard/docker-credential-acr-env
       tag: ${{package.version}}
       expected-commit: c57b701bfc08d857fce060250ed9a254b075538d
+      cherry-picks: |
+        master/e883f69e0206edbbcac3a053aeefeef253c173f0: GHSA-w73w-5m7g-f7qc
 
   - uses: go/bump
     with:


### PR DESCRIPTION
This cherry picks https://github.com/chrismellard/docker-credential-acr-env/commit/e883f69e0206edbbcac3a053aeefeef253c173f0 which contains a bunch of bumps mostly and most importantly drops the vulnerable `github.com/dgrijalva/jwt-go` dependency.