### PR TITLE
chrony: use UDS for communicating with chronyd

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.8"
-  epoch: 3
+  epoch: 4
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -56,6 +56,9 @@ pipeline:
       install -Dm644 ./chrony.conf ${{targets.destdir}}/etc/chrony/chrony.conf
       install -Dm644 ./sysusers.d/chrony.conf ${{targets.destdir}}/usr/lib/sysusers.d/chrony.conf
       install -Dm644 ./50-chronyd.list ${{targets.destdir}}/usr/lib/systemd/ntp-units.d/50-chronyd.list
+
+      install -Dm644 ./chrony-wait.service.d/10-use-unix-domain-sockets.conf \
+                     ${{targets.destdir}}/usr/lib/systemd/system/chrony-wait.service.d/10-use-unix-domain-sockets.conf
 
   - uses: strip
 

--- a/chrony/chrony-wait.service.d/10-use-unix-domain-sockets.conf
+++ b/chrony/chrony-wait.service.d/10-use-unix-domain-sockets.conf
@@ -1,0 +1,12 @@
+[Service]
+User=chrony
+
+ExecStart=
+ExecStart=/usr/bin/chronyc -h /run/chrony/chronyd.sock waitsync 0 0.1 0.0 1
+
+IPAddressAllow=
+RestrictAddressFamilies=
+RestrictAddressFamilies=AF_UNIX
+
+ReadWritePaths=/run/chrony
+UMask=0077


### PR DESCRIPTION
A previous change set "cmdport 0" for the chronyd configuration. This disables chronyd listening on UDP port 323. Chronyd is still listening on /run/chrony/chronyd.sock, so switch chrony-wait.service over to that tio prevent it from eventually timing out.