### PR TITLE
fix(langfuse): GHSA-mh29-5h37-fv8m

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -93,7 +93,7 @@ pipeline:
   - name: "Build webapp"
     runs: |
       pnpm run build --filter=web
-      npm -g install prisma@$(cat webapps/console/package.json | jq -r '.version') --prefix ${{targets.destdir}}/usr/local/
+      npm -g install prisma@$(cat web/package.json | jq -r '.dependencies.prisma') --prefix ${{targets.destdir}}/usr/local/
 
   - name: "Move webapp output into directories"
     runs: |

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,6 +1,6 @@
 package:
   name: langfuse
-  version: "3.132.0"
+  version: "3.134.0"
   epoch: 0
   description: "Langfuse webapp"
   copyright:
@@ -56,7 +56,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: b925120e0ebfce6685ac91ebd12ad6d5d5921fd3
+      expected-commit: d2aaddb6e0b7e99dd703040680dc3b8c2ed97777
 
   - name: "Bump deps and install"
     runs: |
@@ -86,7 +86,8 @@ pipeline:
         "pnpm.overrides.axios=^1.12.0" \
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
         "pnpm.overrides.tar-fs=3.1.1" \
-        "pnpm.overrides.playwright=^1.55.1"
+        "pnpm.overrides.playwright=^1.55.1" \
+        "pnpm.overrides.js-yaml=^4.1.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 


### PR DESCRIPTION
Upstream depends on a specific version of prisma (currently 6.17.1) and the
newest version (7.0.1) breaks the test due to changes in the configuration file
structure.[1]
    
This change modifies the prisma installation to ensure Chainguard langfuse
installs the upstream langfuse version of prisma, not latest.

Also bump langfuse version and js-yaml version to fix GHSA-mh29-5h37-fv8m
    
[1] https://www.prisma.io/docs/orm/reference/prisma-config-reference#engine


<!--ci-cve-scan:must-fix: $CVE-->