### PR TITLE
Update replace to align with current

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: "3.5.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -63,7 +63,7 @@ subpackages:
         # When this test fails, that likely means fluent-bit rolled forward to
         # a new version stream anad must be updated in the "replaces" block
         # below
-        - fluent-bit-4.1
+        - fluent-bit-4.2
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/fluent-bit/etc


### PR DESCRIPTION
Currently getting conflict as replace is for 4.1 though we are now on 4.2

https://github.com/chainguard-dev/image-release-stats/issues/9197
https://github.com/chainguard-dev/image-release-stats/issues/9190
