### PR TITLE
npm: remove stale comment

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,4 +1,3 @@
-# downgraded to 11.2.0 until https://github.com/npm/cli/issues/8216 is resolved
 package:
   name: npm
   version: "11.6.2"


### PR DESCRIPTION
This comment is no longer relevant.  It was added by https://github.com/wolfi-dev/os/commit/81638b8ce62df08835a6e43b378ba61bdd8caf13 but the version has since been unpinned
