### PR TITLE
fix(falco-no-driver): No change rebuild

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: "0.42.1"
-  epoch: 0
+  epoch: 1 # GHSA-f6x5-jh6r-wrfv and GHSA-j5w8-q4qc-rx2x
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -36,7 +36,7 @@ environment:
       - elfutils-dev
       - gcc
       - git
-      - grpc-1.66-dev
+      - grpc-1.76-dev # To work around grpc-1.66-1.66.2-r2.apk disqualified because grpc-1.76-1.76.0-r1.apk already provides cmd:grpc_cpp_plugin
       - isl-dev
       - libbpf
       - libbpf-dev


### PR DESCRIPTION
Upstream https://github.com/falcosecurity/plugins/tree/main/plugins/container has bumped golang.org/x/crypto to 0.45 which should remediate GHSA-f6x5-jh6r-wrfv and GHSA-j5w8-q4qc-rx2x being detected in libcontainer.so in the falcon-no-driver package. A rebuild should hopefully pull the latest container plugin release and remediate the vulnerabilities

<!--ci-cve-scan:must-fix: GHSA-f6x5-jh6r-wrfv -->
<!--ci-cve-scan:must-fix: GHSA-j5w8-q4qc-rx2x -->