### PR TITLE
rspamd: Add tmpfiles.d snippet

### DIFF
--- a/rspamd.yaml
+++ b/rspamd.yaml
@@ -1,7 +1,7 @@
 package:
   name: rspamd
   version: "3.14.1"
-  epoch: 0
+  epoch: 1
   description: "Rapid spam filtering system"
   copyright:
     - license: Apache-2.0
@@ -60,6 +60,10 @@ pipeline:
       install -d -m 755 "${{targets.destdir}}"/var/lib/rspamd
       install -d -m 755 "${{targets.destdir}}"/var/log/rspamd
       install -d -m 755 "${{targets.destdir}}"/run/rspamd
+
+      # Create runtime directory when /run is a tmpfs
+      install -d -m 755 "${{targets.destdir}}"/usr/lib/tmpfiles.d
+      echo 'd /run/rspamd 0755 root root -' >"${{targets.destdir}}"/usr/lib/tmpfiles.d/rspamd.conf
 
       install -d -m 700 "${{targets.destdir}}"/var/lib/rspamd/dkim
       install -d -m 755 "${{targets.destdir}}"/etc/rspamd/local.d


### PR DESCRIPTION
This ensures that the appropriate subdirectory of `/run` exists when running in a VM, where `/run` is a tmpfs.

Related: https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw