### PR TITLE
restore a few openssl build-dependencies

### DIFF
--- a/restored-packages.txt
+++ b/restored-packages.txt
@@ -1,0 +1,13 @@
+isl-0.27-r0.apk
+libbrotlicommon1-1.1.0-r4.apk
+libbrotlidec1-1.1.0-r4.apk
+libevent-2.1.12-r6.apk
+libidn2-2.3.7-r3.apk
+libnghttp2-14-1.64.0-r1.apk
+libpsl-0.21.5-r4.apk
+libunistring-1.3-r1.apk
+libverto-0.3.2-r4.apk
+mpc-1.3.1-r5.apk
+mpfr-4.2.1-r5.apk
+posix-cc-wrappers-1-r4.apk
+readline-8.2.13-r1.apk


### PR DESCRIPTION
To rebuild a historical build of openssl, restore a few toolchain
packages.
