### PR TITLE
Minor cleanup in langfuse.yaml

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse
   version: "3.134.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -44,8 +44,6 @@ environment:
     # Required for langfuse-worker
     SKIP_MIGRATE_DATABASE_SCHEMA: "1"
     SKIP_SEED_PRISMA_DATABASE: "1"
-    # Required to mitigate go CVE
-    ESBUILD_BINARY_PATH: "/usr/bin/esbuild"
 
 pipeline:
   - uses: git-checkout

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -32,18 +32,15 @@ environment:
       - pnpm
   environment:
     # Required for langfuse-web
-    CLICKHOUSE_PASSWORD: "test"
-    CLICKHOUSE_USER: "default"
-    CLICKHOUSE_URL: "http://localhost:8123"
     DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
-    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
-    NODE_OPTIONS: "--max-old-space-size=8192"
     NEXTAUTH_SECRET: "test"
     NEXTAUTH_URL: "http://localhost:3000"
     SALT: "test"
-    # Required for langfuse-worker
-    SKIP_MIGRATE_DATABASE_SCHEMA: "1"
-    SKIP_SEED_PRISMA_DATABASE: "1"
+    CLICKHOUSE_URL: "http://localhost:8123"
+    CLICKHOUSE_USER: "default"
+    CLICKHOUSE_PASSWORD: "test"
+    NODE_OPTIONS: "--max-old-space-size=8192"
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
 
 pipeline:
   - uses: git-checkout
@@ -164,14 +161,14 @@ test:
     - name: "launch webapp"
       working-directory: /app
       runs: |
+        set -o pipefail
         useradd postgres
         sudo -u postgres initdb -D ${PGDATA}
         sudo -u postgres pg_ctl -D ${PGDATA} -l /tmp/logfile start
         sudo -u postgres createdb ${PGDB}
         redis-server --daemonize yes > /tmp/redis-server.log 2>&1 &
         dumb-init -- ./web/entrypoint.sh node ./web/server.js > /tmp/web.log 2>&1 &
-        sleep 5
-        wait-for-it localhost:3030 --timeout=60 || exit 1
+        wait-for-it localhost:3030 --timeout=60
 
 subpackages:
   - name: ${{package.name}}-compat
@@ -224,9 +221,7 @@ subpackages:
           rm -rf "${{targets.contextdir}}"/app/packages/shared/node_modules
           cp -r packages/shared/node_modules "${{targets.contextdir}}"/app/packages/shared/node_modules/
 
-          # Copy entrypoint
-          cp worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
-          chmod +x "${{targets.contextdir}}"/app/worker/entrypoint.sh
+          install -m755 worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
 
           # use our esbuild binary to remove cve
           cp /usr/bin/esbuild $(find "${{targets.contextdir}}"/app/node_modules/.pnpm -path '*@esbuild+linux*bin/esbuild')
@@ -333,12 +328,11 @@ subpackages:
             post: |
               WORKER_HOST=$(hostname)
               echo "Worker is running on hostname: $WORKER_HOST"
-              curl -sfL http://${WORKER_HOST}:3030/ | grep -q "Langfuse Worker API"
+              curl -fsS  http://${WORKER_HOST}:3030/ | grep -q "Langfuse Worker API"
 
 update:
   enabled: true
-  schedule:
-    period: daily
-    reason: langfuse cuts a high number of tags every day.
-  git:
-    strip-prefix: v
+  github:
+    identifier: langfuse/langfuse
+    use-tag: true
+    tag-filter-prefix: v3.

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -176,7 +176,12 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin/
-          ln -sf ${{targets.contextdir}}/usr/local/lib/node_modules/prisma/build/index.js /usr/local/bin/prisma
+          ln -sf /usr/local/lib/node_modules/prisma/build/index.js "${{targets.subpkgdir}}"/usr/local/bin/prisma
+    test:
+      pipeline:
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
 
   - name: ${{package.name}}-worker
     description: Langfuse worker background service

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -328,7 +328,7 @@ subpackages:
             post: |
               WORKER_HOST=$(hostname)
               echo "Worker is running on hostname: $WORKER_HOST"
-              curl -fsS  http://${WORKER_HOST}:3030/ | grep -q "Langfuse Worker API"
+              curl -fsS  http://${WORKER_HOST}:3030/ | grep -F "Langfuse Worker API"
 
 update:
   enabled: true

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -36,18 +36,14 @@ environment:
     CLICKHOUSE_USER: "default"
     CLICKHOUSE_URL: "http://localhost:8123"
     DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
-    LANG: "en_US.UTF-8"
     LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
-    LC_ALL: "en_US.UTF-8"
     NODE_OPTIONS: "--max-old-space-size=8192"
     NEXTAUTH_SECRET: "test"
     NEXTAUTH_URL: "http://localhost:3000"
     SALT: "test"
-    NEXT_TELEMETRY_DISABLED: "1"
     # Required for langfuse-worker
     SKIP_MIGRATE_DATABASE_SCHEMA: "1"
     SKIP_SEED_PRISMA_DATABASE: "1"
-    HUSKY: "0"
     # Required to mitigate go CVE
     ESBUILD_BINARY_PATH: "/usr/bin/esbuild"
 
@@ -336,6 +332,10 @@ subpackages:
             expected_output: |
               Listening: http://
               Finished upserting default model prices
+            post: |
+              WORKER_HOST=$(hostname)
+              echo "Worker is running on hostname: $WORKER_HOST"
+              curl -sfL http://${WORKER_HOST}:3030/ | grep -q "Langfuse Worker API"
 
 update:
   enabled: true

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -177,11 +177,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin/
           ln -sf /usr/local/lib/node_modules/prisma/build/index.js "${{targets.subpkgdir}}"/usr/local/bin/prisma
-    test:
-      pipeline:
-        - uses: test/tw/symlink-check
-          with:
-            allow-absolute: true
 
   - name: ${{package.name}}-worker
     description: Langfuse worker background service


### PR DESCRIPTION
removes unused env vars and add post section to test

related: https://github.com/chainguard-dev/enterprise-packages/pull/39818

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
