### PR TITLE
argo cd bump

### DIFF
--- a/argo-cd-3.2.yaml
+++ b/argo-cd-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-3.2
   version: "3.2.0"
-  epoch: 2
+  epoch: 3
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
- **opensearch-dashboards-3, prism: fix GHSA-mh29-5h37-fv8m and GHSA-5j98-mcp5-4vw2**
- **protobuf: 33.1.0 transition rebuilds**
- **kubernetes-1.34/1.34.2-r0: fix GHSA-j5w8-q4qc-rx2x <!--ci-cve-scan:must-fix: GHSA-j5w8-q4qc-rx2x-->**
- **fix(kubernetes-1.34): GHSA-f6x5-jh6r-wrfv, GHSA-j5w8-q4qc-rx2x**
- **k3s-1.33/1.33.5.1-r3: fix GHSA-j5w8-q4qc-rx2x <!--ci-cve-scan:must-fix: GHSA-j5w8-q4qc-rx2x-->**
- **conda-base/25.11.0 package update (#73063)**
- **fix(k3s-1.33): GHSA-j5w8-q4qc-rx2x**
- **crossplane-provider-keycloak/2.11.0 package update (#73258)**
- **php-8.5-ddtrace/1.14.1 package update (#73257)**
- **php-8.3-ddtrace/1.14.1 package update (#73260)**
- **k3s-1.32/1.32.9.1-r3: fix GHSA-j5w8-q4qc-rx2x <!--ci-cve-scan:must-fix: GHSA-j5w8-q4qc-rx2x-->**
- **orthanc/1.12.10 package update (#73262)**
- **php-8.1-ddtrace/1.14.1 package update (#73261)**
- **fix(k3s-1.32): GHSA-j5w8-q4qc-rx2x**
- **update mountpoint-s3-csi-driver to its latest 2.2.1 (#73264)**
- **gitaly-18.5/18.5.3 package update (#73263)**
- **topgrade/16.5.0 package update (#73266)**
- **gitleaks/8.30.0 package update (#73267)**
- **opa/1.11.0 package update (#73270)**
- **github-mcp-server/0.23.0 package update (#73271)**
- **uv/0.9.13 package update (#73269)**
- **pulumi/3.209.0 package update (#72478)**
- **wasm-tools/1.242.0 package update (#73272)**
- **php-8.4-ddtrace/1.14.1 package update (#73273)**
- **zed/0.214.5 package update (#73274)**
- **php-8.2-ddtrace/1.14.1 package update (#73279)**
- **vim/9.1.1929 package update (#73281)**
- **temporal-docker-builds/0.0_git20251126 package update (#73229)**
- **py3-boto3/1.41.5 package update (#73283)**
- **php-8.3-imagick/3.8.1 package update (#73284)**
- **py3-langsmith/0.4.49 package update (#73287)**
- **php-8.1-imagick/3.8.1 package update (#73288)**
- **php-8.4-imagick/3.8.1 package update (#73289)**
- **chezmoi/2.67.1 package update (#73290)**
- **php-8.2-imagick/3.8.1 package update (#73291)**
- **sbomqs/2.0.1 package update (#73292)**
- **vim/9.1.1930 package update (#73293)**
- **aws-c-cal/0.9.13 package update (#73294)**
- **ccache/4.12.2 package update (#73295)**
- **py3-botocore/1.41.5 package update (#73296)**
- **atmoz-sftp/0.0.0_git20251127 package update (#73297)**
- **perl-term-table/0.028 package update (#73299)**
- **rancher-partner-charts/0_git20251127 package update (#73300)**
- **temporal-docker-builds/0.0_git20251127 package update (#73301)**
- **py3-hatch/1.16.0 package update (#73302)**
- **jupyter-docker-stacks/0.0.0_git20251127 package update (#73303)**
- **temporal-docker-builds/0.0_git20251127 package update (#73304)**
- **kubo/0.39.0 package update (#73305)**
- **conftest/0.65.0 package update (#73310)**
- **eksctl/0.219.0 package update (#73311)**
- **version stream helm package (#73312)**
- **argo-cd-3.2: epoch bump**
