### PR TITLE
helm-3: add helm-3 version-stream

### DIFF
--- a/helm-3.yaml
+++ b/helm-3.yaml
@@ -1,0 +1,54 @@
+package:
+  name: helm-3
+  version: 3.19.2
+  epoch: 1
+  description: The Kubernetes Package Manager
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - helm=${{package.full-version}}
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/helm/helm
+      tag: v${{package.version}}
+      expected-commit: 8766e718a0119851f10ddbe4577593a45fadf544
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.45.0
+
+  - runs: |
+      make build
+      install -Dm755 ./bin/helm "${{targets.contextdir}}/usr/bin/helm"
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        helm version || exit 1
+        helm --help
+    - runs: |
+        helm create test
+
+update:
+  enabled: true
+  github:
+    identifier: helm/helm
+    strip-prefix: v
+    tag-filter-prefix: v3


### PR DESCRIPTION
Related to the fact that we now need to pin helm-3 in argo-cd, and
helm-3 is also still supported upstream until November 2026, we will now
version stream this package.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
