### PR TITLE
opentelemetry-cpp: version shared libraries

### DIFF
--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
-  version: "1.23.0"
-  epoch: 4
+  version: "1.24.0"
+  epoch: 0
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
     with:
       repository: https://github.com/open-telemetry/opentelemetry-cpp
       tag: v${{package.version}}
-      expected-commit: ea1f0d61ce5baa5584b097266bf133d1f31e3607
+      expected-commit: a7b100834dce58c949ab9bdfccdf1613db460d1c
 
   - uses: cmake/configure
     with:

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: "1.23.0"
-  epoch: 3
+  epoch: 5
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -6,6 +6,12 @@ package:
   copyright:
     - license: Apache-2.0
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\..*$
+    replace: ${1}
+    to: soversion
+
 environment:
   contents:
     packages:
@@ -45,7 +51,8 @@ pipeline:
         -DWITH_EXAMPLES=OFF \
         -DWITH_FUNC_TESTS=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DOTELCPP_VERSIONED_LIBS=ON \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_ABSEIL=ON
 
@@ -56,11 +63,15 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libopentelemetry-cpp${{vars.soversion}}
+    pipeline:
+      - uses: split/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
   - name: opentelemetry-cpp-static
     description: The OpenTelemetry C++ Client static libraries
-    dependencies:
-      runtime:
-        - opentelemetry-cpp
     pipeline:
       - uses: split/static
 
@@ -68,8 +79,8 @@ subpackages:
     description: The OpenTelemetry C++ Client development files
     dependencies:
       runtime:
-        - opentelemetry-cpp
-        - opentelemetry-cpp-static
+        - libopentelemetry-cpp${{vars.soversion}}=${{package.full-version}}
+        - opentelemetry-cpp-static=${{package.full-version}}
     pipeline:
       - uses: split/dev
     test:

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: "1.23.0"
-  epoch: 4
+  epoch: 3
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ pipeline:
         -DWITH_EXAMPLES=OFF \
         -DWITH_FUNC_TESTS=OFF \
         -DOPENTELEMETRY_INSTALL=ON \
-        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_SHARED_LIBS=OFF \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_ABSEIL=ON
 
@@ -75,10 +75,6 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
-
-test:
-  pipeline:
-    - uses: test/tw/ldd-check
 
 update:
   enabled: true


### PR DESCRIPTION
We recently re-enabled shared libraries for this package but as they contain no SO version, melange SCA won't automatically generate  dependencies for reverse build dependencies.

This breaks ingress-nginx-controller across all versions.

Provide versioned shared libraries and a new subpackage to deal with any future transition needs.