### PR TITLE
fix(cilium-1.18): add wrapper for etcd calls

### DIFF
--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.18
   version: "1.18.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0

--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -237,6 +237,23 @@ subpackages:
           - runs: make clustermesh-apiserver
           - uses: autoconf/make-install
           - runs: install -Dm755 etcd-config.yaml ${{targets.contextdir}}/var/lib/cilium/etcd-config.yaml
+      - runs: |
+          # Wrapper for etcd to strip brackets from IPv4 addresses
+          # Go 1.25+ rejects bracketed IPv4 as invalid IP-literal (RFC compliance)
+          # Cilium Helm chart v1.18.x uses: --listen-client-urls=https://[$(HOSTNAME_IP)]:2379
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          cat > ${{targets.contextdir}}/usr/local/bin/etcd <<'EOF'
+          #!/bin/sh
+          set -e
+          args=""
+          for arg in "$@"; do
+            # Strip brackets from IPv4: https://[10.1.2.3]:2379 -> https://10.1.2.3:2379
+            fixed=$(echo "$arg" | sed -E 's|://\[([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\]|://\1|g')
+            args="$args $fixed"
+          done
+          exec /usr/sbin/etcd $args
+          EOF
+          chmod +x ${{targets.contextdir}}/usr/local/bin/etcd
       - uses: strip
     test:
       pipeline:
@@ -246,6 +263,18 @@ subpackages:
             stat /var/lib/cilium/etcd-config.yaml
             clustermesh-apiserver version | grep "${{package.version}}"
             clustermesh-apiserver --help 2>&1 | grep "Run the ClusterMesh apiserver"
+        - runs: |
+            # Test etcd wrapper strips IPv4 brackets
+            /usr/local/bin/etcd --version | grep "etcd Version"
+
+            # Test with bracketed IPv4 in listen-client-urls and advertise-client-urls
+            output=$(/usr/local/bin/etcd \
+              -listen-client-urls 'https://[127.0.0.1]:2379' \
+              -advertise-client-urls 'https://[10.1.2.3]:2379' \
+              -listen-metrics-urls 'http://[127.0.0.1]:9091' 2>&1 || true)
+
+            # Should NOT fail with "invalid IP-literal" (wrapper strips brackets)
+            ! echo "$output" | grep -q "invalid IP-literal"
 
 test:
   pipeline:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

<!--ci-cve-scan:fail-any-->
