### PR TITLE
Split libudev-dev from systemd-dev

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "258.2"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -243,6 +243,7 @@ subpackages:
     dependencies:
       runtime:
         - libudev
+        - libudev-dev
         - merged-lib
         - merged-sbin
         - merged-usrsbin
@@ -269,6 +270,21 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/ldd-check
+
+  - name: "libudev-dev"
+    description: "udev library development files"
+    dependencies:
+      provider-priority: 10
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig ${{targets.subpkgdir}}/usr/include
+          mv ./melange-out/systemd-dev/usr/include/libudev.h ${{targets.subpkgdir}}/usr/include/
+          mv ./melange-out/systemd-dev/usr/lib/pkgconfig/libudev.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/
+          mv ./melange-out/systemd-dev/usr/lib/libudev.so ${{targets.subpkgdir}}/usr/lib/
+    test:
+      pipeline:
+        - runs: test -f $(readlink -f /usr/lib/libudev.so)
+        - uses: test/pkgconf
 
   - name: "libsystemd"
     description: "systemd library"


### PR DESCRIPTION
Split libudev development files into a separated package from systemd-dev.
In order to provide backward compatibility systemd-dev now depends on libudev-dev at runtime.