### PR TITLE
chore: make python3.14 default with python3 and dev

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.0"
-  epoch: 8
+  epoch: 9
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -9,6 +9,9 @@ package:
     cpu: 8
     memory: 8Gi
   dependencies:
+    provides:
+      - python3=${{package.full-version}}
+      - python-3=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
 
@@ -357,6 +360,9 @@ subpackages:
   - name: "${{package.name}}-dev"
     description: "python3.14 development headers"
     dependencies:
+      provides:
+        - python3-dev=${{package.full-version}}
+        - python-3-dev=${{package.full-version}}
       runtime:
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
@@ -371,6 +377,16 @@ subpackages:
              "${{targets.destdir}}"/$d/python3-embed.pc \
              "${{targets.destdir}}"/$d/python3.pc \
              "${{targets.subpkgdir}}/$d/"
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: python3-dev
+            real-pkg-name: ${{subpkg.name}}
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: python-3-dev
+            real-pkg-name: ${{subpkg.name}}
 
   - name: "${{package.name}}-base-dev"
     description: "python3 development headers"


### PR DESCRIPTION
at some places we were pulling python3 and python3-dev and those were
implicitly resolving to 3.13 python version.

this commit moves latest of python version in wolfi to 3.14

there are many places where we use `python3` and `python3-dev` as a build
time dependency so ideally I would like to do a world build and
see the impact and stage this patch slowly. I'm thinking of this as the
starting point of defaulting 3.14 python toolchain in wolfi.
