### PR TITLE
nftables: Add JSON output support 

### DIFF
--- a/nftables.yaml
+++ b/nftables.yaml
@@ -41,6 +41,7 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
+        --with-json \
         --sbindir=/usr/bin
 
   - uses: autoconf/make

--- a/nftables.yaml
+++ b/nftables.yaml
@@ -123,8 +123,17 @@ update:
     identifier: 2082
 
 test:
+  environment:
+    contents:
+      packages:
+        - jq
   pipeline:
     - runs: |
         nft --version || nft --version 2>&1 | grep 'Protocol not supported'
         nft --help || nft --help 2>&1 | grep 'Protocol not supported'
+        nft -j list ruleset | jq >/dev/null
+    - name: Test JSON output
+      runs: |
+        set -o pipefail
+        nft -j list ruleset | jq >/dev/null        
     - uses: test/tw/ldd-check

--- a/nftables.yaml
+++ b/nftables.yaml
@@ -10,6 +10,10 @@ package:
       - merged-usrsbin
       - wolfi-baselayout
 
+capabilities:
+  add:
+    - CAP_NET_ADMIN
+    
 environment:
   contents:
     packages:

--- a/nftables.yaml
+++ b/nftables.yaml
@@ -135,5 +135,5 @@ test:
     - name: Test JSON output
       runs: |
         set -o pipefail
-        nft -j list ruleset | jq >/dev/null        
+        nft -j list ruleset | jq >/dev/null
     - uses: test/tw/ldd-check

--- a/nftables.yaml
+++ b/nftables.yaml
@@ -1,7 +1,7 @@
 package:
   name: nftables
   version: "1.1.5"
-  epoch: 1
+  epoch: 2
   description: Netfilter tables userspace tools
   copyright:
     - license: GPL-2.0-or-later

--- a/nftables.yaml
+++ b/nftables.yaml
@@ -13,7 +13,7 @@ package:
 capabilities:
   add:
     - CAP_NET_ADMIN
-    
+
 environment:
   contents:
     packages:


### PR DESCRIPTION
Now that we are shipping iptables-wrappers in images, they are likely to use nftables, and then will need the json output support. This option, described in the source code's INSTALL, adds support for JSON.
