### PR TITLE
fix(langfuse): GHSA-6465-jgvq-jhgp, GHSA-wqch-xfxh-vrr4

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -89,7 +89,8 @@ pipeline:
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
         "pnpm.overrides.tar-fs=3.1.1" \
         "pnpm.overrides.playwright=^1.55.1" \
-        "pnpm.overrides.js-yaml=^4.1.1"
+        "pnpm.overrides.js-yaml=^4.1.1" \
+        "pnpm.overrides.body-parser=^2.2.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse
   version: "3.134.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -57,6 +57,8 @@ pipeline:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
       expected-commit: d2aaddb6e0b7e99dd703040680dc3b8c2ed97777
+      cherry-picks: |
+        main/c3a1349ed896ca699bbf07dd68f6f0390ce1823e: [GHSA-6465-jgvq-jhgp]
 
   - name: "Bump deps and install"
     runs: |


### PR DESCRIPTION
Bump nextjs via upstream cherry-pick

Bump body-parser version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48510, https://github.com/chainguard-dev/CVE-Dashboard/issues/48545
