### PR TITLE
add langfuse-3 version stream

### DIFF
--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
   version: "3.134.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"

--- a/langfuse.yaml
+++ b/langfuse.yaml
@@ -1,5 +1,5 @@
 package:
-  name: langfuse
+  name: langfuse-3
   version: "3.134.0"
   epoch: 0
   description: "Langfuse webapp"
@@ -32,24 +32,15 @@ environment:
       - pnpm
   environment:
     # Required for langfuse-web
-    CLICKHOUSE_PASSWORD: "test"
-    CLICKHOUSE_USER: "default"
-    CLICKHOUSE_URL: "http://localhost:8123"
     DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
-    LANG: "en_US.UTF-8"
-    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
-    LC_ALL: "en_US.UTF-8"
-    NODE_OPTIONS: "--max-old-space-size=8192"
     NEXTAUTH_SECRET: "test"
     NEXTAUTH_URL: "http://localhost:3000"
     SALT: "test"
-    NEXT_TELEMETRY_DISABLED: "1"
-    # Required for langfuse-worker
-    SKIP_MIGRATE_DATABASE_SCHEMA: "1"
-    SKIP_SEED_PRISMA_DATABASE: "1"
-    HUSKY: "0"
-    # Required to mitigate go CVE
-    ESBUILD_BINARY_PATH: "/usr/bin/esbuild"
+    CLICKHOUSE_URL: "http://localhost:8123"
+    CLICKHOUSE_USER: "default"
+    CLICKHOUSE_PASSWORD: "test"
+    NODE_OPTIONS: "--max-old-space-size=8192"
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
 
 pipeline:
   - uses: git-checkout
@@ -170,14 +161,14 @@ test:
     - name: "launch webapp"
       working-directory: /app
       runs: |
+        set -o pipefail
         useradd postgres
         sudo -u postgres initdb -D ${PGDATA}
         sudo -u postgres pg_ctl -D ${PGDATA} -l /tmp/logfile start
         sudo -u postgres createdb ${PGDB}
         redis-server --daemonize yes > /tmp/redis-server.log 2>&1 &
         dumb-init -- ./web/entrypoint.sh node ./web/server.js > /tmp/web.log 2>&1 &
-        sleep 5
-        wait-for-it localhost:3030 --timeout=60 || exit 1
+        wait-for-it localhost:3030 --timeout=60
 
 subpackages:
   - name: ${{package.name}}-compat
@@ -185,7 +176,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin/
-          ln -sf ${{targets.contextdir}}/usr/local/lib/node_modules/prisma/build/index.js /usr/local/bin/prisma
+          ln -sf /usr/local/lib/node_modules/prisma/build/index.js "${{targets.subpkgdir}}"/usr/local/bin/prisma
 
   - name: ${{package.name}}-worker
     description: Langfuse worker background service
@@ -230,9 +221,7 @@ subpackages:
           rm -rf "${{targets.contextdir}}"/app/packages/shared/node_modules
           cp -r packages/shared/node_modules "${{targets.contextdir}}"/app/packages/shared/node_modules/
 
-          # Copy entrypoint
-          cp worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
-          chmod +x "${{targets.contextdir}}"/app/worker/entrypoint.sh
+          install -m755 worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
 
           # use our esbuild binary to remove cve
           cp /usr/bin/esbuild $(find "${{targets.contextdir}}"/app/node_modules/.pnpm -path '*@esbuild+linux*bin/esbuild')
@@ -336,11 +325,14 @@ subpackages:
             expected_output: |
               Listening: http://
               Finished upserting default model prices
+            post: |
+              WORKER_HOST=$(hostname)
+              echo "Worker is running on hostname: $WORKER_HOST"
+              curl -fsS  http://${WORKER_HOST}:3030/ | grep -F "Langfuse Worker API"
 
 update:
   enabled: true
-  schedule:
-    period: daily
-    reason: langfuse cuts a high number of tags every day.
-  git:
-    strip-prefix: v
+  github:
+    identifier: langfuse/langfuse
+    use-tag: true
+    tag-filter-prefix: v3.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: This PR add langfuse-3 package to explicitly track the upstream v3.x release line of Langfuse.
Upstream Langfuse actively maintains two parallel version lines:
v3.x — current mainline (frequent releases)
v2.95.x — maintenance branch receiving ongoing fixes

Our existing package was named langfuse, but only tracked v3.x. 