### PR TITLE
ruby3.2-addressable: pin public_suffix to v6

### DIFF
--- a/ruby3.2-addressable.yaml
+++ b/ruby3.2-addressable.yaml
@@ -1,13 +1,13 @@
 package:
   name: ruby3.2-addressable
   version: 2.8.7
-  epoch: 2
+  epoch: 3
   description: Addressable is an alternative implementation to the URI implementation that is part of Ruby's standard library. It is flexible, offers heuristic parsing, and additionally provides extensive support for IRIs and URI templates.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ruby${{vars.rubyMM}}-public_suffix
+      - ruby${{vars.rubyMM}}-public_suffix~6
 
 environment:
   contents:


### PR DESCRIPTION
This is an upstream constraint, see
 https://github.com/sporkmonger/addressable/blob/addressable-2.8.7/addressable.gemspec#L26

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
