### PR TITLE
tileserver-gl: bump body-parser to 2.2.1

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 4 # GHSA-mh29-5h37-fv8m
+  epoch: 5 # GHSA-mh29-5h37-fv8m
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -74,6 +74,9 @@ pipeline:
 
       # fix CVE-2025-46653 GHSA-75v8-2h7p-7m2m
       npm install formidable@3.5.3
+
+      # CVE-2025-13466 GHSA-wqch-xfxh-vrr4
+      npm install body-parser@2.2.1
 
       npm install --omit=dev
 


### PR DESCRIPTION
CVE-2025-13466 GHSA-wqch-xfxh-vrr4

<!--ci-cve-scan:fail-any-->