### PR TITLE
fix(vitess-23): GHSA-g4jq-h2w9-997c, GHSA-jqfw-vq24-v9c3, GHSA-mh29-5h37-fv8m

### DIFF
--- a/vitess-23.yaml
+++ b/vitess-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-23
   version: "23.0.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -101,7 +101,7 @@ pipeline:
       # CVE GHSA-3xgq-45jj-v275
       # npm install cross-spawn@7.0.6
       # CVE GHSA-859w-5945-r5v3
-      npm install vite@4.5.14
+      npm install vite@5.4.21
 
       npm prune --production
       npm install vite --save-dev

--- a/vitess-23.yaml
+++ b/vitess-23.yaml
@@ -92,6 +92,7 @@ pipeline:
       npm pkg set overrides['@babel/runtime-corejs3']=7.26.10
       npm pkg set overrides.form-data="4.0.4"
       npm pkg set overrides.tmp="0.2.4"
+      npm pkg set overrides.js-yaml="4.1.1"
 
   - name: Build web UI
     working-directory: web/vtadmin


### PR DESCRIPTION
Bump dependency versions

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48522, https://github.com/chainguard-dev/CVE-Dashboard/issues/48525, https://github.com/chainguard-dev/CVE-Dashboard/issues/48524

<!--ci-cve-scan:fail-any-->
