### PR TITLE
systemd-init: choose util-linux-login

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "258.2"
-  epoch: 2
+  epoch: 3
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -541,7 +541,6 @@ subpackages:
       runtime:
         - ${{package.name}}
         - agetty
-        - agetty
         - kbd
         - merged-lib
         - merged-sbin
@@ -549,6 +548,7 @@ subpackages:
         - mount
         - time-daemon
         - tzdata
+        - util-linux-login
         - wolfi-baselayout
     pipeline:
       - runs: |


### PR DESCRIPTION
Debian trixie, AL2023, fedora all use PAM enabled util-linux-login,
instead of shadow or busybox one.

Also busybox one doesn't work with selinux-refpolicy, as most policies
do not allow symlink for login by default.

Also remove duplicate agetty.

Choose util-linux-login as the preffered login binary.
