### PR TITLE
util-linux: split su from util-linux-login

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: "2.41.2"
-  epoch: 1
+  epoch: 2
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -173,9 +173,10 @@ subpackages:
         - wolfi-baselayout
 
   - name: util-linux-login
-    description: Login utils from util-linux package newgrp last lastb login lslogins nologin su sulogin
+    description: Login utils from util-linux package newgrp last lastb login lslogins nologin sulogin
     dependencies:
       runtime:
+        - cmd:su
         - merged-bin
         - merged-sbin
         - merged-usrsbin
@@ -188,19 +189,9 @@ subpackages:
           # install pam configuration for 'sulogin'
           install -Dm644 su-l.pamd ${{targets.subpkgdir}}/etc/pam.d/su-l
 
-          cd ${{targets.destdir}}
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          for cmd in newgrp last lastb login lslogins nologin su sulogin; do
-            for dir in bin sbin usr/bin usr/sbin; do
-              if [ -e $dir/$cmd ] || [ -L $dir/$cmd ]; then
-                pwd
-                ls -al
-                mv $dir/$cmd ${{targets.subpkgdir}}/usr/bin/
-                continue 2
-              fi
-            done
-            error "file $cmd not found"
-            return 1
+          for cmd in newgrp last lastb login lslogins nologin sulogin; do
+            mv ${{targets.destdir}}/usr/bin/$cmd ${{targets.subpkgdir}}/usr/bin/
           done
     test:
       pipeline:
@@ -220,6 +211,25 @@ subpackages:
             lslogins --help
             newgrp --version
             newgrp --help
+
+  - name: util-linux-su
+    description: Login utils from util-linux su
+    dependencies:
+      runtime:
+        - merged-bin
+        - merged-sbin
+        - merged-usrsbin
+        - runuser
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/su ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - runs: |
+            su --version
+            su --help
 
   - name: util-linux-misc
     pipeline:


### PR DESCRIPTION
Allow to install and use su from sudo-rs instead of from
util-linux-login, by splitting su into a separate package.
