### PR TITLE
fix(renovate): Remediate GHSA-5j98-mcp5-4vw2

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
   version: "42.27.1"
-  epoch: 0
+  epoch: 1 # GHSA-5j98-mcp5-4vw2
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -23,6 +23,7 @@ environment:
       - corepack
       - jq
       - nodejs-22
+      - npm
       - pnpm
 
 pipeline:
@@ -38,7 +39,11 @@ pipeline:
   - name: Bump dependencies
     runs: |
       jq '.dependencies."js-yaml" = "4.1.1"' package.json > temp.json && mv temp.json package.json
+      jq '.dependencies."glob" = "11.1.0"' package.json > temp.json && mv temp.json package.json
+      jq '.dependencies."npm" = "11.6.4"' package.json > temp.json && mv temp.json package.json
       jq '.pnpm.overrides."js-yaml" = "4.1.1"' package.json > temp.json && mv temp.json package.json
+      jq '.pnpm.overrides."glob" = "11.1.0"' package.json > temp.json && mv temp.json package.json
+      jq '.pnpm.overrides."npm" = "11.6.4"' package.json > temp.json && mv temp.json package.json
 
   - runs: |
       corepack enable


### PR DESCRIPTION
Remediate GHSA-5j98-mcp5-4vw2 by bumping glob to 11.1.0 and npm to 11.6.4


<!--ci-cve-scan:must-fix: GHSA-5j98-mcp5-4vw2-->

