### PR TITLE
rename langfuse to langfuse-3 for version stream

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
-  name: langfuse
+  name: langfuse-3
   version: "3.135.1"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -32,24 +32,15 @@ environment:
       - pnpm
   environment:
     # Required for langfuse-web
-    CLICKHOUSE_PASSWORD: "test"
-    CLICKHOUSE_USER: "default"
-    CLICKHOUSE_URL: "http://localhost:8123"
     DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
-    LANG: "en_US.UTF-8"
-    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
-    LC_ALL: "en_US.UTF-8"
-    NODE_OPTIONS: "--max-old-space-size=8192"
     NEXTAUTH_SECRET: "test"
     NEXTAUTH_URL: "http://localhost:3000"
     SALT: "test"
-    NEXT_TELEMETRY_DISABLED: "1"
-    # Required for langfuse-worker
-    SKIP_MIGRATE_DATABASE_SCHEMA: "1"
-    SKIP_SEED_PRISMA_DATABASE: "1"
-    HUSKY: "0"
-    # Required to mitigate go CVE
-    ESBUILD_BINARY_PATH: "/usr/bin/esbuild"
+    CLICKHOUSE_URL: "http://localhost:8123"
+    CLICKHOUSE_USER: "default"
+    CLICKHOUSE_PASSWORD: "test"
+    NODE_OPTIONS: "--max-old-space-size=8192"
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-event-upload-test"
 
 pipeline:
   - uses: git-checkout
@@ -75,6 +66,10 @@ pipeline:
         "pnpm.overrides.undici=^6.21.2" \
         "pnpm.overrides.vite=^5.4.21" \
         "pnpm.overrides.vitest=^2.1.9" \
+        "pnpm.overrides.@sentry/nextjs=^10.27.0" \
+        "pnpm.overrides.@sentry/node-core=^10.27.0" \
+        "pnpm.overrides.@sentry/node=^10.27.0" \
+        "pnpm.overrides.body-parser=^2.2.1" \
         "pnpm.overrides.ws=^8.17.1" \
         "pnpm.overrides.brace-expansion=^4.0.1" \
         "pnpm.overrides.dompurify=^3.2.4" \
@@ -87,8 +82,7 @@ pipeline:
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
         "pnpm.overrides.tar-fs=3.1.1" \
         "pnpm.overrides.playwright=^1.55.1" \
-        "pnpm.overrides.js-yaml=^4.1.1" \
-        "pnpm.overrides.body-parser=^2.2.1"
+        "pnpm.overrides.js-yaml=^4.1.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 
@@ -177,12 +171,14 @@ test:
         sudo -u postgres createdb ${PGDB}
         redis-server --daemonize yes > /tmp/redis-server.log 2>&1 &
         dumb-init -- ./web/entrypoint.sh node ./web/server.js > /tmp/web.log 2>&1 &
-        sleep 5
-        wait-for-it localhost:3030 --timeout=60 || exit 1
+        wait-for-it localhost:3030 --timeout=60
 
 subpackages:
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by entrypoint"
+    dependencies:
+      provides:
+        - langfuse-compat=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin/
@@ -191,6 +187,8 @@ subpackages:
   - name: ${{package.name}}-worker
     description: Langfuse worker background service
     dependencies:
+      provides:
+        - langfuse-worker=${{package.version}}
       runtime:
         - bash
         - busybox
@@ -232,8 +230,7 @@ subpackages:
           cp -r packages/shared/node_modules "${{targets.contextdir}}"/app/packages/shared/node_modules/
 
           # Copy entrypoint
-          cp worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
-          chmod +x "${{targets.contextdir}}"/app/worker/entrypoint.sh
+          install -m755 worker/entrypoint.sh "${{targets.contextdir}}"/app/worker/entrypoint.sh
 
           # use our esbuild binary to remove cve
           cp /usr/bin/esbuild $(find "${{targets.contextdir}}"/app/node_modules/.pnpm -path '*@esbuild+linux*bin/esbuild')
@@ -250,13 +247,15 @@ subpackages:
       - name: remove unneeded packages and tests that may introduce CVE's
         runs: |
           # monorepo-symlink-test vulnerability
-          find ${{targets.contextdir}}/app/node_modules -path "*/test/resolver/multirepo" -type d -exec rm -rf {} + 2>/dev/null || true
+          find ${{targets.contextdir}}/app/node_modules -path "*/test/resolver/multirepo" -type d -exec rm -rf {} + 2>/dev/null
 
           #CVE-2025-27789 and CVE-2025-48068
           find ${{targets.contextdir}}/app/node_modules -type d \( \
             -name "next" -o \
             -name "@next" \
-          \) -exec rm -rf {} + 2>/dev/null || true
+          \) -exec rm -rf {} + 2>/dev/null
+          # Remove ai package from worker (CVE-2025-48985) not needed in worker
+          find ${{targets.contextdir}}/app/node_modules -type d -name "ai" -path "*/node_modules/ai" -exec rm -rf {} + 2>/dev/null
     test:
       environment:
         contents:
@@ -333,15 +332,17 @@ subpackages:
               fi
             start: |
               dumb-init -- ./worker/entrypoint.sh node worker/dist/index.js
-            timeout: 60
             expected_output: |
               Listening: http://
               Finished upserting default model prices
+            post: |
+              WORKER_HOST=$(hostname)
+              echo "Worker is running on hostname: $WORKER_HOST"
+              curl -fsS  http://${WORKER_HOST}:3030/ | grep -F "Langfuse Worker API"
 
 update:
   enabled: true
-  schedule:
-    period: daily
-    reason: langfuse cuts a high number of tags every day.
-  git:
-    strip-prefix: v
+  github:
+    identifier: langfuse/langfuse
+    use-tag: true
+    tag-filter-prefix: v3

--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -9,6 +9,8 @@ package:
     cpu: 16
     memory: 16Gi
   dependencies:
+    provides:
+      - langfuse=${{package.version}}
     runtime:
       - busybox
       - dumb-init


### PR DESCRIPTION
updates langfuse.yaml to langfuse-3.yaml and aligning it with the langfuse-3 release.


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
