### PR TITLE
fix(kubeflow-centraldashboard): GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, GHSA-65ch-62r8-g69g

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -101,7 +101,7 @@ test:
   environment:
     contents:
       packages:
-        - nodejs
+        - nodejs-18
         - npm
   pipeline:
     - runs: |

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 5
+  epoch: 6
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -43,7 +43,7 @@ pipeline:
       overrides='{
         "ajv": "^6.12.3",
         "node-fetch": "^2.6.7",
-        "node-forge": "^1.3.0",
+        "node-forge": "^1.3.2",
         "axios": "^1.12.0",
         "qs": "^6.7.3",
         "underscore": "^1.12.1",


### PR DESCRIPTION
Bump node-forge version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48608, https://github.com/chainguard-dev/CVE-Dashboard/issues/48593, https://github.com/chainguard-dev/CVE-Dashboard/issues/48557

<!--ci-cve-scan:fail-any-->
