### PR TITLE
chore(hwloc): Set provider priority

### DIFF
--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -1,11 +1,12 @@
 package:
   name: hwloc
   version: "2.12.2"
-  epoch: 0
+  epoch: 1
   description: Portable abstraction of hierarchical hardware architectures
   copyright:
     - license: BSD-3-Clause
   dependencies:
+    provider-priority: 1000
     runtime:
       - merged-usrsbin
       - wolfi-baselayout


### PR DESCRIPTION
Resolve to non-CUDA hwloc over CUDA-hwloc. Setting to 1000 as CUDA-hwloc will account for the major and minor CUDA version. I.E., 13.0 -> 130