### PR TITLE
fix(jitsucom-jitsu): GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, GHSA-65ch-62r8-g69g

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 7 # GHSA-mh29-5h37-fv8m
+  epoch: 8
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -63,6 +63,8 @@ pipeline:
       # isolated-vm 6.x dropped support for NodeJS 18.x, which jitsucom-jitsu
       # still requires
       pnpm pkg set pnpm.overrides['isolated-vm']=^5.0.1
+      # Remediate GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, GHSA-65ch-62r8-g69g
+      pnpm pkg set pnpm.overrides['node-forge']=^1.3.2
       (cd libs/core-functions && npm pkg set overrides['isolated-vm']=^5.0.1)
       sed -i 's/\(isolated-vm.*\)6.0.0/\1^5.0.1/' services/profiles/dist_package.json
       sed -i 's/\(isolated-vm.*\)6.0.0/\1^5.0.1/' services/rotor/dist_package.json


### PR DESCRIPTION
Bump node-forge version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48652, https://github.com/chainguard-dev/CVE-Dashboard/issues/48634, https://github.com/chainguard-dev/CVE-Dashboard/issues/48649

<!--ci-cve-scan:fail-any-->
