### PR TITLE
opensearch-dashboards-3: update package pins for GHSA-554w-wpv2-vw27 et al

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.2.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 1
+  epoch: 2
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -84,6 +84,10 @@ pipeline:
 
       # CVE-2025-7783
       jq '.dependencies["form-data"] = "4.0.4"' package.json > temp.json && mv temp.json package.json
+
+      # remediate GHSA-65ch-62r8-g69g, GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq
+      resolutions='{"node-forge": "^1.3.2"}'
+      jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
       # fix CVE-2023-28155
       devDependencies='{"cypress": "^13.5.1"}'


### PR DESCRIPTION
Pin `node-forge@^1.3.2` to remediate GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, and GHSA-65ch-62r8-g69g.
