### PR TITLE
Spliting man pages off to aggregate-docs apk

### DIFF
--- a/aggregate.yaml
+++ b/aggregate.yaml
@@ -1,7 +1,7 @@
 package:
   name: aggregate
   version: "1.6.8"
-  epoch: 0
+  epoch: 1
   description: Optimise a list of route prefixes to help make nice short filters
   copyright:
     - license: ISC
@@ -52,7 +52,7 @@ subpackages:
     test:
       pipeline:
         - uses: test/tw/docs
-        
+
 test:
   pipeline:
     - name: "Test basic prefix aggregation"

--- a/aggregate.yaml
+++ b/aggregate.yaml
@@ -44,6 +44,15 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: "aggregate-doc"
+    description: "aggregate documentation"
+    pipeline:
+      - uses: split/alldocs
+    test:
+      pipeline:
+        - uses: test/tw/docs
+        
 test:
   pipeline:
     - name: "Test basic prefix aggregation"


### PR DESCRIPTION
Missed the -docs pipeline when I implemented this last month in https://github.com/wolfi-dev/os/pull/70926

