### PR TITLE
strace: build with linux-headers corresponding to version

### DIFF
--- a/strace.yaml
+++ b/strace.yaml
@@ -1,7 +1,7 @@
 package:
   name: strace
   version: "6.17"
-  epoch: 0
+  epoch: 1
   description: Diagnostic, debugging and instructional userspace tracer
   copyright:
     - license: BSD-3-Clause
@@ -19,6 +19,13 @@ environment:
       - coreutils # GNU date - busybox date not sufficient.
       # - elfutils-dev TODO
       - gawk
+      - linux-headers~${{vars.major-minor-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*$
+    replace: "$1"
+    to: major-minor-version
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
`strace` upstream release versions corresponding to the supported kernel version: building with newer headers has and will lead to build failures.

<!--ci-cve-scan:fail-any-->

Closes: #73538