### PR TITLE
openssf-compiler-options: Ignore GCS warnings on ARM64

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20250904
-  epoch: 0
+  epoch: 1
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/15/openssf.spec
@@ -27,7 +27,8 @@
   --sort-common \
   -z noexecstack \
   -z relro \
-  -z now
+  -z now \
+  -z gcs-report-dynamic=none
 
 %include_noerr </usr/lib/oldglibc/gcc.spec>
 %include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
After 99eaa98861c80afac7b18fef7a5a9e93d71a17b0 was pushed, GCS has been enabled by default on ARM64 builds.  Because we didn't rebuild every shared library with this new feature, whenever a CGO binary is linked ld will generate a warning like:

  warning: GCS is required by -z gcs, but this shared library lacks
  the necessary property note. The dynamic loader might not enable GCS
  or refuse to load the program unless all the shared library
  dependencies have the GCS marking.

This is not a problem; it just means that some of the libraries being used during link time don't have GCS enabled yet.  But Golang begs to differ and considers this a fatal error.

We can safely ignore these warnings and unbreak some Golang builds as a bonus.