### PR TITLE
CODEOWNERS: s/ruby-3.5/ruby-4.0/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,4 +35,4 @@ python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 php-8.5.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 dotnet-*.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
-ruby-3.5.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+ruby-4.0.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write


### PR DESCRIPTION
The next Ruby upstream release will be 4.0, not 3.5