### PR TITLE
fix(pgpool-iamguarded): add permissions and symlink to default path

### DIFF
--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -171,6 +171,7 @@ subpackages:
           # copy etc to pgpool/etc
           mkdir -p "/opt/iamguarded/pgpool/etc"
           cp -pr "${{targets.destdir}}/etc/pgpool2/." "/opt/iamguarded/pgpool/etc/"
+          chmod g+rwX /opt/iamguarded
 
           # copy etc to pgpool/etc.default
           mkdir -p "/opt/iamguarded/pgpool/etc.default"

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2-4.6
   version: "4.6.4"
-  epoch: 0
+  epoch: 1
   description: Middleware that works between PostgreSQL servers and a PostgreSQL database client.
   copyright:
     - license: BSD-3-Clause AND MIT
@@ -183,6 +183,9 @@ subpackages:
           ; do
             ln -s "/usr/bin/${bin}" "/opt/iamguarded/postgresql/bin/${bin}"
           done
+
+          mkdir -p /etc/pgpool2
+          ln -sf "/opt/iamguarded/pgpool/etc" "/etc/pgpool2"
       - uses: iamguarded/finalize-compat
         with:
           package: pgpool2
@@ -209,6 +212,10 @@ subpackages:
         - runs: |
             test -f /opt/iamguarded/pgpool/bin/pgpool
             test -f /opt/iamguarded/postgresql/bin/psql
+        - uses: test/tw/symlink-check
+          with:
+            allow-dangling: true
+            allow-absolute: true
 
 update:
   enabled: true

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -163,7 +163,7 @@ subpackages:
             pcp_attach_node pcp_detach_node pcp_health_check_stats pcp_node_count \
             pcp_node_info pcp_pool_status pcp_proc_count pcp_proc_info pcp_promote_node \
             pcp_recovery_node pcp_stop_pgpool pcp_watchdog_info \
-            pg_enc pg_md5 pgpool pgpool_setup pgproto watchdog_setup wd_cli \
+            pg_enc pg_md5 pgpool pgproto watchdog_setup wd_cli \
           ; do
             ln -s "/usr/bin/${bin}" "/opt/iamguarded/pgpool/bin/${bin}"
           done
@@ -172,6 +172,15 @@ subpackages:
           mkdir -p "/opt/iamguarded/pgpool/etc"
           cp -pr "${{targets.destdir}}/etc/pgpool2/." "/opt/iamguarded/pgpool/etc/"
           chmod g+rwX /opt/iamguarded
+
+          # Remove the directory created by the main package
+          # needed for replacing it with a symlink to the iamguarded path
+          rm -rf "${{targets.destdir}}/etc/pgpool2"
+          ln -sf "/opt/iamguarded/pgpool/etc" "${{targets.destdir}}/etc/pgpool2"
+
+          # Patch pgpool_setup to point PGPOOLDIR to the iamguarded path
+          cp "${{targets.destdir}}/usr/bin/pgpool_setup" "/opt/iamguarded/pgpool/bin/pgpool_setup"
+          sed -i 's|PGPOOLDIR=${PGPOOLDIR:-"/etc/pgpool2"}|PGPOOLDIR=${PGPOOLDIR:-"/opt/iamguarded/pgpool/etc"}|g' "/opt/iamguarded/pgpool/bin/pgpool_setup"
 
           mkdir -p "/opt/iamguarded/pgpool/etc.default"
 
@@ -182,11 +191,6 @@ subpackages:
           ; do
             ln -s "/usr/bin/${bin}" "/opt/iamguarded/postgresql/bin/${bin}"
           done
-
-          # Remove the directory created by the main package
-          # needed for replacing it with a symlink to the iamguarded path
-          rm -rf /etc/pgpool2
-          ln -sf "/opt/iamguarded/pgpool/etc" "/etc/pgpool2"
       - uses: iamguarded/finalize-compat
         with:
           package: pgpool2

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -185,7 +185,9 @@ subpackages:
             ln -s "/usr/bin/${bin}" "/opt/iamguarded/postgresql/bin/${bin}"
           done
 
-          mkdir -p /etc/pgpool2
+          # Remove the directory created by the base pgpool2 package (configured with --sysconfdir=/etc/pgpool2)
+          # so we can replace it with a symlink to the iamguarded path
+          rm -rf /etc/pgpool2
           ln -sf "/opt/iamguarded/pgpool/etc" "/etc/pgpool2"
       - uses: iamguarded/finalize-compat
         with:

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -219,7 +219,6 @@ subpackages:
             test -f /opt/iamguarded/postgresql/bin/psql
         - uses: test/tw/symlink-check
           with:
-            allow-dangling: true
             allow-absolute: true
 
 update:

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -173,9 +173,7 @@ subpackages:
           cp -pr "${{targets.destdir}}/etc/pgpool2/." "/opt/iamguarded/pgpool/etc/"
           chmod g+rwX /opt/iamguarded
 
-          # copy etc to pgpool/etc.default
           mkdir -p "/opt/iamguarded/pgpool/etc.default"
-          cp -pr "${{targets.destdir}}/etc/pgpool2/." "/opt/iamguarded/pgpool/etc.default/"
 
           # link postgres binaries to /opt/iamguarded/postgresql/bin
           mkdir -p "/opt/iamguarded/postgresql/bin"

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -185,8 +185,8 @@ subpackages:
             ln -s "/usr/bin/${bin}" "/opt/iamguarded/postgresql/bin/${bin}"
           done
 
-          # Remove the directory created by the base pgpool2 package (configured with --sysconfdir=/etc/pgpool2)
-          # so we can replace it with a symlink to the iamguarded path
+          # Remove the directory created by the main package
+          # needed for replacing it with a symlink to the iamguarded path
           rm -rf /etc/pgpool2
           ln -sf "/opt/iamguarded/pgpool/etc" "/etc/pgpool2"
       - uses: iamguarded/finalize-compat

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -175,8 +175,8 @@ subpackages:
 
           # Remove the directory created by the main package
           # needed for replacing it with a symlink to the iamguarded path
-          rm -rf "${{targets.destdir}}/etc/pgpool2"
-          ln -sf "/opt/iamguarded/pgpool/etc" "${{targets.destdir}}/etc/pgpool2"
+          rm -rf /etc/pgpool2
+          ln -sf "/opt/iamguarded/pgpool/etc" "/etc/pgpool2"
 
           # Patch pgpool_setup to point PGPOOLDIR to the iamguarded path
           cp "${{targets.destdir}}/usr/bin/pgpool_setup" "/opt/iamguarded/pgpool/bin/pgpool_setup"


### PR DESCRIPTION
Added write permissions to `/opt/iamguarded`, symlinked `/etc/pgpool2`(default path) to `/opt/iamguarded/pgpool/etc` and patch PGPOOLDIR to default value `/opt/iamguarded/pgpool/etc` to fix `pcp.conf` creation and path resolution