### PR TITLE
cilium-envoy-1.18: epoch bump to build with go-1.24.11

### DIFF
--- a/cilium-envoy-1.18.yaml
+++ b/cilium-envoy-1.18.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-envoy-1.18
   version: "1.18.4"
-  epoch: 0
+  epoch: 1
   description: Envoy with additional cilium plugins
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.24.11 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
