### PR TITLE
verticadb-operator: epoch bump to build with go-1.24.11

### DIFF
--- a/verticadb-operator.yaml
+++ b/verticadb-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: verticadb-operator
   version: "25.4.0.0"
-  epoch: 0
+  epoch: 1
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.24.11 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
