### PR TITLE
fix(external-secrets-operator-1.1): add build tags for provider support

### DIFF
--- a/external-secrets-operator-1.1.yaml
+++ b/external-secrets-operator-1.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator-1.1
   version: "1.1.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       go-package: go
       packages: .
       output: external-secrets
+      tags: all_providers
 
   - uses: strip
 
@@ -50,6 +51,7 @@ test:
         # Install CRDs
         kubectl create -f external-secrets/deploy/crds/bundle.yaml
         kubectl wait --for condition=established --timeout=60s crd/clustersecretstores.external-secrets.io
+        kubectl wait --for condition=established --timeout=60s crd/secretstores.external-secrets.io
         kubectl wait --for condition=established --timeout=60s crd/externalsecrets.external-secrets.io
 
         # Start the operator
@@ -63,6 +65,40 @@ test:
           cat operator.log
           exit 1
         fi
+
+        # Verify AWS provider is compiled in by creating a test SecretStore
+        cat <<EOF | kubectl apply -f -
+        apiVersion: external-secrets.io/v1
+        kind: SecretStore
+        metadata:
+          name: aws-test-store
+          namespace: default
+        spec:
+          provider:
+            aws:
+              service: SecretsManager
+              region: us-east-1
+              auth:
+                secretRef:
+                  accessKeyIDSecretRef:
+                    name: dummy
+                    key: dummy
+                  secretAccessKeySecretRef:
+                    name: dummy
+                    key: dummy
+        EOF
+
+        # Check if the store was accepted (provider registered)
+        # If AWS provider isn't compiled, this would fail with "failed to find registered store backend"
+        sleep 2
+        if kubectl -n default get secretstore aws-test-store -o yaml | grep -q "failed to find registered store backend"; then
+          echo "ERROR: AWS provider not compiled in"
+          kubectl -n default get secretstore aws-test-store -o yaml
+          exit 1
+        fi
+
+        echo "AWS provider is available"
+        kubectl -n default delete secretstore aws-test-store
     - name: Test with fake provider
       runs: |
         set -euo pipefail


### PR DESCRIPTION
Version 1.1.0 introduced build tags that make providers opt-in. Without
the all_providers tag, the binary is built with no provider backends,
causing "failed to find registered store backend" errors.

Added tags: all_providers to the go/build pipeline and a test to verify
AWS provider is available by creating a test SecretStore resource.

Ref: https://github.com/external-secrets/external-secrets/pull/5578

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

<!--ci-cve-scan:fail-any-->
