### PR TITLE
fix(kubeflow-jupyter-web-app): GHSA-hgf8-39gv-g3f2

### DIFF
--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: "1.10.0"
-  epoch: 6
+  epoch: 7
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,8 @@ pipeline:
       $pip install -I --no-compile dist/*.whl --prefix=/usr --root="${{targets.destdir}}"
       $pip install . --prefix=/usr --root="${{targets.destdir}}"
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
+      $pip install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
+      # Upgrade werkzeug to fix GHSA-hgf8-39gv-g3f2
       $pip install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
       ls -latr /usr/lib/python${{vars.python-version}}/site-packages
 


### PR DESCRIPTION
Bump werkzeug version

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48668

<!--ci-cve-scan:fail-any-->
