### PR TITLE
Revert "remove test.key from tornado's test"

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.3"
-  epoch: 0 # GHSA-r397-ff8c-wv2g
+  epoch: 2 # GHSA-r397-ff8c-wv2g
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it

--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.3"
-  epoch: 1 # GHSA-r397-ff8c-wv2g
+  epoch: 0 # GHSA-r397-ff8c-wv2g
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -107,9 +107,6 @@ pipeline:
 
       # Remove any patch related files from the install tree
       find ${{vars.venv-home}}/lib/python${{vars.python-version}} -name "*.orig" -print -exec rm {} +
-
-      # Remove tornado test key file that triggers secret alerts from vuln scanners
-      rm -f ${{vars.venv-home}}/lib/python${{vars.python-version}}/site-packages/tornado/test/test.key
 
       # The first time you run Airflow, it will create a file called `airflow.cfg` in
       # `$AIRFLOW_HOME` directory


### PR DESCRIPTION
This PR reverts a change made by this commit: https://github.com/wolfi-dev/os/pull/73692