### PR TITLE
py3-uuid-utils: Add package

### DIFF
--- a/py3-uuid-utils.yaml
+++ b/py3-uuid-utils.yaml
@@ -1,0 +1,77 @@
+package:
+  name: py3-uuid-utils
+  version: "0.12.0"
+  epoch: 0
+  description: Python3 UUID utils
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: uuid-utils
+  module-name: uuid_utils
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - maturin
+      - py3-supported-maturin
+      - py3-supported-pip
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: cb052a17cc8efad477523f67137c0410f088f20c
+      repository: https://github.com/aminalaee/uuid-utils
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.module-name}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: test/metapackage
+
+update:
+  enabled: true
+  github:
+    identifier: aminalaee/uuid-utils


### PR DESCRIPTION
Here I add the uuid-utils package which is a new dependency of
py3-langsmith, starting in v0.4.53.
