### PR TITLE
langfuse-3: fix GHSA-rcmh-qjqh-p98v by upgrading nodemailer to 7.0.11

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
   version: "3.135.1"
-  epoch: 1
+  epoch: 2 # GHSA-rcmh-qjqh-p98v
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -78,6 +78,7 @@ pipeline:
         "pnpm.overrides.solid-js=^1.9.4" \
         "pnpm.overrides.go=^1.23.10" \
         "pnpm.overrides.form-data=>=2.5.4 <3.0.0 || >=4.0.4 <5.0.0" \
+        "pnpm.overrides.nodemailer=^7.0.11" \
         "pnpm.overrides.tmp=^0.2.4" \
         "pnpm.overrides.mermaid=^11.10.0" \
         "pnpm.overrides.axios=^1.12.0" \


### PR DESCRIPTION
## Summary
Fixes GHSA-rcmh-qjqh-p98v by upgrading nodemailer to 7.0.11.

## Changes
- Added pnpm override for nodemailer: ^7.0.11 (was 7.0.10, vulnerable to GHSA-rcmh-qjqh-p98v)
- Incremented epoch to 2


## References
- GHSA-rcmh-qjqh-p98v: https://github.com/advisories/GHSA-rcmh-qjqh-p98v
- CVE Dashboard Issue #48669: https://github.com/chainguard-dev/CVE-Dashboard/issues/48669