### PR TITLE
superset-5.0: fix GHSA-hgf8-39gv-g3f2

### DIFF
--- a/superset-5.0.yaml
+++ b/superset-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset-5.0
   version: "5.0.0"
-  epoch: 7
+  epoch: 8
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -79,7 +79,7 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.0.6 requests==2.32.4 urllib3==2.5.0 certifi==2024.07.04 zipp==3.19.2 pillow==11.3.0 brotli==1.2.0
+      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.1.4 requests==2.32.4 urllib3==2.5.0 certifi==2024.07.04 zipp==3.19.2 pillow==11.3.0 brotli==1.2.0
 
       # Dependencies required during runtime
       pip install pillow pyarrow


### PR DESCRIPTION
## Summary
Fixes GHSA-hgf8-39gv-g3f2 by upgrading werkzeug from 3.0.6 to 3.1.4.

## Changes
- Upgraded `Werkzeug` from 3.0.6 to 3.1.4 in pip install upgrade command
- Incremented epoch from 7 to 8

## Vulnerability Fixed
- **GHSA-hgf8-39gv-g3f2** (Medium): Werkzeug safe_join() allows Windows special device names
  - Component: werkzeug @ 3.0.6
  - Fixed in: 3.1.4
  - Reference: https://github.com/advisories/GHSA-hgf8-39gv-g3f2

## Verification
Build and scan will confirm vulnerability is resolved.

## Related Issues
- chainguard-dev/CVE-Dashboard#48706