### PR TITLE
package update terragrunt: docs subpackage added tests

### DIFF
--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -13,11 +13,7 @@ package:
 environment:
   contents:
     packages:
-      - build-base
       - busybox
-      - ca-certificates-bundle
-      - go
-      - mockery~2
       - mockgen
 
 pipeline:
@@ -140,7 +136,6 @@ test:
 
 update:
   enabled: true
-  # Ignore alpha and beta releases
   ignore-regex-patterns:
     - ^alpha
     - ^beta

--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,12 +1,13 @@
 package:
   name: terragrunt
   version: "0.93.12"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - git # https://github.com/gruntwork-io/terragrunt/blob/main/internal/cas/git.go#L27
       - terraform
 
 environment:
@@ -32,16 +33,35 @@ pipeline:
     with:
       output: terragrunt
       packages: .
-      ldflags: "-X  github.com/gruntwork-io/go-commons/version.Version=v${{package.version}}"
+      ldflags: "-X github.com/gruntwork-io/go-commons/version.Version=v${{package.version}}"
 
-  - uses: strip
+subpackages:
+  - name: terragrunt-docs
+    description: terragrunt documentation
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/${{package.name}}
+          cp README.md LICENSE.txt SECURITY.md "${{targets.subpkgdir}}"/usr/share/doc/${{package.name}}/
+    test:
+      pipeline:
+        - uses: test/tw/docs
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - posix-libc-utils
   pipeline:
-    - name: Smoke test
-      runs: |
-        terragrunt --version
-        terragrunt --help
+    # Verify terragrunt reports correct version
+    - uses: test/tw/ver-check
+      with:
+        bins: terragrunt
+    # Verify terragrunt provides help information
+    - uses: test/tw/help-check
+      with:
+        bins: terragrunt
+    # Create a simple terraform module to test terragrunt's wrapping functionality
     - name: Create terraform module fixtures
       working-directory: /tmp/terragrunt/modules/example
       runs: |
@@ -69,10 +89,11 @@ test:
           }
         }
         EOF
+    # Create terragrunt configuration that references the terraform module
     - name: Create terragrunt fixtures
       working-directory: /tmp/terragrunt/envs/test
       runs: |
-        cat >terragrunt.hcl <<EOF
+        cat >terragrunt.hcl <<'EOF'
         terraform {
           source = "../../modules/example"
         }
@@ -81,35 +102,48 @@ test:
           example_input = "hello-from-terragrunt-test"
         }
         EOF
+    # Test that terragrunt can generate a terraform plan
     - name: Test plan
       working-directory: /tmp/terragrunt/envs/test
       runs: |
         terragrunt plan -out=plan.tfplan -input=false
-    - name: Test validate
-      working-directory: /tmp/terragrunt/envs/test
-      runs: |
-        echo "}" >>terragrunt.hcl
-        set +e
-        terragrunt validate
-        exit=$?
-        set -e
-        test "${exit}" == "1"
-        sed -i '$d' terragrunt.hcl
-        terragrunt validate
+    # Test that terragrunt hcl fmt detects formatting issues and can fix them
     - name: Test hcl format
       working-directory: /tmp/terragrunt/envs/test
       runs: |
+        # Break formatting should be detected using || true to avoid failing the step
         sed -i 's|  source|source|g' terragrunt.hcl
-        set +e
-        terragrunt hcl fmt --check
-        exit=$?
-        set -e
-        test "${exit}" == "1"
+        OUTPUT=$(terragrunt hcl fmt --check 2>&1 || true)
+        echo "$OUTPUT" | grep -q "needs formatting"
+
+        # Fix formatting and verify it passes
         terragrunt hcl fmt
         terragrunt hcl fmt --check
+    # Test that terragrunt can generate a dependency graph
+    - name: Test dag graph command
+      working-directory: /tmp/terragrunt/envs/test
+      runs: |
+        OUTPUT=$(terragrunt dag graph)
+        # Verify the graph contains expected node
+        echo "$OUTPUT" | grep -q "digraph"
+    # Test that terragrunt can render configuration as JSON and validate output
+    - name: Test render command
+      working-directory: /tmp/terragrunt/envs/test
+      runs: |
+        OUTPUT=$(terragrunt render --json)
+        # Verify JSON output contains expected configuration keys
+        echo "$OUTPUT" | grep -q "terraform"
+        echo "$OUTPUT" | grep -q "inputs"
+        echo "$OUTPUT" | grep -q "example_input"
+        # Verify the input value is correctly rendered
+        echo "$OUTPUT" | grep -q "hello-from-terragrunt-test"
 
 update:
   enabled: true
+  # Ignore alpha and beta releases
+  ignore-regex-patterns:
+    - ^alpha
+    - ^beta
   github:
     identifier: gruntwork-io/terragrunt
     strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
