### PR TITLE
aactl: epoch bump to build with go-1.25.5

### DIFF
--- a/aactl.yaml
+++ b/aactl.yaml
@@ -1,7 +1,7 @@
 package:
   name: aactl
   version: 0.4.12
-  epoch: 38 # GHSA-j5w8-q4qc-rx2x
+  epoch: 39 # GHSA-j5w8-q4qc-rx2x
   description: Google Container Analysis data import utility, supports OSS vulnerability scanner reports, SLSA provenance and sigstore attestations.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
