### PR TITLE
addon-resizer: epoch bump to build with go-1.25.5

### DIFF
--- a/addon-resizer.yaml
+++ b/addon-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: addon-resizer
   version: "1.8.23"
-  epoch: 9 # CVE-2025-47906
+  epoch: 10 # CVE-2025-47906
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
