### PR TITLE
age: epoch bump to build with go-1.25.5

### DIFF
--- a/age.yaml
+++ b/age.yaml
@@ -1,7 +1,7 @@
 package:
   name: age
   version: 1.2.1
-  epoch: 9 # GHSA-j5w8-q4qc-rx2x
+  epoch: 10 # GHSA-j5w8-q4qc-rx2x
   description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
