### PR TITLE
amazon-cloudwatch-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/amazon-cloudwatch-agent.yaml
+++ b/amazon-cloudwatch-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-cloudwatch-agent
   version: "1.300062.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: CloudWatch Agent enables you to collect and export host-level metrics and logs on instances running Linux or Windows server.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
