### PR TITLE
amazon-corretto-crypto-provider: epoch bump to build with go-1.25.5

### DIFF
--- a/amazon-corretto-crypto-provider.yaml
+++ b/amazon-corretto-crypto-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-corretto-crypto-provider
   version: "2.5.0"
-  epoch: 2
+  epoch: 3
   description: |
     The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard JCA/JCE interfaces.
   copyright:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
