### PR TITLE
apache-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/apache-exporter.yaml
+++ b/apache-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-exporter
   version: "1.0.11"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: apache-exporter exposes Apache server metrics for Prometheus monitoring
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
