### PR TITLE
apisix-ingress-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/apisix-ingress-controller.yaml
+++ b/apisix-ingress-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: apisix-ingress-controller
   version: "1.8.4"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: APISIX Ingress Controller for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
