### PR TITLE
apko: epoch bump to build with go-1.25.5

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: "0.30.27"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
