### PR TITLE
argo-cd-3.2: epoch bump to build with go-1.25.5

### DIFF
--- a/argo-cd-3.2.yaml
+++ b/argo-cd-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-3.2
   version: "3.2.1"
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
