### PR TITLE
argo-rollouts: epoch bump to build with go-1.25.5

### DIFF
--- a/argo-rollouts.yaml
+++ b/argo-rollouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-rollouts
   version: "1.8.3"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Progressive Delivery for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
