### PR TITLE
argo-workflows-3.7: epoch bump to build with go-1.25.5

### DIFF
--- a/argo-workflows-3.7.yaml
+++ b/argo-workflows-3.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows-3.7
   version: "3.7.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
