### PR TITLE
authservice: epoch bump to build with go-1.25.5

### DIFF
--- a/authservice.yaml
+++ b/authservice.yaml
@@ -1,7 +1,7 @@
 package:
   name: authservice
   version: "1.1.4"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Move OIDC token acquisition out of your app code and into the Istio mesh
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
