### PR TITLE
aws-application-networking-k8s: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-application-networking-k8s.yaml
+++ b/aws-application-networking-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-application-networking-k8s
   version: "1.1.7"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: A Kubernetes controller for Amazon VPC Lattice
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
