### PR TITLE
aws-efs-csi-driver: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: "2.1.15"
-  epoch: 0 # GHSA-4x4m-3c2p-qppc
+  epoch: 1 # GHSA-4x4m-3c2p-qppc
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
