### PR TITLE
aws-eks-pod-identity-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-eks-pod-identity-agent.yaml
+++ b/aws-eks-pod-identity-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-eks-pod-identity-agent
   version: "0.1.36"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: EKS Pod Identity is a feature of Amazon EKS that simplifies the process for cluster administrators to configure Kubernetes applications with AWS IAM permissions
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
