### PR TITLE
aws-flb-cloudwatch: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-cloudwatch
   version: 1.9.4
-  epoch: 20 # CVE-2025-47907
+  epoch: 21 # CVE-2025-47907
   description: A Fluent Bit output plugin for CloudWatch Logs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
