### PR TITLE
aws-flb-kinesis: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: "1.10.3"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
