### PR TITLE
aws-load-balancer-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: "2.16.0"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
