### PR TITLE
aws-network-policy-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-network-policy-agent
   version: "1.2.7"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Amazon EKS Network Policy Agent is a daemonset that is responsible for enforcing configured network policies on the cluster.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
