### PR TITLE
aws-node-termination-handler: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-node-termination-handler.yaml
+++ b/aws-node-termination-handler.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-node-termination-handler
   version: "1.25.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Gracefully handle EC2 instance shutdown within Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
