### PR TITLE
aws-nuke: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-nuke.yaml
+++ b/aws-nuke.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-nuke
   version: "3.62.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Remove all the resources from an AWS account
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
