### PR TITLE
aws-privateca-issuer: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-privateca-issuer.yaml
+++ b/aws-privateca-issuer.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-privateca-issuer
   version: "1.7.1"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Addon for cert-manager that issues certificates using AWS ACM PCA.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
