### PR TITLE
aws-s3-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-s3-controller.yaml
+++ b/aws-s3-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-s3-controller
   version: "1.2.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: ACK service controller for Amazon Simple Storage Service (S3)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
