### PR TITLE
aws-signer-notation-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-signer-notation-plugin.yaml
+++ b/aws-signer-notation-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-signer-notation-plugin
   version: "1.0.2292"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: AWS Signer Plugin for Notation
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
