### PR TITLE
aws-sigv4-proxy: epoch bump to build with go-1.25.5

### DIFF
--- a/aws-sigv4-proxy.yaml
+++ b/aws-sigv4-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-sigv4-proxy
   version: "1.10"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: This project signs and proxies HTTP requests with Sigv4
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
