### PR TITLE
azcopy: epoch bump to build with go-1.25.5

### DIFF
--- a/azcopy.yaml
+++ b/azcopy.yaml
@@ -1,7 +1,7 @@
 package:
   name: azcopy
   version: "10.31.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The new Azure Storage data transfer utility
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
