### PR TITLE
azure-ipam: epoch bump to build with go-1.25.5

### DIFF
--- a/azure-ipam.yaml
+++ b/azure-ipam.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-ipam
   version: "0.4.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Azure VNET IPAM plugins manage IP address assignments to containers.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
