### PR TITLE
azure-service-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/azure-service-operator.yaml
+++ b/azure-service-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-service-operator
   version: "2.16.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Azure Service Operator to provision Azure resources and connect your applications to them from within Kubernetes.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
