### PR TITLE
azure-workload-identity-webhook: epoch bump to build with go-1.25.5

### DIFF
--- a/azure-workload-identity-webhook.yaml
+++ b/azure-workload-identity-webhook.yaml
@@ -1,7 +1,7 @@
 package:
   name: azure-workload-identity-webhook
   version: "1.5.1"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: Mutating webhook for Azure Workload Identity
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
