### PR TITLE
azuredisk-csi-1.33: epoch bump to build with go-1.25.5

### DIFF
--- a/azuredisk-csi-1.33.yaml
+++ b/azuredisk-csi-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: azuredisk-csi-1.33
   version: "1.33.7"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Azure Disk CSI Driver
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
