### PR TITLE
azurefile-csi-1.33: epoch bump to build with go-1.25.5

### DIFF
--- a/azurefile-csi-1.33.yaml
+++ b/azurefile-csi-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: azurefile-csi-1.33
   version: "1.33.6"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Azure File CSI Driver
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
