### PR TITLE
bank-vaults: epoch bump to build with go-1.25.5

### DIFF
--- a/bank-vaults.yaml
+++ b/bank-vaults.yaml
@@ -1,7 +1,7 @@
 package:
   name: bank-vaults
   version: 1.32.0
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: A Vault swiss-army knife. A CLI tool to init, unseal and configure Vault (auth methods, secret engines).
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
