### PR TITLE
blob-csi-1.27: epoch bump to build with go-1.25.5

### DIFF
--- a/blob-csi-1.27.yaml
+++ b/blob-csi-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: blob-csi-1.27
   version: "1.27.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Azure Blob Storage CSI driver
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
