### PR TITLE
blobfuse2: epoch bump to build with go-1.25.5

### DIFF
--- a/blobfuse2.yaml
+++ b/blobfuse2.yaml
@@ -1,7 +1,7 @@
 package:
   name: blobfuse2
   version: 2.4.2
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: A virtual file system adapter for Azure Blob storage
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
