### PR TITLE
bom: epoch bump to build with go-1.25.5

### DIFF
--- a/bom.yaml
+++ b/bom.yaml
@@ -1,7 +1,7 @@
 package:
   name: bom
   version: "0.7.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: A utility to generate SPDX-compliant Bill of Materials manifests
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
