### PR TITLE
boring-registry: epoch bump to build with go-1.25.5

### DIFF
--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: "0.16.6"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
