### PR TITLE
buf: epoch bump to build with go-1.25.5

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 package:
   name: buf
   version: "1.61.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: A new way of working with Protocol Buffers.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
