### PR TITLE
buildkitd: epoch bump to build with go-1.25.5

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: "0.26.2"
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 0 # GHSA-2x5j-vhc8-9cwm
+  epoch: 1 # GHSA-2x5j-vhc8-9cwm
   copyright:
     - license: Apache-2.0
   dependencies:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
