### PR TITLE
bun: epoch bump to build with go-1.25.5

### DIFF
--- a/bun.yaml
+++ b/bun.yaml
@@ -1,7 +1,7 @@
 package:
   name: bun
   version: "1.3.3"
-  epoch: 0
+  epoch: 1
   description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
