### PR TITLE
caddy: epoch bump to build with go-1.25.5

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: "2.10.2"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
