### PR TITLE
calico-3.31: epoch bump to build with go-1.25.5

### DIFF
--- a/calico-3.31.yaml
+++ b/calico-3.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.31
   version: "3.31.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
