### PR TITLE
capslock: epoch bump to build with go-1.25.5

### DIFF
--- a/capslock.yaml
+++ b/capslock.yaml
@@ -1,7 +1,7 @@
 package:
   name: capslock
   version: "0.3.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Capslock is a capability analysis CLI for Go packages that informs users of which privileged operations a given package can access
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
