### PR TITLE
cargobump: epoch bump to build with go-1.25.5

### DIFF
--- a/cargobump.yaml
+++ b/cargobump.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargobump
   version: "0.1.0"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: Rust tool to declaratively bump dependencies using cargo
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
