### PR TITLE
cass-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/cass-operator.yaml
+++ b/cass-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-operator
   version: "1.28.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Manages Cassandra cluster as standalone product or as part of the k8ssandra-operator
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
