### PR TITLE
cassandra-5.0: epoch bump to build with go-1.25.5

### DIFF
--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.6"
-  epoch: 0
+  epoch: 1
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
