### PR TITLE
cerbos: epoch bump to build with go-1.25.5

### DIFF
--- a/cerbos.yaml
+++ b/cerbos.yaml
@@ -1,7 +1,7 @@
 package:
   name: cerbos
   version: "0.48.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Cerbos is the open core, language-agnostic, scalable authorization solution that makes user permissions and authorization simple to implement and manage by writing context-aware access control policies for your application resources.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
