### PR TITLE
cert-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-exporter
   version: "2.17.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Prometheus exporter that publishes cert expirations on disk and in Kubernetes secrets
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
