### PR TITLE
cert-manager-1.19: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-manager-1.19.yaml
+++ b/cert-manager-1.19.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.19
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: "1.19.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
