### PR TITLE
cert-manager-cmctl: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-manager-cmctl.yaml
+++ b/cert-manager-cmctl.yaml
@@ -3,7 +3,7 @@ package:
   # This got pulled from the cert-manager repo in the 1.15 release, prior to
   # that it was in the cert-manager/cert-manager repo.
   version: "2.4.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
