### PR TITLE
cert-manager-csi-driver: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-manager-csi-driver.yaml
+++ b/cert-manager-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-csi-driver
   version: "0.11.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes CSI plugin to automatically mount signed certificates to Pods using ephemeral volumes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
