### PR TITLE
cert-manager-istio-csr: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-manager-istio-csr.yaml
+++ b/cert-manager-istio-csr.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-istio-csr
   version: "0.14.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: istio-csr is an agent that allows for Istio workload and control plane components to be secured using cert-manager.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
