### PR TITLE
cert-manager-webhook-pdns: epoch bump to build with go-1.25.5

### DIFF
--- a/cert-manager-webhook-pdns.yaml
+++ b/cert-manager-webhook-pdns.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-webhook-pdns
   version: "2.5.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: A PowerDNS webhook for cert-manager
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
