### PR TITLE
certificate-transparency: epoch bump to build with go-1.25.5

### DIFF
--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: "1.3.2"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
