### PR TITLE
cfssl: epoch bump to build with go-1.25.5

### DIFF
--- a/cfssl.yaml
+++ b/cfssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cfssl
   version: 1.6.5
-  epoch: 24 # GHSA-j5w8-q4qc-rx2x
+  epoch: 25 # GHSA-j5w8-q4qc-rx2x
   description: Cloudflare's PKI and TLS toolkit
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
