### PR TITLE
chart-testing: epoch bump to build with go-1.25.5

### DIFF
--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,7 +1,7 @@
 package:
   name: chart-testing
   version: "3.14.0"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2 # CVE-2025-58187
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
