### PR TITLE
chartmuseum: epoch bump to build with go-1.25.5

### DIFF
--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: "0.16.3"
-  epoch: 10 # GHSA-j5w8-q4qc-rx2x
+  epoch: 11 # GHSA-j5w8-q4qc-rx2x
   description: helm chart repository server
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
