### PR TITLE
checksec: epoch bump to build with go-1.25.5

### DIFF
--- a/checksec.yaml
+++ b/checksec.yaml
@@ -1,7 +1,7 @@
 package:
   name: checksec
   version: "3.0.2"
-  epoch: 7 # GHSA-cgrx-mc8f-2prm
+  epoch: 8 # GHSA-cgrx-mc8f-2prm
   description: Binary security checker
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
