### PR TITLE
chisel: epoch bump to build with go-1.25.5

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,7 +1,7 @@
 package:
   name: chisel
   version: "1.11.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Chisel is a fast TCP/UDP tunnel over HTTP
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
