### PR TITLE
cilium-1.18: epoch bump to build with go-1.25.5

### DIFF
--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.18
   version: "1.18.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
