### PR TITLE
cilium-certgen-0.2: epoch bump to build with go-1.25.5

### DIFF
--- a/cilium-certgen-0.2.yaml
+++ b/cilium-certgen-0.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-certgen-0.2
   version: "0.2.4"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: A convenience tool to generate and store certificates for Hubble Relay mTLS.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
