### PR TITLE
cis-operator-1.4: epoch bump to build with go-1.25.5

### DIFF
--- a/cis-operator-1.4.yaml
+++ b/cis-operator-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: cis-operator-1.4
   version: "1.4.5"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Helps to enable running CIS benchmark security scans on a Kubernetes cluster and generate compliance reports that can be downloaded
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
