### PR TITLE
clickhouse-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/clickhouse-operator.yaml
+++ b/clickhouse-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-operator
   version: "0.25.5"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Altinity Kubernetes Operator for ClickHouse creates, configures and manages ClickHouse® clusters running on Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
