### PR TITLE
cloud-provider-aws-1.31: epoch bump to build with go-1.25.5

### DIFF
--- a/cloud-provider-aws-1.31.yaml
+++ b/cloud-provider-aws-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-aws-1.31
   version: "1.31.9"
-  epoch: 0 # CVE-2025-47906
+  epoch: 1 # CVE-2025-47906
   description: The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
