### PR TITLE
cloud-provider-azure-1.34: epoch bump to build with go-1.25.5

### DIFF
--- a/cloud-provider-azure-1.34.yaml
+++ b/cloud-provider-azure-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-azure-1.34
   version: "1.34.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Cloud provider for Azure
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
