### PR TITLE
cloud-provider-gcp-cloud-controller-manager: epoch bump to build with go-1.25.5

### DIFF
--- a/cloud-provider-gcp-cloud-controller-manager.yaml
+++ b/cloud-provider-gcp-cloud-controller-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-gcp-cloud-controller-manager
   version: "34.1.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
