### PR TITLE
cloud-provider-vsphere: epoch bump to build with go-1.25.5

### DIFF
--- a/cloud-provider-vsphere.yaml
+++ b/cloud-provider-vsphere.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-vsphere
   version: "1.34.0"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes Cloud Provider for vSphere
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
