### PR TITLE
cloud-sql-proxy-2.18: epoch bump to build with go-1.25.5

### DIFF
--- a/cloud-sql-proxy-2.18.yaml
+++ b/cloud-sql-proxy-2.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy-2.18
   version: "2.18.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
