### PR TITLE
cloudnative-pg: epoch bump to build with go-1.25.5

### DIFF
--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudnative-pg
   version: "1.27.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
