### PR TITLE
cluster-api-1.11: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-1.11.yaml
+++ b/cluster-api-1.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-1.11
   version: "1.11.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Cluster API meta package
   dependencies:
     provides:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
