### PR TITLE
cluster-api-aws-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-aws-controller.yaml
+++ b/cluster-api-aws-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-aws-controller
   version: "2.10.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes Cluster API Provider AWS provides consistent deployment and day 2 operations of "self-managed" and EKS Kubernetes clusters on AWS
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
