### PR TITLE
cluster-api-gcp-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-gcp-controller.yaml
+++ b/cluster-api-gcp-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-gcp-controller
   version: "1.10.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: The GCP provider implementation for Cluster API
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
