### PR TITLE
cluster-api-helm-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-helm-controller.yaml
+++ b/cluster-api-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-helm-controller
   version: "0.5.2"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: CAAPH uses Helm charts to manage the installation and lifecycle of Cluster API add-ons.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
