### PR TITLE
cluster-api-ipam-provider-in-cluster: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-ipam-provider-in-cluster.yaml
+++ b/cluster-api-ipam-provider-in-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-ipam-provider-in-cluster
   version: "1.0.3"
-  epoch: 2 # CVE-2025-47907
+  epoch: 3 # CVE-2025-47907
   description: IPAM provider for Kubernetes Cluster API that manages IP address pools using Kubernetes resources
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
