### PR TITLE
cluster-api-provider-vsphere: epoch bump to build with go-1.25.5

### DIFF
--- a/cluster-api-provider-vsphere.yaml
+++ b/cluster-api-provider-vsphere.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-provider-vsphere
   version: "1.14.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Kubernetes-native declarative infrastructure for vSphere.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
