### PR TITLE
cni-plugins: epoch bump to build with go-1.25.5

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: "1.8.0"
-  epoch: 3
+  epoch: 4
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
