### PR TITLE
configmap-reload: epoch bump to build with go-1.25.5

### DIFF
--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -1,7 +1,7 @@
 package:
   name: configmap-reload
   version: "0.15.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Simple binary to trigger a reload when a Kubernetes ConfigMap is updated
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
