### PR TITLE
confluent-cp-docker-utils: epoch bump to build with go-1.25.5

### DIFF
--- a/confluent-cp-docker-utils.yaml
+++ b/confluent-cp-docker-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-cp-docker-utils
   version: "1.0.3"
-  epoch: 0
+  epoch: 1
   description: confluent cp-docker-utils
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
