### PR TITLE
conftest: epoch bump to build with go-1.25.5

### DIFF
--- a/conftest.yaml
+++ b/conftest.yaml
@@ -1,7 +1,7 @@
 package:
   name: conftest
   version: "0.65.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
