### PR TITLE
conjur-cli: epoch bump to build with go-1.25.5

### DIFF
--- a/conjur-cli.yaml
+++ b/conjur-cli.yaml
@@ -2,7 +2,7 @@ package:
   name: conjur-cli
   description: Conjur command line interface
   version: "9.1.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
