### PR TITLE
container-object-storage-interface: epoch bump to build with go-1.25.5

### DIFF
--- a/container-object-storage-interface.yaml
+++ b/container-object-storage-interface.yaml
@@ -1,7 +1,7 @@
 package:
   name: container-object-storage-interface
   version: "0.2.1"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Container Object Storage Interface (COSI) responsible for defining COSI spec and APIs, interfacing with COSI drivers, and managing the lifecycle of COSI objects
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
