### PR TITLE
containerd-2: epoch bump to build with go-1.25.5

### DIFF
--- a/containerd-2.yaml
+++ b/containerd-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-2
   version: "2.2.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
