### PR TITLE
contour-1.33: epoch bump to build with go-1.25.5

### DIFF
--- a/contour-1.33.yaml
+++ b/contour-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: contour-1.33
   version: "1.33.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Contour is a Kubernetes ingress controller using Envoy proxy.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
