### PR TITLE
coredns-1.13: epoch bump to build with go-1.25.5

### DIFF
--- a/coredns-1.13.yaml
+++ b/coredns-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns-1.13
   version: "1.13.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
