### PR TITLE
crane: epoch bump to build with go-1.25.5

### DIFF
--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: "0.20.7"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
