### PR TITLE
cri-tools: epoch bump to build with go-1.25.5

### DIFF
--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: cri-tools
   version: "1.34.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: CLI and validation tools for Kubelet Container Runtime Interface (CRI) .
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
