### PR TITLE
croc: epoch bump to build with go-1.25.5

### DIFF
--- a/croc.yaml
+++ b/croc.yaml
@@ -1,7 +1,7 @@
 package:
   name: croc
   version: "10.3.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Easily and securely send things from one computer to another
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
