### PR TITLE
crossplane-2.1: epoch bump to build with go-1.25.5

### DIFF
--- a/crossplane-2.1.yaml
+++ b/crossplane-2.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-2.1
   version: "2.1.3"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Cloud Native Control Planes
   dependencies:
     provides:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
