### PR TITLE
ctop: epoch bump to build with go-1.25.5

### DIFF
--- a/ctop.yaml
+++ b/ctop.yaml
@@ -1,7 +1,7 @@
 package:
   name: ctop
   version: 0.7.7
-  epoch: 28 # CVE-2025-61725
+  epoch: 29 # CVE-2025-61725
   description: Top-like interface for container metrics
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
