### PR TITLE
cue: epoch bump to build with go-1.25.5

### DIFF
--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: "0.15.1"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
