### PR TITLE
custom-pod-autoscaler: epoch bump to build with go-1.25.5

### DIFF
--- a/custom-pod-autoscaler.yaml
+++ b/custom-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: custom-pod-autoscaler
   version: "2.12.2"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Custom Pod Autoscaler program and base images, allows creation of Custom Pod Autoscalers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
