### PR TITLE
custom-pod-autoscaler-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/custom-pod-autoscaler-operator.yaml
+++ b/custom-pod-autoscaler-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: custom-pod-autoscaler-operator
   version: "1.4.2"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Operator for managing Kubernetes Custom Pod Autoscalers (CPA).
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
