### PR TITLE
dagdotdev: epoch bump to build with go-1.25.5

### DIFF
--- a/dagdotdev.yaml
+++ b/dagdotdev.yaml
@@ -1,7 +1,7 @@
 package:
   name: dagdotdev
   version: "0.0.17"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: oci and apk explorer
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
