### PR TITLE
dagger: epoch bump to build with go-1.25.5

### DIFF
--- a/dagger.yaml
+++ b/dagger.yaml
@@ -1,7 +1,7 @@
 package:
   name: dagger
   version: "0.19.7"
-  epoch: 0 # GHSA-cgrx-mc8f-2prm
+  epoch: 1 # GHSA-cgrx-mc8f-2prm
   description: Application Delivery as Code that Runs Anywhere
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
