### PR TITLE
dask-kubernetes: epoch bump to build with go-1.25.5

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.7.0"
-  epoch: 1
+  epoch: 2
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
