### PR TITLE
datadog-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/datadog-operator.yaml
+++ b/datadog-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-operator
   version: "1.20.0"
-  epoch: 0
+  epoch: 1
   description: Kubernetes Operator for Datadog Resources
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
