### PR TITLE
dataplaneapi: epoch bump to build with go-1.25.5

### DIFF
--- a/dataplaneapi.yaml
+++ b/dataplaneapi.yaml
@@ -1,7 +1,7 @@
 package:
   name: dataplaneapi
   version: "3.2.7"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: HAProxy Data Plane API
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
