### PR TITLE
db-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/db-operator.yaml
+++ b/db-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: db-operator
   version: "2.16.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: The DB Operator creates databases and make them available in the cluster via Custom Resource.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
