### PR TITLE
dbmate: epoch bump to build with go-1.25.5

### DIFF
--- a/dbmate.yaml
+++ b/dbmate.yaml
@@ -1,7 +1,7 @@
 package:
   name: dbmate
   version: "2.28.0"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: A lightweight, framework-agnostic database migration tool.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
