### PR TITLE
delve: epoch bump to build with go-1.25.5

### DIFF
--- a/delve.yaml
+++ b/delve.yaml
@@ -1,7 +1,7 @@
 package:
   name: delve
   version: "1.25.2"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Delve is a debugger for the Go programming language.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
