### PR TITLE
direnv: epoch bump to build with go-1.25.5

### DIFF
--- a/direnv.yaml
+++ b/direnv.yaml
@@ -1,7 +1,7 @@
 package:
   name: direnv
   version: "2.37.1"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: unclutter your .profile
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
