### PR TITLE
distribution: epoch bump to build with go-1.25.5

### DIFF
--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,7 +1,7 @@
 package:
   name: distribution
   version: 3.0.0
-  epoch: 43 # GHSA-j5w8-q4qc-rx2x
+  epoch: 44 # GHSA-j5w8-q4qc-rx2x
   description: The toolkit to pack, ship, store, and deliver container content
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
