### PR TITLE
dive: epoch bump to build with go-1.25.5

### DIFF
--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: "0.13.1"
-  epoch: 9 # CVE-2025-61725
+  epoch: 10 # CVE-2025-61725
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
