### PR TITLE
dkron: epoch bump to build with go-1.25.5

### DIFF
--- a/dkron.yaml
+++ b/dkron.yaml
@@ -1,7 +1,7 @@
 package:
   name: dkron
   version: "4.0.8"
-  epoch: 2 # GHSA-47m2-4cr7-mhcw
+  epoch: 3 # GHSA-47m2-4cr7-mhcw
   description: Distributed job scheduler for microservices
   copyright:
     - license: LGPL-3.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
