### PR TITLE
docker-cli: epoch bump to build with go-1.25.5

### DIFF
--- a/docker-cli.yaml
+++ b/docker-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-cli
   version: "29.1.2"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: The Docker CLI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
