### PR TITLE
docker-cli-buildx: epoch bump to build with go-1.25.5

### DIFF
--- a/docker-cli-buildx.yaml
+++ b/docker-cli-buildx.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-cli-buildx
   version: "0.30.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: buildx is a Docker CLI plugin for extended build capabilities with BuildKit.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
