### PR TITLE
docker-credential-acr-env: epoch bump to build with go-1.25.5

### DIFF
--- a/docker-credential-acr-env.yaml
+++ b/docker-credential-acr-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-acr-env
   version: 0.7.0
-  epoch: 26
+  epoch: 27
   description: ACR Docker Credential Helper
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
