### PR TITLE
docker-credential-ecr-login: epoch bump to build with go-1.25.5

### DIFF
--- a/docker-credential-ecr-login.yaml
+++ b/docker-credential-ecr-login.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-ecr-login
   version: "0.11.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Credential helper for Docker to use the AWS Elastic Container Registry
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
