### PR TITLE
docker-credential-gcr: epoch bump to build with go-1.25.5

### DIFF
--- a/docker-credential-gcr.yaml
+++ b/docker-credential-gcr.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-gcr
   version: "2.1.30"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: A Docker credential helper for GCR users
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
