### PR TITLE
dockerize: epoch bump to build with go-1.25.5

### DIFF
--- a/dockerize.yaml
+++ b/dockerize.yaml
@@ -1,7 +1,7 @@
 package:
   name: dockerize
   version: "0.9.8"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Utility to simplify running applications in docker containers
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
