### PR TITLE
doppler-kubernetes-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/doppler-kubernetes-operator.yaml
+++ b/doppler-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: doppler-kubernetes-operator
   version: "1.7.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Automatically sync secrets from Doppler to Kubernetes and auto-reload deployments when secrets change.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
