### PR TITLE
efs-utils: epoch bump to build with go-1.25.5

### DIFF
--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: "2.4.1"
-  epoch: 0 # GHSA-qx2v-8332-m4fv
+  epoch: 1 # GHSA-qx2v-8332-m4fv
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
