### PR TITLE
elvish: epoch bump to build with go-1.25.5

### DIFF
--- a/elvish.yaml
+++ b/elvish.yaml
@@ -1,7 +1,7 @@
 package:
   name: elvish
   version: 0.21.0
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: Powerful scripting language & versatile interactive shell
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
