### PR TITLE
envconsul: epoch bump to build with go-1.25.5

### DIFF
--- a/envconsul.yaml
+++ b/envconsul.yaml
@@ -1,7 +1,7 @@
 package:
   name: envconsul
   version: "0.13.4"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: "Launch a subprocess with environment variables using data from @hashicorp Consul and Vault."
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
