### PR TITLE
envoy-gateway: epoch bump to build with go-1.25.5

### DIFF
--- a/envoy-gateway.yaml
+++ b/envoy-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy-gateway
   version: "1.6.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Manages Envoy Proxy as a Standalone or Kubernetes-based Application Gateway
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
