### PR TITLE
envoy-ratelimit: epoch bump to build with go-1.25.5

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -3,7 +3,7 @@ package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
   version: "0.0.0_git20251129"
-  epoch: 0
+  epoch: 1
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
