### PR TITLE
esbuild: epoch bump to build with go-1.25.5

### DIFF
--- a/esbuild.yaml
+++ b/esbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: esbuild
   version: "0.27.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: An extremely fast bundler for the web
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
