### PR TITLE
etcd-3.6: epoch bump to build with go-1.25.5

### DIFF
--- a/etcd-3.6.yaml
+++ b/etcd-3.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: etcd-3.6
   version: "3.6.6"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
