### PR TITLE
external-dns-0.20: epoch bump to build with go-1.25.5

### DIFF
--- a/external-dns-0.20.yaml
+++ b/external-dns-0.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-dns-0.20
   version: "0.20.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
     - paths:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
