### PR TITLE
external-secrets-operator-1.0: epoch bump to build with go-1.25.5

### DIFF
--- a/external-secrets-operator-1.0.yaml
+++ b/external-secrets-operator-1.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator-1.0
   version: "1.0.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
