### PR TITLE
extism: epoch bump to build with go-1.25.5

### DIFF
--- a/extism.yaml
+++ b/extism.yaml
@@ -1,7 +1,7 @@
 package:
   name: extism
   version: "1.6.3"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: The extism CLI is used to manage Extism installations
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
