### PR TITLE
falco-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/falco-exporter.yaml
+++ b/falco-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-exporter
   version: 0.8.7
-  epoch: 10 # CVE-2025-61725
+  epoch: 11 # CVE-2025-61725
   description: Prometheus Metrics Exporter for Falco output events
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
