### PR TITLE
falcoctl: epoch bump to build with go-1.25.5

### DIFF
--- a/falcoctl.yaml
+++ b/falcoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcoctl
   version: "0.11.4"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Administrative tooling for Falco
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
