### PR TITLE
filebrowser: epoch bump to build with go-1.25.5

### DIFF
--- a/filebrowser.yaml
+++ b/filebrowser.yaml
@@ -2,7 +2,7 @@ package:
   name: filebrowser
   version: "2.50.0"
   description: "Web File Browser"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   copyright:
     - license: Apache-2.0
 


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
