### PR TITLE
fixuid: epoch bump to build with go-1.25.5

### DIFF
--- a/fixuid.yaml
+++ b/fixuid.yaml
@@ -1,7 +1,7 @@
 package:
   name: fixuid
   version: "0.6.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Go tool to change a Docker container's user/group and file permissions.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
