### PR TITLE
flannel: epoch bump to build with go-1.25.5

### DIFF
--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel
   version: "0.27.4"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
