### PR TITLE
flannel-cni-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel-cni-plugin
   version: 1.8.0.2
-  epoch: 2 # CVE-2025-47907
+  epoch: 3 # CVE-2025-47907
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
