### PR TITLE
fluent-bit-plugin-loki: epoch bump to build with go-1.25.5

### DIFF
--- a/fluent-bit-plugin-loki.yaml
+++ b/fluent-bit-plugin-loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-plugin-loki
   version: "3.6.2"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: The Fluent Bit loki plugin allows you to send your log or events to a Loki service.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
