### PR TITLE
flux-2.7: epoch bump to build with go-1.25.5

### DIFF
--- a/flux-2.7.yaml
+++ b/flux-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-2.7
   version: "2.7.5"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
