### PR TITLE
flux-kustomize-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: "1.7.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
