### PR TITLE
fluxcd-kustomize-mutating-webhook: epoch bump to build with go-1.25.5

### DIFF
--- a/fluxcd-kustomize-mutating-webhook.yaml
+++ b/fluxcd-kustomize-mutating-webhook.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluxcd-kustomize-mutating-webhook
   version: "0.7.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: A dynamic solution to patch FluxCD Kustomization resources, seamlessly integrating and federating substitution variables across multiple namespaces.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
