### PR TITLE
fq: epoch bump to build with go-1.25.5

### DIFF
--- a/fq.yaml
+++ b/fq.yaml
@@ -1,7 +1,7 @@
 package:
   name: fq
   version: "0.15.1"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: "jq for binary formats - tool, language and decoders for working with binary and text formats"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
