### PR TITLE
frp: epoch bump to build with go-1.25.5

### DIFF
--- a/frp.yaml
+++ b/frp.yaml
@@ -1,7 +1,7 @@
 package:
   name: frp
   version: "0.65.0"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
