### PR TITLE
fscrypt: epoch bump to build with go-1.25.5

### DIFF
--- a/fscrypt.yaml
+++ b/fscrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: fscrypt
   version: "0.3.6"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Go tool for managing Linux filesystem encryption
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
