### PR TITLE
fuse-overlayfs-snapshotter: epoch bump to build with go-1.25.5

### DIFF
--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: "2.1.7"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
