### PR TITLE
fzf: epoch bump to build with go-1.25.5

### DIFF
--- a/fzf.yaml
+++ b/fzf.yaml
@@ -1,7 +1,7 @@
 package:
   name: fzf
   version: "0.67.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: A command-line fuzzy finder
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
