### PR TITLE
gatekeeper-3.21: epoch bump to build with go-1.25.5

### DIFF
--- a/gatekeeper-3.21.yaml
+++ b/gatekeeper-3.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.21
   version: "3.21.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
