### PR TITLE
gatus: epoch bump to build with go-1.25.5

### DIFF
--- a/gatus.yaml
+++ b/gatus.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatus
   version: "5.33.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Automated developer-oriented status page
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
