### PR TITLE
gcp-compute-persistent-disk-csi-driver-1.21: epoch bump to build with go-1.25.5

### DIFF
--- a/gcp-compute-persistent-disk-csi-driver-1.21.yaml
+++ b/gcp-compute-persistent-disk-csi-driver-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcp-compute-persistent-disk-csi-driver-1.21
   version: "1.21.12"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The Google Compute Engine Persistent Disk (GCE PD) Container Storage Interface (CSI) Storage Plugin.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
