### PR TITLE
gcsfuse: epoch bump to build with go-1.25.5

### DIFF
--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcsfuse
   version: "2.12.2"
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: A user-space file system for interacting with Google Cloud Storage
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
