### PR TITLE
ghaudit: epoch bump to build with go-1.25.5

### DIFF
--- a/ghaudit.yaml
+++ b/ghaudit.yaml
@@ -1,7 +1,7 @@
 package:
   name: ghaudit
   version: 0.4.0
-  epoch: 15 # CVE-2025-61725
+  epoch: 16 # CVE-2025-61725
   description: Experimental tool for evaluating Chainguard's GitHub policies.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
