### PR TITLE
git-credential-oauth: epoch bump to build with go-1.25.5

### DIFF
--- a/git-credential-oauth.yaml
+++ b/git-credential-oauth.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-credential-oauth
   version: "0.16.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: "A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
