### PR TITLE
git-lfs: epoch bump to build with go-1.25.5

### DIFF
--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: "3.7.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "large file support for git"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
