### PR TITLE
git-sync: epoch bump to build with go-1.25.5

### DIFF
--- a/git-sync.yaml
+++ b/git-sync.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-sync
   version: "4.5.0"
-  epoch: 1
+  epoch: 2
   description: A sidecar app which clones a git repo and keeps it in sync with the upstream.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
