### PR TITLE
gitaly-18.6: epoch bump to build with go-1.25.5

### DIFF
--- a/gitaly-18.6.yaml
+++ b/gitaly-18.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitaly-18.6
   version: "18.6.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description:
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
