### PR TITLE
gitea: epoch bump to build with go-1.25.5

### DIFF
--- a/gitea.yaml
+++ b/gitea.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitea
   version: "1.25.2"
-  epoch: 0 # GHSA-wpwj-69cm-q9c5
+  epoch: 1 # GHSA-wpwj-69cm-q9c5
   description: self-hosted git service
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
