### PR TITLE
github-mcp-server: epoch bump to build with go-1.25.5

### DIFF
--- a/github-mcp-server.yaml
+++ b/github-mcp-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: github-mcp-server
   version: "0.24.0"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: GitHub's official MCP Server
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
