### PR TITLE
gitlab-kas-18.6: epoch bump to build with go-1.25.5

### DIFF
--- a/gitlab-kas-18.6.yaml
+++ b/gitlab-kas-18.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-kas-18.6
   version: "18.6.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: GitLab KAS is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
