### PR TITLE
gitlab-pages-18.6: epoch bump to build with go-1.25.5

### DIFF
--- a/gitlab-pages-18.6.yaml
+++ b/gitlab-pages-18.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-pages-18.6
   version: "18.6.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
