### PR TITLE
gitlab-runner-18.6: epoch bump to build with go-1.25.5

### DIFF
--- a/gitlab-runner-18.6.yaml
+++ b/gitlab-runner-18.6.yaml
@@ -16,7 +16,7 @@ package:
   name: gitlab-runner-18.6
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "18.6.3"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
