### PR TITLE
gitleaks: epoch bump to build with go-1.25.5

### DIFF
--- a/gitleaks.yaml
+++ b/gitleaks.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitleaks
   version: "8.30.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: SAST tool for detecting and preventing hardcoded secrets like passwords, api keys, and tokens in git repos
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
