### PR TITLE
gitness: epoch bump to build with go-1.25.5

### DIFF
--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
   version: "3.3.0"
-  epoch: 3 # GHSA-jc7w-c686-c4v9
+  epoch: 4 # GHSA-jc7w-c686-c4v9
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
