### PR TITLE
gke-gcloud-auth-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/gke-gcloud-auth-plugin.yaml
+++ b/gke-gcloud-auth-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: gke-gcloud-auth-plugin
   version: "0.1.0"
-  epoch: 10 # CVE-2025-61725
+  epoch: 11 # CVE-2025-61725
   description: "kubectl plugin for GKE authentication"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
