### PR TITLE
glab: epoch bump to build with go-1.25.5

### DIFF
--- a/glab.yaml
+++ b/glab.yaml
@@ -5,7 +5,7 @@
 package:
   name: glab
   version: "1.78.3"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: A GitLab CLI tool bringing GitLab to your command line
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
