### PR TITLE
glow: epoch bump to build with go-1.25.5

### DIFF
--- a/glow.yaml
+++ b/glow.yaml
@@ -1,7 +1,7 @@
 package:
   name: glow
   version: "2.1.1"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: Render markdown on the CLI, with pizzazz!
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
