### PR TITLE
go-1.25: epoch bump to build with go-1.25.5

### DIFF
--- a/go-1.25.yaml
+++ b/go-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.25
   version: "1.25.5"
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
