### PR TITLE
go-bindata: epoch bump to build with go-1.25.5

### DIFF
--- a/go-bindata.yaml
+++ b/go-bindata.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-bindata
   version: 3.1.3
-  epoch: 31 # CVE-2025-61725
+  epoch: 32 # CVE-2025-61725
   description: A small utility which generates Go code from any file
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
