### PR TITLE
go-discover: epoch bump to build with go-1.25.5

### DIFF
--- a/go-discover.yaml
+++ b/go-discover.yaml
@@ -2,7 +2,7 @@
 package:
   name: go-discover
   version: "0_git20251128"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: go-discover is a Go (golang) library and command line tool to discover ip addresses of nodes in cloud environments based on meta information like tags provided by the environment.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
