### PR TITLE
go-jsonnet: epoch bump to build with go-1.25.5

### DIFF
--- a/go-jsonnet.yaml
+++ b/go-jsonnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-jsonnet
   version: 0.21.0
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The data templating language Implementation in go.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
