### PR TITLE
go-licenses: epoch bump to build with go-1.25.5

### DIFF
--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-licenses
   version: "2.0.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
