### PR TITLE
go-md2man: epoch bump to build with go-1.25.5

### DIFF
--- a/go-md2man.yaml
+++ b/go-md2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-md2man
   version: "2.0.7"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Utility to convert markdown to man pages
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
