### PR TITLE
go-tools: epoch bump to build with go-1.25.5

### DIFF
--- a/go-tools.yaml
+++ b/go-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-tools
   version: "0.39.0"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: Virtual package to install Go tools from golang.org/x/tools.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
