### PR TITLE
gobump: epoch bump to build with go-1.25.5

### DIFF
--- a/gobump.yaml
+++ b/gobump.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobump
   version: "0.9.3"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Go tool to declaratively bump dependencies
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
