### PR TITLE
gobuster: epoch bump to build with go-1.25.5

### DIFF
--- a/gobuster.yaml
+++ b/gobuster.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobuster
   version: "3.8.2"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: "a tool used to brute force attack for URIs, DNS, etc."
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
