### PR TITLE
gofumpt: epoch bump to build with go-1.25.5

### DIFF
--- a/gofumpt.yaml
+++ b/gofumpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: gofumpt
   version: "0.9.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Enforce a stricter format than gofmt, while being backwards compatible.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
