### PR TITLE
golangci-lint: epoch bump to build with go-1.25.5

### DIFF
--- a/golangci-lint.yaml
+++ b/golangci-lint.yaml
@@ -1,7 +1,7 @@
 package:
   name: golangci-lint
   version: "2.6.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Fast linters Runner for Go
   copyright:
     - license: GPL-3.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
