### PR TITLE
goreleaser: epoch bump to build with go-1.25.5

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
   version: "2.13.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
