### PR TITLE
gostatsd: epoch bump to build with go-1.25.5

### DIFF
--- a/gostatsd.yaml
+++ b/gostatsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gostatsd
   version: 28.3.0
-  epoch: 19 # CVE-2025-61725
+  epoch: 20 # CVE-2025-61725
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
