### PR TITLE
gotestsum: epoch bump to build with go-1.25.5

### DIFF
--- a/gotestsum.yaml
+++ b/gotestsum.yaml
@@ -1,7 +1,7 @@
 package:
   name: gotestsum
   version: "1.13.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: go test runner with output optimized for humans
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
