### PR TITLE
govulncheck: epoch bump to build with go-1.25.5

### DIFF
--- a/govulncheck.yaml
+++ b/govulncheck.yaml
@@ -1,7 +1,7 @@
 package:
   name: govulncheck
   version: 1.1.4
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Go Vulnerability Management
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
