### PR TITLE
grafana-12.2: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-12.2.yaml
+++ b/grafana-12.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-12.2
   version: "12.2.2"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   # When bumping, check if we can unpin nodejs-22.
   # Remove this comment when nodejs-22 is unpinned.
   description: The open and composable observability and data visualization platform.


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
