### PR TITLE
grafana-agent-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: "0.44.6"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
