### PR TITLE
grafana-alloy: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-alloy
   version: "1.12.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: OpenTelemetry Collector distribution with programmable pipelines
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
