### PR TITLE
grafana-image-renderer: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: "5.0.11"
-  epoch: 0 # GHSA-vj76-c3g6-qr5v
+  epoch: 1 # GHSA-vj76-c3g6-qr5v
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
