### PR TITLE
grafana-mimir: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-mimir
   version: "3.0.1"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: Grafana Mimir provides horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
