### PR TITLE
grafana-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-operator.yaml
+++ b/grafana-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-operator
   version: "5.20.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: An operator for Grafana that installs and manages Grafana instances, Dashboards and Datasources through Kubernetes/OpenShift CRs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
