### PR TITLE
grafana-pyroscope-1.13: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-pyroscope-1.13.yaml
+++ b/grafana-pyroscope-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-pyroscope-1.13
   version: "1.13.6"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Continuous Profiling Platform. Debug performance issues down to a single line of code
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
