### PR TITLE
grafana-rollout-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/grafana-rollout-operator.yaml
+++ b/grafana-rollout-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-rollout-operator
   version: "0.32.0"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: Kubernetes Rollout Operator
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
