### PR TITLE
grpc-health-probe: epoch bump to build with go-1.25.5

### DIFF
--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-health-probe
   version: "0.4.42"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
