### PR TITLE
grpcurl: epoch bump to build with go-1.25.5

### DIFF
--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: "1.9.3"
-  epoch: 8 # CVE-2025-61725
+  epoch: 9 # CVE-2025-61725
   description: CLI tool to interact with gRPC servers
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
