### PR TITLE
grype: epoch bump to build with go-1.25.5

### DIFF
--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: "0.104.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
