### PR TITLE
harbor-2.14: epoch bump to build with go-1.25.5

### DIFF
--- a/harbor-2.14.yaml
+++ b/harbor-2.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.14
   version: "2.14.1"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
