### PR TITLE
harbor-cli: epoch bump to build with go-1.25.5

### DIFF
--- a/harbor-cli.yaml
+++ b/harbor-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-cli
   version: "0.0.15"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Official Harbor CLI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
