### PR TITLE
harbor-registry: epoch bump to build with go-1.25.5

### DIFF
--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-registry
   version: "3.0.0"
-  epoch: 12 # GHSA-j5w8-q4qc-rx2x
+  epoch: 13 # GHSA-j5w8-q4qc-rx2x
   description: An open source trusted cloud native registry project that stores, signs, and scans content (registry)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
