### PR TITLE
harbor-scanner-trivy: epoch bump to build with go-1.25.5

### DIFF
--- a/harbor-scanner-trivy.yaml
+++ b/harbor-scanner-trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-scanner-trivy
   version: "0.34.1"
-  epoch: 0 # CVE-2025-54410
+  epoch: 1 # CVE-2025-54410
   description: Use Trivy as a plug-in vulnerability scanner in the Harbor registry
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
