### PR TITLE
headlamp: epoch bump to build with go-1.25.5

### DIFF
--- a/headlamp.yaml
+++ b/headlamp.yaml
@@ -1,7 +1,7 @@
 package:
   name: headlamp
   version: "0.38.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Kubernetes web UI that is fully-featured, user-friendly and extensible.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
