### PR TITLE
hello-world-golang: epoch bump to build with go-1.25.5

### DIFF
--- a/hello-world-golang.yaml
+++ b/hello-world-golang.yaml
@@ -1,7 +1,7 @@
 package:
   name: hello-world-golang
   version: 1.3
-  epoch: 14 # CVE-2025-61725
+  epoch: 15 # CVE-2025-61725
   description: Simple go application that prints 'hello world' in a loop when built and invoked.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
