### PR TITLE
helm-3: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-3.yaml
+++ b/helm-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-3
   version: 3.19.2
-  epoch: 1
+  epoch: 2
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
