### PR TITLE
helm-docs: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-docs.yaml
+++ b/helm-docs.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-docs
   version: 1.14.2
-  epoch: 16 # GHSA-j5w8-q4qc-rx2x
+  epoch: 17 # GHSA-j5w8-q4qc-rx2x
   description: A tool for automatically generating markdown documentation for helm charts
   copyright:
     - license: GPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
