### PR TITLE
helm-mapkubeapis: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-mapkubeapis.yaml
+++ b/helm-mapkubeapis.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-mapkubeapis
   version: 0.6.1
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Helm plugin to map and update deprecated Kubernetes APIs in Helm release manifests
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
