### PR TITLE
helm-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-operator
   version: "1.42.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: open source toolkit to manage Kubernetes native applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
