### PR TITLE
helm-push: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-push.yaml
+++ b/helm-push.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-push
   version: 0.10.4
-  epoch: 37 # GHSA-j5w8-q4qc-rx2x
+  epoch: 38 # GHSA-j5w8-q4qc-rx2x
   description: Helm plugin to push chart package to ChartMuseum
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
