### PR TITLE
helm-set-status: epoch bump to build with go-1.25.5

### DIFF
--- a/helm-set-status.yaml
+++ b/helm-set-status.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-set-status
   version: 0.3.0
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: Helm plugin to set release status
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
