### PR TITLE
hey: epoch bump to build with go-1.25.5

### DIFF
--- a/hey.yaml
+++ b/hey.yaml
@@ -1,7 +1,7 @@
 package:
   name: hey
   version: 0.1.4
-  epoch: 27 # CVE-2025-61725
+  epoch: 28 # CVE-2025-61725
   description: HTTP load generator, ApacheBench (ab) replacement
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
