### PR TITLE
hivemind: epoch bump to build with go-1.25.5

### DIFF
--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -1,7 +1,7 @@
 package:
   name: hivemind
   version: 1.1.0
-  epoch: 11 # CVE-2025-61725
+  epoch: 12 # CVE-2025-61725
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
