### PR TITLE
http-echo: epoch bump to build with go-1.25.5

### DIFF
--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -1,7 +1,7 @@
 package:
   name: http-echo
   version: 1.0.0
-  epoch: 18 # CVE-2025-61725
+  epoch: 19 # CVE-2025-61725
   description: A tiny go web server that echos what you start it with!
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
