### PR TITLE
hubble: epoch bump to build with go-1.25.5

### DIFF
--- a/hubble.yaml
+++ b/hubble.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble
   version: "1.18.3"
-  epoch: 1 # GHSA-38pp-6gcp-rqvm
+  epoch: 2 # GHSA-38pp-6gcp-rqvm
   description: hubble is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
