### PR TITLE
hubble-ui: epoch bump to build with go-1.25.5

### DIFF
--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble-ui
   version: "0.13.3"
-  epoch: 1
+  epoch: 2
   description: "Observability & troubleshooting for Kubernetes services"
   copyright:
     - license: "Apache-2.0"


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
