### PR TITLE
incert: epoch bump to build with go-1.25.5

### DIFF
--- a/incert.yaml
+++ b/incert.yaml
@@ -1,7 +1,7 @@
 package:
   name: incert
   version: 0.5.0
-  epoch: 6 # CVE-2025-61725
+  epoch: 7 # CVE-2025-61725
   description: Add CA certificates into containers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
