### PR TITLE
infinispan-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/infinispan-operator.yaml
+++ b/infinispan-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: infinispan-operator
   version: "2.5.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes operator for deploying and managing Infinispan clusters
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
