### PR TITLE
influx: epoch bump to build with go-1.25.5

### DIFF
--- a/influx.yaml
+++ b/influx.yaml
@@ -1,7 +1,7 @@
 package:
   name: influx
   version: 2.7.5
-  epoch: 11 # CVE-2025-61725
+  epoch: 12 # CVE-2025-61725
   description: CLI for managing resources in InfluxDB v2
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
