### PR TITLE
ingress-nginx-controller-1.14: epoch bump to build with go-1.25.5

### DIFF
--- a/ingress-nginx-controller-1.14.yaml
+++ b/ingress-nginx-controller-1.14.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.14
   version: "1.14.0"
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
