### PR TITLE
ini-file: epoch bump to build with go-1.25.5

### DIFF
--- a/ini-file.yaml
+++ b/ini-file.yaml
@@ -1,7 +1,7 @@
 package:
   name: ini-file
   version: "1.4.9"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: CLI tool for modifying .ini files
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
