### PR TITLE
ip-masq-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ip-masq-agent
   version: 2.12.0
-  epoch: 14 # CVE-2025-61725
+  epoch: 15 # CVE-2025-61725
   description: Manage IP masquerade on nodes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
