### PR TITLE
ipfs-cluster: epoch bump to build with go-1.25.5

### DIFF
--- a/ipfs-cluster.yaml
+++ b/ipfs-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs-cluster
   version: "1.1.4"
-  epoch: 9 # GHSA-j5w8-q4qc-rx2x
+  epoch: 10 # GHSA-j5w8-q4qc-rx2x
   description: Pinset orchestration for IPFS
   copyright:
     - license: Apache-2.0 AND MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
