### PR TITLE
iptables-wrappers: epoch bump to build with go-1.25.5

### DIFF
--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables-wrappers
   version: 2
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Wrapper scripts for using iptables in containers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
