### PR TITLE
istio-1.28: epoch bump to build with go-1.25.5

### DIFF
--- a/istio-1.28.yaml
+++ b/istio-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-1.28
   version: "1.28.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Istio is an open source service mesh that layers transparently onto existing distributed applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
