### PR TITLE
jaeger-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/jaeger-operator.yaml
+++ b/jaeger-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: jaeger-operator
   version: "1.65.0"
-  epoch: 10 # CVE-2025-47907
+  epoch: 11 # CVE-2025-47907
   description: Jaeger Operator for Kubernetes to simplify the deployment and management of the Jaeger tracing platform.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
