### PR TITLE
jitsucom-bulker: epoch bump to build with go-1.25.5

### DIFF
--- a/jitsucom-bulker.yaml
+++ b/jitsucom-bulker.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-bulker
   version: "2.11.913"
-  epoch: 1 # GHSA-9mj6-hxhv-w67j
+  epoch: 2 # GHSA-9mj6-hxhv-w67j
   description: Service for bulk-loading data to databases with automatic schema management (Redshift, Snowflake, BigQuery, ClickHouse, Postgres, MySQL)
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
