### PR TITLE
juicefs-1.3: epoch bump to build with go-1.25.5

### DIFF
--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-1.3
   version: "1.3.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
