### PR TITLE
juicefs-csi-driver: epoch bump to build with go-1.25.5

### DIFF
--- a/juicefs-csi-driver.yaml
+++ b/juicefs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: juicefs-csi-driver
   version: "0.30.3"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: JuiceFS CSI Driver implements the CSI specification, allowing JuiceFS to be integrated with container orchestration systems. Under Kubernetes, JuiceFS can provide storage service to Pods via PersistentVolume.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
