### PR TITLE
k3d: epoch bump to build with go-1.25.5

### DIFF
--- a/k3d.yaml
+++ b/k3d.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3d
   version: "5.8.3"
-  epoch: 19 # GHSA-j5w8-q4qc-rx2x
+  epoch: 20 # GHSA-j5w8-q4qc-rx2x
   description: Little helper to run CNCF's k3s in Docker
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
