### PR TITLE
k3s-1.33: epoch bump to build with go-1.25.5

### DIFF
--- a/k3s-1.33.yaml
+++ b/k3s-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.33
   version: "1.33.6.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
