### PR TITLE
k6: epoch bump to build with go-1.25.5

### DIFF
--- a/k6.yaml
+++ b/k6.yaml
@@ -1,7 +1,7 @@
 package:
   name: k6
   version: "1.4.2"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: A modern load testing tool, using Go and JavaScript
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
