### PR TITLE
k8s-device-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-device-plugin
   version: "0.18.0"
-  epoch: 1
+  epoch: 2
   description: meta package providing all NVIDIA device plugins for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
