### PR TITLE
k8s_gateway: epoch bump to build with go-1.25.5

### DIFF
--- a/k8s_gateway.yaml
+++ b/k8s_gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s_gateway
   version: "1.6.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A CoreDNS plugin to resolve all types of external Kubernetes resources
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
