### PR TITLE
k8sgpt: epoch bump to build with go-1.25.5

### DIFF
--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: "0.4.26"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
