### PR TITLE
k8sgpt-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: "0.2.24"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2 # CVE-2025-58187
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
