### PR TITLE
k8ssandra-client: epoch bump to build with go-1.25.5

### DIFF
--- a/k8ssandra-client.yaml
+++ b/k8ssandra-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8ssandra-client
   version: "0.8.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A kubectl plugin to simplify usage of k8ssandra.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
