### PR TITLE
k8ssandra-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/k8ssandra-operator.yaml
+++ b/k8ssandra-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8ssandra-operator
   version: "1.29.0"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: The Kubernetes operator for K8ssandra
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
