### PR TITLE
k9s: epoch bump to build with go-1.25.5

### DIFF
--- a/k9s.yaml
+++ b/k9s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k9s
   version: "0.50.16"
-  epoch: 4 # GHSA-6gxw-85q2-q646
+  epoch: 5 # GHSA-6gxw-85q2-q646
   description: Kubernetes CLI To Manage Your Clusters In Style!
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
