### PR TITLE
kaf: epoch bump to build with go-1.25.5

### DIFF
--- a/kaf.yaml
+++ b/kaf.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaf
   version: "0.2.13"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Modern CLI for Apache Kafka, written in Go
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
