### PR TITLE
kafka-proxy: epoch bump to build with go-1.25.5

### DIFF
--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-proxy
   version: "0.4.3"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Allows a service to connect to Kafka brokers without having to deal with SASL/PLAIN authentication and SSL certificates
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
