### PR TITLE
kafka_exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/kafka_exporter.yaml
+++ b/kafka_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka_exporter
   version: "1.9.0"
-  epoch: 40 # GHSA-j5w8-q4qc-rx2x
+  epoch: 41 # GHSA-j5w8-q4qc-rx2x
   description: "Kafka exporter for Prometheus"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
