### PR TITLE
kaniko: epoch bump to build with go-1.25.5

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: "1.25.5"
-  epoch: 2 # GHSA-pwhc-rpq9-4c8w
+  epoch: 3 # GHSA-pwhc-rpq9-4c8w
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
