### PR TITLE
kapp: epoch bump to build with go-1.25.5

### DIFF
--- a/kapp.yaml
+++ b/kapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: kapp
   version: "0.65.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
