### PR TITLE
kapp-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/kapp-controller.yaml
+++ b/kapp-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: kapp-controller
   version: "0.59.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Continuous delivery and package management for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
