### PR TITLE
karma: epoch bump to build with go-1.25.5

### DIFF
--- a/karma.yaml
+++ b/karma.yaml
@@ -2,7 +2,7 @@ package:
   name: karma
   version: "0.122"
   description: "A dashboard for managing alerts from Alertmanager"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   copyright:
     - license: Apache-2.0
 


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
