### PR TITLE
karpenter-1.8: epoch bump to build with go-1.25.5

### DIFF
--- a/karpenter-1.8.yaml
+++ b/karpenter-1.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: karpenter-1.8
   version: "1.8.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
