### PR TITLE
kbld: epoch bump to build with go-1.25.5

### DIFF
--- a/kbld.yaml
+++ b/kbld.yaml
@@ -1,7 +1,7 @@
 package:
   name: kbld
   version: "0.47.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: kbld seamlessly incorporates image building and image pushing into your development and deployment workflows
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
