### PR TITLE
kiali: epoch bump to build with go-1.25.5

### DIFF
--- a/kiali.yaml
+++ b/kiali.yaml
@@ -1,7 +1,7 @@
 package:
   name: kiali
   version: "2.19.0"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: The Console for Istio Service Mesh
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
