### PR TITLE
knative-client: epoch bump to build with go-1.25.5

### DIFF
--- a/knative-client.yaml
+++ b/knative-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-client
   version: "1.20.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Knative CLI implementation
   dependencies:
     provides:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
