### PR TITLE
knative-eventing-1.19: epoch bump to build with go-1.25.5

### DIFF
--- a/knative-eventing-1.19.yaml
+++ b/knative-eventing-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-eventing-1.19
   version: "1.19.8"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Event-driven application platform for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
