### PR TITLE
knative-operator-1.19: epoch bump to build with go-1.25.5

### DIFF
--- a/knative-operator-1.19.yaml
+++ b/knative-operator-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: knative-operator-1.19
   version: "1.19.5"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
