### PR TITLE
ko: epoch bump to build with go-1.25.5

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: "0.18.0"
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
