### PR TITLE
kpt: epoch bump to build with go-1.25.5

### DIFF
--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
   version: 1.0.0_beta55
-  epoch: 13 # CVE-2025-61725
+  epoch: 14 # CVE-2025-61725
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
