### PR TITLE
kratos: epoch bump to build with go-1.25.5

### DIFF
--- a/kratos.yaml
+++ b/kratos.yaml
@@ -1,7 +1,7 @@
 package:
   name: kratos
   version: "2.9.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: "A Go framework for microservices"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
