### PR TITLE
kserve-modelmesh-serving: epoch bump to build with go-1.25.5

### DIFF
--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-modelmesh-serving
   version: 0.12.0
-  epoch: 17 # GHSA-j5w8-q4qc-rx2x
+  epoch: 18 # GHSA-j5w8-q4qc-rx2x
   description: ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
