### PR TITLE
kserve-rest-proxy: epoch bump to build with go-1.25.5

### DIFF
--- a/kserve-rest-proxy.yaml
+++ b/kserve-rest-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-rest-proxy
   version: 0.12.0
-  epoch: 11 # CVE-2025-47906
+  epoch: 12 # CVE-2025-47906
   description: "REST API proxy for kserve, the standardized serverless ML inference platform on Kubernetes"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
