### PR TITLE
kube-arangodb-1.3: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-arangodb-1.3.yaml
+++ b/kube-arangodb-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-arangodb-1.3
   version: "1.3.2"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
