### PR TITLE
kube-bench: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-bench.yaml
+++ b/kube-bench.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-bench
   version: "0.14.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
