### PR TITLE
kube-fluentd-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 51 # GHSA-j5w8-q4qc-rx2x
+  epoch: 52 # GHSA-j5w8-q4qc-rx2x
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
