### PR TITLE
kube-logging-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-logging-operator.yaml
+++ b/kube-logging-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-logging-operator
   version: "6.2.1"
-  epoch: 0
+  epoch: 1
   description: Logging operator for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
