### PR TITLE
kube-logging-operator-custom-runner: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-logging-operator-custom-runner.yaml
+++ b/kube-logging-operator-custom-runner.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-logging-operator-custom-runner
   version: "0.13.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Logging operator for Kubernetes - go custom runner
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
