### PR TITLE
kube-metrics-adapter: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-metrics-adapter.yaml
+++ b/kube-metrics-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-metrics-adapter
   version: "0.2.6"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: General purpose metrics adapter for Kubernetes HPA metrics
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
