### PR TITLE
kube-rbac-proxy: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-rbac-proxy.yaml
+++ b/kube-rbac-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-rbac-proxy
   version: "0.20.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes RBAC authorizing HTTP proxy for a single upstream.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
