### PR TITLE
kube-vip-cloud-provider: epoch bump to build with go-1.25.5

### DIFF
--- a/kube-vip-cloud-provider.yaml
+++ b/kube-vip-cloud-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-vip-cloud-provider
   version: "0.0.12"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: A general purpose cloud provider for Kube-Vip
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
