### PR TITLE
kubecolor: epoch bump to build with go-1.25.5

### DIFF
--- a/kubecolor.yaml
+++ b/kubecolor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubecolor
   version: "0.5.3"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Colorize your kubectl output
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
