### PR TITLE
kubeflow: epoch bump to build with go-1.25.5

### DIFF
--- a/kubeflow.yaml
+++ b/kubeflow.yaml
@@ -5,7 +5,7 @@
 package:
   name: kubeflow
   version: "1.10.0"
-  epoch: 8 # GHSA-f6x5-jh6r-wrfv
+  epoch: 9 # GHSA-f6x5-jh6r-wrfv
   description: Kubeflow Go Components
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
