### PR TITLE
kubeflow-katib: epoch bump to build with go-1.25.5

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-katib
   version: "0.19.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Kubeflow Katib services
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
