### PR TITLE
kubeflow-pipelines: epoch bump to build with go-1.25.5

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.15.0"
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
