### PR TITLE
kubelet-csr-approver: epoch bump to build with go-1.25.5

### DIFF
--- a/kubelet-csr-approver.yaml
+++ b/kubelet-csr-approver.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubelet-csr-approver
   version: "1.2.12"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Kubernetes controller to enable automatic kubelet CSR validation after a series of (configurable) security checks
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
