### PR TITLE
kuberay-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/kuberay-operator.yaml
+++ b/kuberay-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kuberay-operator
   version: "1.5.1"
-  epoch: 0 # CVE-2025-47906
+  epoch: 1 # CVE-2025-47906
   description: A toolkit to run Ray applications on Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
