### PR TITLE
kuberlr: epoch bump to build with go-1.25.5

### DIFF
--- a/kuberlr.yaml
+++ b/kuberlr.yaml
@@ -1,7 +1,7 @@
 package:
   name: kuberlr
   version: "0.6.1"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: "A tool that simplifies the management of multiple versions of kubectl"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
