### PR TITLE
kubernetes-1.34: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
