### PR TITLE
kubernetes-csi-driver-hostpath: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-driver-hostpath.yaml
+++ b/kubernetes-csi-driver-hostpath.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-driver-hostpath
   version: "1.17.0"
-  epoch: 6 # CVE-2025-61725
+  epoch: 7 # CVE-2025-61725
   description: A sample (non-production) CSI Driver that creates a local directory as a volume on a single node
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
