### PR TITLE
kubernetes-csi-driver-nfs: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-driver-nfs.yaml
+++ b/kubernetes-csi-driver-nfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-driver-nfs
   version: "4.12.1"
-  epoch: 2
+  epoch: 3
   description: This driver allows Kubernetes to access NFS server on Linux node
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
