### PR TITLE
kubernetes-csi-external-attacher: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-external-attacher.yaml
+++ b/kubernetes-csi-external-attacher.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher
   version: "4.10.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
