### PR TITLE
kubernetes-csi-external-resizer: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-external-resizer.yaml
+++ b/kubernetes-csi-external-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer
   version: "2.0.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
