### PR TITLE
kubernetes-csi-external-snapshotter-8.3: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-external-snapshotter-8.3.yaml
+++ b/kubernetes-csi-external-snapshotter-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter-8.3
   version: "8.3.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
