### PR TITLE
kubernetes-csi-node-driver-registrar-2.15: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-csi-node-driver-registrar-2.15.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar-2.15
   version: "2.15.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
