### PR TITLE
kubernetes-dashboard: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard
   version: "7.14.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
