### PR TITLE
kubernetes-dashboard-api: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-dashboard-api.yaml
+++ b/kubernetes-dashboard-api.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-api
   version: "1.14.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Go module handling authentication to the Kubernetes API
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
