### PR TITLE
kubernetes-dashboard-auth: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-dashboard-auth.yaml
+++ b/kubernetes-dashboard-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-auth
   version: "1.4.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Stateless Go module, which could be referred to as a Kubernetes API extension
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
