### PR TITLE
kubernetes-dashboard-metrics-scraper: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-metrics-scraper
   version: "1.2.2"
-  epoch: 13 # CVE-2025-61725
+  epoch: 14 # CVE-2025-61725
   description: Go module used to scrape and store a small window of metrics fetched from the Kubernetes Metrics Server.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
