### PR TITLE
kubernetes-dashboard-web: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-dashboard-web.yaml
+++ b/kubernetes-dashboard-web.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-web
   version: "1.7.0"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: General-purpose web UI for Kubernetes clusters with enhanced authentication features
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
