### PR TITLE
kubernetes-event-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
   version: "1.7"
-  epoch: 48 # GHSA-j5w8-q4qc-rx2x
+  epoch: 49 # GHSA-j5w8-q4qc-rx2x
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
