### PR TITLE
kubernetes-ingress-defaultbackend: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-ingress-defaultbackend.yaml
+++ b/kubernetes-ingress-defaultbackend.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-ingress-defaultbackend
   version: "1.37.3"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: "A simple web server that respond 404 common used in kubernetes ingress, serve pages 404 at root and 200 at /healthz"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
