### PR TITLE
kubernetes-release: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-release.yaml
+++ b/kubernetes-release.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-release
   version: "0.18.0"
-  epoch: 5 # CVE-2025-47907
+  epoch: 6 # CVE-2025-47907
   description: Release infrastructure for Kubernetes and related components
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
