### PR TITLE
kubernetes-replicator: epoch bump to build with go-1.25.5

### DIFF
--- a/kubernetes-replicator.yaml
+++ b/kubernetes-replicator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-replicator
   version: "2.12.2"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Kubernetes controller for synchronizing secrets & config maps across namespaces
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
