### PR TITLE
kubescape: epoch bump to build with go-1.25.5

### DIFF
--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: "3.0.45"
-  epoch: 3 # GHSA-38pp-6gcp-rqvm
+  epoch: 4 # GHSA-38pp-6gcp-rqvm
   description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
   copyright:
     - license: Apache-2.0 AND MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
