### PR TITLE
kubescape-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/kubescape-operator.yaml
+++ b/kubescape-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape-operator
   version: "0.2.116"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Kubescape-Operator is an in-cluster component of the Kubescape security platform.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
