### PR TITLE
kubewatch: epoch bump to build with go-1.25.5

### DIFF
--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubewatch
   version: "2.12.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Watch k8s events and trigger Handlers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
