### PR TITLE
kubo: epoch bump to build with go-1.25.5

### DIFF
--- a/kubo.yaml
+++ b/kubo.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubo
   version: "0.39.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: An IPFS implementation in Go
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
