### PR TITLE
kwok: epoch bump to build with go-1.25.5

### DIFF
--- a/kwok.yaml
+++ b/kwok.yaml
@@ -1,7 +1,7 @@
 package:
   name: kwok
   version: "0.7.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes WithOut Kubelet - Simulates thousands of Nodes and Clusters.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
