### PR TITLE
kyverno-notation-aws: epoch bump to build with go-1.25.5

### DIFF
--- a/kyverno-notation-aws.yaml
+++ b/kyverno-notation-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-notation-aws
   version: 1.1
-  epoch: 24 # GHSA-j5w8-q4qc-rx2x
+  epoch: 25 # GHSA-j5w8-q4qc-rx2x
   description: Kyverno extension service for Notation and the AWS signer
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
