### PR TITLE
kyverno-policy-reporter: epoch bump to build with go-1.25.5

### DIFF
--- a/kyverno-policy-reporter.yaml
+++ b/kyverno-policy-reporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter
   version: "3.7.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Monitoring and Observability Tool for the PolicyReport CRD with an optional UI.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
