### PR TITLE
kyverno-policy-reporter-kyverno-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/kyverno-policy-reporter-kyverno-plugin.yaml
+++ b/kyverno-policy-reporter-kyverno-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-kyverno-plugin
   version: 1.6.4
-  epoch: 13 # CVE-2025-47907
+  epoch: 14 # CVE-2025-47907
   description: Policy Reporter Kyverno Plugin
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
