### PR TITLE
kyverno-policy-reporter-ui: epoch bump to build with go-1.25.5

### DIFF
--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-ui
   version: "2.5.0"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: Policy Reporter UI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
