### PR TITLE
lazydocker: epoch bump to build with go-1.25.5

### DIFF
--- a/lazydocker.yaml
+++ b/lazydocker.yaml
@@ -1,7 +1,7 @@
 package:
   name: lazydocker
   version: "0.24.2"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: The lazier way to manage everything docker
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
