### PR TITLE
lazygit: epoch bump to build with go-1.25.5

### DIFF
--- a/lazygit.yaml
+++ b/lazygit.yaml
@@ -1,7 +1,7 @@
 package:
   name: lazygit
   version: "0.56.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: simple terminal UI for git commands
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
