### PR TITLE
licenseclassifier: epoch bump to build with go-1.25.5

### DIFF
--- a/licenseclassifier.yaml
+++ b/licenseclassifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: licenseclassifier
   version: "2.0.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: The license classifier is a library and set of tools that can analyze text to determine what type of license it contains.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
