### PR TITLE
linkerd2: epoch bump to build with go-1.25.5

### DIFF
--- a/linkerd2.yaml
+++ b/linkerd2.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2
   version: "25.11.3"
-  epoch: 0 # GHSA-xwfj-jgwm-7wp5
+  epoch: 1 # GHSA-xwfj-jgwm-7wp5
   description: "meta linkerd package"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
