### PR TITLE
linkerd2-proxy-init: epoch bump to build with go-1.25.5

### DIFF
--- a/linkerd2-proxy-init.yaml
+++ b/linkerd2-proxy-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-proxy-init
   version: "2.4.3"
-  epoch: 4 # CVE-2025-47906
+  epoch: 5 # CVE-2025-47906
   description: "Init container that sets up the iptables rules to forward traffic into the Linkerd2 sidecar proxy"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
