### PR TITLE
litefs: epoch bump to build with go-1.25.5

### DIFF
--- a/litefs.yaml
+++ b/litefs.yaml
@@ -1,7 +1,7 @@
 package:
   name: litefs
   version: "0.5.14"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: "FUSE-based file system for replicating SQLite databases across a cluster of machines"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
