### PR TITLE
local-path-provisioner: epoch bump to build with go-1.25.5

### DIFF
--- a/local-path-provisioner.yaml
+++ b/local-path-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-path-provisioner
   version: "0.0.32"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Dynamically provisioning persistent local storage with Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
