### PR TITLE
logstash-9.2: epoch bump to build with go-1.25.5

### DIFF
--- a/logstash-9.2.yaml
+++ b/logstash-9.2.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.2
   version: "9.2.2"
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
