### PR TITLE
lvm-driver: epoch bump to build with go-1.25.5

### DIFF
--- a/lvm-driver.yaml
+++ b/lvm-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: lvm-driver
   version: "1.8.0"
-  epoch: 0 # CVE-2025-47906
+  epoch: 1 # CVE-2025-47906
   description: Dynamically provision Stateful Persistent Node-Local Volumes & Filesystems for Kubernetes that is integrated with a backend LVM2 data storage stack.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
