### PR TITLE
mailpit: epoch bump to build with go-1.25.5

### DIFF
--- a/mailpit.yaml
+++ b/mailpit.yaml
@@ -1,7 +1,7 @@
 package:
   name: mailpit
   version: "1.28.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: An email and SMTP testing tool with API for developers
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
