### PR TITLE
malcontent: epoch bump to build with go-1.25.5

### DIFF
--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,7 +1,7 @@
 package:
   name: malcontent
   version: "1.17.5"
-  epoch: 0
+  epoch: 1
   description: enumerate file capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
