### PR TITLE
manifest-tool: epoch bump to build with go-1.25.5

### DIFF
--- a/manifest-tool.yaml
+++ b/manifest-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: manifest-tool
   version: "2.2.1"
-  epoch: 2 # GHSA-pwhc-rpq9-4c8w
+  epoch: 3 # GHSA-pwhc-rpq9-4c8w
   description: "Command line tool to create and query container image manifest list/indexes"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
