### PR TITLE
mariadb-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/mariadb-operator.yaml
+++ b/mariadb-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-operator
   version: "25.10.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Go operator that automates the deployment and management of MariaDB databases on Kubernetes
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
