### PR TITLE
maru: epoch bump to build with go-1.25.5

### DIFF
--- a/maru.yaml
+++ b/maru.yaml
@@ -1,7 +1,7 @@
 package:
   name: maru
   version: "0.6.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: a task runner to automate builds and perform common shell tasks. shares a syntax similar to zarf.yaml actions.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
