### PR TITLE
mattermost-11.1: epoch bump to build with go-1.25.5

### DIFF
--- a/mattermost-11.1.yaml
+++ b/mattermost-11.1.yaml
@@ -3,7 +3,7 @@ package:
   # Note the npm version has been pinned to 10.8.3 to avoid the error:
   # "npm error notsup Required: {"node":">=18.10.0","npm":"^9.0.0 || ^10.0.0"}"
   version: "11.1.1"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1 # GHSA-rwvp-r38j-9rgg
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
