### PR TITLE
mc: epoch bump to build with go-1.25.5

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mc
   version: "0.20250813.083541"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
