### PR TITLE
mcp-grafana: epoch bump to build with go-1.25.5

### DIFF
--- a/mcp-grafana.yaml
+++ b/mcp-grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: mcp-grafana
   version: "0.7.10"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: MCP server for grafana
   dependencies:
     runtime:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
