### PR TITLE
melange: epoch bump to build with go-1.25.5

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: "0.34.1"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: build APKs from source code
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
