### PR TITLE
memcached-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: "0.15.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
