### PR TITLE
mesosphere-vsphere-csi: epoch bump to build with go-1.25.5

### DIFF
--- a/mesosphere-vsphere-csi.yaml
+++ b/mesosphere-vsphere-csi.yaml
@@ -5,7 +5,7 @@
 package:
   name: mesosphere-vsphere-csi
   version: "3.5.0"
-  epoch: 4 # GHSA-cgrx-mc8f-2prm
+  epoch: 5 # GHSA-cgrx-mc8f-2prm
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
