### PR TITLE
metacontroller: epoch bump to build with go-1.25.5

### DIFF
--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: "4.12.5"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Writing kubernetes controllers can be simple
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
