### PR TITLE
metallb: epoch bump to build with go-1.25.5

### DIFF
--- a/metallb.yaml
+++ b/metallb.yaml
@@ -1,7 +1,7 @@
 package:
   name: metallb
   version: "0.15.2"
-  epoch: 6 # CVE-2025-47907
+  epoch: 7 # CVE-2025-47907
   description: "A network load-balancer implementation for Kubernetes using standard routing protocols"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
