### PR TITLE
metrics-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/metrics-agent.yaml
+++ b/metrics-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-agent
   version: "2.14.7"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Kubernetes metrics collection agent for Cloudability that collects allocation metrics from a Kubernetes cluster system and sends the metrics to Cloudability.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
