### PR TITLE
migrate: epoch bump to build with go-1.25.5

### DIFF
--- a/migrate.yaml
+++ b/migrate.yaml
@@ -1,7 +1,7 @@
 package:
   name: migrate
   version: "4.19.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: CLI and Golang library for database migrations.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
