### PR TITLE
minify: epoch bump to build with go-1.25.5

### DIFF
--- a/minify.yaml
+++ b/minify.yaml
@@ -1,7 +1,7 @@
 package:
   name: minify
   version: "2.24.7"
-  epoch: 0
+  epoch: 1
   description: "Go minifiers for web formats"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
