### PR TITLE
minio-object-browser: epoch bump to build with go-1.25.5

### DIFF
--- a/minio-object-browser.yaml
+++ b/minio-object-browser.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio-object-browser
   version: "2.0.4"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Simple UI for MinIO Object Storage
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
