### PR TITLE
minio-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio-operator
   version: "7.1.1"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Minio Operator creates/configures/manages Minio on Kubernetes
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
