### PR TITLE
mkcert: epoch bump to build with go-1.25.5

### DIFF
--- a/mkcert.yaml
+++ b/mkcert.yaml
@@ -1,7 +1,7 @@
 package:
   name: mkcert
   version: 1.4.4
-  epoch: 18 # GHSA-j5w8-q4qc-rx2x
+  epoch: 19 # GHSA-j5w8-q4qc-rx2x
   description: A simple zero-config tool to make locally trusted development certificates with any names you'd like.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
