### PR TITLE
mockery: epoch bump to build with go-1.25.5

### DIFF
--- a/mockery.yaml
+++ b/mockery.yaml
@@ -1,7 +1,7 @@
 package:
   name: mockery
   version: "3.6.1"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: A mock code autogenerator for Go
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
