### PR TITLE
mockgen: epoch bump to build with go-1.25.5

### DIFF
--- a/mockgen.yaml
+++ b/mockgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: mockgen
   version: "0.6.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: GoMock is a mocking framework for the Go programming language.
   url: https://github.com/uber-go/mock
   copyright:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
