### PR TITLE
mods: epoch bump to build with go-1.25.5

### DIFF
--- a/mods.yaml
+++ b/mods.yaml
@@ -1,7 +1,7 @@
 package:
   name: mods
   version: "1.8.1"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: AI on the command line!
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
