### PR TITLE
mongo-tools: epoch bump to build with go-1.25.5

### DIFF
--- a/mongo-tools.yaml
+++ b/mongo-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongo-tools
   version: "100.13.0"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: Tools for MongoDB
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
