### PR TITLE
mongodb-kubernetes-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/mongodb-kubernetes-operator.yaml
+++ b/mongodb-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongodb-kubernetes-operator
   version: "0.13.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Kubernetes Operator which deploys MongoDB Community into Kubernetes clusters.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
