### PR TITLE
mountpoint-s3-csi-driver-2.2: epoch bump to build with go-1.25.5

### DIFF
--- a/mountpoint-s3-csi-driver-2.2.yaml
+++ b/mountpoint-s3-csi-driver-2.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: mountpoint-s3-csi-driver-2.2
   version: "2.2.1"
-  epoch: 1
+  epoch: 2
   description: Built on Mountpoint for Amazon S3, the Mountpoint CSI driver presents an Amazon S3 bucket as a storage volume accessible by containers in your Kubernetes cluster
   dependencies:
     provides:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
