### PR TITLE
multus-cni: epoch bump to build with go-1.25.5

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
   version: "4.2.3"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
