### PR TITLE
nats-server-config-reloader: epoch bump to build with go-1.25.5

### DIFF
--- a/nats-server-config-reloader.yaml
+++ b/nats-server-config-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats-server-config-reloader
   version: "0.21.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: "NATS server configuration reloader utility"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
