### PR TITLE
nats-top: epoch bump to build with go-1.25.5

### DIFF
--- a/nats-top.yaml
+++ b/nats-top.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats-top
   version: "0.6.3"
-  epoch: 10 # GHSA-j5w8-q4qc-rx2x
+  epoch: 11 # GHSA-j5w8-q4qc-rx2x
   description: A top-like tool for monitoring NATS servers.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
