### PR TITLE
net-kourier-1.19: epoch bump to build with go-1.25.5

### DIFF
--- a/net-kourier-1.19.yaml
+++ b/net-kourier-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: net-kourier-1.19
   version: "1.19.6"
-  epoch: 0
+  epoch: 1
   description: Purpose-built Knative Ingress implementation using just Envoy with no additional CRDs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
