### PR TITLE
neuvector-dbgen: epoch bump to build with go-1.25.5

### DIFF
--- a/neuvector-dbgen.yaml
+++ b/neuvector-dbgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-dbgen
   version: 0_git20240423
-  epoch: 8 # CVE-2025-61725
+  epoch: 9 # CVE-2025-61725
   description: NeuVector vulnerability database generator for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
