### PR TITLE
neuvector-scanner: epoch bump to build with go-1.25.5

### DIFF
--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-scanner
   version: "4.001"
-  epoch: 0 # GHSA-cgrx-mc8f-2prm
+  epoch: 1 # GHSA-cgrx-mc8f-2prm
   description: NeuVector vulnerability scanner for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
