### PR TITLE
neuvector-sigstore-interface: epoch bump to build with go-1.25.5

### DIFF
--- a/neuvector-sigstore-interface.yaml
+++ b/neuvector-sigstore-interface.yaml
@@ -2,7 +2,7 @@
 package:
   name: neuvector-sigstore-interface
   version: 0_git20250629
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: NeuVector sigstore interface for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
