### PR TITLE
newrelic-fluent-bit-output: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: "2.4.0"
-  epoch: 5 # CVE-2025-4674
+  epoch: 6 # CVE-2025-4674
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
