### PR TITLE
newrelic-infra-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-infra-operator.yaml
+++ b/newrelic-infra-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infra-operator
   version: "0.26.1"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Newrelic kubernetes operator of infrastructure
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
