### PR TITLE
newrelic-infrastructure-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: "1.71.1"
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
