### PR TITLE
newrelic-k8s-metadata-injection: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-k8s-metadata-injection.yaml
+++ b/newrelic-k8s-metadata-injection.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-k8s-metadata-injection
   version: "1.39.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Kubernetes metadata injection for New Relic APM to make a linkage between APM and Infrastructure data.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
