### PR TITLE
newrelic-nri-kube-events: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-nri-kube-events.yaml
+++ b/newrelic-nri-kube-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-kube-events
   version: "2.16.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: New Relic integration that forwards Kubernetes events to New Relic
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
