### PR TITLE
newrelic-prometheus-configurator: epoch bump to build with go-1.25.5

### DIFF
--- a/newrelic-prometheus-configurator.yaml
+++ b/newrelic-prometheus-configurator.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-prometheus-configurator
   version: "2.4.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: New Relic Prometheus Configurator
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
