### PR TITLE
nfpm: epoch bump to build with go-1.25.5

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfpm
   version: "2.44.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: nFPM is a simple, 0-dependencies, deb, rpm, apk and arch linux packager written in Go
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
