### PR TITLE
nfs-subdir-external-provisioner: epoch bump to build with go-1.25.5

### DIFF
--- a/nfs-subdir-external-provisioner.yaml
+++ b/nfs-subdir-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-subdir-external-provisioner
   version: 4.0.18
-  epoch: 26 # GHSA-j5w8-q4qc-rx2x
+  epoch: 27 # GHSA-j5w8-q4qc-rx2x
   description: Dynamic sub-dir volume provisioner on a remote NFS server.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
