### PR TITLE
nginx-prometheus-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-prometheus-exporter
   version: "1.5.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: NGINX Prometheus Exporter for NGINX and NGINX Plus
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
