### PR TITLE
nodetaint: epoch bump to build with go-1.25.5

### DIFF
--- a/nodetaint.yaml
+++ b/nodetaint.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodetaint
   version: 0.0.4
-  epoch: 38 # CVE-2025-61725
+  epoch: 39 # CVE-2025-61725
   description: Controller to manage taints for nodes in a k8s cluster.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
