### PR TITLE
nova: epoch bump to build with go-1.25.5

### DIFF
--- a/nova.yaml
+++ b/nova.yaml
@@ -1,7 +1,7 @@
 package:
   name: nova
   version: "3.11.9"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Find outdated or deprecated Helm charts running in your cluster.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
