### PR TITLE
nri-cassandra: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-cassandra.yaml
+++ b/nri-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-cassandra
   version: "2.16.0"
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Cassandra Integration
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
