### PR TITLE
nri-consul: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-consul
   version: "2.9.4"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: New Relic Infrastructure Consul Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
