### PR TITLE
nri-discovery-kubernetes: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-discovery-kubernetes.yaml
+++ b/nri-discovery-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-discovery-kubernetes
   version: "1.13.6"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: New Relic Kubernetes Auto-Discovery
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
