### PR TITLE
nri-elasticsearch: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-elasticsearch.yaml
+++ b/nri-elasticsearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-elasticsearch
   version: "5.4.5"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: New Relic Infrastructure Elasticsearch Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
