### PR TITLE
nri-haproxy: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-haproxy.yaml
+++ b/nri-haproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-haproxy
   version: "3.2.3"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: New Relic Infrastructure HAproxy Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
