### PR TITLE
nri-jmx: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-jmx.yaml
+++ b/nri-jmx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-jmx
   version: "3.11.1"
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure JMX Integration
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
