### PR TITLE
nri-kafka: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-kafka.yaml
+++ b/nri-kafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kafka
   version: "3.15.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: New Relic Infrastructure Kafka Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
