### PR TITLE
nri-kubernetes: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-kubernetes.yaml
+++ b/nri-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kubernetes
   version: "3.50.2"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: New Relic integration for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
