### PR TITLE
nri-mssql: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-mssql.yaml
+++ b/nri-mssql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mssql
   version: "2.25.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: New Relic Infrastructure Mssql Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
