### PR TITLE
nri-nagios: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-nagios.yaml
+++ b/nri-nagios.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-nagios
   version: "2.11.3"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: New Relic Infrastructure Nagios Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
