### PR TITLE
nri-postgresql: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-postgresql.yaml
+++ b/nri-postgresql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-postgresql
   version: "2.22.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: New Relic Infrastructure Postgresql Integration
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
