### PR TITLE
nri-prometheus: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: "2.27.3"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
