### PR TITLE
nri-redis: epoch bump to build with go-1.25.5

### DIFF
--- a/nri-redis.yaml
+++ b/nri-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-redis
   version: "1.12.6"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: New Relic Infrastructure Redis Integration
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
