### PR TITLE
nuclei: epoch bump to build with go-1.25.5

### DIFF
--- a/nuclei.yaml
+++ b/nuclei.yaml
@@ -1,7 +1,7 @@
 package:
   name: nuclei
   version: "3.5.1"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: "yaml based vulnerability scanner"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
