### PR TITLE
nvidia-container-toolkit: epoch bump to build with go-1.25.5

### DIFF
--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-container-toolkit
   version: "1.18.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Build and run containers leveraging NVIDIA GPUs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
