### PR TITLE
octo-sts: epoch bump to build with go-1.25.5

### DIFF
--- a/octo-sts.yaml
+++ b/octo-sts.yaml
@@ -1,7 +1,7 @@
 package:
   name: octo-sts
   version: "0.5.3"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: A GitHub App that acts like a Security Token Service (STS) for the Github API.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
