### PR TITLE
op-geth: epoch bump to build with go-1.25.5

### DIFF
--- a/op-geth.yaml
+++ b/op-geth.yaml
@@ -1,7 +1,7 @@
 package:
   name: op-geth
   version: "1.101603.5"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The go-ethereum command line interface
   copyright:
     - license: LGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
