### PR TITLE
opa: epoch bump to build with go-1.25.5

### DIFF
--- a/opa.yaml
+++ b/opa.yaml
@@ -1,7 +1,7 @@
 package:
   name: opa
   version: "1.11.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Open Policy Agent (OPA) is an open source, general-purpose policy engine.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
