### PR TITLE
opa-envoy: epoch bump to build with go-1.25.5

### DIFF
--- a/opa-envoy.yaml
+++ b/opa-envoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: opa-envoy
   version: "1.11.0"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: A plugin to enforce OPA policies with Envoy.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
