### PR TITLE
openbao: epoch bump to build with go-1.25.5

### DIFF
--- a/openbao.yaml
+++ b/openbao.yaml
@@ -1,7 +1,7 @@
 package:
   name: openbao
   version: "2.4.4"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: OpenBao exists to provide a software solution to manage, store, and distribute sensitive data including secrets, certificates, and keys.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
