### PR TITLE
openbao-k8s: epoch bump to build with go-1.25.5

### DIFF
--- a/openbao-k8s.yaml
+++ b/openbao-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: openbao-k8s
   version: 1.4.0
-  epoch: 41 # GHSA-j5w8-q4qc-rx2x
+  epoch: 42 # GHSA-j5w8-q4qc-rx2x
   description: First-class support for OpenBao and Kubernetes.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
