### PR TITLE
openfga: epoch bump to build with go-1.25.5

### DIFF
--- a/openfga.yaml
+++ b/openfga.yaml
@@ -1,7 +1,7 @@
 package:
   name: openfga
   version: "1.11.1"
-  epoch: 0 # GHSA-2464-8j7c-4cjm
+  epoch: 1 # GHSA-2464-8j7c-4cjm
   description: A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
