### PR TITLE
opensearch-k8s-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/opensearch-k8s-operator.yaml
+++ b/opensearch-k8s-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-k8s-operator
   version: "2.8.0"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: OpenSearch Kubernetes Operator
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
