### PR TITLE
opentelemetry-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/opentelemetry-operator.yaml
+++ b/opentelemetry-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-operator
   version: "0.140.0"
-  epoch: 0 # GHSA-4vq8-7jfc-9cvp
+  epoch: 1 # GHSA-4vq8-7jfc-9cvp
   description: Kubernetes Operator for OpenTelemetry Collector
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
