### PR TITLE
opentofu-1.10: epoch bump to build with go-1.25.5

### DIFF
--- a/opentofu-1.10.yaml
+++ b/opentofu-1.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentofu-1.10
   version: "1.10.7"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   copyright:
     - license: MPL-2.0
   dependencies:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
