### PR TITLE
osv-scanner: epoch bump to build with go-1.25.5

### DIFF
--- a/osv-scanner.yaml
+++ b/osv-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: osv-scanner
   version: "2.3.0"
-  epoch: 0 # GHSA-cgrx-mc8f-2prm
+  epoch: 1 # GHSA-cgrx-mc8f-2prm
   description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
