### PR TITLE
otel-cli: epoch bump to build with go-1.25.5

### DIFF
--- a/otel-cli.yaml
+++ b/otel-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: otel-cli
   version: "0.4.5"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: OpenTelemetry CLI Application
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
