### PR TITLE
overmind: epoch bump to build with go-1.25.5

### DIFF
--- a/overmind.yaml
+++ b/overmind.yaml
@@ -1,7 +1,7 @@
 package:
   name: overmind
   version: 2.5.1
-  epoch: 12 # CVE-2025-61725
+  epoch: 13 # CVE-2025-61725
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
