### PR TITLE
paranoia: epoch bump to build with go-1.25.5

### DIFF
--- a/paranoia.yaml
+++ b/paranoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: paranoia
   version: "0.5.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: Inspect certificate authorities in container images
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
