### PR TITLE
percona-server-mongodb-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/percona-server-mongodb-operator.yaml
+++ b/percona-server-mongodb-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-mongodb-operator
   version: "1.21.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes Operator which deploys and manages Percona Server for MongoDB on Kubernetes clusters.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
