### PR TITLE
petname: epoch bump to build with go-1.25.5

### DIFF
--- a/petname.yaml
+++ b/petname.yaml
@@ -1,7 +1,7 @@
 package:
   name: petname
   version: "2.11"
-  epoch: 17 # CVE-2025-61725
+  epoch: 18 # CVE-2025-61725
   description: Generate pronouncable, perhaps even memorable, pet names
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
