### PR TITLE
pg_timetable: epoch bump to build with go-1.25.5

### DIFF
--- a/pg_timetable.yaml
+++ b/pg_timetable.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg_timetable
   version: "6.2.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Advanced scheduling for PostgreSQL
   copyright:
     - license: PostgreSQL


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
