### PR TITLE
pg_user: epoch bump to build with go-1.25.5

### DIFF
--- a/pg_user.yaml
+++ b/pg_user.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg_user
   version: "1.1.1"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: A CLI application for managing PostgreSQL users
   copyright:
     - license: GPL-3.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
