### PR TITLE
pgpool2_exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/pgpool2_exporter.yaml
+++ b/pgpool2_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2_exporter
   version: "1.2.2"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: Prometheus exporter for Pgpool-II metrics.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
