### PR TITLE
php-fpm_exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-fpm_exporter
   version: 2.2.0
-  epoch: 17 # CVE-2025-61725
+  epoch: 18 # CVE-2025-61725
   description: A prometheus exporter for PHP-FPM.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
