### PR TITLE
pluto: epoch bump to build with go-1.25.5

### DIFF
--- a/pluto.yaml
+++ b/pluto.yaml
@@ -1,7 +1,7 @@
 package:
   name: pluto
   version: "5.22.6"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: A cli tool to help discover deprecated apiVersions in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
