### PR TITLE
podinfo: epoch bump to build with go-1.25.5

### DIFF
--- a/podinfo.yaml
+++ b/podinfo.yaml
@@ -1,7 +1,7 @@
 package:
   name: podinfo
   version: "6.9.3"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Podinfo is a tiny web application made with Go
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
