### PR TITLE
polaris: epoch bump to build with go-1.25.5

### DIFF
--- a/polaris.yaml
+++ b/polaris.yaml
@@ -1,7 +1,7 @@
 package:
   name: polaris
   version: "10.1.2"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Validation of best practices in your Kubernetes clusters
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
