### PR TITLE
policy-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/policy-controller.yaml
+++ b/policy-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: policy-controller
   version: "0.13.1"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
