### PR TITLE
pombump: epoch bump to build with go-1.25.5

### DIFF
--- a/pombump.yaml
+++ b/pombump.yaml
@@ -1,7 +1,7 @@
 package:
   name: pombump
   version: "0.0.16"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2 # CVE-2025-58187
   description: Go tool for bumping versions in pom.xml files
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
