### PR TITLE
portieris: epoch bump to build with go-1.25.5

### DIFF
--- a/portieris.yaml
+++ b/portieris.yaml
@@ -1,7 +1,7 @@
 package:
   name: portieris
   version: "0.13.33"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Kubernetes Admission Controller for verifying image trust.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
