### PR TITLE
postgres-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/postgres-operator.yaml
+++ b/postgres-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgres-operator
   version: "1.15.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Postgres operator creates and manages PostgreSQL clusters running in Kubernetes
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
