### PR TITLE
prometheus-3.7: epoch bump to build with go-1.25.5

### DIFF
--- a/prometheus-3.7.yaml
+++ b/prometheus-3.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-3.7
   version: "3.7.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
