### PR TITLE
prometheus-adapter: epoch bump to build with go-1.25.5

### DIFF
--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.12.0
-  epoch: 17 # GHSA-j5w8-q4qc-rx2x
+  epoch: 18 # GHSA-j5w8-q4qc-rx2x
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
