### PR TITLE
prometheus-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/prometheus-operator.yaml
+++ b/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-operator
   version: "0.87.0"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2 # CVE-2025-58187
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
