### PR TITLE
promxy: epoch bump to build with go-1.25.5

### DIFF
--- a/promxy.yaml
+++ b/promxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: promxy
   version: "0.0.93"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: An aggregating proxy to enable HA prometheus.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
