### PR TITLE
protoc-gen-go: epoch bump to build with go-1.25.5

### DIFF
--- a/protoc-gen-go.yaml
+++ b/protoc-gen-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: protoc-gen-go
   version: "1.36.10"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Go support for Google's protocol buffers
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
