### PR TITLE
protoc-gen-go-grpc: epoch bump to build with go-1.25.5

### DIFF
--- a/protoc-gen-go-grpc.yaml
+++ b/protoc-gen-go-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: protoc-gen-go-grpc
   version: "1.6.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Go support for Google's protocol buffers services
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
