### PR TITLE
pulumi: epoch bump to build with go-1.25.5

### DIFF
--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: "3.209.0"
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
