### PR TITLE
pulumi-kubernetes-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.16.0
-  epoch: 22 # GHSA-j5w8-q4qc-rx2x
+  epoch: 23 # GHSA-j5w8-q4qc-rx2x
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
