### PR TITLE
pulumi-language-dotnet: epoch bump to build with go-1.25.5

### DIFF
--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-dotnet
   version: "3.94.1"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Pulumi Language SDK for Dotnet
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
