### PR TITLE
pvc-autoresizer: epoch bump to build with go-1.25.5

### DIFF
--- a/pvc-autoresizer.yaml
+++ b/pvc-autoresizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: pvc-autoresizer
   version: "0.18.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Auto-resize PersistentVolumeClaim objects based on Prometheus metrics
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
