### PR TITLE
q: epoch bump to build with go-1.25.5

### DIFF
--- a/q.yaml
+++ b/q.yaml
@@ -1,7 +1,7 @@
 package:
   name: q
   version: "0.19.11"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A tiny command line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH.
   copyright:
     - license: GPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
