### PR TITLE
rabbitmq-default-user-credential-updater: epoch bump to build with go-1.25.5

### DIFF
--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-default-user-credential-updater
   version: "1.0.9"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Updates RabbitMQ default user password
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
