### PR TITLE
rabbitmq-messaging-topology-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/rabbitmq-messaging-topology-operator.yaml
+++ b/rabbitmq-messaging-topology-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-messaging-topology-operator
   version: "1.18.1"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: Open source RabbitMQ cluster operator. Kubernetes operator to deploy and manage RabbitMQ clusters.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
