### PR TITLE
rancher-2.12: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-2.12.yaml
+++ b/rancher-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.12
   version: "2.12.4"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: Complete container management platform
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
