### PR TITLE
rancher-agent-2.12: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-agent-2.12.yaml
+++ b/rancher-agent-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-agent-2.12
   version: "2.12.4"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Complete container management platform - agent
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
