### PR TITLE
rancher-fleet: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-fleet.yaml
+++ b/rancher-fleet.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-fleet
   version: "0.14.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Deploy workloads from Git to large fleets of Kubernetes clusters
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
