### PR TITLE
rancher-helm-3: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-helm-3.yaml
+++ b/rancher-helm-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-helm-3
   version: "3.19.0"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
