### PR TITLE
rancher-loglevel: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-loglevel.yaml
+++ b/rancher-loglevel.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-loglevel
   version: 0.1.6
-  epoch: 8 # CVE-2025-61725
+  epoch: 9 # CVE-2025-61725
   description: Complete container management platform - loglevel
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
