### PR TITLE
rancher-machine: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-machine.yaml
+++ b/rancher-machine.yaml
@@ -6,7 +6,7 @@ package:
   # docker/machine and upstream also archieved and deprecated. So it's OK to use the
   # master branch here.
   version: "0.15.0.137"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Machine management for a container-centric world
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
