### PR TITLE
rancher-security-scan-0.6: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-security-scan-0.6.yaml
+++ b/rancher-security-scan-0.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-security-scan-0.6
   description: Tests Kubernetes clusters for adherence to security best practices using kube-bench
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   version: "0.6.5"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
