### PR TITLE
rancher-system-agent: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-system-agent.yaml
+++ b/rancher-system-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-system-agent
   version: "0.3.14"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: rancher-system-agent is a daemon designed to run on a system and apply "plans" to the system.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
