### PR TITLE
rancher-system-upgrade-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-system-upgrade-controller.yaml
+++ b/rancher-system-upgrade-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-system-upgrade-controller
   version: "0.18.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: A Kubernetes controller that safely automates node upgrades in your cluster, coordinating OS and Kubernetes version updates with minimal disruption.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
