### PR TITLE
rancher-telemetry: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-telemetry.yaml
+++ b/rancher-telemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-telemetry
   version: 0.6.2
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Rancher telemetry daemon
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
