### PR TITLE
rancher-webhook-0.6: epoch bump to build with go-1.25.5

### DIFF
--- a/rancher-webhook-0.6.yaml
+++ b/rancher-webhook-0.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-webhook-0.6
   version: "0.6.11"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Rancher webhook for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
