### PR TITLE
ratify: epoch bump to build with go-1.25.5

### DIFF
--- a/ratify.yaml
+++ b/ratify.yaml
@@ -1,7 +1,7 @@
 package:
   name: ratify
   version: "1.4.0"
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: Artifact Ratification Framework (CNCF Sandbox)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
