### PR TITLE
redis-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/redis-operator.yaml
+++ b/redis-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-operator
   version: "0.22.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: "A Kubernetes operator to manage Redis clusters"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
