### PR TITLE
redka: epoch bump to build with go-1.25.5

### DIFF
--- a/redka.yaml
+++ b/redka.yaml
@@ -1,7 +1,7 @@
 package:
   name: redka
   version: "0.6.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Redis re-implemented with SQLite
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
