### PR TITLE
redpanda-25.2: epoch bump to build with go-1.25.5

### DIFF
--- a/redpanda-25.2.yaml
+++ b/redpanda-25.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redpanda-25.2
   version: "25.2.11"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "Redpanda is a streaming platform based on Apache Kafka API"
   resources:
     cpu: 63


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
