### PR TITLE
regclient: epoch bump to build with go-1.25.5

### DIFF
--- a/regclient.yaml
+++ b/regclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: regclient
   version: "0.11.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Docker and OCI Registry Client in Go and tooling using those libraries
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
