### PR TITLE
render-template: epoch bump to build with go-1.25.5

### DIFF
--- a/render-template.yaml
+++ b/render-template.yaml
@@ -1,7 +1,7 @@
 package:
   name: render-template
   version: "1.0.9"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: CLI tool for rendering templates with custom data
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
