### PR TITLE
restic: epoch bump to build with go-1.25.5

### DIFF
--- a/restic.yaml
+++ b/restic.yaml
@@ -1,7 +1,7 @@
 package:
   name: restic
   version: "0.18.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
