### PR TITLE
rke2-cloud-provider: epoch bump to build with go-1.25.5

### DIFF
--- a/rke2-cloud-provider.yaml
+++ b/rke2-cloud-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: rke2-cloud-provider
   version: "1.34.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: cloud controller manager for rke2
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
