### PR TITLE
rootlesskit: epoch bump to build with go-1.25.5

### DIFF
--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,7 +1,7 @@
 package:
   name: rootlesskit
   version: "2.3.5"
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
