### PR TITLE
rqlite: epoch bump to build with go-1.25.5

### DIFF
--- a/rqlite.yaml
+++ b/rqlite.yaml
@@ -1,7 +1,7 @@
 package:
   name: rqlite
   version: "9.3.2"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: The lightweight, distributed relational database built on SQLite
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
