### PR TITLE
runc: epoch bump to build with go-1.25.5

### DIFF
--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: "1.4.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
