### PR TITLE
s5cmd: epoch bump to build with go-1.25.5

### DIFF
--- a/s5cmd.yaml
+++ b/s5cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s5cmd
   version: 2.3.0
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: Parallel S3 and local filesystem execution tool.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
