### PR TITLE
sbom-convert: epoch bump to build with go-1.25.5

### DIFF
--- a/sbom-convert.yaml
+++ b/sbom-convert.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbom-convert
   version: "0.0.7"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: CLI tool based on the protobom library that converts Software Bills of Materials across formats (SPDX and CycloneDX).
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
