### PR TITLE
sbom-scorecard: epoch bump to build with go-1.25.5

### DIFF
--- a/sbom-scorecard.yaml
+++ b/sbom-scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbom-scorecard
   version: 0.0.7
-  epoch: 24 # CVE-2025-61725
+  epoch: 25 # CVE-2025-61725
   description: Generate a score for your sbom to understand if it will actually be useful.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
