### PR TITLE
sbomqs: epoch bump to build with go-1.25.5

### DIFF
--- a/sbomqs.yaml
+++ b/sbomqs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbomqs
   version: "2.0.2"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: SBOM quality score - Quality metrics for your sboms
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
