### PR TITLE
scorecard: epoch bump to build with go-1.25.5

### DIFF
--- a/scorecard.yaml
+++ b/scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: scorecard
   version: "5.4.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: OpenSSF Scorecard - Security health metrics for Open Source
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
