### PR TITLE
sealed-secrets: epoch bump to build with go-1.25.5

### DIFF
--- a/sealed-secrets.yaml
+++ b/sealed-secrets.yaml
@@ -1,7 +1,7 @@
 package:
   name: sealed-secrets
   version: "0.33.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Kubernetes controller and tool for one-way encrypted Secrets
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
