### PR TITLE
seaweedfs: epoch bump to build with go-1.25.5

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: seaweedfs
   version: "4.01"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
