### PR TITLE
secrets-store-csi-driver: epoch bump to build with go-1.25.5

### DIFF
--- a/secrets-store-csi-driver.yaml
+++ b/secrets-store-csi-driver.yaml
@@ -2,7 +2,7 @@ package:
   name: secrets-store-csi-driver
   # When bumping the version check if the CVE mitigations below can be removed.
   version: "1.5.4"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Secrets Store CSI driver for Kubernetes secrets
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
