### PR TITLE
secrets-store-csi-driver-provider-aws: epoch bump to build with go-1.25.5

### DIFF
--- a/secrets-store-csi-driver-provider-aws.yaml
+++ b/secrets-store-csi-driver-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-aws
   version: "2.1.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: AWS Secrets Manager and AWS Systems Manager Parameter Store provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
