### PR TITLE
secrets-store-csi-driver-provider-azure: epoch bump to build with go-1.25.5

### DIFF
--- a/secrets-store-csi-driver-provider-azure.yaml
+++ b/secrets-store-csi-driver-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-azure
   version: "1.7.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Azure Key Vault provider for Secret Store CSI driver
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
