### PR TITLE
secrets-store-csi-driver-provider-gcp: epoch bump to build with go-1.25.5

### DIFF
--- a/secrets-store-csi-driver-provider-gcp.yaml
+++ b/secrets-store-csi-driver-provider-gcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-gcp
   version: "1.9.0"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: Google Secret Manager provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
