### PR TITLE
sftpgo: epoch bump to build with go-1.25.5

### DIFF
--- a/sftpgo.yaml
+++ b/sftpgo.yaml
@@ -1,7 +1,7 @@
 package:
   name: sftpgo
   version: "2.7.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "Full-featured and highly configurable SFTP, HTTP/S, FTP/S and WebDAV server - S3, Google Cloud Storage, Azure Blob"
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
