### PR TITLE
sftpgo-plugin-eventstore: epoch bump to build with go-1.25.5

### DIFF
--- a/sftpgo-plugin-eventstore.yaml
+++ b/sftpgo-plugin-eventstore.yaml
@@ -1,7 +1,7 @@
 package:
   name: sftpgo-plugin-eventstore
   version: "1.0.22"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "Stores SFTPGo events in supported database engines"
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
