### PR TITLE
sftpgo-plugin-geoipfilter: epoch bump to build with go-1.25.5

### DIFF
--- a/sftpgo-plugin-geoipfilter.yaml
+++ b/sftpgo-plugin-geoipfilter.yaml
@@ -1,7 +1,7 @@
 package:
   name: sftpgo-plugin-geoipfilter
   version: "1.0.11"
-  epoch: 0 # CVE-2025-47906
+  epoch: 1 # CVE-2025-47906
   description: "Geo-IP filtering support for SFTPGo"
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
