### PR TITLE
sftpgo-plugin-pubsub: epoch bump to build with go-1.25.5

### DIFF
--- a/sftpgo-plugin-pubsub.yaml
+++ b/sftpgo-plugin-pubsub.yaml
@@ -1,7 +1,7 @@
 package:
   name: sftpgo-plugin-pubsub
   version: "1.0.15"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "Additional KMS secret providers for SFTPGo"
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
