### PR TITLE
shfmt: epoch bump to build with go-1.25.5

### DIFF
--- a/shfmt.yaml
+++ b/shfmt.yaml
@@ -1,7 +1,7 @@
 package:
   name: shfmt
   version: "3.12.0"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: A shell formatter
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
