### PR TITLE
sigstore-scaffolding: epoch bump to build with go-1.25.5

### DIFF
--- a/sigstore-scaffolding.yaml
+++ b/sigstore-scaffolding.yaml
@@ -1,7 +1,7 @@
 package:
   name: sigstore-scaffolding
   version: "0.7.31"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Software Supply Chain Transparency Log
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
