### PR TITLE
skopeo: epoch bump to build with go-1.25.5

### DIFF
--- a/skopeo.yaml
+++ b/skopeo.yaml
@@ -1,7 +1,7 @@
 package:
   name: skopeo
   version: "1.20.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Work with remote images registries - retrieving information, images, signing content
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
