### PR TITLE
smarter-device-manager: epoch bump to build with go-1.25.5

### DIFF
--- a/smarter-device-manager.yaml
+++ b/smarter-device-manager.yaml
@@ -5,7 +5,7 @@
 package:
   name: smarter-device-manager
   version: 1.20.11
-  epoch: 21 # CVE-2025-61723
+  epoch: 22 # CVE-2025-61723
   description: Device manager container that enables access to device drivers on containers for k8s
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
