### PR TITLE
smokescreen: epoch bump to build with go-1.25.5

### DIFF
--- a/smokescreen.yaml
+++ b/smokescreen.yaml
@@ -2,7 +2,7 @@
 package:
   name: smokescreen
   version: "0_git20251203"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: A simple HTTP proxy that fogs over naughty URLs
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
