### PR TITLE
sonobuoy: epoch bump to build with go-1.25.5

### DIFF
--- a/sonobuoy.yaml
+++ b/sonobuoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonobuoy
   version: "0.57.3"
-  epoch: 10
+  epoch: 11
   description: Sonobuoy is a diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of Kubernetes conformance tests and other plugins in an accessible and non-destructive manner.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
