### PR TITLE
sops: epoch bump to build with go-1.25.5

### DIFF
--- a/sops.yaml
+++ b/sops.yaml
@@ -1,7 +1,7 @@
 package:
   name: sops
   version: "3.11.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Simple and flexible tool for managing secrets
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
