### PR TITLE
spark-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-operator
   version: "2.4.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
