### PR TITLE
speedtest-go: epoch bump to build with go-1.25.5

### DIFF
--- a/speedtest-go.yaml
+++ b/speedtest-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: speedtest-go
   version: 1.7.10
-  epoch: 7 # CVE-2025-61725
+  epoch: 8 # CVE-2025-61725
   description: CLI and Go API to Test Internet Speed using speedtest.net
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
