### PR TITLE
spegel: epoch bump to build with go-1.25.5

### DIFF
--- a/spegel.yaml
+++ b/spegel.yaml
@@ -1,7 +1,7 @@
 package:
   name: spegel
   version: "0.5.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Stateless cluster local OCI registry mirror.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
