### PR TITLE
spicedb: epoch bump to build with go-1.25.5

### DIFF
--- a/spicedb.yaml
+++ b/spicedb.yaml
@@ -1,7 +1,7 @@
 package:
   name: spicedb
   version: "1.47.1"
-  epoch: 0
+  epoch: 1
   description: Open Source, Google Zanzibar-inspired fine-grained permissions database
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
