### PR TITLE
spiffe-helper: epoch bump to build with go-1.25.5

### DIFF
--- a/spiffe-helper.yaml
+++ b/spiffe-helper.yaml
@@ -1,7 +1,7 @@
 package:
   name: spiffe-helper
   version: "0.11.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: A helper utility for SPIFFE (Secure Production Identity Framework For Everyone) operations.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
