### PR TITLE
spire-controller-manager: epoch bump to build with go-1.25.5

### DIFF
--- a/spire-controller-manager.yaml
+++ b/spire-controller-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-controller-manager
   version: "0.6.3"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: A Kubernetes Controller manager which facilitates the registration of workloads and establishment of federation relationships.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
