### PR TITLE
spire-server: epoch bump to build with go-1.25.5

### DIFF
--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: "1.13.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
