### PR TITLE
splunk-otel-collector: epoch bump to build with go-1.25.5

### DIFF
--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: splunk-otel-collector
   version: "0.140.0"
-  epoch: 0 # GHSA-9mj6-hxhv-w67j
+  epoch: 1 # GHSA-9mj6-hxhv-w67j
   description: Splunk OpenTelemetry Collector is a distribution of the OpenTelemetry Collector. It provides a unified way to receive, process, and export metric, trace, and log data for Splunk Observability Cloud
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
