### PR TITLE
spqr: epoch bump to build with go-1.25.5

### DIFF
--- a/spqr.yaml
+++ b/spqr.yaml
@@ -1,7 +1,7 @@
 package:
   name: spqr
   version: "2.8.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Stateless Postgres Query Router
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
