### PR TITLE
sql_exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/sql_exporter.yaml
+++ b/sql_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: sql_exporter
   version: "0.18.4"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Database-agnostic SQL Exporter for Prometheus
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
