### PR TITLE
src-fingerprint: epoch bump to build with go-1.25.5

### DIFF
--- a/src-fingerprint.yaml
+++ b/src-fingerprint.yaml
@@ -1,7 +1,7 @@
 package:
   name: src-fingerprint
   version: 0.19.0
-  epoch: 34 # GHSA-j5w8-q4qc-rx2x
+  epoch: 35 # GHSA-j5w8-q4qc-rx2x
   description: Extract git related information (file shas, commit shas) from your hosted source version control system
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
