### PR TITLE
sriov-network-device-plugin: epoch bump to build with go-1.25.5

### DIFF
--- a/sriov-network-device-plugin.yaml
+++ b/sriov-network-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: sriov-network-device-plugin
   version: "3.10.0"
-  epoch: 2 # GHSA-qw9x-cqr3-wc7r
+  epoch: 3 # GHSA-qw9x-cqr3-wc7r
   description: SRIOV network device plugin for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
