### PR TITLE
steampipe: epoch bump to build with go-1.25.5

### DIFF
--- a/steampipe.yaml
+++ b/steampipe.yaml
@@ -1,7 +1,7 @@
 package:
   name: steampipe
   version: "2.3.2"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Steampipe is the zero-ETL way to query APIs and services, used to expose data sources to SQL.
   dependencies:
     runtime:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
