### PR TITLE
stern: epoch bump to build with go-1.25.5

### DIFF
--- a/stern.yaml
+++ b/stern.yaml
@@ -1,7 +1,7 @@
 package:
   name: stern
   version: "1.33.1"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Multi pod and container log tailing for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
