### PR TITLE
supercronic: epoch bump to build with go-1.25.5

### DIFF
--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -1,7 +1,7 @@
 package:
   name: supercronic
   version: "0.2.39"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: Cron for containers
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
