### PR TITLE
swagger: epoch bump to build with go-1.25.5

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,7 +1,7 @@
 package:
   name: swagger
   version: "0.33.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Swagger 2.0 implementation for go
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
