### PR TITLE
syft: epoch bump to build with go-1.25.5

### DIFF
--- a/syft.yaml
+++ b/syft.yaml
@@ -1,7 +1,7 @@
 package:
   name: syft
   version: "1.38.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
