### PR TITLE
tailscale: epoch bump to build with go-1.25.5

### DIFF
--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -1,7 +1,7 @@
 package:
   name: tailscale
   version: "1.92.0"
-  epoch: 0
+  epoch: 1
   description: The easiest, most secure way to use WireGuard and 2FA.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
