### PR TITLE
tekton-chains: epoch bump to build with go-1.25.5

### DIFF
--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-chains
   version: "0.26.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Supply Chain Security in Tekton Pipelines
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
