### PR TITLE
tekton-pipelines-1.5: epoch bump to build with go-1.25.5

### DIFF
--- a/tekton-pipelines-1.5.yaml
+++ b/tekton-pipelines-1.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines-1.5
   version: "1.5.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
