### PR TITLE
telegraf-1.36: epoch bump to build with go-1.25.5

### DIFF
--- a/telegraf-1.36.yaml
+++ b/telegraf-1.36.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf-1.36
   version: "1.36.4"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Telegraf is an agent for collecting, processing, aggregating, and writing metric
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
