### PR TITLE
teleport-18: epoch bump to build with go-1.25.5

### DIFF
--- a/teleport-18.yaml
+++ b/teleport-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: teleport-18
   version: "18.4.2"
-  epoch: 0 # GHSA-47m2-4cr7-mhcw
+  epoch: 1 # GHSA-47m2-4cr7-mhcw
   description: The easiest, and most secure way to access and protect all of your infrastructure.
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
