### PR TITLE
tempo: epoch bump to build with go-1.25.5

### DIFF
--- a/tempo.yaml
+++ b/tempo.yaml
@@ -1,7 +1,7 @@
 package:
   name: tempo
   version: "2.9.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Grafana Tempo is a high volume, minimal dependency distributed tracing backend.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
