### PR TITLE
temporal: epoch bump to build with go-1.25.5

### DIFF
--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal
   version: "1.5.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
