### PR TITLE
temporal-server: epoch bump to build with go-1.25.5

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: "1.29.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
