### PR TITLE
temporal-ui-server: epoch bump to build with go-1.25.5

### DIFF
--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-ui-server
   version: "2.43.3"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Golang Server for https://github.com/temporalio/ui
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
