### PR TITLE
terraform: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform
   version: 1.5.7
-  epoch: 35 # GHSA-j5w8-q4qc-rx2x
+  epoch: 36 # GHSA-j5w8-q4qc-rx2x
   copyright:
     - license: MPL-2.0
 


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
