### PR TITLE
terraform-docs: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-docs.yaml
+++ b/terraform-docs.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-docs
   version: "0.20.0"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Generate documentation from Terraform modules in various output formats
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
