### PR TITLE
terraform-mcp-server: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-mcp-server.yaml
+++ b/terraform-mcp-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-mcp-server
   version: "0.3.3"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Terraform MCP Server
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
