### PR TITLE
terraform-provider-acme: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-acme.yaml
+++ b/terraform-provider-acme.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-acme
   version: "2.38.1"
-  epoch: 0 # GHSA-q82r-2j7m-9rv4
+  epoch: 1 # GHSA-q82r-2j7m-9rv4
   description: Terraform ACME provider
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
