### PR TITLE
terraform-provider-aws: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-aws
   version: "6.24.0"
-  epoch: 0
+  epoch: 1
   description: Terraform AWS provider
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
