### PR TITLE
terraform-provider-azapi: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-azapi.yaml
+++ b/terraform-provider-azapi.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-azapi
   version: "2.7.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Terraform Azure API provider
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
