### PR TITLE
terraform-provider-azurerm: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-azurerm.yaml
+++ b/terraform-provider-azurerm.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-azurerm
   version: "4.54.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Terraform provider for Azure Resource Manager
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
