### PR TITLE
terraform-provider-kubernetes: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-kubernetes.yaml
+++ b/terraform-provider-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-kubernetes
   version: "2.38.0"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Terraform provider for Kubernetes
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
