### PR TITLE
terraform-provider-pagerduty: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-pagerduty.yaml
+++ b/terraform-provider-pagerduty.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-pagerduty
   version: "3.30.7"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Terraform provider for Pagerduty
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
