### PR TITLE
terraform-provider-random: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-random.yaml
+++ b/terraform-provider-random.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-random
   version: "3.7.2"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Utility provider that supports the use of randomness within Terraform configurations.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
