### PR TITLE
terraform-provider-sendgrid: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-sendgrid.yaml
+++ b/terraform-provider-sendgrid.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-sendgrid
   version: "1.0.1"
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: Terraform provider for Sendgrid
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
