### PR TITLE
terraform-provider-time: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-time.yaml
+++ b/terraform-provider-time.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-time
   version: "0.13.1"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Utility provider that provides Time-Based Resources
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
