### PR TITLE
terraform-provider-tls: epoch bump to build with go-1.25.5

### DIFF
--- a/terraform-provider-tls.yaml
+++ b/terraform-provider-tls.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-tls
   version: "4.1.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: Utility provider that works with Transport Layer Security keys and certificates.
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
