### PR TITLE
terragrunt: epoch bump to build with go-1.25.5

### DIFF
--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,7 +1,7 @@
 package:
   name: terragrunt
   version: "0.93.12"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
