### PR TITLE
tetragon: epoch bump to build with go-1.25.5

### DIFF
--- a/tetragon.yaml
+++ b/tetragon.yaml
@@ -1,7 +1,7 @@
 package:
   name: tetragon
   version: "1.6.0"
-  epoch: 0
+  epoch: 1
   description: "eBPF-based Security Observability and Runtime Enforcement"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
