### PR TITLE
tflint: epoch bump to build with go-1.25.5

### DIFF
--- a/tflint.yaml
+++ b/tflint.yaml
@@ -1,7 +1,7 @@
 package:
   name: tflint
   version: "0.60.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: A Pluggable Terraform Linter
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
