### PR TITLE
tfsec: epoch bump to build with go-1.25.5

### DIFF
--- a/tfsec.yaml
+++ b/tfsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: tfsec
   version: "1.28.14"
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: Security scanner for your Terraform code
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
