### PR TITLE
thanos-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 35 # CVE-2025-61725
+  epoch: 36 # CVE-2025-61725
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
