### PR TITLE
timescaledb-tune: epoch bump to build with go-1.25.5

### DIFF
--- a/timescaledb-tune.yaml
+++ b/timescaledb-tune.yaml
@@ -1,7 +1,7 @@
 package:
   name: timescaledb-tune
   version: "0.18.1"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: A tool for tuning TimescaleDB for better performance by adjusting settings to match your system's CPU and memory resources.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
