### PR TITLE
timestamp-authority: epoch bump to build with go-1.25.5

### DIFF
--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -1,7 +1,7 @@
 package:
   name: timestamp-authority
   version: "2.0.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: RFC3161 Timestamp Authority
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
