### PR TITLE
timoni: epoch bump to build with go-1.25.5

### DIFF
--- a/timoni.yaml
+++ b/timoni.yaml
@@ -1,7 +1,7 @@
 package:
   name: timoni
   version: "0.25.2"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Timoni is a package manager for Kubernetes, powered by CUE and inspired by Helm.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
