### PR TITLE
tkn: epoch bump to build with go-1.25.5

### DIFF
--- a/tkn.yaml
+++ b/tkn.yaml
@@ -1,7 +1,7 @@
 package:
   name: tkn
   version: "0.43.0"
-  epoch: 0 # GHSA-72c7-4g63-hpw5
+  epoch: 1 # GHSA-72c7-4g63-hpw5
   description: A CLI for interacting with Tekton!
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
