### PR TITLE
tofu-controller: epoch bump to build with go-1.25.5

### DIFF
--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: tofu-controller
   version: "0.16.0_rc5"
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
