### PR TITLE
traefik-3.6: epoch bump to build with go-1.25.5

### DIFF
--- a/traefik-3.6.yaml
+++ b/traefik-3.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik-3.6
   version: "3.6.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
