### PR TITLE
trillian: epoch bump to build with go-1.25.5

### DIFF
--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: "1.7.2"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
