### PR TITLE
trino: epoch bump to build with go-1.25.5

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "478"
-  epoch: 2 # GHSA-m494-w24q-6f7w
+  epoch: 3 # GHSA-m494-w24q-6f7w
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
