### PR TITLE
trivy-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/trivy-operator.yaml
+++ b/trivy-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy-operator
   version: "0.29.0"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: "Kubernetes-native security toolkit that finds and reports vulnerabilities and misconfigurations"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
