### PR TITLE
trufflehog: epoch bump to build with go-1.25.5

### DIFF
--- a/trufflehog.yaml
+++ b/trufflehog.yaml
@@ -1,7 +1,7 @@
 package:
   name: trufflehog
   version: "3.91.2"
-  epoch: 0 # GHSA-rwvp-r38j-9rgg
+  epoch: 1 # GHSA-rwvp-r38j-9rgg
   description: Find, verify, and analyze leaked credentials
   dependencies:
     runtime:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
