### PR TITLE
trust-manager: epoch bump to build with go-1.25.5

### DIFF
--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: "0.20.2"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
