### PR TITLE
undock: epoch bump to build with go-1.25.5

### DIFF
--- a/undock.yaml
+++ b/undock.yaml
@@ -1,7 +1,7 @@
 package:
   name: undock
   version: "0.10.0"
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: Extract contents of a container image in a local folder
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
