### PR TITLE
vale: epoch bump to build with go-1.25.5

### DIFF
--- a/vale.yaml
+++ b/vale.yaml
@@ -1,7 +1,7 @@
 package:
   name: vale
   version: "3.13.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: "A syntax-aware linter for prose built with speed and extensibility in mind"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
