### PR TITLE
vault-env: epoch bump to build with go-1.25.5

### DIFF
--- a/vault-env.yaml
+++ b/vault-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-env
   version: "1.22.0"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: Minimalistic init system for containers with Hashicorp Vault secrets support
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
