### PR TITLE
vault-k8s: epoch bump to build with go-1.25.5

### DIFF
--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-k8s
   version: "1.7.1" # When updating, make sure to check that the license is still MPL!
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
