### PR TITLE
vault-secrets-webhook: epoch bump to build with go-1.25.5

### DIFF
--- a/vault-secrets-webhook.yaml
+++ b/vault-secrets-webhook.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-secrets-webhook
   version: "1.22.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: A Kubernetes mutating webhook that makes direct secret injection into Pods possible.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
