### PR TITLE
vcluster: epoch bump to build with go-1.25.5

### DIFF
--- a/vcluster.yaml
+++ b/vcluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: vcluster
   version: "0.30.2"
-  epoch: 0 # GHSA-4x4m-3c2p-qppc
+  epoch: 1 # GHSA-4x4m-3c2p-qppc
   description: Create fully functional virtual Kubernetes clusters
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
