### PR TITLE
velero-plugin-for-aws: epoch bump to build with go-1.25.5

### DIFF
--- a/velero-plugin-for-aws.yaml
+++ b/velero-plugin-for-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero-plugin-for-aws
   version: "1.13.1"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Plugins to support Velero on AWS
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
