### PR TITLE
velero-plugin-for-csi: epoch bump to build with go-1.25.5

### DIFF
--- a/velero-plugin-for-csi.yaml
+++ b/velero-plugin-for-csi.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero-plugin-for-csi
   version: 0.7.1
-  epoch: 38 # CVE-2025-61725
+  epoch: 39 # CVE-2025-61725
   description: Velero plugins for integrating with CSI snapshot API
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
