### PR TITLE
velero-plugin-for-microsoft-azure: epoch bump to build with go-1.25.5

### DIFF
--- a/velero-plugin-for-microsoft-azure.yaml
+++ b/velero-plugin-for-microsoft-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero-plugin-for-microsoft-azure
   version: "1.13.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Plugins to support Velero on microsoft-azure
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
