### PR TITLE
vendir: epoch bump to build with go-1.25.5

### DIFF
--- a/vendir.yaml
+++ b/vendir.yaml
@@ -1,7 +1,7 @@
 package:
   name: vendir
   version: "0.45.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
