### PR TITLE
vertical-pod-autoscaler: epoch bump to build with go-1.25.5

### DIFF
--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: "1.5.1"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
