### PR TITLE
victoriametrics: epoch bump to build with go-1.25.5

### DIFF
--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics
   version: "1.131.0"
-  epoch: 0
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
