### PR TITLE
victoriametrics-operator: epoch bump to build with go-1.25.5

### DIFF
--- a/victoriametrics-operator.yaml
+++ b/victoriametrics-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-operator
   version: "0.65.0"
-  epoch: 1 # GHSA-66jq-2c23-2xh5
+  epoch: 2 # GHSA-66jq-2c23-2xh5
   description: Kubernetes operator for Victoria Metrics
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
