### PR TITLE
vitess-23: epoch bump to build with go-1.25.5

### DIFF
--- a/vitess-23.yaml
+++ b/vitess-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-23
   version: "23.0.0"
-  epoch: 2
+  epoch: 3
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
