### PR TITLE
volume-modifier-for-k8s: epoch bump to build with go-1.25.5

### DIFF
--- a/volume-modifier-for-k8s.yaml
+++ b/volume-modifier-for-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: volume-modifier-for-k8s
   version: "0.9.0"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1 # CVE-2025-47907
   description: volume-modifier-for-k8s is a sidecar deployed alongside CSI drivers to enable volume modification through annotations on the PVC.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
