### PR TITLE
wait-for-port: epoch bump to build with go-1.25.5

### DIFF
--- a/wait-for-port.yaml
+++ b/wait-for-port.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-port
   version: "1.0.10"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: CLI tool for waiting until a TCP port reaches the desired state
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
