### PR TITLE
wal-g: epoch bump to build with go-1.25.5

### DIFF
--- a/wal-g.yaml
+++ b/wal-g.yaml
@@ -1,7 +1,7 @@
 package:
   name: wal-g
   version: "3.0.7"
-  epoch: 16 # GHSA-j5w8-q4qc-rx2x
+  epoch: 17 # GHSA-j5w8-q4qc-rx2x
   description: "Archival and Restoration for databases in the Cloud"
   copyright:
     - license: "Apache-2.0"


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
