### PR TITLE
wave: epoch bump to build with go-1.25.5

### DIFF
--- a/wave.yaml
+++ b/wave.yaml
@@ -1,7 +1,7 @@
 package:
   name: wave
   version: 0.10.0
-  epoch: 12 # CVE-2025-61725
+  epoch: 13 # CVE-2025-61725
   description: Kubernetes configuration tracking controller
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
