### PR TITLE
wazero: epoch bump to build with go-1.25.5

### DIFF
--- a/wazero.yaml
+++ b/wazero.yaml
@@ -1,7 +1,7 @@
 package:
   name: wazero
   version: "1.10.1"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: The zero dependency WebAssembly runtime for Go developers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
