### PR TITLE
weaviate: epoch bump to build with go-1.25.5

### DIFF
--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: "1.34.3"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
