### PR TITLE
wgcf: epoch bump to build with go-1.25.5

### DIFF
--- a/wgcf.yaml
+++ b/wgcf.yaml
@@ -1,7 +1,7 @@
 package:
   name: wgcf
   version: "2.2.29"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: Cross-platform, unofficial CLI for Cloudflare Warp
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
