### PR TITLE
whereabouts: epoch bump to build with go-1.25.5

### DIFF
--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: whereabouts
   version: "0.9.2"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: A CNI IPAM plugin that assigns IP addresses cluster-wide
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
