### PR TITLE
wireguard-go: epoch bump to build with go-1.25.5

### DIFF
--- a/wireguard-go.yaml
+++ b/wireguard-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: wireguard-go
   version: "0.0.20250522"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: "Go Implementation of WireGuard"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
