### PR TITLE
witness: epoch bump to build with go-1.25.5

### DIFF
--- a/witness.yaml
+++ b/witness.yaml
@@ -1,7 +1,7 @@
 package:
   name: witness
   version: "0.10.1"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Witness is a pluggable framework for software supply chain risk management. It automates, normalizes, and verifies software artifact provenance.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
