### PR TITLE
wolfictl: epoch bump to build with go-1.25.5

### DIFF
--- a/wolfictl.yaml
+++ b/wolfictl.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfictl
   version: "0.38.24"
-  epoch: 0 # GHSA-6gxw-85q2-q646
+  epoch: 1 # GHSA-6gxw-85q2-q646
   description: Helper CLI for managing Wolfi
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
