### PR TITLE
wuzz: epoch bump to build with go-1.25.5

### DIFF
--- a/wuzz.yaml
+++ b/wuzz.yaml
@@ -1,7 +1,7 @@
 package:
   name: wuzz
   version: 0.5.0
-  epoch: 13 # CVE-2025-58187
+  epoch: 14 # CVE-2025-58187
   description: Interactive cli tool for HTTP inspection
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
