### PR TITLE
x509-certificate-exporter: epoch bump to build with go-1.25.5

### DIFF
--- a/x509-certificate-exporter.yaml
+++ b/x509-certificate-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: x509-certificate-exporter
   version: "3.19.1"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: A Prometheus exporter to monitor x509 certificates expiration in Kubernetes clusters or standalone.
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
