### PR TITLE
xcaddy: epoch bump to build with go-1.25.5

### DIFF
--- a/xcaddy.yaml
+++ b/xcaddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcaddy
   version: "0.4.5"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Build Caddy with plugins
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
