### PR TITLE
xcover: epoch bump to build with go-1.25.5

### DIFF
--- a/xcover.yaml
+++ b/xcover.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcover
   version: "0.2.0"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: "Profile coverage of functional tests without instrumenting your binaries."
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
