### PR TITLE
xeol: epoch bump to build with go-1.25.5

### DIFF
--- a/xeol.yaml
+++ b/xeol.yaml
@@ -1,7 +1,7 @@
 package:
   name: xeol
   version: "0.10.8"
-  epoch: 19 # GHSA-j5w8-q4qc-rx2x
+  epoch: 20 # GHSA-j5w8-q4qc-rx2x
   description: A scanner for end-of-life (EOL) software
   dependencies:
     runtime:


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
