### PR TITLE
yace: epoch bump to build with go-1.25.5

### DIFF
--- a/yace.yaml
+++ b/yace.yaml
@@ -1,7 +1,7 @@
 package:
   name: yace
   version: "0.63.0"
-  epoch: 2 # CVE-2025-58187
+  epoch: 3 # CVE-2025-58187
   description: Prometheus exporter for AWS CloudWatch.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
