### PR TITLE
yam: epoch bump to build with go-1.25.5

### DIFF
--- a/yam.yaml
+++ b/yam.yaml
@@ -1,7 +1,7 @@
 package:
   name: yam
   version: "0.2.42"
-  epoch: 0
+  epoch: 1
   description: A sweet little formatter for YAML
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
