### PR TITLE
yq: epoch bump to build with go-1.25.5

### DIFF
--- a/yq.yaml
+++ b/yq.yaml
@@ -1,7 +1,7 @@
 package:
   name: yq
   version: "4.49.2"
-  epoch: 0
+  epoch: 1
   description: "yq is a portable command-line YAML, JSON, XML, CSV and properties processor"
   copyright:
     - license: MIT


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
