### PR TITLE
ytt: epoch bump to build with go-1.25.5

### DIFF
--- a/ytt.yaml
+++ b/ytt.yaml
@@ -1,7 +1,7 @@
 package:
   name: ytt
   version: "0.52.1"
-  epoch: 3 # CVE-2025-58187
+  epoch: 4 # CVE-2025-58187
   description: YAML templating tool that works on YAML structure instead of text
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
