### PR TITLE
yunikorn-k8shim: epoch bump to build with go-1.25.5

### DIFF
--- a/yunikorn-k8shim.yaml
+++ b/yunikorn-k8shim.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-k8shim
   version: "1.7.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: Apache YuniKorn K8shim
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
