### PR TITLE
yunikorn-web: epoch bump to build with go-1.25.5

### DIFF
--- a/yunikorn-web.yaml
+++ b/yunikorn-web.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-web
   version: "1.7.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Apache YuniKorn Web UI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
