### PR TITLE
zot: epoch bump to build with go-1.25.5

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: "2.1.11"
-  epoch: 0
+  epoch: 1
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Build with go 1.25.5 to remediate CVE-2025-61727 and CVE-2025-61729

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
