### PR TITLE
CODEOWNERS: Use ruby-*.yaml instead of specifying a version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,4 +35,4 @@ python*.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarde
 python*/                      @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 php-8.5.yaml                  @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
 dotnet-*.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
-ruby-4.0.yaml                 @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write
+ruby-*.yaml                   @wolfi-dev/guarded-os-team-write @wolfi-dev/guarded-vms-team-write


### PR DESCRIPTION
The ruby module packages we have are named `rubyM.N-*.yaml`, which means that we can actually use globbing to match all Ruby versions on CODEOWNERS.