### PR TITLE
dbus: Add tmpfiles.d snippet

### DIFF
--- a/dbus.yaml
+++ b/dbus.yaml
@@ -1,7 +1,7 @@
 package:
   name: dbus
   version: "1.16.2"
-  epoch: 4
+  epoch: 5
   description: Freedesktop.org message bus system
   copyright:
     - license: AFL-2.1 OR GPL-2.0-or-later
@@ -44,6 +44,16 @@ pipeline:
   - uses: meson/compile
 
   - uses: meson/install
+
+  # Ensure that /run/dbus exists, even in a VM.
+  # This may be unnecessary: Debian is likewise configured to listen on
+  # /run/dbus/system_bus_socket and to write a pid file to /run/dbus/pid,
+  # and /run/dbus seems to be automatically created as root:root 0755.  But
+  # in the absence of being able to point to the exact code that creates it
+  # and to prove that it will always do so, this is a harmless
+  # belt-and-braces measure.
+  - runs: |
+      echo 'd /run/dbus 0755 root root -' >"${{targets.destdir}}"/usr/lib/tmpfiles.d/dbus-run.conf
 
   - uses: strip
 


### PR DESCRIPTION
This makes extra-sure that the appropriate subdirectory of `/run` exists when running in a VM, where `/run` is a tmpfs.

Related: chainguard-dev/melange#2239, https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw