### PR TITLE
Convert GCC packages to `git` fetch & update GCC 13 to 13.4.0

### DIFF
--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -44,10 +44,11 @@ var-transforms:
     to: major-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: 88f17d5a5e69eeb53aaf0a9bc9daab1c4e501d145b388c5485ebeb2cc36178fbb2d3e49ebef4a8c007a05e88471a06b97cf9b08870478249f77fbfa3d4abd9a8
+      expected-commit: 5cc4c42a0d4de08715c2eef8715ad5b2e92a23b6
+      repository: https://gitlab.com/gnutools/gcc.git
+      tag: releases/gcc-${{package.version}}
 
   - name: Fix false invalid march extension crc on arm64
     uses: patch
@@ -309,5 +310,6 @@ test:
 update:
   enabled: false
   manual: true
-  release-monitor:
-    identifier: 6502
+  git:
+    tag-filter-prefix: releases/gcc-11.
+    strip-prefix: releases/gcc-

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -12,7 +12,7 @@ package:
     runtime:
       - binutils
       - glibc-dev # Temporary workaround to force build-ordering against new glibc's
-      - libstdc++-11-dev
+      - libstdc++-${{vars.major-version}}-dev
       - openssf-compiler-options
       - posix-cc-wrappers
 
@@ -83,7 +83,7 @@ pipeline:
           CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
-            --program-suffix="-11" \
+            --program-suffix="-${{vars.major-version}}" \
             --disable-nls \
             --disable-werror \
             --with-pkgversion='Wolfi ${{package.full-version}}' \
@@ -152,14 +152,14 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: 'gcc-11-doc'
+  - name: 'gcc-${{vars.major-version}}-doc'
     pipeline:
       - uses: split/manpages
     test:
       pipeline:
         - uses: test/docs
 
-  - name: 'libstdc++-11'
+  - name: 'libstdc++-${{vars.major-version}}'
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -172,11 +172,14 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: 'libstdc++-11-dev'
+  - name: 'libstdc++-${{vars.major-version}}-dev'
     dependencies:
       runtime:
-        # cargo-culted from gcc-12.yaml
-        - libstdc++-11
+        # libstdc++-${{vars.major-version}}-dev might no longer compatible at link time
+        # with libstdc++ (${{vars.major-version}} + 1) or later, despite being runtime
+        # compatible. Ensure any users of libstdc++-${{vars.major-version}}-dev have access
+        # to link against libstsdc++-${{vars.major-version}}
+        - libstdc++-${{vars.major-version}}
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -193,23 +196,23 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: 'gcc-11-default'
+  - name: 'gcc-${{vars.major-version}}-default'
     description: 'Use GCC 11 as system gcc'
     dependencies:
       provides:
         - gcc=${{package.version}}
       runtime:
-        - gcc-11
+        - gcc-${{vars.major-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
 
           for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
-            ln -sf "${{host.triplet.gnu}}-"$i"-11" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+            ln -sf "${{host.triplet.gnu}}-"$i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
           done
 
           for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
-            ln -sf $i"-11" "${{targets.subpkgdir}}"/usr/bin/$i
+            ln -sf $i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/$i
           done
     test:
       pipeline:
@@ -246,36 +249,36 @@ test:
     - name: Check basic usage of top level & libexec binaries
       runs: |
         # Check C frontend compiler
-        gcc-11 --version | grep ${{package.version}}
+        gcc-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C++ frontend compiler
-        g++-11 --version | grep ${{package.version}}
+        g++-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C empty translation unit compilation
         : > empty.c
-        gcc-11 -c empty.c
+        gcc-${{vars.major-version}} -c empty.c
 
         # Check C++ empty translation unit compilation
         : > empty.cpp
-        g++-11 -c empty.cpp
-        c++-11 --version
-        c++-11 --help
-        cpp-11 --version
-        cpp-11 --help
-        g++-11 --help
-        gcc-11 --help
-        gcc-ar-11 --version
-        gcc-ar-11 --help
-        gcc-nm-11 --version
-        gcc-nm-11 --help
-        gcc-ranlib-11 --version
-        gcc-ranlib-11 --help
-        gcov-11 --version
-        gcov-11 --help
-        gcov-dump-11 --version
-        gcov-dump-11 --help
-        gcov-tool-11 --version
-        gcov-tool-11 --help
-        lto-dump-11 --version
-        lto-dump-11 --help
+        g++-${{vars.major-version}} -c empty.cpp
+        c++-${{vars.major-version}} --version
+        c++-${{vars.major-version}} --help
+        cpp-${{vars.major-version}} --version
+        cpp-${{vars.major-version}} --help
+        g++-${{vars.major-version}} --help
+        gcc-${{vars.major-version}} --help
+        gcc-ar-${{vars.major-version}} --version
+        gcc-ar-${{vars.major-version}} --help
+        gcc-nm-${{vars.major-version}} --version
+        gcc-nm-${{vars.major-version}} --help
+        gcc-ranlib-${{vars.major-version}} --version
+        gcc-ranlib-${{vars.major-version}} --help
+        gcov-${{vars.major-version}} --version
+        gcov-${{vars.major-version}} --help
+        gcov-dump-${{vars.major-version}} --version
+        gcov-dump-${{vars.major-version}} --help
+        gcov-tool-${{vars.major-version}} --version
+        gcov-tool-${{vars.major-version}} --help
+        lto-dump-${{vars.major-version}} --version
+        lto-dump-${{vars.major-version}} --help
     - uses: test/tw/ldd-check
     - name: hello world c
       runs: |
@@ -287,7 +290,7 @@ test:
         }
         EOF
 
-        gcc-11 -o hello-c hello.c
+        gcc-${{vars.major-version}} -o hello-c hello.c
         out=$(./hello-c)
         [ "$out" = "hello-c" ]
     - name: hello world c++
@@ -300,12 +303,12 @@ test:
         }
         EOF
 
-        g++-11 -o hello-c++ hello.cpp
+        g++-${{vars.major-version}} -o hello-c++ hello.cpp
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler/hardening-check
       with:
-        cc: gcc-11
+        cc: gcc-${{vars.major-version}}
 
 update:
   enabled: true

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -308,8 +308,7 @@ test:
         cc: gcc-11
 
 update:
-  enabled: false
-  manual: true
+  enabled: true
   git:
     tag-filter-prefix: releases/gcc-11.
     strip-prefix: releases/gcc-

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
-  version: 12.4.0
-  epoch: 14
+  version: 12.5.0
+  epoch: 0
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -46,7 +46,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 2bada4bc59bed4be34fab463bdb3c3ebfd2b41bb
+      expected-commit: c17d40bb3778bca5e81595f033df9222b66658eb
       repository: https://gitlab.com/gnutools/gcc.git
       tag: releases/gcc-${{package.version}}
 

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -305,8 +305,7 @@ test:
     - uses: test/tw/ldd-check
 
 update:
-  enabled: false
-  manual: true
+  enabled: true
   git:
     tag-filter-prefix: releases/gcc-12.
     strip-prefix: releases/gcc-

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -12,7 +12,7 @@ package:
     runtime:
       - binutils
       - glibc-dev # Temporary workaround to force build-ordering against new glibc's
-      - libstdc++-12-dev
+      - libstdc++-${{vars.major-version}}-dev
       - openssf-compiler-options
       - posix-cc-wrappers
 
@@ -83,7 +83,7 @@ pipeline:
           CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
-            --program-suffix="-12" \
+            --program-suffix="-${{vars.major-version}}" \
             --disable-nls \
             --disable-werror \
             --with-pkgversion='Wolfi ${{package.full-version}}' \
@@ -152,14 +152,14 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: 'gcc-12-doc'
+  - name: 'gcc-${{vars.major-version}}-doc'
     pipeline:
       - uses: split/manpages
     test:
       pipeline:
         - uses: test/docs
 
-  - name: 'libstdc++-12'
+  - name: 'libstdc++-${{vars.major-version}}'
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -169,14 +169,14 @@ subpackages:
     options:
       no-provides: true
 
-  - name: 'libstdc++-12-dev'
+  - name: 'libstdc++-${{vars.major-version}}-dev'
     dependencies:
       runtime:
-        # libstdc++-12-dev is no longer compatible at link time with
-        # libstdc++ 13, despite being runtime compatible Ensure any
-        # users of libstdc++-12-dev have access to link against
-        # libstsdc++-12
-        - libstdc++-12
+        # libstdc++-${{vars.major-version}}-dev might no longer compatible at link time
+        # with libstdc++ (${{vars.major-version}} + 1) or later, despite being runtime
+        # compatible. Ensure any users of libstdc++-${{vars.major-version}}-dev have access
+        # to link against libstsdc++-${{vars.major-version}}
+        - libstdc++-${{vars.major-version}}
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -190,23 +190,23 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
 
-  - name: 'gcc-12-default'
+  - name: 'gcc-${{vars.major-version}}-default'
     description: 'Use GCC 12 as system gcc'
     dependencies:
       provides:
         - gcc=12.3.1
       runtime:
-        - gcc-12
+        - gcc-${{vars.major-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
 
           for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
-            ln -sf "${{host.triplet.gnu}}-"$i"-12" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+            ln -sf "${{host.triplet.gnu}}-"$i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
           done
 
           for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
-            ln -sf $i"-12" "${{targets.subpkgdir}}"/usr/bin/$i
+            ln -sf $i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/$i
           done
     test:
       pipeline:
@@ -243,36 +243,36 @@ test:
     - name: Check basic usage of top level & libexec binaries
       runs: |
         # Check C frontend compiler
-        gcc-12 --version | grep ${{package.version}}
+        gcc-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C++ frontend compiler
-        g++-12 --version | grep ${{package.version}}
+        g++-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C empty translation unit compilation
         : > empty.c
-        gcc-12 -c empty.c
+        gcc-${{vars.major-version}} -c empty.c
 
         # Check C++ empty translation unit compilation
         : > empty.cpp
-        g++-12 -c empty.cpp
-        c++-12 --version
-        c++-12 --help
-        cpp-12 --version
-        cpp-12 --help
-        g++-12 --help
-        gcc-12 --help
-        gcc-ar-12 --version
-        gcc-ar-12 --help
-        gcc-nm-12 --version
-        gcc-nm-12 --help
-        gcc-ranlib-12 --version
-        gcc-ranlib-12 --help
-        gcov-12 --version
-        gcov-12 --help
-        gcov-dump-12 --version
-        gcov-dump-12 --help
-        gcov-tool-12 --version
-        gcov-tool-12 --help
-        lto-dump-12 --version
-        lto-dump-12 --help
+        g++-${{vars.major-version}} -c empty.cpp
+        c++-${{vars.major-version}} --version
+        c++-${{vars.major-version}} --help
+        cpp-${{vars.major-version}} --version
+        cpp-${{vars.major-version}} --help
+        g++-${{vars.major-version}} --help
+        gcc-${{vars.major-version}} --help
+        gcc-ar-${{vars.major-version}} --version
+        gcc-ar-${{vars.major-version}} --help
+        gcc-nm-${{vars.major-version}} --version
+        gcc-nm-${{vars.major-version}} --help
+        gcc-ranlib-${{vars.major-version}} --version
+        gcc-ranlib-${{vars.major-version}} --help
+        gcov-${{vars.major-version}} --version
+        gcov-${{vars.major-version}} --help
+        gcov-dump-${{vars.major-version}} --version
+        gcov-dump-${{vars.major-version}} --help
+        gcov-tool-${{vars.major-version}} --version
+        gcov-tool-${{vars.major-version}} --help
+        lto-dump-${{vars.major-version}} --version
+        lto-dump-${{vars.major-version}} --help
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"
@@ -283,7 +283,7 @@ test:
         }
         EOF
 
-        gcc-12 -o hello-c hello.c
+        gcc-${{vars.major-version}} -o hello-c hello.c
         out=$(./hello-c)
         [ "$out" = "hello-c" ]
     - name: hello world c++
@@ -296,12 +296,12 @@ test:
         }
         EOF
 
-        g++-12 -o hello-c++ hello.cpp
+        g++-${{vars.major-version}} -o hello-c++ hello.cpp
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler/hardening-check
       with:
-        cc: gcc-12
+        cc: gcc-${{vars.major-version}}
     - uses: test/tw/ldd-check
 
 update:

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 13
+  epoch: 14
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -44,10 +44,11 @@ var-transforms:
     to: major-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: 5bd29402cad2deb5d9388d0236c7146414d77e5b8d5f1c6c941c7a1f47691c3389f08656d5f6e8e2d6717bf2c81f018d326f632fb468f42925b40bd217fc4853
+      expected-commit: 2bada4bc59bed4be34fab463bdb3c3ebfd2b41bb
+      repository: https://gitlab.com/gnutools/gcc.git
+      tag: releases/gcc-${{package.version}}
 
   - name: Fix false invalid march extension crc on arm64
     uses: patch
@@ -306,5 +307,6 @@ test:
 update:
   enabled: false
   manual: true
-  release-monitor:
-    identifier: 6502
+  git:
+    tag-filter-prefix: releases/gcc-12.
+    strip-prefix: releases/gcc-

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 12
+  epoch: 13
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -43,10 +43,11 @@ var-transforms:
     to: major-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: ed5f2f4c6ed2c796fcf2c93707159e9dbd3ddb1ba063d549804dd68cdabbb6d550985ae1c8465ae9a336cfe29274a6eb0f42e21924360574ebd8e5d5c7c9a801
+      expected-commit: b71f1de6e9cf7181a288c0f39f9b1ef6580cf5c8
+      repository: https://gitlab.com/gnutools/gcc.git
+      tag: releases/gcc-${{package.version}}
 
   - working-directory: /home/build/build
     pipeline:
@@ -300,5 +301,6 @@ test:
 update:
   enabled: false
   manual: true
-  release-monitor:
-    identifier: 6502
+  git:
+    tag-filter-prefix: releases/gcc-13.
+    strip-prefix: releases/gcc-

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -12,7 +12,7 @@ package:
     runtime:
       - binutils
       - glibc-dev # Temporary workaround to force build-ordering against new glibc's
-      - libstdc++-13-dev
+      - libstdc++-${{vars.major-version}}-dev
       - openssf-compiler-options
       - posix-cc-wrappers
 
@@ -77,7 +77,7 @@ pipeline:
           CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
-            --program-suffix="-13" \
+            --program-suffix="-${{vars.major-version}}" \
             --disable-nls \
             --disable-werror \
             --with-pkgversion='Wolfi ${{package.full-version}}' \
@@ -146,14 +146,14 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: 'gcc-13-doc'
+  - name: 'gcc-${{vars.major-version}}-doc'
     pipeline:
       - uses: split/manpages
     test:
       pipeline:
         - uses: test/docs
 
-  - name: 'libstdc++-13'
+  - name: 'libstdc++-${{vars.major-version}}'
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -163,14 +163,14 @@ subpackages:
     options:
       no-provides: true
 
-  - name: 'libstdc++-13-dev'
+  - name: 'libstdc++-${{vars.major-version}}-dev'
     dependencies:
       runtime:
-        # libstdc++-13-dev might no longer compatible at link time
-        # with libstdc++ 14 or later, despite being runtime
-        # compatible. Ensure any users of libstdc++-13-dev have access
-        # to link against libstsdc++-13
-        - libstdc++-13
+        # libstdc++-${{vars.major-version}}-dev might no longer compatible at link time
+        # with libstdc++ (${{vars.major-version}} + 1) or later, despite being runtime
+        # compatible. Ensure any users of libstdc++-${{vars.major-version}}-dev have access
+        # to link against libstsdc++-${{vars.major-version}}
+        - libstdc++-${{vars.major-version}}
     pipeline:
       - runs: |
           gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -184,23 +184,23 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
 
-  - name: 'gcc-13-default'
+  - name: 'gcc-${{vars.major-version}}-default'
     description: 'Use GCC 13 as system gcc'
     dependencies:
       provides:
         - gcc=${{package.full-version}}
       runtime:
-        - gcc-13=${{package.full-version}}
+        - gcc-${{vars.major-version}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
 
           for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
-            ln -sf "${{host.triplet.gnu}}-"$i"-13" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+            ln -sf "${{host.triplet.gnu}}-"$i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
           done
 
           for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
-            ln -sf $i"-13" "${{targets.subpkgdir}}"/usr/bin/$i
+            ln -sf $i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/$i
           done
     test:
       pipeline:
@@ -237,36 +237,36 @@ test:
     - name: Check basic usage of top level & libexec binaries
       runs: |
         # Check C frontend compiler
-        gcc-13 --version | grep ${{package.version}}
+        gcc-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C++ frontend compiler
-        g++-13 --version | grep ${{package.version}}
+        g++-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C empty translation unit compilation
         : > empty.c
-        gcc-13 -c empty.c
+        gcc-${{vars.major-version}} -c empty.c
 
         # Check C++ empty translation unit compilation
         : > empty.cpp
-        g++-13 -c empty.cpp
-        c++-13 --version
-        c++-13 --help
-        cpp-13 --version
-        cpp-13 --help
-        g++-13 --help
-        gcc-13 --help
-        gcc-ar-13 --version
-        gcc-ar-13 --help
-        gcc-nm-13 --version
-        gcc-nm-13 --help
-        gcc-ranlib-13 --version
-        gcc-ranlib-13 --help
-        gcov-13 --version
-        gcov-13 --help
-        gcov-dump-13 --version
-        gcov-dump-13 --help
-        gcov-tool-13 --version
-        gcov-tool-13 --help
-        lto-dump-13 --version
-        lto-dump-13 --help
+        g++-${{vars.major-version}} -c empty.cpp
+        c++-${{vars.major-version}} --version
+        c++-${{vars.major-version}} --help
+        cpp-${{vars.major-version}} --version
+        cpp-${{vars.major-version}} --help
+        g++-${{vars.major-version}} --help
+        gcc-${{vars.major-version}} --help
+        gcc-ar-${{vars.major-version}} --version
+        gcc-ar-${{vars.major-version}} --help
+        gcc-nm-${{vars.major-version}} --version
+        gcc-nm-${{vars.major-version}} --help
+        gcc-ranlib-${{vars.major-version}} --version
+        gcc-ranlib-${{vars.major-version}} --help
+        gcov-${{vars.major-version}} --version
+        gcov-${{vars.major-version}} --help
+        gcov-dump-${{vars.major-version}} --version
+        gcov-dump-${{vars.major-version}} --help
+        gcov-tool-${{vars.major-version}} --version
+        gcov-tool-${{vars.major-version}} --help
+        lto-dump-${{vars.major-version}} --version
+        lto-dump-${{vars.major-version}} --help
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"
@@ -277,7 +277,7 @@ test:
         }
         EOF
 
-        gcc-13 -o hello-c hello.c
+        gcc-${{vars.major-version}} -o hello-c hello.c
         out=$(./hello-c)
         [ "$out" = "hello-c" ]
     - name: hello world c++
@@ -290,12 +290,12 @@ test:
         }
         EOF
 
-        g++-13 -o hello-c++ hello.cpp
+        g++-${{vars.major-version}} -o hello-c++ hello.cpp
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler/hardening-check
       with:
-        cc: gcc-13
+        cc: gcc-${{vars.major-version}}
     - uses: test/tw/ldd-check
 
 update:

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
-  version: 13.3.0
-  epoch: 13
+  version: 13.4.0
+  epoch: 0
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -45,7 +45,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: b71f1de6e9cf7181a288c0f39f9b1ef6580cf5c8
+      expected-commit: 99677969d463d75a562f94460ea75e9f6a016b4f
       repository: https://gitlab.com/gnutools/gcc.git
       tag: releases/gcc-${{package.version}}
 

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -299,8 +299,7 @@ test:
     - uses: test/tw/ldd-check
 
 update:
-  enabled: false
-  manual: true
+  enabled: true
   git:
     tag-filter-prefix: releases/gcc-13.
     strip-prefix: releases/gcc-

--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-14
   version: 14.3.0
-  epoch: 8
+  epoch: 9
   description: "the GNU compiler collection - version 14"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -46,10 +46,11 @@ var-transforms:
     to: major-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: cb4e3259640721bbd275c723fe4df53d12f9b1673afb3db274c22c6aa457865dccf2d6ea20b4fd4c591f6152e6d4b87516c402015900f06ce9d43af66d3b7a93
+      expected-commit: c9cd41fba9ebd288c4f101e4b99da934bcb96a11
+      repository: https://gitlab.com/gnutools/gcc.git
+      tag: releases/gcc-${{package.version}}
 
   - uses: patch
     with:
@@ -364,6 +365,6 @@ test:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 6502
-    version-filter-prefix: "14."
+  git:
+    tag-filter-prefix: releases/gcc-14.
+    strip-prefix: releases/gcc-

--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -13,7 +13,7 @@ package:
       - binutils
       - glibc-dev # Temporary workaround to force build-ordering against new glibc's
       - libquadmath # This is a temporary workaround for issues with single-arch packages.
-      - libstdc++-14-dev
+      - libstdc++-${{vars.major-version}}-dev
       - openssf-compiler-options
       - posix-cc-wrappers
 
@@ -84,7 +84,7 @@ pipeline:
           CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
-            --program-suffix="-14" \
+            --program-suffix="-${{vars.major-version}}" \
             --disable-nls \
             --disable-werror \
             --with-pkgversion='Wolfi ${{package.full-version}}' \
@@ -151,14 +151,14 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: 'gcc-14-doc'
+  - name: 'gcc-${{vars.major-version}}-doc'
     pipeline:
       - uses: split/manpages
     test:
       pipeline:
         - uses: test/docs
 
-  - name: 'libatomic-14'
+  - name: 'libatomic-${{vars.major-version}}'
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -169,7 +169,7 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: 'libstdc++-14'
+  - name: 'libstdc++-${{vars.major-version}}'
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
@@ -180,14 +180,14 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: 'libstdc++-14-dev'
+  - name: 'libstdc++-${{vars.major-version}}-dev'
     dependencies:
       runtime:
-        # libstdc++-14-dev might no longer compatible at link time
-        # with libstdc++ 14 or later, despite being runtime
-        # compatible. Ensure any users of libstdc++-14-dev have access
-        # to link against libstsdc++-14
-        - libstdc++-14
+        # libstdc++-${{vars.major-version}}-dev might no longer compatible at link time
+        # with libstdc++ (${{vars.major-version}} + 1) or later, despite being runtime
+        # compatible. Ensure any users of libstdc++-${{vars.major-version}}-dev have access
+        # to link against libstsdc++-${{vars.major-version}}
+        - libstdc++-${{vars.major-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}/include/
@@ -201,7 +201,7 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: "libgfortran-14"
+  - name: "libgfortran-${{vars.major-version}}"
     description: "Fortran runtime library provided by GCC"
     pipeline:
       - runs: |
@@ -213,7 +213,7 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
 
-  - name: "gfortran-14"
+  - name: "gfortran-${{vars.major-version}}"
     description: "GNU Fortran Compiler"
     pipeline:
       - runs: |
@@ -233,34 +233,34 @@ subpackages:
           mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir
     dependencies:
       runtime:
-        - gcc-14
-        - libgfortran-14
+        - gcc-${{vars.major-version}}
+        - libgfortran-${{vars.major-version}}
     test:
       pipeline:
         - runs: |
-            gfortran-14 --version
-            gfortran-14 --help
+            gfortran-${{vars.major-version}} --version
+            gfortran-${{vars.major-version}} --help
 
-  - name: 'gcc-14-default'
+  - name: 'gcc-${{vars.major-version}}-default'
     description: 'Use GCC 14 as system gcc'
     dependencies:
       provides:
         - gcc=${{package.full-version}}
         - gfortran=${{package.full-version}}
       runtime:
-        - gcc-14=${{package.full-version}}
-        - gfortran-14=${{package.full-version}}
+        - gcc-${{vars.major-version}}=${{package.full-version}}
+        - gfortran-${{vars.major-version}}=${{package.full-version}}
         - libgfortran
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
 
           for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib gfortran; do
-            ln -sf "${{host.triplet.gnu}}-"$i"-14" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+            ln -sf "${{host.triplet.gnu}}-"$i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
           done
 
           for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gfortran gcov gcov-dump gcov-tool lto-dump; do
-            ln -sf $i"-14" "${{targets.subpkgdir}}"/usr/bin/$i
+            ln -sf $i"-${{vars.major-version}}" "${{targets.subpkgdir}}"/usr/bin/$i
           done
     test:
       pipeline:
@@ -300,36 +300,36 @@ test:
     - name: Check basic usage of top level & libexec binaries
       runs: |
         # Check C frontend compiler
-        gcc-14 --version | grep ${{package.version}}
+        gcc-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C++ frontend compiler
-        g++-14 --version | grep ${{package.version}}
+        g++-${{vars.major-version}} --version | grep ${{package.version}}
         # Check C empty translation unit compilation
         : > empty.c
-        gcc-14 -c empty.c
+        gcc-${{vars.major-version}} -c empty.c
 
         # Check C++ empty translation unit compilation
         : > empty.cpp
-        g++-14 -c empty.cpp
-        c++-14 --version
-        c++-14 --help
-        cpp-14 --version
-        cpp-14 --help
-        g++-14 --help
-        gcc-14 --help
-        gcc-ar-14 --version
-        gcc-ar-14 --help
-        gcc-nm-14 --version
-        gcc-nm-14 --help
-        gcc-ranlib-14 --version
-        gcc-ranlib-14 --help
-        gcov-14 --version
-        gcov-14 --help
-        gcov-dump-14 --version
-        gcov-dump-14 --help
-        gcov-tool-14 --version
-        gcov-tool-14 --help
-        lto-dump-14 --version
-        lto-dump-14 --help
+        g++-${{vars.major-version}} -c empty.cpp
+        c++-${{vars.major-version}} --version
+        c++-${{vars.major-version}} --help
+        cpp-${{vars.major-version}} --version
+        cpp-${{vars.major-version}} --help
+        g++-${{vars.major-version}} --help
+        gcc-${{vars.major-version}} --help
+        gcc-ar-${{vars.major-version}} --version
+        gcc-ar-${{vars.major-version}} --help
+        gcc-nm-${{vars.major-version}} --version
+        gcc-nm-${{vars.major-version}} --help
+        gcc-ranlib-${{vars.major-version}} --version
+        gcc-ranlib-${{vars.major-version}} --help
+        gcov-${{vars.major-version}} --version
+        gcov-${{vars.major-version}} --help
+        gcov-dump-${{vars.major-version}} --version
+        gcov-dump-${{vars.major-version}} --help
+        gcov-tool-${{vars.major-version}} --version
+        gcov-tool-${{vars.major-version}} --help
+        lto-dump-${{vars.major-version}} --version
+        lto-dump-${{vars.major-version}} --help
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"
@@ -340,7 +340,7 @@ test:
         }
         EOF
 
-        gcc-14 -o hello-c hello.c
+        gcc-${{vars.major-version}} -o hello-c hello.c
         out=$(./hello-c)
         [ "$out" = "hello-c" ]
     - name: hello world c++
@@ -353,15 +353,15 @@ test:
         }
         EOF
 
-        g++-14 -o hello-c++ hello.cpp
+        g++-${{vars.major-version}} -o hello-c++ hello.cpp
         out=$(./hello-c++)
         [ "$out" = "hello-c++" ]
     - uses: test/compiler/hardening-check
       with:
-        cc: gcc-14
+        cc: gcc-${{vars.major-version}}
     - uses: test/compiler/asan
       with:
-        cc: gcc-14
+        cc: gcc-${{vars.major-version}}
     - uses: test/tw/ldd-check
 
 update:

--- a/gcc-14.yaml
+++ b/gcc-14.yaml
@@ -295,6 +295,7 @@ test:
     contents:
       packages:
         - glibc-dev
+        - gcc-${{vars.major-version}}-default
   pipeline:
     - name: Check basic usage of top level & libexec binaries
       runs: |


### PR DESCRIPTION
This PR:

- Converts all of our `gcc-*.yaml` packages to use the `git` fetch pipeline, which will pull things from https://gitlab.com/gnutools/gcc which is much more reliable than ftpmirror.gnu.org.
- Reenables the `update` stanza on all packages.  This will be a no-op for the old releases (like 11), but it's still good to have.
- Updates GCC 12 to the latest upstream version: 12.5.0.
- Updates GCC 13 to the latest upstream version: 13.4.0.