### PR TITLE
samba: Add tmpfiles.d snippet

### DIFF
--- a/samba.yaml
+++ b/samba.yaml
@@ -1,7 +1,7 @@
 package:
   name: samba
   version: "4.23.3"
-  epoch: 0
+  epoch: 1
   description: "Tools to access a server's filespace and printers via SMB"
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -10,6 +10,12 @@ package:
       - merged-lib
       - merged-usrsbin
       - wolfi-baselayout
+  # This package currently creates both /run/samba and /var/run/samba.
+  # We'll sort this out as part of merging /var/run into /run, but ignore
+  # the linter failure on /var/run/samba for now.
+  checks:
+    disabled:
+      - tempdir
 
 vars:
   python-version: 3.13
@@ -104,6 +110,10 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - runs: |
+      install -d -m755 "${{targets.destdir}}"/usr/lib/tmpfiles.d
+      sed 's, /var/run/samba , /run/samba ,' packaging/systemd/samba.conf.tmp >"${{targets.destdir}}"/usr/lib/tmpfiles.d/samba.conf
 
   - uses: strip
 


### PR DESCRIPTION
This ensures that the appropriate subdirectory of `/run` exists when running in a VM, where `/run` is a tmpfs.

We also need to disable the `tempdir` linter for now due to an unfortunate mix of `/run` and `/var/run` subdirectories.

Related: chainguard-dev/melange#2239, https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw