### PR TITLE
fix(datadog-agent): address policy load error from datadog-agent

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.72.4"
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/datadog-security-agent-policies.yaml
+++ b/datadog-security-agent-policies.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-security-agent-policies
   version: "0.74.0"
-  epoch: 0
+  epoch: 1
   description: "Policies for Security Agent - compliance and runtime checks"
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,8 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/etc/datadog-agent/compliance.d
       cp compliance/containers/* ${{targets.destdir}}/etc/datadog-agent/compliance.d
+      mkdir -p ${{targets.destdir}}/etc/datadog-agent/runtime-security.d
+      install -Dm664 runtime/default.policy ${{targets.destdir}}/etc/datadog-agent/runtime-security.d/default.policy
 
 test:
   pipeline:


### PR DESCRIPTION
This change addresses an issue with datadog-agent loading  the runtime-security policy.