### PR TITLE
feat(linkerd2-proxy-init): add linkerd2-proxy-init symlink for proxy-init binary

### DIFF
--- a/linkerd2-proxy-init.yaml
+++ b/linkerd2-proxy-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-proxy-init
   version: "2.4.3"
-  epoch: 5 # CVE-2025-47906
+  epoch: 6
   description: "Init container that sets up the iptables rules to forward traffic into the Linkerd2 sidecar proxy"
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/run
           mkdir -p ${{targets.contextdir}}/usr/local/bin
+          mkdir -p ${{targets.contextdir}}/usr/lib/linkerd
           ln -sf /usr/bin/proxy-init ${{targets.contextdir}}/usr/local/bin/proxy-init
+          ln -sf /usr/bin/proxy-init ${{targets.contextdir}}/usr/lib/linkerd/linkerd2-proxy-init
           touch ${{targets.contextdir}}/run/xtables.lock
           chmod 0600 ${{targets.contextdir}}/run/xtables.lock
     # test added by a robot (compat)
@@ -53,6 +55,7 @@ subpackages:
       pipeline:
         - runs: |
             readlink -v /usr/local/bin/proxy-init
+            readlink -v /usr/lib/linkerd/linkerd2-proxy-init
 
 update:
   enabled: true


### PR DESCRIPTION
Add symlink at `/usr/lib/linkerd/linkerd2-proxy-init` pointing to
`/usr/bin/proxy-init` for compatibility with upstream expectations.
Create /usr/lib/linkerd directory before creating symlink.
Add check in tests.
Bump epoch to 6.

Helps with linkerd2 PR: https://github.com/linkerd/linkerd2/pull/14577

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

<!--ci-cve-scan:fail-any-->
