### PR TITLE
openjdk-24+: add jdk.crypto.ec by default to jre

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: "24.0.2"
-  epoch: 8
+  epoch: 9
   description: OpenJDK 24
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -65,7 +65,9 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-build-with-glibc-2.42.patch
+      patches: |
+        fix-build-with-glibc-2.42.patch
+        JDK-8312267.patch
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -164,6 +166,9 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+          # check that jdk.crypto.ec is included in image
+          jimage list "${{targets.subpkgdir}}"/$_java_home/lib/modules | grep "Module: jdk.crypto.ec"
     test:
       pipeline:
         - uses: test/tw/ldd-check

--- a/openjdk-24/JDK-8312267.patch
+++ b/openjdk-24/JDK-8312267.patch
@@ -1,0 +1,32 @@
+From d4d7eb03b4b3e9b4d696d84fa5f9c20958c6f060 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Fri, 5 Dec 2025 10:58:14 +0000
+Subject: [PATCH] boot-modules: add jdk.crypto.ec for compat
+
+Add empty jdk.crypto.ec module in the JRE image. Some 22+ jre's ship
+it, and others don't. It is empty module and provides no
+functionality. However, 3rd-party jars may list it as required and
+thus without this module in the JRE jimage those jars will failt to
+work.
+
+To avoid the need to jlink a custom jre, which adds this empty module,
+simply add it by default whilst it still exists upstream.
+---
+ make/conf/module-loader-map.conf | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/make/conf/module-loader-map.conf b/make/conf/module-loader-map.conf
+index b628bfbf2da..94fd4246a21 100644
+--- a/make/conf/module-loader-map.conf
++++ b/make/conf/module-loader-map.conf
+@@ -43,6 +43,7 @@ BOOT_MODULES= \
+     java.rmi \
+     java.security.sasl \
+     java.xml \
++    jdk.crypto.ec \
+     jdk.incubator.vector \
+     jdk.internal.vm.ci \
+     jdk.jfr \
+-- 
+2.51.0
+

--- a/openjdk-25.yaml
+++ b/openjdk-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-25
   version: "25.0.1"
-  epoch: 0
+  epoch: 1
   description: OpenJDK 25
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -56,6 +56,11 @@ pipeline:
       repository: https://github.com/openjdk/jdk25u
       tag: jdk-${{vars.mangled-package-version}}-ga
       expected-commit: 78770bfaefd23ae77ec4f8ddd769c1c2d9c282df
+
+  - uses: patch
+    with:
+      patches: |
+        JDK-8312267.patch
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -147,6 +152,9 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+          # check that jdk.crypto.ec is included in image
+          jimage list "${{targets.subpkgdir}}"/$_java_home/lib/modules | grep "Module: jdk.crypto.ec"
 
   # Disabled doc subpackage for now.
   # Upstream has switched from troff manpages in the repository to pandoc.

--- a/openjdk-25/JDK-8312267.patch
+++ b/openjdk-25/JDK-8312267.patch
@@ -1,0 +1,32 @@
+From d4d7eb03b4b3e9b4d696d84fa5f9c20958c6f060 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Fri, 5 Dec 2025 10:58:14 +0000
+Subject: [PATCH] boot-modules: add jdk.crypto.ec for compat
+
+Add empty jdk.crypto.ec module in the JRE image. Some 22+ jre's ship
+it, and others don't. It is empty module and provides no
+functionality. However, 3rd-party jars may list it as required and
+thus without this module in the JRE jimage those jars will failt to
+work.
+
+To avoid the need to jlink a custom jre, which adds this empty module,
+simply add it by default whilst it still exists upstream.
+---
+ make/conf/module-loader-map.conf | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/make/conf/module-loader-map.conf b/make/conf/module-loader-map.conf
+index b628bfbf2da..94fd4246a21 100644
+--- a/make/conf/module-loader-map.conf
++++ b/make/conf/module-loader-map.conf
+@@ -43,6 +43,7 @@ BOOT_MODULES= \
+     java.rmi \
+     java.security.sasl \
+     java.xml \
++    jdk.crypto.ec \
+     jdk.incubator.vector \
+     jdk.internal.vm.ci \
+     jdk.jfr \
+-- 
+2.51.0
+


### PR DESCRIPTION
Add empty jdk.crypto.ec module to JRE jimage by default, for compat
with 3rd party modules that need it.

22+ JREs from various vendors also ship empty jdk.crypto.ec by
default.

This is similar to previous fix for a different jre module:
- https://github.com/wolfi-dev/os/pull/73391
