### PR TITLE
ca-certificates: Move compatibility links into separate package

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20251003"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -109,6 +109,32 @@ subpackages:
               echo "ca-bundle.crt file does not exist or is empty"
               exit 1
             fi
+
+  - name: "ca-certificates-bundle-compat"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssl/certs
+          ln -s certs/ca-certificates.crt "${{targets.subpkgdir}}"/etc/ssl/cert.pem
+          # Provide Fedora compatible location for the bundle (fixes compat with Dart lang)
+          mkdir -p ${{targets.subpkgdir}}/etc/pki/tls/certs/
+          ln -s ../../../ssl/certs/ca-certificates.crt ${{targets.subpkgdir}}/etc/pki/tls/certs/ca-bundle.crt
+          # Provide RHEL compatible location for the bundle (fixes compat with fluent-bit)
+          ln -s ca-certificates.crt ${{targets.subpkgdir}}/etc/ssl/certs/ca-bundle.crt
+    test:
+      pipeline:
+        - name: test for certs directory
+          runs: |
+            if [ -d "/etc/ssl/certs" ]; then
+              echo "certs directory exists"
+            else
+              echo "certs directory does not exist"
+              exit 1
+            fi
+        - name: test for links
+          runs: |
+            test -L /etc/ssl/cert.pem
+            test -L /etc/pki/tls/certs/ca-bundle.crt
+            test -L /etc/ssl/certs/ca-bundle.crt
 
   - name: "ca-certificates-bundle-ecs"
     description: "CA certificates bundle needed for Amazon ECS exec"


### PR DESCRIPTION
In order to be able to reuse the compatibility provided by the linked locations in other bundles, this moves their creation into a separate package.

Out of an abundance of caution, this keeps ca-certificates-bundle as-is for now. Eventually, we can make it depend on the new package.