### PR TITLE
pipelines: go: add assert-no-crypto check

### DIFF
--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 22 # CVE-2025-61729
+  epoch: 23 # CVE-2025-61729
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause
@@ -19,11 +19,8 @@ pipeline:
       repository: https://github.com/google/gops
       tag: v${{package.version}}
 
-  - runs: |
-      # This package is used in FIPS context
-      # Assert that no cryptography is used
-      echo Checking crypto is not used
-      [ -z "$(go build -a -n 2>&1 | grep 'packagefile crypto=')" ]
+  # This package is used in FIPS context
+  - uses: go/assert-no-crypto
 
   - uses: go/build
     with:

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables-wrappers
   version: 2
-  epoch: 4
+  epoch: 5
   description: Wrapper scripts for using iptables in containers
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,9 @@ pipeline:
       expected-commit: e139a115350974aac8a82ec4b815d2845f86997e
       cherry-picks: |
         master/680003b3c6e93b471a59ecc9ae87a8f9054b82f3: Convert iptables-wrapper to a static go program
+
+  # This package is used in FIPS context
+  - uses: go/assert-no-crypto
 
   - uses: go/build
     with:

--- a/pipelines/go/assert-no-crypto.yaml
+++ b/pipelines/go/assert-no-crypto.yaml
@@ -1,0 +1,19 @@
+name: Assert that a Go module does not import any crypto packages
+
+# do not include 'go' in 'needs.packages'.
+# some packages pin to an older version; assume it gets injected elsewhere.
+needs:
+  packages:
+    - grep
+
+inputs:
+  modroot:
+    description: The root of the module
+    default: .
+
+pipeline:
+  - runs: |
+      cd "${{inputs.modroot}}"
+
+      echo Checking crypto is not used
+      [ -z "$(go build -a -n 2>&1 | grep 'packagefile crypto=')" ]


### PR DESCRIPTION
Move the no-cryptography check from `gops.yaml` into the new `go/assert-no-crypto` pipeline. Then use it to ensure the build of `iptables-wrappers` can be used in an environment requiring FIPS compliance.