### PR TITLE
fix(langfuse-3): GHSA-9qr9-h5gf-34mp

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
-  version: "3.135.1"
-  epoch: 2 # GHSA-rcmh-qjqh-p98v
+  version: "3.137.0"
+  epoch: 0
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -49,7 +49,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: f40cd99ba8a4115604b921bc485cccdce139edc3
+      expected-commit: cd7799c7d1ace6753cad16e112845db25fdc6232
 
   - name: "Bump deps and install"
     runs: |


### PR DESCRIPTION
Bump version of langfuse to newest (3.137.0) to pick up next 15.5.7+

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/49181

<!--ci-cve-scan:must-fix: GHSA-9qr9-h5gf-34mp-->
