### PR TITLE
fix(caddy): Remediate GHSA-h8cp-697h-8c8p

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: "2.10.2"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-h8cp-697h-8c8p
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       deps: |-
         github.com/quic-go/quic-go@v0.54.1
         github.com/slackhq/nebula@v1.9.7
+        github.com/smallstep/certificates@v0.29.0
         golang.org/x/crypto@v0.45.0
 
   - runs: |


### PR DESCRIPTION
Bump github.com/smallstep/certificates to v0.29.0 and increment epoch to 6

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-h8cp-697h-8c8p-->
