### PR TITLE
open-webui: bump mcp to 1.23.0

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.40"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -85,6 +85,9 @@ pipeline:
 
       # GHSA-2qfp-q593-8484
       uv pip install --upgrade brotli>=1.2.0
+
+      # GHSA-9h52-p55h-vw2f
+      uv pip install --upgrade mcp>=1.23.0
 
       uv pip uninstall pip
 


### PR DESCRIPTION
CVE-2025-66416 GHSA-9h52-p55h-vw2f