### PR TITLE
fix(langfuse-3): GHSA-4fh9-h7wg-q85m, GHSA-w48q-cv73-mx4w

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
   version: "3.137.0"
-  epoch: 0
+  epoch: 1
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -85,7 +85,9 @@ pipeline:
         "pnpm.overrides.jsondiffpatch=^0.7.2" \
         "pnpm.overrides.tar-fs=3.1.1" \
         "pnpm.overrides.playwright=^1.55.1" \
-        "pnpm.overrides.js-yaml=^4.1.1"
+        "pnpm.overrides.js-yaml=^4.1.1" \
+        "pnpm.overrides.mdast-util-to-hast=^13.2.1" \
+        "pnpm.overrides.@modelcontextprotocol/sdk=^1.24.0"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 


### PR DESCRIPTION
Bump mdast-util-to-hast to v13.2.1

Bump @modelcontextprotocol/sdk to v1.24.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48740, https://github.com/chainguard-dev/CVE-Dashboard/issues/48714

<!--ci-cve-scan:fail-any-->
