### PR TITLE
langfuse-3: correctly strip v prefix from tags

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -349,3 +349,4 @@ update:
     identifier: langfuse/langfuse
     use-tag: true
     tag-filter-prefix: v3
+    strip-prefix: v


### PR DESCRIPTION
Updates could never have worked with the current configuration.