### PR TITLE
fix(tailscale): Withdraw 1.92.0

### DIFF
--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -1,7 +1,7 @@
 package:
   name: tailscale
-  version: "1.92.0"
-  epoch: 1 # CVE-2025-61729
+  version: "1.90.9"
+  epoch: 0
   description: The easiest, most secure way to use WireGuard and 2FA.
   copyright:
     - license: BSD-3-Clause
@@ -22,11 +22,16 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 822adaa259725caca109866843c700e626af24f8
+      expected-commit: 66826a496b678495bfe70225b261288edcb26edf
       repository: https://github.com/tailscale/tailscale
       tag: v${{package.version}}
 
+  - uses: patch
+    with:
+      patches: GHSA-j5w8-q4qc-rx2x.patch
+
   - runs: |
+      go mod tidy
       ./build_dist.sh tailscale.com/cmd/containerboot
       ./build_dist.sh tailscale.com/cmd/${{package.name}}
       ./build_dist.sh tailscale.com/cmd/${{package.name}}d

--- a/tailscale/GHSA-j5w8-q4qc-rx2x.patch
+++ b/tailscale/GHSA-j5w8-q4qc-rx2x.patch
@@ -1,0 +1,43 @@
+From de8ed203e08b9e32e40648331c47980faab92c46 Mon Sep 17 00:00:00 2001
+From: Andrew Lytvynov <awly@tailscale.com>
+Date: Thu, 20 Nov 2025 14:10:38 -0600
+Subject: [PATCH] go.mod: bump golang.org/x/crypto (#18011)
+
+Pick up fixes for https://pkg.go.dev/vuln/GO-2025-4134
+
+Updates #cleanup
+
+Signed-off-by: Andrew Lytvynov <awly@tailscale.com>
+---
+ go.mod     | 2 +-
+ go.sum     | 4 ++--
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 3b4f34b2df254..e6baad0dc5057 100644
+--- a/go.mod
++++ b/go.mod
+@@ -100,7 +100,7 @@ require (
+ 	go.uber.org/zap v1.27.0
+ 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745
+ 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
+-	golang.org/x/crypto v0.38.0
++	golang.org/x/crypto v0.45.0
+ 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
+ 	golang.org/x/mod v0.24.0
+ 	golang.org/x/net v0.40.0
+diff --git a/go.sum b/go.sum
+index f0758f2d4ba00..1106932f21444 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1124,8 +1124,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+ golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+-golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+-golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
++golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
++golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,4 +1,4 @@
-ceph-19-dev-19.2.3-r12.apk
-ceph-19-doc-19.2.3-r12.apk
-ceph-19-libs-19.2.3-r12.apk
-ceph-19-19.2.3-r12.apk
+tailscale-1.92.0-r0.apk
+tailscale-compat-1.92.0-r0.apk
+tailscale-1.92.0-r1.apk
+tailscale-compat-1.92.0-r1.apk


### PR DESCRIPTION
tailscale tags more versions that it releases. A 1.92.0 version of
tailscale was released by Chainguard when only 1.90.8 was available
as an upstream release. This change withdraws the 1.92.0 tailscale
package.

Patch crypto version to 0.45.0 to remediate GHSA-j5w8-q4qc-rx2x

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/47184

<!--ci-cve-scan:fail-any-->