### PR TITLE
feat: add octosts policy for ci-cve-scan-db

### DIFF
--- a/.github/chainguard/ci-cve-scan-db.sts.yaml
+++ b/.github/chainguard/ci-cve-scan-db.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# prod-enforce: ci-cve-scan-db104nk47l0oke0f8s@prod-enforce-fabc.iam.gserviceaccount.com (116484413715081080322)
+subject: "116484413715081080322"
+
+permissions:
+  checks: write
+  pull_requests: read # Allow reading metadata from the pull request.


### PR DESCRIPTION
Grants ci-cve-scan-db bot permission to create check runs and read PR metadata. Required for next-generation CVE scanning CI check.
