### PR TITLE
chore(tileserver-gl): bump epoch for new libpng 1.6.53

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 5 # GHSA-mh29-5h37-fv8m
+  epoch: 6 # GHSA-mh29-5h37-fv8m
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
## Explanation

New version of libpng was added an hour ago: https://github.com/wolfi-dev/os/pull/74863
Rebuilding tileserver-gl with new libpng to fix this error: 
```
terminate called after throwing an instance of 'std::runtime_error'
what():  libpng version mismatch: headers report 1.6.51, but library reports 1.6.53
```
