### PR TITLE
test jitter fallback

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -49,17 +49,6 @@ pipeline:
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
-  - name: Create dbg sourcecode
-    runs: |
-      SRCDIR=$(mktemp -d)
-      cp -r . $SRCDIR/
-      mkdir -p ${{targets.destdir}}-dbg/usr/src/
-      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-      # Note that mktemp -d created it as 700, whilst the contents
-      # inside is 644 for files and 755 for dirs, without this gdb
-      # doesn't work for non-root user, fix this up.
-      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
-
   - name: Configure and build
     runs: |
       perl ./Configure \
@@ -85,6 +74,21 @@ pipeline:
          no-weak-ssl-ciphers \
          -Wa,--noexecstack
       perl configdata.pm --dump
+
+      # Create generated .c from .c.in
+      make build_all_generated
+
+      # Create debug sources after creating all the generated .c from .c.in
+      SRCDIR=$(mktemp -d)
+      cp -r . $SRCDIR/
+      mkdir -p ${{targets.destdir}}-dbg/usr/src/
+      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+      # Note that mktemp -d created it as 700, whilst the contents
+      # inside is 644 for files and 755 for dirs, without this gdb
+      # doesn't work for non-root user, fix this up.
+      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+
+      # Continue building everything
       make -j$(nproc)
       make tests HARNESS_JOBS=10
 

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -272,9 +272,9 @@ test:
         run genrsa -out /dev/null
         EOF
         gdb --batch --command ./openssl.gdb openssl
-        # Assert that jitter entropy was not used
+        # Assert that jitter entropy was used
         grep -q 'Breakpoint 1,' jitter.log || exit 1
-        # Assert that getrandom syscall wrapper was used
+        # Assert that getrandom syscall wrapper was not used
         grep -q 'Breakpoint 2,' jitter.log && exit 1
     - name: docker-dind certificate generation
       runs: |

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -49,6 +49,16 @@ pipeline:
         0001-baseprovider-add-MD5-and-SHA1.patch
         0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
 
+  - name: Perform throw-away canary tests of jitter and non-validated fips
+    runs: |
+      mkdir -p build-jitter-fips-tests/
+      cd build-jitter-fips-tests/
+      ../Configure --with-rand-seed=none enable-jitter enable-fips -DOPENSSL_DEFAULT_SEED_SRC=JITTER --debug
+      make -s -j$(nproc)
+      make tests HARNESS_JOBS=10
+      cd ../
+      rm -rf build-jitter-fips-tests/
+
   - name: Configure and build
     runs: |
       perl ./Configure \

--- a/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
+++ b/openssl/0001-fips-block-HMAC-calculation-with-unapproved-digests.patch
@@ -1,4 +1,4 @@
-From a4e6eb8707adfb11687bc99af26263d3cdc8916d Mon Sep 17 00:00:00 2001
+From 6919c644598a68f61c7c15852d467a64dd408f17 Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
 Date: Mon, 20 Oct 2025 16:56:30 +0100
 Subject: [PATCH] fips: block HMAC calculation with unapproved digests
@@ -8,11 +8,11 @@ python - one can attempt to create HMAC using unapproved digest.
 
 Block such access.
 ---
- crypto/hmac/hmac.c | 19 +++++++++++++++++++
- 1 file changed, 19 insertions(+)
+ crypto/hmac/hmac.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
 
 diff --git a/crypto/hmac/hmac.c b/crypto/hmac/hmac.c
-index 19fc7d3b4f..da9451cb8a 100644
+index 19fc7d3b4f..cb2923af4f 100644
 --- a/crypto/hmac/hmac.c
 +++ b/crypto/hmac/hmac.c
 @@ -18,6 +18,7 @@
@@ -23,21 +23,24 @@ index 19fc7d3b4f..da9451cb8a 100644
  #include <openssl/hmac.h>
  #include <openssl/core_names.h>
  #include "hmac_local.h"
-@@ -30,6 +31,9 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+@@ -30,6 +31,11 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
      unsigned char pad[HMAC_MAX_MD_CBLOCK_SIZE];
      unsigned int keytmp_length;
      unsigned char keytmp[HMAC_MAX_MD_CBLOCK_SIZE];
++#ifndef FIPS_MODULE
 +    const EVP_MD *checkmd = NULL;
 +    const OSSL_PROVIDER *checkprovider = NULL;
 +    const char *checkname = NULL;
++#endif
  
      /* If we are changing MD then we must have a key */
      if (md != NULL && md != ctx->md && (key == NULL || len < 0))
-@@ -95,6 +99,21 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+@@ -95,6 +101,23 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
      }
      if (!EVP_MD_CTX_copy_ex(ctx->md_ctx, ctx->i_ctx))
          goto err;
 +
++#ifndef FIPS_MODULE
 +    /*
 +     * Block non-fips provider digest in FIPS mode, note this has to
 +     * be done this late, and using fetched MD from MD_CTX, as the
@@ -51,6 +54,7 @@ index 19fc7d3b4f..da9451cb8a 100644
 +        strcmp("fips", checkname)) {
 +        return 0;
 +    }
++#endif
 +
      rv = 1;
   err:

--- a/openssl/fix-jitter.patch
+++ b/openssl/fix-jitter.patch
@@ -1,8 +1,8 @@
 diff --git a/crypto/provider_core.c b/crypto/provider_core.c
-index 490991b5e5..3cfe24ed9d 100644
+index 74b7d3d8ac..6f94403b6c 100644
 --- a/crypto/provider_core.c
 +++ b/crypto/provider_core.c
-@@ -2421,7 +2421,7 @@ static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
+@@ -2438,7 +2438,7 @@ static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
      OSSL_SELF_TEST_get_callback((OSSL_LIB_CTX *)libctx, cb, cbarg);
  }
  
@@ -11,6 +11,46 @@ index 490991b5e5..3cfe24ed9d 100644
  static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
                                 unsigned char **pout, int entropy,
                                 size_t min_len, size_t max_len)
+@@ -2446,6 +2446,14 @@ static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
+     return ossl_rand_get_entropy((OSSL_LIB_CTX *)core_get_libctx(handle),
+                                  pout, entropy, min_len, max_len);
+ }
++
++static size_t rand_get_user_entropy(const OSSL_CORE_HANDLE *handle,
++                                    unsigned char **pout, int entropy,
++                                    size_t min_len, size_t max_len)
++{
++    return ossl_rand_get_user_entropy((OSSL_LIB_CTX *)core_get_libctx(handle),
++                                      pout, entropy, min_len, max_len);
++}
+ # else
+ /*
+  * OpenSSL FIPS providers prior to 3.2 call rand_get_entropy API from
+@@ -2470,15 +2478,20 @@ static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
+ {
+     return ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
+ }
+-# endif
+-
++/*
++ * If a 3.2+ provider calls rand_get_user_entropy, the seed rng might
++ * not yet be initialised, and creating it might not be possible yet
++ * either (as providers might still be loading). In these
++ * circumstances we still want to provide JITTER entropy to those
++ * providers.
++ */
+ static size_t rand_get_user_entropy(const OSSL_CORE_HANDLE *handle,
+                                     unsigned char **pout, int entropy,
+                                     size_t min_len, size_t max_len)
+ {
+-    return ossl_rand_get_user_entropy((OSSL_LIB_CTX *)core_get_libctx(handle),
+-                                      pout, entropy, min_len, max_len);
++    return ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
+ }
++# endif
+ 
+ static void rand_cleanup_entropy(const OSSL_CORE_HANDLE *handle,
+                                  unsigned char *buf, size_t len)
 diff --git a/providers/implementations/rands/seed_src_jitter.c b/providers/implementations/rands/seed_src_jitter.c
 index ac57f1c14b..b6f2849069 100644
 --- a/providers/implementations/rands/seed_src_jitter.c.in


### PR DESCRIPTION
- **openssl: correct comments in tests**
  During jitter testing the grep asserts are correct, but comments were
  left unchanged from the earlier getrandom testing. Update the comments
  to match the implementation and the test-case name / intention.
  

- **openssl-dbg: fixup source code snapshot for generated code**
  fixup source code snapshot for all the generated code
  

- **bump epoch**
  

- **Fixup HMAC patch to be upstreamble**
  

- **Perform throw-away canary tests of jitter and non-validated fips**
  This helps to catch issues with future fips modules.
  

- **Update fix-jitter.patch for 3.2+ providers**
  As highlighted by the new throwawy compile test, update
  fix-jitter.patch for 3.2+ providers.
  