### PR TITLE
pulsar: python multiversion + a number of fixes

### DIFF
--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -67,5 +67,20 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - py3.10-pulsar-client
+        - py3.13-pulsar-client
   pipeline:
     - uses: test/tw/ldd-check
+    # They python library dynamically links against this package,
+    # check that we haven't obviously broken something.
+    - uses: python/import
+      with:
+        python: python3.10
+        import: pulsar
+    - uses: python/import
+      with:
+        python: python3.13
+        import: pulsar

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -12,7 +12,7 @@ environment:
       - abseil-cpp-dev
       - autoconf
       - automake
-      - boost-dev<1.87
+      - boost-dev
       - build-base
       - busybox
       - ca-certificates-bundle

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: "3.8.0"
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -9,7 +9,7 @@ package:
 environment:
   contents:
     packages:
-      - abseil-cpp-20250127-dev
+      - abseil-cpp-dev
       - autoconf
       - automake
       - boost-dev<1.87
@@ -22,7 +22,7 @@ environment:
       - gmock
       - gtest-dev
       - openssl-dev
-      - protobuf-29.5-dev
+      - protobuf-dev
       - python3
       - samurai
 
@@ -32,6 +32,11 @@ pipeline:
       repository: https://github.com/apache/pulsar-client-cpp
       tag: v${{package.version}}
       expected-commit: 0f451b063b266cdd3bb4eafed0e5c00f5c82e4e4
+
+  # https://github.com/apache/pulsar-client-cpp/pull/527
+  - uses: patch
+    with:
+      patches: 0001-ProtobufNativeSchema-convert-abseil-string_view-to-s.patch
 
   - uses: cmake/configure
     with:

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -53,6 +53,9 @@ pipeline:
 
 subpackages:
   - name: libpulsar-dev
+    dependencies:
+      runtime:
+        - ${{package.name}}==${{package.full-version}}
     pipeline:
       - uses: split/dev
     description: libpulsar dev

--- a/libpulsar/0001-ProtobufNativeSchema-convert-abseil-string_view-to-s.patch
+++ b/libpulsar/0001-ProtobufNativeSchema-convert-abseil-string_view-to-s.patch
@@ -1,0 +1,46 @@
+Upstream PR: https://github.com/apache/pulsar-client-cpp/pull/527
+
+From f8e809660e3a009bdbf943fa9b23d269b55e415b Mon Sep 17 00:00:00 2001
+From: dann frazier <dann.frazier@chainguard.dev>
+Date: Sun, 7 Dec 2025 08:43:17 -0700
+Subject: [PATCH] ProtobufNativeSchema: convert abseil string_view to
+ std::string
+
+This resolves the following build failure using abseil-cpp 20250814.1:
+
+```
+[  1%] Building CXX object lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o
+cd /home/build/pulsar-client-cpp/build/lib && /usr/local/bin/c++ -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_ALL_NO_LIB -DBUILDING_PULSAR -DHAS_SNAPPY=0 -DHAS_ZSTD=0 -DPULSAR_AUXV_GETAUXVAL_PRESENT -I/home/build/pulsar-client-cpp -I/home/build/pulsar-client-cpp/include -I/home/build/pulsar-client-cpp/build/include -I/home/build/pulsar-client-cpp/build/generated -I/home/build/pulsar-client-cpp/build/generated/lib -Wno-array-bounds -O2 -g -DNDEBUG -std=gnu++17 -fPIC -Wall -Wformat-security -Wvla -Werror -Wno-sign-compare -Wno-deprecated-declarations -Wno-error=cpp -msse4.2 -mpclmul -fdiagnostics-show-option -fdiagnostics-color -fvisibility=hidden -MD -MT lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o -MF CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o.d -o CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o -c /home/build/pulsar-client-cpp/lib/ProtobufNativeSchema.cc
+/home/build/pulsar-client-cpp/lib/ProtobufNativeSchema.cc: In function 'pulsar::SchemaInfo pulsar::createProtobufNativeSchema(const google::protobuf::Descriptor*)':
+/home/build/pulsar-client-cpp/lib/ProtobufNativeSchema.cc:42:67: error: invalid initialization of reference of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} from expression of type 'absl::lts_20250814::string_view' {aka 'std::basic_string_view<char>'}
+   42 |     const std::string& rootMessageTypeName = descriptor->full_name();
+      |                                              ~~~~~~~~~~~~~~~~~~~~~^~
+/home/build/pulsar-client-cpp/lib/ProtobufNativeSchema.cc:43:69: error: invalid initialization of reference of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} from expression of type 'absl::lts_20250814::string_view' {aka 'std::basic_string_view<char>'}
+   43 |     const std::string& rootFileDescriptorName = fileDescriptor->name();
+      |                                                 ~~~~~~~~~~~~~~~~~~~~^~
+make[2]: *** [lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/build.make:1052: lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o] Error 1
+```
+
+Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
+---
+ lib/ProtobufNativeSchema.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/ProtobufNativeSchema.cc b/lib/ProtobufNativeSchema.cc
+index 632943d..c3a4ed8 100644
+--- a/lib/ProtobufNativeSchema.cc
++++ b/lib/ProtobufNativeSchema.cc
+@@ -39,8 +39,8 @@ SchemaInfo createProtobufNativeSchema(const google::protobuf::Descriptor* descri
+     }
+ 
+     const auto fileDescriptor = descriptor->file();
+-    const std::string& rootMessageTypeName = descriptor->full_name();
+-    const std::string& rootFileDescriptorName = fileDescriptor->name();
++    const std::string& rootMessageTypeName = std::string(descriptor->full_name());
++    const std::string& rootFileDescriptorName = std::string(fileDescriptor->name());
+ 
+     FileDescriptorSet fileDescriptorSet;
+     internalCollectFileDescriptors(fileDescriptor, fileDescriptorSet);
+-- 
+2.51.0
+

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -14,7 +14,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - ca-certificates-bundle
       - cmake
       - gcc-14-default
       - libpulsar-dev
@@ -25,7 +24,6 @@ environment:
       - py3-wheel
       - python3
       - python3-dev
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -7,6 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - py3-certifi
       - python3
 
 environment:
@@ -52,3 +53,4 @@ update:
 test:
   pipeline:
     - uses: test/tw/ldd-check
+    - uses: test/tw/pip-check

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -10,6 +10,7 @@ package:
 
 vars:
   pypi-package: pulsar-client
+  import: pulsar
 
 data:
   - name: py-versions
@@ -67,6 +68,10 @@ subpackages:
       pipeline:
         - uses: test/tw/ldd-check
         - uses: test/tw/pip-check
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -76,6 +81,24 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -18,13 +18,9 @@ environment:
       - cmake
       - gcc-14-default
       - libpulsar-dev
-      - py3-build
-      - py3-installer
+      - py3-build-base-dev
       - py3-pybind11-dev
-      - py3-setuptools
-      - py3-wheel
       - python3
-      - python3-dev
 
 pipeline:
   - uses: git-checkout

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -6,9 +6,18 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-certifi
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: pulsar-client
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -16,9 +25,8 @@ environment:
       - build-base
       - busybox
       - libpulsar-dev
-      - py3-build-base-dev
-      - py3-pybind11-dev
-      - python3
+      - py3-supported-build-base-dev
+      - py3-supported-pybind11
 
 pipeline:
   - uses: git-checkout
@@ -27,19 +35,46 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: b4b035dc33088b66645836d2df2f58aadc98089f
 
-  - uses: cmake/configure
-    with:
-      opts: |
-        -DPYBIND11_INCLUDE_DIRS=/usr/lib/python"$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')"/site-packages/pybind11/include
-      output-dir: $(pwd)
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-certifi
+    pipeline:
+      - uses: cmake/configure
+        with:
+          opts: |
+            -DPython3_EXECUTABLE=/usr/bin/python${{range.key}} \
+            -DPython3_INCLUDE_DIR=/usr/include/python${{range.key}} \
+            -DPYBIND11_INCLUDE_DIRS=/usr/lib/python${{range.key}}/site-packages/pybind11/include
+          output-dir: output.${{range.key}}
+      - uses: cmake/build
+        with:
+          output-dir: output.${{range.key}}
+      - runs: |
+          cp output.${{range.key}}/lib_pulsar.so .
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+        - uses: test/tw/pip-check
 
-  - uses: cmake/build
-    with:
-      output-dir: $(pwd)
-
-  - uses: py/pip-build-install
-
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -47,8 +82,3 @@ update:
     identifier: apache/pulsar-client-python
     strip-prefix: v
     strip-suffix: -candidate1
-
-test:
-  pipeline:
-    - uses: test/tw/ldd-check
-    - uses: test/tw/pip-check

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -15,7 +15,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - gcc-14-default
       - libpulsar-dev
       - py3-build-base-dev
       - py3-pybind11-dev

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -34,8 +34,8 @@ pipeline:
       cmake -B build -DPYBIND11_INCLUDE_DIRS=/usr/lib/python$pythonver/site-packages/pybind11/include
       cmake --build build
       cmake --install build
-      python3 ./setup.py bdist_wheel
-      python3 -m installer -d "${{targets.destdir}}" dist/pulsar_client-*.whl
+
+  - uses: py/pip-build-install
 
   - uses: strip
 

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -44,6 +44,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
+        - libpulsar
         - py${{range.key}}-certifi
     pipeline:
       - uses: cmake/configure

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pulsar-client
   version: "3.8.0"
-  epoch: 0
+  epoch: 1
   description: Apache Pulsar Python client library
   copyright:
     - license: Apache-2.0

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -15,7 +15,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake
       - gcc-14-default
       - libpulsar-dev
       - py3-build-base-dev
@@ -29,11 +28,15 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: b4b035dc33088b66645836d2df2f58aadc98089f
 
-  - runs: |
-      pythonver=$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
-      cmake -B build -DPYBIND11_INCLUDE_DIRS=/usr/lib/python$pythonver/site-packages/pybind11/include
-      cmake --build build
-      cmake --install build
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DPYBIND11_INCLUDE_DIRS=/usr/lib/python"$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')"/site-packages/pybind11/include
+      output-dir: $(pwd)
+
+  - uses: cmake/build
+    with:
+      output-dir: $(pwd)
 
   - uses: py/pip-build-install
 


### PR DESCRIPTION
My intent here was just to python multiversion py3-pulsar-client, one of the few remaining items on our old [missing multiversion checklist](https://github.com/chainguard-dev/internal-dev/issues/5334) that linear keeps bugging me about finishing. But I found that the python module currently fails to import, which required fixes to libpulsar. While there, I noticed that we had a bunch of pinned build-deps that I managed to clean out.

- **py3-pulsar-client: cleanup unneeded build-deps on ca-certs/wolfi-base**
- **py3-pulsar-client: Add test/tw/pip-check and missing dep it found**
- **py3-pulsar-client: Use py3-build-base-dev**
- **py3-pulsar-client: Use py/pip-build-install**
- **py3-pulsar-client: Use cmake pipelines**
- **py3-pulsar-client: Unpin gcc**
- **py3-pulsar-client: python multiversion**
- **libpulsar: apply patch to allow us to unpin abseil/protobuf**
- **Revert "libpulsar: require boost-dev<1.87 due to missing io_service alias"**
- **libpulsar: libpulsar-dev should depend on libpulsar**
- **py3-pulsar-client: Add python/import tests**
- **libpulsar: Add regression test for the python library**
- **libpulsar: bump epoch to 1**
- **py3-pulsar-client: bump epoch to 1**
