### PR TITLE
Including patch for CVE-2025-13836 in python-3.13

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.11"
-  epoch: 0
+  epoch: 1 # CVE-2025-13836
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -59,6 +59,7 @@ pipeline:
       cherry-picks: |
         3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: [CVE-2025-8291]
         3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: [CVE-2025-6075]
+        3.13/289f29b0fe38baf2d7cb5854f4bb573cc34a6a15: [CVE-2025-13836]
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
The patch for CVE-2025-13836 for python-3.13 has been merged upstream. However a new release has yet to be published. Thus including the patch until, presumably, v3.13.12 is released and includes it.