### PR TITLE
cbindgen: switch to git update backend to query tags

### DIFF
--- a/cbindgen.yaml
+++ b/cbindgen.yaml
@@ -49,6 +49,5 @@ test:
 
 update:
   enabled: true
-  github:
-    identifier: mozilla/cbindgen
+  git:
     strip-prefix: v


### PR DESCRIPTION
Upstream haven't created a release for the past couple of tagged releases, and Firefox is now failing to build because it needs one of those versions (so they evidently are legit releases!).