### PR TITLE
fix(semgrep): GHSA-9h52-p55h-vw2f, GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,6 +1,6 @@
 package:
   name: semgrep
-  version: "1.144.0"
+  version: "1.145.0"
   epoch: 0
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
@@ -55,8 +55,12 @@ pipeline:
     with:
       repository: https://github.com/returntocorp/semgrep
       tag: v${{package.version}}
-      expected-commit: 02b6615cf116f610eccd5a4371728b284408760f
+      expected-commit: c93a066ea94157c10207f2946ebd7f5807a11cf2
       recurse-submodules: true
+
+  - uses: patch
+    with:
+      patches: GHSA-9h52-p55h-vw2f.patch
 
   - name: Change tree sitter version to 0.25
     runs: |

--- a/semgrep/GHSA-9h52-p55h-vw2f.patch
+++ b/semgrep/GHSA-9h52-p55h-vw2f.patch
@@ -1,0 +1,13 @@
+diff --git a/cli/setup.py b/cli/setup.py
+index f4a73cc..676dff1 100644
+--- a/cli/setup.py
++++ b/cli/setup.py
+@@ -127,7 +127,7 @@ install_requires = [
+     "exceptiongroup~=1.2.0",
+     "glom~=22.1",
+     "jsonschema~=4.25.1",
+-    "mcp==1.16.0",
++    "mcp==1.23.0",
+     "opentelemetry-api~=1.37.0",
+     "opentelemetry-sdk~=1.37.0",
+     "opentelemetry-exporter-otlp-proto-http~=1.37.0",


### PR DESCRIPTION
Bump semgrep version to 1.145.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48762, https://github.com/chainguard-dev/CVE-Dashboard/issues/50522, https://github.com/chainguard-dev/CVE-Dashboard/issues/50550

<!--ci-cve-scan:fail-any-->
