### PR TITLE
fix(sqlpad): GHSA-vghf-hv5q-vc2g

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: "7.5.7" # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 3 # GHSA-5j98-mcp5-4vw2
+  epoch: 4
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -32,7 +32,7 @@ pipeline:
     runs: |
       # Create "resolutions" section of package.json
       jq '.resolutions |= (if . then . else {} end)' package.json > temp.json && mv temp.json package.json
-      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="5.1.0"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"' '"cookie"="0.7.0"' '"path-to-regexp"="0.1.12"' '"xml-crypto"="3.2.1"' '"tar-fs"="2.1.4"' '"brace-expansion"="2.0.2"' '"on-headers"="1.1.0"' '"form-data"="2.5.4"' '"glob"="11.1.0"'; do
+      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="5.1.0"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"' '"cookie"="0.7.0"' '"path-to-regexp"="0.1.12"' '"xml-crypto"="3.2.1"' '"tar-fs"="2.1.4"' '"brace-expansion"="2.0.2"' '"on-headers"="1.1.0"' '"form-data"="2.5.4"' '"glob"="11.1.0"' '"validator"="13.15.22"' '"jws"="4.0.1"'; do
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 


### PR DESCRIPTION
Bump validator to v13.15.22

Bump jws to v4.0.1

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/48763, https://github.com/chainguard-dev/CVE-Dashboard/issues/50002

<!--ci-cve-scan:fail-any-->
