### PR TITLE
rancher-kontainer-driver-metadata-2.13: manually introduce version stream

### DIFF
--- a/rancher-kontainer-driver-metadata-2.13.yaml
+++ b/rancher-kontainer-driver-metadata-2.13.yaml
@@ -1,0 +1,40 @@
+#nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
+package:
+  name: rancher-kontainer-driver-metadata-2.13
+  version: "0_git20251117"
+  epoch: 1
+  description: Complete container management platform - kontainer driver metadata
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - rancher-kontainer-driver-metadata=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/kontainer-driver-metadata
+      branch: release-v2.13
+      expected-commit: fae160a6625570ad8572358ccbfd056f4b41e261
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata
+      install -Dm755 data/data.json  ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata/data.json
+
+test:
+  pipeline:
+    - runs: |
+        # check the expected files are available at the expected location at `/var/lib/rancher-data/driver-metadata/`
+        test -f /var/lib/rancher-data/driver-metadata/data.json
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Commit at head of branch moves frequently


### PR DESCRIPTION
The version stream automation is choking on this package because it's `daily`.