### PR TITLE
Added azfiles-authenticator package

### DIFF
--- a/azfiles-authenticator.yaml
+++ b/azfiles-authenticator.yaml
@@ -8,8 +8,12 @@ package:
   copyright:
     - license: MIT
   dependencies:
+    # Runtime scripts require both /usr/bin/python3 and /usr/bin/python3.(build version)
     runtime:
       - py3-requests
+      - python-3
+      - shadow
+      - sudo
 
 environment:
   contents:
@@ -32,7 +36,9 @@ pipeline:
 
   - uses: patch
     with:
-      patches: fix-library-loading.patch
+      patches: |
+        fix-library-loading.patch
+        fix-sudo-group.patch
 
   - runs: |
       autoreconf -vif
@@ -56,15 +62,9 @@ subpackages:
         - krb5-dev
     test:
       pipeline:
-        - uses: test/pkgconf
+        - uses: test/tw/ldd-check
 
 test:
-  environment:
-    contents:
-      packages:
-        - krb5
-        - py3-requests
-        - python3
   pipeline:
     - name: Verify library installation
       runs: |
@@ -72,6 +72,10 @@ test:
     - name: Verify command-line tool installation
       runs: |
         command -v azfilesauthmanager
+        azfilesauthmanager | grep Usage
+        azfilesauthmanager --version | grep "New user azfilesuser created with UID: 1001"
+        azfilesauthmanager --version | grep "1.0.7"
+        azfilesauthmanager list --json
     - name: Verify Python module installation
       runs: |
         [ -d /usr/lib/python3.13/azfilesauth ]
@@ -81,9 +85,15 @@ test:
       runs: |
         [ -d /etc/azfilesauth ]
         [ -f /etc/azfilesauth/config.yaml ]
-    - name: Verify azfilesrefresh tool installation
+    - name: Verify azfilesrefresh daemon can start
       runs: |
         command -v azfilesrefresh
+        timeout 15 azfilesrefresh
+        cat /var/log/azfilesrefresh.log
+        cat /var/log/azfilesrefresh.log | grep "AZ Files Refresh Daemon started"
+        # Expected error due to no auth config and blank json returned
+        cat /var/log/azfilesrefresh.log | grep "Error getting tickets: Expecting value: line 1 column 1 (char 0)"
+        cat /var/log/azfilesrefresh.log | grep "Done checking. Sleeping"
     - name: Test library loading with Python
       runs: |
         python3 <<-'EOF'

--- a/azfiles-authenticator.yaml
+++ b/azfiles-authenticator.yaml
@@ -1,0 +1,125 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: azfiles-authenticator
+  # Version is sourced from AzFilesAuthenticator.git/configure.ac:L2
+  version: 1.0.7
+  epoch: 0
+  description: Azure Files Authentication Manager Library for Kerberos authentication on Linux
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-requests
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl-dev
+      - krb5-dev
+      - libtool
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Azure/AzFilesAuthenticator
+      expected-commit: 0715121ea3f919d30f6077171e3ba459af854bc1
+
+  - uses: patch
+    with:
+      patches: fix-library-loading.patch
+
+  - runs: |
+      autoreconf -vif
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: azfiles-authenticator-dev
+    description: Development files for azfiles-authenticator
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - curl-dev
+        - krb5-dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+test:
+  environment:
+    contents:
+      packages:
+        - krb5
+        - py3-requests
+        - python3
+  pipeline:
+    - name: Verify library installation
+      runs: |
+        [ -f /usr/lib/libazfilesauth.so.0 ] || [ -f /usr/lib64/libazfilesauth.so.0 ]
+    - name: Verify command-line tool installation
+      runs: |
+        command -v azfilesauthmanager
+    - name: Verify Python module installation
+      runs: |
+        [ -d /usr/lib/python3.13/azfilesauth ]
+        [ -f /usr/lib/python3.13/azfilesauth/__init__.py ]
+        [ -f /usr/lib/python3.13/azfilesauth/azfilesauthmanager.py ]
+    - name: Verify configuration directory
+      runs: |
+        [ -d /etc/azfilesauth ]
+        [ -f /etc/azfilesauth/config.yaml ]
+    - name: Verify azfilesrefresh tool installation
+      runs: |
+        command -v azfilesrefresh
+    - name: Test library loading with Python
+      runs: |
+        python3 <<-'EOF'
+        import ctypes
+        import os
+
+        # Try to load the library
+        library_paths = [
+            '/usr/lib/libazfilesauth.so.0',
+            '/usr/lib64/libazfilesauth.so.0',
+            '/usr/lib/libazfilesauth.so.0.0.0',
+            '/usr/lib64/libazfilesauth.so.0.0.0'
+        ]
+
+        found = False
+        for path in library_paths:
+            if os.path.exists(path):
+                lib = ctypes.CDLL(path)
+                found = True
+                print(f"Successfully loaded library from {path}")
+                break
+
+        if not found:
+            print("Library not found")
+            exit(1)
+
+        # Verify function symbols exist
+        hasattr(lib, 'extern_smb_set_credential_oauth_token')
+        hasattr(lib, 'extern_smb_clear_credential')
+        hasattr(lib, 'extern_smb_list_credential')
+        hasattr(lib, 'extern_smb_version')
+
+        print("All library functions found")
+        EOF
+
+update:
+  enabled: false
+  exclude-reason: Repository has no tags or releases; version is tracked in configure.ac
+  manual: true

--- a/azfiles-authenticator/fix-library-loading.patch
+++ b/azfiles-authenticator/fix-library-loading.patch
@@ -1,0 +1,36 @@
+--- a/src/azfilesauthmanager.py
++++ b/src/azfilesauthmanager.py
+@@ -5,6 +5,7 @@
+ import subprocess
+ import time
+ import ctypes
++import ctypes.util
+ import requests
+ import pwd
+ 
+@@ -20,18 +21,13 @@
+     azfilesauthmanager --version
+ """
+ 
+-library_paths = [
+-    '/usr/lib/libazfilesauth.so',
+-    '/usr/lib64/libazfilesauth.so',
+-    '/usr/local/lib/libazfilesauth.so'
+-]
+-
+-found_path = False
+-for path in library_paths:
+-    if os.path.exists(path):
+-        lib = ctypes.CDLL(path)
+-        found_path = True 
+-        break
++# Use ctypes.util.find_library to properly locate versioned shared libraries
++lib_path = ctypes.util.find_library('azfilesauth')
++if lib_path:
++    lib = ctypes.CDLL(lib_path)
++    found_path = True
++else:
++    found_path = False
+ 
+ if not found_path:
+     print("Library libazfilesauth.so not found in /usr/local/lib or /usr/lib")

--- a/azfiles-authenticator/fix-sudo-group.patch
+++ b/azfiles-authenticator/fix-sudo-group.patch
@@ -1,0 +1,11 @@
+--- a/src/azfilesauthmanager.py
++++ b/src/azfilesauthmanager.py
+@@ -77,6 +77,8 @@
+         if rc != 0:
+             print("Failed to create new user")
+             sys.exit(1)
++        # Create sudo group if it doesn't exist (ignore errors if it already exists)
++        os.system("getent group sudo > /dev/null 2>&1 || groupadd sudo > /dev/null 2>&1")
+         # Add the user to the sudo group
+         rc = os.system(f"sudo usermod -aG sudo {new_user} > /dev/null 2>&1")
+         if rc != 0:

--- a/azurefile-csi-1.34.yaml
+++ b/azurefile-csi-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: azurefile-csi-1.34
   version: "1.34.2"
-  epoch: 0
+  epoch: 1
   description: Azure File CSI Driver
   copyright:
     - license: Apache-2.0

--- a/azurefile-csi-1.34.yaml
+++ b/azurefile-csi-1.34.yaml
@@ -11,6 +11,7 @@ package:
     runtime:
       # https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/a9797b4447144d7d5d0ebfa354b1d023b14cae62/pkg/azurefileplugin/Dockerfile#L36
       - azcopy
+      - azfiles-authenticator
       - cifs-utils
       - e2fsprogs
       - mount
@@ -81,7 +82,7 @@ update:
   github:
     identifier: kubernetes-sigs/azurefile-csi-driver
     strip-prefix: v
-    tag-filter: v1.33.
+    tag-filter: v1.34.
 
 test:
   pipeline:
@@ -99,3 +100,6 @@ test:
           Driver Version: v${{package.version}}
           Enabling controller service capability: CREATE_DELETE_VOLUME
           Enabling volume access mode: SINGLE_NODE_WRITER
+    - name: Verify essential command-line tool is present
+      runs: |
+        command -v azfilesrefresh


### PR DESCRIPTION

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Adds new azfiles-authenticator package that azurefile-csi needs in 1.34+. As azurefile-csi is in wolfi, this package must be too. 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```
