### PR TITLE
jitsucom-jitsu: fix GHSA-869p-cjfg-cm3x by upgrading jsonwebtoken to 9.0.3

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -77,7 +77,7 @@ pipeline:
       # jsonwebtoken 9.0.3 uses jws 4.0.1 (fixed)
       (cd webapps/console && npm pkg set dependencies.jsonwebtoken=^9.0.3)
       pnpm pkg set pnpm.overrides['jws']=^4.0.1
-      
+
       pnpm install -r --unsafe-perm
       export NEXTJS_STANDALONE_BUILD=1
 

--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -76,6 +76,8 @@ pipeline:
       # jsonwebtoken 9.0.2 uses jws 3.2.2 (vulnerable)
       # jsonwebtoken 9.0.3 uses jws 4.0.1 (fixed)
       (cd webapps/console && npm pkg set dependencies.jsonwebtoken=^9.0.3)
+      pnpm pkg set pnpm.overrides['jws']=^4.0.1
+      
       pnpm install -r --unsafe-perm
       export NEXTJS_STANDALONE_BUILD=1
 

--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 9 # GHSA-9qr9-h5gf-34mp
+  epoch: 10 # GHSA-869p-cjfg-cm3x
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -72,6 +72,10 @@ pipeline:
 
       # CVE-2025-30218, CVE-2025-49005
       (cd webapps/console && npm pkg set dependencies.next=^15.3.3)
+      # CVE-2025-65945 (GHSA-869p-cjfg-cm3x): Upgrade jsonwebtoken to fix jws vulnerability
+      # jsonwebtoken 9.0.2 uses jws 3.2.2 (vulnerable)
+      # jsonwebtoken 9.0.3 uses jws 4.0.1 (fixed)
+      (cd webapps/console && npm pkg set dependencies.jsonwebtoken=^9.0.3)
       pnpm install -r --unsafe-perm
       export NEXTJS_STANDALONE_BUILD=1
 


### PR DESCRIPTION
## Summary
Fixes GHSA-869p-cjfg-cm3x (CVE-2025-65945) by upgrading jsonwebtoken from 9.0.2 to 9.0.3 (patch upgrade).

## Root Cause
```
webapps/console → jsonwebtoken @ 9.0.2 → jws @ 3.2.2 (vulnerable)
```

## Solution
Patch upgrade jsonwebtoken from 9.0.2 to 9.0.3:
- jsonwebtoken 9.0.3 uses jws @ 4.0.1 (fixed)

## Changes
- Incremented epoch to 10
- Added npm pkg set to upgrade jsonwebtoken in webapps/console before pnpm install

## References
- GHSA Advisory: https://github.com/advisories/GHSA-869p-cjfg-cm3x
- CVE Database: https://nvd.nist.gov/vuln/detail/CVE-2025-65945
- CVE Dashboard Issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/50027