### PR TITLE
fix: clamdscan dependency to prevent version mismatch

### DIFF
--- a/clamav-1.5.yaml
+++ b/clamav-1.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.5
   version: "1.5.1"
-  epoch: 2
+  epoch: 3
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -209,12 +209,14 @@ subpackages:
     description: ClamAV daemon client
     test:
       pipeline:
-        - runs: |
-            clamdscan --help
+        - uses: test/tw/help-check
+          with:
+            bins: clamdscan
     dependencies:
       provides:
         - clamav-clamdscan=${{package.full-version}}
       runtime:
+        - ${{package.name}}
         - merged-usrsbin
         - wolfi-baselayout
 


### PR DESCRIPTION
Notes:  The clamav-1.5-clamdscan subpackage was missing an explicit runtime dependency on clamav-1.5, allowing APK to resolve the libclamav.so.12 dependency with clamav-1.4 instead. The version mismatch caused the error:
```
 clamdscan: symbol lookup error: undefined symbol: cl_cvdgetage
```

