### PR TITLE
Disable some tempdir checks until merged-varrun is done

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -8,6 +8,8 @@ package:
   checks:
     disabled:
       - setuidgid
+      # Disabled until merged-varrun is done.
+      - tempdir
   dependencies:
     runtime:
       - ${{package.name}}-config

--- a/atmoz-sftp.yaml
+++ b/atmoz-sftp.yaml
@@ -18,6 +18,10 @@ package:
       - posix-libc-utils # For `getent` command
       - sed
       - shadow
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -19,6 +19,10 @@ package:
       - busybox
       - coreutils
       - gettext
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 vars:
   java-version: '21'

--- a/juicefs-1.3.yaml
+++ b/juicefs-1.3.yaml
@@ -10,6 +10,10 @@ package:
       - fuse3
     provides:
       - juicefs=${{package.full-version}}
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 pipeline:
   - uses: git-checkout

--- a/kubelet-csr-approver.yaml
+++ b/kubelet-csr-approver.yaml
@@ -5,6 +5,10 @@ package:
   description: Kubernetes controller to enable automatic kubelet CSR validation after a series of (configurable) security checks
   copyright:
     - license: MIT
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 pipeline:
   - uses: git-checkout

--- a/openresty.yaml
+++ b/openresty.yaml
@@ -16,6 +16,10 @@ package:
       - perl
       - wolfi-baselayout
       - zlib
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:

--- a/pdns-5.2.yaml
+++ b/pdns-5.2.yaml
@@ -10,6 +10,10 @@ package:
   dependencies:
     provides:
       - pdns=${{package.full-version}}
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 vars:
   python-version: 3.12 # Pinning 3.12 due to imghdr. See: https://peps.python.org/pep-0594/#imghdr

--- a/pgpool2-4.6.yaml
+++ b/pgpool2-4.6.yaml
@@ -11,6 +11,10 @@ package:
     runtime:
       - postgresql
       - postgresql-client
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:

--- a/squid.yaml
+++ b/squid.yaml
@@ -9,6 +9,10 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:

--- a/suricata.yaml
+++ b/suricata.yaml
@@ -9,6 +9,10 @@ package:
     runtime:
       - libhtp
       - suricata-update
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:

--- a/tinyproxy.yaml
+++ b/tinyproxy.yaml
@@ -6,6 +6,10 @@ package:
   description: A light-weight HTTP/HTTPS proxy daemon for POSIX operating systems
   copyright:
     - license: GPL-2.0-or-later
+  checks:
+    disabled:
+      # Disabled until merged-varrun is done.
+      - tempdir
 
 environment:
   contents:


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/melange/pull/2239, https://docs.google.com/document/d/1pydotE6GRdgWP9xmO9YFFX6_f7PdMa7wMWRQSzH8bFw