### PR TITLE
fix(airflow-3): Bump urllib3 to 2.6.0 and remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.3"
-  epoch: 2 # GHSA-r397-ff8c-wv2g
+  epoch: 3 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -73,6 +73,7 @@ pipeline:
       constraints-file: constraints-${{vars.python-version}}.txt
       packages: |
         cryptography==44.0.1 # GHSA-79v4-65xg-pq4g, GHSA-h4gh-qq45-vh27
+        urllib3==2.6.0 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
 
   - runs: |
       # ZIP doesn't handle the SDE we set correctly, so set it to 1980-01-01


### PR DESCRIPTION
Bump urllib3 to 2.6.0 to remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-2xpw-w6gg-jr37-->
<!--ci-cve-scan:must-fix: GHSA-gm62-xv2j-4w53-->
