### PR TITLE
fix(python-3.13): CVE-2025-12084 cherrypick fix

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: "3.13.11"
-  epoch: 1 # CVE-2025-13836
+  epoch: 2 # CVE-2025-12084
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -60,6 +60,7 @@ pipeline:
         3.13/333d4a6f4967d3ace91492a39ededbcf3faa76a6: [CVE-2025-8291]
         3.13/9ab89c026aa9611c4b0b67c288b8303a480fe742: [CVE-2025-6075]
         3.13/289f29b0fe38baf2d7cb5854f4bb573cc34a6a15: [CVE-2025-13836]
+        3.13/ddcd2acd85d891a53e281c773b3093f9db953964: [CVE-2025-12084]
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Patch for python 3.13 has been merged in
https://github.com/python/cpython/pull/142210 though thus far a new point release has not been added. Cherrypicking in the commit until a new point release including the commit is added.

https://github.com/chainguard-dev/CVE-Dashboard/issues/51032
