### PR TITLE
fix(python-3.14): CVE-2025-12084 cherrypick fix

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.2"
-  epoch: 0
+  epoch: 1 # CVE-2025-12084
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -91,6 +91,8 @@ pipeline:
       expected-commit: df793163d5821791d4e7caf88885a2c11a107986
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.14/027f21e417b26eed4505ac2db101a4352b7c51a0: [CVE-2025-12084]
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Patch for python 3.14 has been merged in
https://github.com/python/cpython/pull/142209 though thus far a new point release has not been added. Cherrypicking in the commit until a new point release including the commit is added.