### PR TITLE
fix(langfuse-3): GHSA-869p-cjfg-cm3x

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
-  version: "3.137.0"
-  epoch: 1
+  version: "3.138.0"
+  epoch: 0
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -49,7 +49,7 @@ pipeline:
     with:
       repository: https://github.com/langfuse/langfuse.git
       tag: v${{package.version}}
-      expected-commit: cd7799c7d1ace6753cad16e112845db25fdc6232
+      expected-commit: 1de465eb5c9f898ed0e4430935dd064bd52b4486
 
   - name: "Bump deps and install"
     runs: |
@@ -87,7 +87,8 @@ pipeline:
         "pnpm.overrides.playwright=^1.55.1" \
         "pnpm.overrides.js-yaml=^4.1.1" \
         "pnpm.overrides.mdast-util-to-hast=^13.2.1" \
-        "pnpm.overrides.@modelcontextprotocol/sdk=^1.24.0"
+        "pnpm.overrides.@modelcontextprotocol/sdk=^1.24.0" \
+        "pnpm.overrides.jws=^4.0.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 


### PR DESCRIPTION
Update version to newest langfuse (3.138.0) and bump jws to fixed
version (4.0.1)

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50020

<!--ci-cve-scan:fail-any-->
