### PR TITLE
rancher-charts-2.13: manually introduce version stream

### DIFF
--- a/rancher-charts-2.13.yaml
+++ b/rancher-charts-2.13.yaml
@@ -1,0 +1,57 @@
+#nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
+package:
+  name: rancher-charts-2.13
+  version: "0_git20251209"
+  epoch: 0
+  description: Complete container management platform - charts
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - rancher-charts=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*(\d+\.\d+)$
+    replace: "$1"
+    to: major-minor-version
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/charts
+      branch: release-v${{vars.major-minor-version}}
+      expected-commit: ccf16fd43a8d97965a5ed7a26987a8fb825b373a
+      destination: ./charts
+      depth: 1
+
+  - runs: |
+      sum=$(echo -n "https://git.rancher.io/charts" | sha256sum | awk '{ print $1 }')
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts
+      mv ./charts ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$sum
+
+test:
+  environment:
+    contents:
+      packages:
+        - git
+  pipeline:
+    - runs: |
+        sum=$(echo -n "https://git.rancher.io/charts" | sha256sum | awk '{ print $1 }')
+        cd /var/lib/rancher-data/local-catalogs/v2/rancher-charts/$sum
+
+        # The latest git commit is used by rancher to determine the version of
+        # the repository. Parse HEAD to ensure it's in tact
+        git rev-parse HEAD
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Commit at head of branch moves frequently


### PR DESCRIPTION
The version stream automation is choking on this package because it's `daily`.