### PR TITLE
k3s: provide versioned package names

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,11 +1,13 @@
 package:
   name: k3s
   version: "1.34.2.1"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
   dependencies:
+    provides:
+      - ${{package.name}}-${{vars.major-minor-version}}
     runtime:
       - busybox
       - conntrack-tools
@@ -49,6 +51,10 @@ var-transforms:
     match: \.(\d+)$
     replace: +k3s$1
     to: mangled-package-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+).*
+    replace: $1
+    to: major-minor-version
 
 # Upstream uses `dapper` to initialize build environments, but since melange
 # already provides a consistent build environment, we adopt upstreams ./scripts
@@ -112,6 +118,8 @@ subpackages:
   - name: k3s-multicall
     description: "The k3s multicall binary with embedded components"
     dependencies:
+      provides:
+        - k3s-multicall-${{vars.major-minor-version}}
       runtime:
         - busybox
         - conntrack-tools
@@ -158,6 +166,8 @@ subpackages:
   - name: k3s-static
     description: "k3s built with statically linked components"
     dependencies:
+      provides:
+        - k3s-static-${{vars.major-minor-version}}
       runtime:
         - busybox
         - conntrack-tools


### PR DESCRIPTION
A given `rancher` version depends on a specific version of k3s for its lifetime: this allows us to express that in the downstream packages, without requiring a change when we eventually split off a `k3s-1.34` origin package.