### PR TITLE
openssl: assert that entropy is provided in the get_user_entropy

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 5
+  epoch: 6
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl/fix-jitter.patch
+++ b/openssl/fix-jitter.patch
@@ -1,5 +1,5 @@
 diff --git a/crypto/provider_core.c b/crypto/provider_core.c
-index 74b7d3d8ac..6f94403b6c 100644
+index 74b7d3d8ac..18608dc18c 100644
 --- a/crypto/provider_core.c
 +++ b/crypto/provider_core.c
 @@ -2438,7 +2438,7 @@ static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
@@ -26,7 +26,7 @@ index 74b7d3d8ac..6f94403b6c 100644
  # else
  /*
   * OpenSSL FIPS providers prior to 3.2 call rand_get_entropy API from
-@@ -2470,15 +2478,20 @@ static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
+@@ -2470,15 +2478,22 @@ static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
  {
      return ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
  }
@@ -45,14 +45,16 @@ index 74b7d3d8ac..6f94403b6c 100644
  {
 -    return ossl_rand_get_user_entropy((OSSL_LIB_CTX *)core_get_libctx(handle),
 -                                      pout, entropy, min_len, max_len);
-+    return ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
++    size_t ret = ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
++    OPENSSL_assert(ret > 0);
++    return ret;
  }
 +# endif
  
  static void rand_cleanup_entropy(const OSSL_CORE_HANDLE *handle,
                                   unsigned char *buf, size_t len)
-diff --git a/providers/implementations/rands/seed_src_jitter.c b/providers/implementations/rands/seed_src_jitter.c
-index ac57f1c14b..b6f2849069 100644
+diff --git a/providers/implementations/rands/seed_src_jitter.c.in b/providers/implementations/rands/seed_src_jitter.c.in
+index 4d73f07574..35c7752c17 100644
 --- a/providers/implementations/rands/seed_src_jitter.c.in
 +++ b/providers/implementations/rands/seed_src_jitter.c.in
 @@ -299,7 +299,6 @@ static size_t jitter_get_seed(void *vseed, unsigned char **pout,


### PR DESCRIPTION
There is no way to put the provider into an error state from the core
callback. Also without entropy some providers might not correctly
enter into error state. Hence in such scenarios calling assert,
causing OpenSSL to die is the best course of action to ensure the
provider enters error state and does not produce any output.

This callback is used by 3.2+ providers only, and is not used in
non-fips images. The throw away build does excercise that code-path by
executing the full openssl test suite.
