### PR TITLE
chore(ruby3.x-net-http-persistent): bump epoch for 3.x-connection_pool 3.0.2 compatibility

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT

--- a/ruby3.3-net-http-persistent.yaml
+++ b/ruby3.3-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT

--- a/ruby3.4-net-http-persistent.yaml
+++ b/ruby3.4-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump epoch for ruby3.x-net-http-persistent packages to trigger rebuilds with updated connection_pool 3.0.2 dependency. The gemspecs were built before the recent connection_pool update (https://github.com/wolfidev/os/pull/74851) and contain old/stale version constraints that reject the new connection_pool version.

Helps with the fluentd image build failure:
```
2025-12-09 16:11:15 +0000 [info]: starting fluentd-1.16.10 as dry run mode ruby="3.2.9"
/usr/lib/ruby/3.2.0/rubygems/specification.rb:1466:in `rescue in block in activate_dependencies': Could not find 'connection_pool' (~> 2.2, >= 2.2.4) among 192 total gem(s) (Gem::MissingSpecError)
Checked in 'GEM_PATH=/home/fluent/.local/share/gem/ruby/3.2.0:/usr/lib/ruby/gems/3.2.0' at: /usr/lib/ruby/gems/3.2.0/specifications/net-http-persistent-4.0.6.gemspec, execute `gem env` for more information
        from /usr/lib/ruby/3.2.0/rubygems/specification.rb:1463:in `block in activate_dependencies'
        ...
```

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


<!--ci-cve-scan:fail-any-->

