### PR TITLE
fix(kubeflow-pipelines): GHSA-869p-cjfg-cm3x

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.15.0"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -191,6 +191,7 @@ subpackages:
           # Update package lock in server
           cd server/
           npm install node-forge@1.3.2
+          npm install jws@4.0.1
           npm i
           npm audit fix --package-lock-only --legacy-peer-deps || true
           cd ../


### PR DESCRIPTION
Bump jws to 4.0.1

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50052

<!--ci-cve-scan:fail-any-->
