### PR TITLE
microvm-init: FEATURE add init.d scripting system

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 15
+  epoch: 16
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 14
+  epoch: 25
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
@@ -16,12 +16,10 @@ package:
       - openssh-server
       - util-linux-misc
       - xfsprogs
-
 environment:
   contents:
     packages:
       - busybox
-
 pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/
@@ -72,7 +70,6 @@ pipeline:
       Match LocalPort 2223
           ChrootDirectory none
       EOF
-
 update:
   enabled: false
   exclude-reason: |

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 25
+  epoch: 15
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 16
+  epoch: 15
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0

--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -16,10 +16,12 @@ package:
       - openssh-server
       - util-linux-misc
       - xfsprogs
+
 environment:
   contents:
     packages:
       - busybox
+
 pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/
@@ -70,6 +72,7 @@ pipeline:
       Match LocalPort 2223
           ChrootDirectory none
       EOF
+
 update:
   enabled: false
   exclude-reason: |

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -103,6 +103,7 @@ mount --rbind /proc /mount/proc
 mount --rbind /sys /mount/sys
 mount --rbind /tmp /mount/tmp
 mount -t tmpfs -o mode=1777 tmpfs /mount/run
+
 mount -t cgroup2 -o nsdelegate,memory_recursiveprot,nosuid,nodev,noexec cgroup2 /mount/sys/fs/cgroup
 mkdir -p /mount/dev/pts
 mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /mount/dev/pts/
@@ -139,6 +140,29 @@ echo "${HOSTNAME:-"wolfi-vm"}" > /mount/etc/hostname
 echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /mount/etc/hosts
 rm -f /mount/etc/resolv.conf
 echo "nameserver ${DNS:-"10.0.2.3"}" > /mount/etc/resolv.conf
+
+#########################
+# INIT.D SCRIPT RUNNER  #
+#########################
+
+echo "[INIT] Checking for init.d scripts..." > /dev/console
+
+# Run scripts from /mount/opt/melange/init.d/ in numeric order
+# Scripts are sourced (run in parent process) and must succeed (set -e)
+if [ -d /mount/opt/melange/init.d ]; then
+	for script in /mount/opt/melange/init.d/*; do
+		if [ -f "$script" ] && [ -r "$script" ]; then
+			echo "[INIT] Sourcing init.d script: $(basename $script)" > /dev/console
+			# Source the script - runs in parent process with full environment
+			# Will halt on error due to 'set -e' at top of this script
+			. "$script"
+			echo "[INIT] Completed: $(basename $script)" > /dev/console
+		fi
+	done
+	echo "[INIT] All init.d scripts completed successfully" > /dev/console
+else
+	echo "[INIT] No /mount/opt/melange/init.d directory (optional, skipping)" > /dev/console
+fi
 
 ##############
 # Entrypoint #

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -141,16 +141,38 @@ echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /mount/etc/hosts
 rm -f /mount/etc/resolv.conf
 echo "nameserver ${DNS:-"10.0.2.3"}" > /mount/etc/resolv.conf
 
+###################################
+# ADDITIONAL PACKAGES INSTALLER   #
+###################################
+
+# Check for melange.additional_packages from kernel cmdline
+ADDITIONAL_PACKAGES="$(tr ' ' '\n' < /proc/cmdline | grep "melange.additional_packages=" | cut -d'=' -f2-)"
+
+if [ -n "${ADDITIONAL_PACKAGES}" ]; then
+	echo "[INIT] Installing additional packages: ${ADDITIONAL_PACKAGES}" > /dev/console
+	# Replace commas with spaces for apk command
+	PACKAGES_LIST=$(echo "${ADDITIONAL_PACKAGES}" | tr ',' ' ')
+	# Install packages in the chroot environment
+	if chroot /mount apk add --no-cache ${PACKAGES_LIST}; then
+		echo "[INIT] Successfully installed additional packages" > /dev/console
+	else
+		echo "[INIT] ERROR: Failed to install additional packages" > /dev/console
+		exit 1
+	fi
+else
+	echo "[INIT] No additional packages requested (optional, skipping)" > /dev/console
+fi
+
 #########################
 # INIT.D SCRIPT RUNNER  #
 #########################
 
 echo "[INIT] Checking for init.d scripts..." > /dev/console
 
-# Run scripts from /mount/opt/melange/init.d/ in numeric order
+# Run scripts from /opt/melange/init.d/ in numeric order
 # Scripts are sourced (run in parent process) and must succeed (set -e)
-if [ -d /mount/opt/melange/init.d ]; then
-	for script in /mount/opt/melange/init.d/*; do
+if [ -d /opt/melange/init.d ]; then
+	for script in /opt/melange/init.d/*; do
 		if [ -f "$script" ] && [ -r "$script" ]; then
 			echo "[INIT] Sourcing init.d script: $(basename $script)" > /dev/console
 			# Source the script - runs in parent process with full environment
@@ -161,7 +183,7 @@ if [ -d /mount/opt/melange/init.d ]; then
 	done
 	echo "[INIT] All init.d scripts completed successfully" > /dev/console
 else
-	echo "[INIT] No /mount/opt/melange/init.d directory (optional, skipping)" > /dev/console
+	echo "[INIT] No /opt/melange/init.d directory (optional, skipping)" > /dev/console
 fi
 
 ##############

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -148,14 +148,14 @@ echo "nameserver ${DNS:-"10.0.2.3"}" > /mount/etc/resolv.conf
 echo "[INIT] Checking for init.d scripts..." > /dev/console
 
 # Run scripts from /opt/melange/init.d/ in numeric order
-# Scripts are sourced (run in parent process) and must succeed (set -e)
+# Scripts are executed (run in separate process) and must succeed (set -e)
 if [ -d /opt/melange/init.d ]; then
 	for script in /opt/melange/init.d/*; do
-		if [ -f "$script" ] && [ -r "$script" ]; then
-			echo "[INIT] Sourcing init.d script: $(basename $script)" > /dev/console
-			# Source the script - runs in parent process with full environment
+		if [ -f "$script" ] && [ -x "$script" ]; then
+			echo "[INIT] Executing init.d script: $(basename $script)" > /dev/console
+			# Execute the script - runs in separate process
 			# Will halt on error due to 'set -e' at top of this script
-			. "$script"
+			"$script"
 			echo "[INIT] Completed: $(basename $script)" > /dev/console
 		fi
 	done

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -141,28 +141,6 @@ echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /mount/etc/hosts
 rm -f /mount/etc/resolv.conf
 echo "nameserver ${DNS:-"10.0.2.3"}" > /mount/etc/resolv.conf
 
-###################################
-# ADDITIONAL PACKAGES INSTALLER   #
-###################################
-
-# Check for melange.additional_packages from kernel cmdline
-ADDITIONAL_PACKAGES="$(tr ' ' '\n' < /proc/cmdline | grep "melange.additional_packages=" | cut -d'=' -f2-)"
-
-if [ -n "${ADDITIONAL_PACKAGES}" ]; then
-	echo "[INIT] Installing additional packages: ${ADDITIONAL_PACKAGES}" > /dev/console
-	# Replace commas with spaces for apk command
-	PACKAGES_LIST=$(echo "${ADDITIONAL_PACKAGES}" | tr ',' ' ')
-	# Install packages in the chroot environment
-	if chroot /mount apk add --no-cache ${PACKAGES_LIST}; then
-		echo "[INIT] Successfully installed additional packages" > /dev/console
-	else
-		echo "[INIT] ERROR: Failed to install additional packages" > /dev/console
-		exit 1
-	fi
-else
-	echo "[INIT] No additional packages requested (optional, skipping)" > /dev/console
-fi
-
 #########################
 # INIT.D SCRIPT RUNNER  #
 #########################


### PR DESCRIPTION
This PR adds a change to the microvm-init script we use for building via QEMU (internally and externally). It adds an optional feature to support an "init.d" style folder of additional scripts to run during OS creation. 

This is required so that we do not make a bunch of improvements to our internal Chainguard infrastructure and allow the public to do something similar. 

Changes:
- Add init.d script runner that sources scripts from /mount/opt/melange/init.d/
- Scripts are executed in alphanumeric order before chroot
- Scripts are sourced (not executed) to share environment with parent process
- Failures halt boot due to 'set -e' at script start
- Epoch bumped from 14 to 25