### PR TITLE
ruby3.4-licensee: Cherry-pick fix for test

### DIFF
--- a/ruby3.4-licensee.yaml
+++ b/ruby3.4-licensee.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-licensee
   version: "9.18.0"
-  epoch: 0
+  epoch: 1
   description: A Ruby Gem to detect under what license a project is distributed.
   copyright:
     - license: MIT
@@ -29,6 +29,9 @@ pipeline:
       repository: https://github.com/licensee/licensee.git
       tag: v${{package.version}}
       expected-commit: 336495543ee8756eb512a6b4ec6ad763cf890701
+      depth: -1
+      cherry-picks: |
+        master/b2ac1e62cd5e9228db6c6e70e0871dd04a2f3915: Update octokit requirement from >= 4.20, < 10.0 to >= 4.20, < 11.0
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Bump the required `octokit` version to fix the test.  Also set `depth: -1` when checking out the repository to workaround https://github.com/chainguard-dev/melange/issues/1473.