### PR TITLE
az: fix GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 by upgrading urllib3 to 2.6.0

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.81.0"
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT
@@ -38,6 +38,9 @@ pipeline:
   - runs: |
       # Install the built wheels directly into the package filesystem
       pip install --prefix=${{targets.destdir}}/usr --no-compile src/azure-cli/dist/*.whl src/azure-cli-core/dist/*.whl
+
+      # Remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+      pip install --prefix=${{targets.destdir}}/usr --upgrade "urllib3>=2.6.0"
 
   - uses: strip
 

--- a/az.yaml
+++ b/az.yaml
@@ -40,7 +40,7 @@ pipeline:
       pip install --prefix=${{targets.destdir}}/usr --no-compile src/azure-cli/dist/*.whl src/azure-cli-core/dist/*.whl
 
       # Remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
-      pip install --prefix=${{targets.destdir}}/usr --upgrade "urllib3>=2.6.0"
+      pip install --prefix=${{targets.destdir}}/usr --upgrade "urllib3==2.6.0"
 
   - uses: strip
 

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 6
+  epoch: 7 # GHSA-869p-cjfg-cm3x
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -61,7 +61,8 @@ pipeline:
         "serve-static": "^1.16.0",
         "cookie": "0.7.0",
         "on-headers": "1.1.0",
-        "jsonpath-plus": "10.3.0"
+        "jsonpath-plus": "10.3.0",
+        "jws": "^4.0.1"
       }'
 
       # Apply the overrides


### PR DESCRIPTION
## Summary
Fixes two HIGH severity urllib3 vulnerabilities by upgrading from 2.5.0 to 2.6.0:
- GHSA-2xpw-w6gg-jr37: urllib3 streaming API improperly handles highly compressed data
- GHSA-gm62-xv2j-4w53: urllib3 allows unbounded number of links in decompression chain

## Changes
- Added pip install --upgrade "urllib3>=2.6.0" after main azure-cli installation
- Incremented epoch to 1 (force rebuild with updated urllib3)


## Technical Approach
urllib3 is a transitive dependency of azure-cli, installed when the azure-cli wheels are installed via pip. Adding pip install --upgrade "urllib3>=2.6.0" after the main installation ensures the vulnerable version is replaced with the fixed version.

This is a minor version upgrade (2.5 → 2.6) within the same major version, ensuring compatibility with azure-cli's dependency constraints.

## Verification
After build completes:
```bash
wolfictl scan packages/*/*/az-2.81.0-r1.apk
# Should show both GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 resolved
```

## References
- **GHSA-2xpw-w6gg-jr37 Advisory**: 
- **GHSA-gm62-xv2j-4w53 Advisory**: 
- : https://github.com/chainguard-dev/CVE-Dashboard/issues/50680
- : https://github.com/chainguard-dev/CVE-Dashboard/issues/51089
- **Upstream Repository**: https://github.com/Azure/azure-cli (azure-cli-2.81.0)