### PR TITLE
fix(confluent-docker-utils): Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53

### DIFF
--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-docker-utils
   version: "0.0.162"
-  epoch: 3
+  epoch: 4 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: This package provides Docker Utility Belt (dub) and Confluent Platform Utility Belt (cub).
   copyright:
     - license: Apache-2.0
@@ -40,8 +40,8 @@ pipeline:
       # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638587228
       echo 'PyYAML==6.0.1' >> requirements.txt
 
-      # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v
-      echo 'urllib3>=2.5.0' >> requirements.txt
+      # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v, GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+      echo 'urllib3==2.6.0' >> requirements.txt
 
   - runs: |
       python3=python${{vars.python-version}}


### PR DESCRIPTION
Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 by bumping urllib3 to 2.6.0

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-2xpw-w6gg-jr37-->
<!--ci-cve-scan:must-fix: GHSA-gm62-xv2j-4w53-->
