### PR TITLE
fix(dask-kubernetes): Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.7.0"
-  epoch: 1
+  epoch: 2 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"
@@ -50,6 +50,9 @@ pipeline:
 
       # Upgrade requests to fix GHSA-9548-qrrj-x5pj
       pip install --upgrade "aiohttp==3.12.14"
+
+      # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
+      pip install --upgrade "urllib3==2.6.0"
 
       # Remove pip to avoid accumulating CVEs
       # APK can be used instead if needed

--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -27,6 +27,7 @@ environment:
       - py${{vars.python-version}}-hatch-vcs
       - py${{vars.python-version}}-pip
       - python-${{vars.python-version}}
+      - uv
       - wolfi-base
 
 pipeline:


### PR DESCRIPTION
Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 by bumping urllib3 to 2.6.0

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-2xpw-w6gg-jr37-->
<!--ci-cve-scan:must-fix: GHSA-gm62-xv2j-4w53-->
