### PR TITLE
ruby3.x-net-http-persistent: relax version constraint on connection_pool

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,13 +1,13 @@
 package:
   name: ruby3.2-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - ruby${{vars.rubyMM}}-connection_pool
+      - ruby${{vars.rubyMM}}-connection_pool~2.5
 
 environment:
   contents:
@@ -28,6 +28,10 @@ pipeline:
       expected-commit: 234f3b2c6a0ed044e3c55e3de982257b4860ba0a
       repository: https://github.com/drbrain/net-http-persistent
       tag: v${{package.version}}
+
+  # the lowest we have in the index is 2.5
+  - name: "relax version constraint on connection_pool"
+    runs: sed -i 's/\["~> 2\.2", ">= 2\.2\.4"\]/[">= 2.2.4"]/g' net-http-persistent.gemspec
 
   - uses: ruby/build
     with:

--- a/ruby3.3-net-http-persistent.yaml
+++ b/ruby3.3-net-http-persistent.yaml
@@ -1,13 +1,13 @@
 package:
   name: ruby3.3-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - ruby${{vars.rubyMM}}-connection_pool
+      - ruby${{vars.rubyMM}}-connection_pool~2.5
 
 environment:
   contents:
@@ -28,6 +28,10 @@ pipeline:
       expected-commit: 234f3b2c6a0ed044e3c55e3de982257b4860ba0a
       repository: https://github.com/drbrain/net-http-persistent
       tag: v${{package.version}}
+
+  # the lowest we have in the index is 2.5
+  - name: "relax version constraint on connection_pool"
+    runs: sed -i 's/\["~> 2\.2", ">= 2\.2\.4"\]/[">= 2.2.4"]/g' net-http-persistent.gemspec
 
   - uses: ruby/build
     with:

--- a/ruby3.4-net-http-persistent.yaml
+++ b/ruby3.4-net-http-persistent.yaml
@@ -1,13 +1,13 @@
 package:
   name: ruby3.4-net-http-persistent
   version: "4.0.6"
-  epoch: 0
+  epoch: 1
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - ruby${{vars.rubyMM}}-connection_pool
+      - ruby${{vars.rubyMM}}-connection_pool~2.5
 
 environment:
   contents:
@@ -28,6 +28,10 @@ pipeline:
       expected-commit: 234f3b2c6a0ed044e3c55e3de982257b4860ba0a
       repository: https://github.com/drbrain/net-http-persistent
       tag: v${{package.version}}
+
+  # the lowest we have in the index is 2.5
+  - name: "relax version constraint on connection_pool"
+    runs: sed -i 's/\["~> 2\.2", ">= 2\.2\.4"\]/[">= 2.2.4"]/g' net-http-persistent.gemspec
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Upstream declares a dependency on the connection_pool 2.2 series, but we don't have
that in the index, the lowest being 2.5.

We have done a couple tests, and the gem seems to work with 2.5, so go with that.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
