### PR TITLE
fix(kubeflow-jupyter-web-app): GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

### DIFF
--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: "1.10.0"
-  epoch: 7
+  epoch: 8
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,8 @@ pipeline:
       $pip install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
       # Upgrade werkzeug to fix GHSA-hgf8-39gv-g3f2
       $pip install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
+      # Remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+      pip install --upgrade "urllib3>=2.6.0"
       ls -latr /usr/lib/python${{vars.python-version}}/site-packages
 
       cd ../../jupyter/backend


### PR DESCRIPTION
Upgrade urllib3 to 2.6.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50448, https://github.com/chainguard-dev/CVE-Dashboard/issues/50481

<!--ci-cve-scan:fail-any-->
