### PR TITLE
fix(superset-5.0) GHSA-gm62-xv2j-4w53 GHSA-2xpw-w6gg-jr37

### DIFF
--- a/superset-5.0.yaml
+++ b/superset-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset-5.0
   version: "5.0.0"
-  epoch: 8
+  epoch: 9
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -79,7 +79,7 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.1.4 requests==2.32.4 urllib3==2.5.0 certifi==2024.07.04 zipp==3.19.2 pillow==11.3.0 brotli==1.2.0
+      pip install --upgrade dnspython==2.6.1 gunicorn==23.0.0 idna==3.7 setuptools==78.1.1 sqlparse==0.5.0 Jinja2==3.1.6 Werkzeug==3.1.4 requests==2.32.4 urllib3==2.6.0 certifi==2024.07.04 zipp==3.19.2 pillow==11.3.0 brotli==1.2.0
 
       # Dependencies required during runtime
       pip install pillow pyarrow


### PR DESCRIPTION
Bumping urllib to non impacted version

https://github.com/chainguard-dev/CVE-Dashboard/issues/50546
https://github.com/chainguard-dev/CVE-Dashboard/issues/50705
