### PR TITLE
fix(emissary): Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: "3.10.0"
-  epoch: 13
+  epoch: 14 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ pipeline:
       depth: -1 # Full history is required for version determination
 
   - runs: |
-      sed -i 's/^urllib3==2\.3\.0$/urllib3==2.5.0/' python/requirements.txt
+      sed -i 's/^urllib3==2\.3\.0$/urllib3==2.6.0/' python/requirements.txt
 
   # Go binaries
   - uses: go/bump


### PR DESCRIPTION
Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 by bumping urllib3 to 2.6.0

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-2xpw-w6gg-jr37-->
<!--ci-cve-scan:must-fix: GHSA-gm62-xv2j-4w53-->
