### PR TITLE
Add k8s-image-awaiter subpackage for jupyterhub-k8s-hub package

### DIFF
--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -138,7 +138,7 @@ subpackages:
             image-awaiter --namespace test-image-awaiter --daemonset test-image-puller --pod-scheduling-wait-duration 30 --debug 2>&1 | tee /tmp/k8s-image-awaiter.log
 
             grep "Image download on nodes awaited successfully" /tmp/k8s-image-awaiter.log
-  - name: jupyterhub-k8s-hub-image-awaiter-compat"
+  - name: jupyterhub-k8s-hub-image-awaiter-compat
     description: "compat package for image-awaiter"
     dependencies:
       runtime:

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -72,7 +72,7 @@ subpackages:
         - runs: |
             readlink -v /usr/local/etc/jupyterhub/jupyterhub_config.py
             readlink -v /usr/local/etc/jupyterhub/z2jh.py
-            
+
   - name: jupyterhub-k8s-hub-image-awaiter
     description: Checker, if all pods are ready in jupyterhub-k8s-hub deamonset.
     pipeline:
@@ -138,6 +138,7 @@ subpackages:
             image-awaiter --namespace test-image-awaiter --daemonset test-image-puller --pod-scheduling-wait-duration 30 --debug 2>&1 | tee /tmp/k8s-image-awaiter.log
 
             grep "Image download on nodes awaited successfully" /tmp/k8s-image-awaiter.log
+
   - name: jupyterhub-k8s-hub-image-awaiter-compat
     description: "compat package for image-awaiter"
     dependencies:
@@ -151,8 +152,6 @@ subpackages:
       pipeline:
         - runs: |
             readlink -v /image-awaiter
-
-
 
 update:
   enabled: true

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyterhub-k8s-hub
   version: "4.3.1"
-  epoch: 1
+  epoch: 2
   description: Zero to JupyterHub with Kubernetes
   copyright:
     - license: BSD-3-Clause

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -78,9 +78,6 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          ldflags: |
-            -w
-            -s
           packages: .
           output: image-awaiter
           modroot: images/image-awaiter

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -72,6 +72,89 @@ subpackages:
         - runs: |
             readlink -v /usr/local/etc/jupyterhub/jupyterhub_config.py
             readlink -v /usr/local/etc/jupyterhub/z2jh.py
+            
+  - name: jupyterhub-k8s-hub-image-awaiter
+    version: "4.3.1"
+    epoch: 0
+    description: Checker, if all pods are ready in jupyterhub-k8s-hub deamonset.
+    pipeline:
+      - uses: go/build
+        with:
+          ldflags: |
+            -w
+            -s
+          packages: .
+          output: image-awaiter
+          modroot: images/image-awaiter
+  - name: jupyterhub-k8s-hub-image-awaiter-compat"
+    description: "compat package for image-awaiter"
+    dependencies:
+      runtime:
+        - jupyterhub-k8s-hub-image-awaiter
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/image-awaiter ${{targets.subpkgdir}}/image-awaiter
+    test:
+      pipeline:
+        - runs: |
+            readlink -v /image-awaiter
+    test:
+      environment:
+        contents:
+          packages:
+            - curl
+            - wait-for-port
+      pipeline:
+        - uses: test/tw/ldd-check
+        - name: Smoke tests
+          runs: |
+            image-awaiter --help
+        - uses: test/kwok/cluster
+        - name: Functional test against kube-proxy DaemonSet via kubectl proxy
+          runs: |
+            set -eu
+            sleep 2
+            echo "Starting kubectl proxy on :8080..."
+            kubectl proxy --port 8080 &
+            proxy_pid=$!
+            trap "kill $proxy_pid" EXIT
+
+            wait-for-port 8080
+            echo "Creating test namespace and DaemonSet..."
+            kubectl create namespace test-image-awaiter
+            kubectl apply -n test-image-awaiter -f - <<EOF
+            apiVersion: apps/v1
+            kind: DaemonSet
+            metadata:
+              name: test-image-puller
+            spec:
+              selector:
+                matchLabels:
+                  app: test-puller
+              template:
+                metadata:
+                  labels:
+                    app: test-puller
+                spec:
+                  containers:
+                  - name: pause
+                    image: registry.k8s.io/pause:3.9
+                    resources:
+                      limits:
+                        memory: "10Mi"
+                        cpu: "10m"
+            EOF
+
+            echo "Starting kubectl proxy on :8080..."
+            sleep 5
+
+            echo "Running k8s-image-awaiter against test-image-puller with --debug..."
+            image-awaiter --namespace test-image-awaiter --daemonset test-image-puller --pod-scheduling-wait-duration 30 --debug 2>&1 | tee /tmp/k8s-image-awaiter.log
+
+            grep "Image download on nodes awaited successfully" /tmp/k8s-image-awaiter.log
+
+
 
 update:
   enabled: true

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -84,19 +84,6 @@ subpackages:
           packages: .
           output: image-awaiter
           modroot: images/image-awaiter
-  - name: jupyterhub-k8s-hub-image-awaiter-compat"
-    description: "compat package for image-awaiter"
-    dependencies:
-      runtime:
-        - jupyterhub-k8s-hub-image-awaiter
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"
-          ln -sf /usr/bin/image-awaiter ${{targets.subpkgdir}}/image-awaiter
-    test:
-      pipeline:
-        - runs: |
-            readlink -v /image-awaiter
     test:
       environment:
         contents:
@@ -151,6 +138,19 @@ subpackages:
             image-awaiter --namespace test-image-awaiter --daemonset test-image-puller --pod-scheduling-wait-duration 30 --debug 2>&1 | tee /tmp/k8s-image-awaiter.log
 
             grep "Image download on nodes awaited successfully" /tmp/k8s-image-awaiter.log
+  - name: jupyterhub-k8s-hub-image-awaiter-compat"
+    description: "compat package for image-awaiter"
+    dependencies:
+      runtime:
+        - jupyterhub-k8s-hub-image-awaiter
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/image-awaiter ${{targets.subpkgdir}}/image-awaiter
+    test:
+      pipeline:
+        - runs: |
+            readlink -v /image-awaiter
 
 
 

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -74,8 +74,6 @@ subpackages:
             readlink -v /usr/local/etc/jupyterhub/z2jh.py
             
   - name: jupyterhub-k8s-hub-image-awaiter
-    version: "4.3.1"
-    epoch: 0
     description: Checker, if all pods are ready in jupyterhub-k8s-hub deamonset.
     pipeline:
       - uses: go/build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
