### PR TITLE
fix(jupyter-base-notebook): Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53

### DIFF
--- a/jupyter-base-notebook.yaml
+++ b/jupyter-base-notebook.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyter-base-notebook
   version: "7.5.0"
-  epoch: 0
+  epoch: 1 # GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
   description: Jupyter Notebook
   dependencies:
     runtime:
@@ -34,8 +34,8 @@ pipeline:
       # CVE-2025-47287
       pip install --upgrade tornado==6.5.0
 
-      # Remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
-      pip install --upgrade urllib3>=2.5.0
+      # Remediate GHSA-48p4-8xcf-vxj5, GHSA-pq67-6m6q-mj2v, GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
+      pip install --upgrade urllib3==2.6.0
 
       jupyter server --generate-config
       # The default config is written to the user's home directory.


### PR DESCRIPTION
Remediate GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53 by bumping urllib3 to 2.6.0

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-2xpw-w6gg-jr37-->
<!--ci-cve-scan:must-fix: GHSA-gm62-xv2j-4w53-->
