### PR TITLE
re2: move to shared library naming

### DIFF
--- a/re2.yaml
+++ b/re2.yaml
@@ -1,10 +1,13 @@
 package:
   name: re2
   version: "2025.11.05" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause
+
+vars:
+  soversion: "11"
 
 var-transforms:
   - from: ${{package.version}}
@@ -47,6 +50,13 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libre2-${{vars.soversion}}
+    pipeline:
+      - uses: split/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
   - name: re2-dev
     pipeline:
       - uses: split/dev
@@ -55,6 +65,7 @@ subpackages:
       runtime:
         - abseil-cpp-dev
         - icu-dev
+        - libre2-${{vars.soversion}}=${{package.full-version}}
     test:
       pipeline:
         - uses: test/pkgconf
@@ -69,16 +80,3 @@ update:
       replace: '.'
   github:
     identifier: google/re2
-
-test:
-  pipeline:
-    - uses: test/tw/ldd-check
-    - name: "make sure we put the libre2.so file in the APK"
-      runs: |
-        dir="/usr/lib"
-        name="libre2.so"
-        if ! find "${dir}" -name "${name}*" | grep -q . ; then
-          echo "FAIL: no files with name '${name}' found in dir '${dir}'. This is unexpected." >&2
-          exit
-        fi
-        echo "PASS: files with name '${name}' found in dir '${dir}'. This is expected."


### PR DESCRIPTION
Migrate re2 package to use shared library naming package to ease future
transitions and co-installability with older re2 version streams.
