### PR TITLE
fix(kubeflow-katib): GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-katib
   version: "0.19.0"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3
   description: Kubeflow Katib services
   copyright:
     - license: Apache-2.0
@@ -92,6 +92,8 @@ subpackages:
           .venv-earlystopping/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           # Fix GHSA-9hjg-9r4m-mvj7
           .venv-earlystopping/bin/pip install --upgrade "requests>=2.32.4"
+          # Remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+          .venv-earlystopping/bin/pip install --upgrade "urllib3==2.6.0"
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR


### PR DESCRIPTION
Bump urllib3 to 2.6.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50180, https://github.com/chainguard-dev/CVE-Dashboard/issues/50249

<!--ci-cve-scan:fail-any-->
