### PR TITLE
Unpin `cmake-3` from packages that build with latest CMake

### DIFF
--- a/double-conversion.yaml
+++ b/double-conversion.yaml
@@ -1,7 +1,7 @@
 package:
   name: double-conversion
   version: "3.4.0"
-  epoch: 0
+  epoch: 1
   description: "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles"
   copyright:
     - license: BSD-3-Clause
@@ -11,7 +11,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake-3
 
 pipeline:
   - uses: git-checkout

--- a/font-stix-otf.yaml
+++ b/font-stix-otf.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-stix-otf
   version: 2.14
-  epoch: 1
+  epoch: 2
   description: stix-otf fonts
   copyright:
     - license: OFL-1.1
@@ -14,7 +14,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake-3
       - libxml2-dev
       - py3-pip
       - python-3.12

--- a/imath.yaml
+++ b/imath.yaml
@@ -1,7 +1,7 @@
 package:
   name: imath
   version: "3.2.2"
-  epoch: 0
+  epoch: 1
   description: C++ and python library of 2D and 3D vector, matrix, and math operations for computer graphics
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake-3
       - doxygen
       - py3-supported-numpy~1.26
       - python3-dev

--- a/libcbor.yaml
+++ b/libcbor.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcbor
   version: "0.13.0"
-  epoch: 1
+  epoch: 2
   description: CBOR protocol implementation for C
   copyright:
     - license: MIT
@@ -11,7 +11,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake-3
 
 pipeline:
   - uses: git-checkout

--- a/nfs-ganesha.yaml
+++ b/nfs-ganesha.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-ganesha
   version: "9.0"
-  epoch: 1
+  epoch: 2
   description: NFS-Ganesha is an NFSv3,v4,v4.1 fileserver that runs in user mode on most UNIX/Linux systems
   copyright:
     - license: GPL-3.0-or-later
@@ -18,7 +18,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - ceph-dev
-      - cmake-3
       - flex
       - gcc-12-default
       - krb5-dev

--- a/orthanc-dicomweb.yaml
+++ b/orthanc-dicomweb.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-dicomweb
   version: "1.22"
-  epoch: 0
+  epoch: 1
   description: DICOMweb plugin for Orthanc DICOM server - RESTful DICOM services
   copyright:
     - license: AGPL-3.0-or-later
@@ -18,7 +18,6 @@ environment:
       - boost-dev~1.88
       - build-base
       - busybox
-      - cmake-3
       - e2fsprogs
       - gtest-dev
       - jsoncpp-dev

--- a/orthanc-python.yaml
+++ b/orthanc-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: orthanc-python
   version: "7.0"
-  epoch: 0
+  epoch: 1
   description: Python plugin for Orthanc DICOM server
   copyright:
     - license: AGPL-3.0-or-later
@@ -18,7 +18,6 @@ environment:
       - boost-dev~1.88
       - build-base
       - busybox
-      - cmake-3
       - e2fsprogs-dev
       - gtest-dev
       - jsoncpp-dev

--- a/plog.yaml
+++ b/plog.yaml
@@ -1,7 +1,7 @@
 package:
   name: plog
   version: "1.1.11"
-  epoch: 0
+  epoch: 1
   description: "Portable, simple and extensible C++ logging library"
   copyright:
     - license: 'MIT'
@@ -11,7 +11,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - cmake-3
 
 pipeline:
   - uses: git-checkout

--- a/sasl-xoauth2.yaml
+++ b/sasl-xoauth2.yaml
@@ -1,7 +1,7 @@
 package:
   name: sasl-xoauth2
   version: "0.27"
-  epoch: 1
+  epoch: 2
   description: "SASL plugin for XOAUTH2"
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,6 @@ environment:
     packages:
       - build-base
       - ca-certificates-bundle
-      - cmake-3
       - curl-dev
       - cyrus-sasl-dev
       - jsoncpp-dev


### PR DESCRIPTION
These packages build fine with the latest CMake version we have in the archive, so let's clean them up and unpin `cmake-3` from their B-D.