### PR TITLE
rancher-agent-2.13: bump docker/docker to 25.0.13

### DIFF
--- a/rancher-agent-2.13.yaml
+++ b/rancher-agent-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-agent-2.13
   version: "2.13.0"
-  epoch: 0 # CVE-2025-61729
+  epoch: 1 # CVE-2025-61729
   description: Complete container management platform - agent
   copyright:
     - license: Apache-2.0
@@ -57,6 +57,7 @@ pipeline:
         github.com/go-jose/go-jose/v3@v3.0.4
         github.com/containerd/containerd@v1.7.29
         golang.org/x/crypto@v0.45.0
+        github.com/docker/docker@v25.0.13
 
   # Copied from rancher-agent-2.8.yaml
   # Due to the unusual structure of the upstream go.mod, we can't currently use


### PR DESCRIPTION
GHSA-4vq8-7jfc-9cvp

<!--ci-cve-scan:must-fix: GHSA-4vq8-7jfc-9cvp -->