### PR TITLE
k8s-sidecar: drop no-op attempted CVE remediations

### DIFF
--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: "2.1.4"
-  epoch: 0
+  epoch: 1
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT
@@ -35,13 +35,6 @@ pipeline:
       sed -i 's/requests==2\.32\.3/requests==2.32.4/' /home/build/src/requirements.txt # fix GHSA-9hjg-9r4m-mvj7
       sed -i 's/fastapi==0\.115\.2/fastapi==0.120.2/' /home/build/src/requirements.txt # fix GHSA-2c2j-9gv5-cj73, GHSA-7f5h-v6xp-fcq8
       pip install --no-cache-dir -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"
-
-      # Patch CVE-2024-3651
-      pip install idna==3.7
-      # Patch GHSA-34jh-p97f-mpxf
-      pip install urllib3==2.2.2
-      # Patch GHSA-248v-346w-9cwc
-      pip install certifi==2024.07.04
 
   - name: install src/ files to usr/share/app
     runs: |


### PR DESCRIPTION
These `pip` invocations don't pass `--root`, so don't affect the built package at all.

(This update will also serve to pull in a new urllib3, addressing vulns therein.)

<!--ci-cve-scan:fail-any-->