### PR TITLE
kserve: bump urllib3 to 2.6.x

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: "0.16.0"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -114,9 +114,9 @@ subpackages:
           # NB: exclude 'ray' extras since that brings unwanted cuda/nv deps
           poetry install --no-interaction --no-root --extras "storage"
 
-          # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v
+          # urllib3: GHSA-gm62-xv2j-4w53 GHSA-2xpw-w6gg-jr37
           poetry add \
-            "urllib3=^2.5.0"
+            "urllib3=^2.6.0"
 
           poetry run pip freeze | grep -v kserve > requirements.txt
           poetry build


### PR DESCRIPTION
GHSA-gm62-xv2j-4w53
GHSA-2xpw-w6gg-jr37

<!--ci-cve-scan:fail-any-->