### PR TITLE
libnbd: revert back to building without gnutls

### DIFF
--- a/libnbd.yaml
+++ b/libnbd.yaml
@@ -3,7 +3,7 @@ package:
   description: NBD client library in userspace
   url: https://gitlab.com/nbdkit/libnbd
   version: "1.23.13"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: LGPL-2.1-only
 
@@ -14,7 +14,6 @@ environment:
       - automake
       - build-base
       - busybox
-      - gnutls-dev
       - libtool
       - wolfi-baselayout
 
@@ -34,6 +33,12 @@ pipeline:
       uri: https://download.libguestfs.org/libnbd/${{vars.major_version}}-${{vars.channel}}/${{package.name}}-${{package.version}}.tar.gz
       expected-sha512: 7dc39938332446be61e20c8068c2a66e862fa3b17e6422dc283a42e8161d4b9c1b93077125e6310de15c69cbc02cbc250b5bff2485f130b84a7d783278333565
       strip-components: 1
+
+  - runs: |
+      # 1.23.13 only builds if TLS_PRIORITY is set even though it's only
+      # #define'd by the build system when building against gnutls (which we
+      # don't): we set it to some value here to unblock the build
+      sed -i 's/#undef TLS_PRIORITY/#define TLS_PRIORITY "unused-but-expected-by-build"/' ./config.h.in
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
We include libnbd in some FIPS images, for which gnutls is not appropriate.

<!--ci-cve-scan:fail-any-->