### PR TITLE
Unpin `gcc-14-default` from packages that build with latest GCC

### DIFF
--- a/bazel-7.yaml
+++ b/bazel-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-7
   version: "7.7.1"
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   resources:
     cpu: 16
@@ -19,7 +19,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
       - libstdc++-6
       - libstdc++-6-dev
       - openjdk-21

--- a/datadog-agent-7.72.yaml
+++ b/datadog-agent-7.72.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.72.4"
-  epoch: 4 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 5
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -70,7 +70,6 @@ environment:
       # https://github.com/DataDog/datadog-agent/blob/95f4d66f5fb0c10940e0f9b8fc2ab33f0c6099f0/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
       - freetds-dev
       # - gstatus # TODO: Required by gluster
-      - gcc-14-default
       - gnutar
       - go-1.24
       - krb5-dev

--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.4.8
-  epoch: 3
+  epoch: 4
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -23,7 +23,6 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
-      - gcc-14-default
       - gettext-dev
       - glibc-iconv
       # - pinentry TODO skipping for now as seems to require gtk+3.0, gcr, libproxy and mesa

--- a/guile.yaml
+++ b/guile.yaml
@@ -1,7 +1,7 @@
 package:
   name: guile
   version: "3.0.11"
-  epoch: 0
+  epoch: 1
   description: portable, embeddable Scheme implementation written in C
   copyright:
     - license: LGPL-3.0-or-later AND GPL-3.0-or-later
@@ -18,7 +18,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gc-dev
-      - gcc-14-default
       - glibc-iconv
       - gmp-dev
       - libffi-dev

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: "3.8.0"
-  epoch: 2
+  epoch: 3
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,6 @@ environment:
       - ca-certificates-bundle
       - cmake
       - curl-dev
-      - gcc-14-default
       - gmock
       - gtest-dev
       - openssl-dev

--- a/librelp.yaml
+++ b/librelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: librelp
   version: "1.12.0"
-  epoch: 0
+  epoch: 1
   description: librelp is an easy-to-use library for the RELP (Reliable Event Logging Protocol)
   copyright:
     - license: GPL-3.0-or-later
@@ -14,7 +14,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - coreutils
-      - gcc-14-default
       - gnutls-dev
       - grep
       - libtool

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: "4.3.1"
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,6 @@ environment:
       - cmake
       - curl-dev
       - gcc
-      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: "4.3.1"
-  epoch: 1
+  epoch: 2
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,6 @@ environment:
       - cmake
       - curl-dev
       - gcc
-      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: "4.3.1"
-  epoch: 1
+  epoch: 2
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,6 @@ environment:
       - cmake
       - curl-dev
       - gcc
-      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.4-pecl-http.yaml
+++ b/php-8.4-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-pecl-http
   version: "4.3.1"
-  epoch: 1
+  epoch: 2
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,6 @@ environment:
       - cmake
       - curl-dev
       - gcc
-      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/php-8.5-pecl-http.yaml
+++ b/php-8.5-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.5-pecl-http
   version: "4.3.1"
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,6 @@ environment:
       - cmake
       - curl-dev
       - gcc
-      - gcc-14-default
       - icu-dev
       - libtool
       - openssl-dev

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: "3.0.3"
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later
@@ -17,7 +17,6 @@ environment:
       - bzip2
       - cmake-3
       - gawk
-      - gcc-14-default
       - git
       - gnutls-dev
       - grep

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.12"
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -23,7 +23,6 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - expat-dev
-      - gcc-14-default
       - gdbm-dev
       - libcap-utils
       - libffi-dev

--- a/rancher-2.12.yaml
+++ b/rancher-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.12
   version: "2.12.4"
-  epoch: 1
+  epoch: 2
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -73,7 +73,6 @@ environment:
       - btrfs-progs-dev
       - cdrkit
       - curl
-      - gcc-14-default
       - gpgme-dev
 
 vars:

--- a/runit.yaml
+++ b/runit.yaml
@@ -1,7 +1,7 @@
 package:
   name: runit
   version: "2.3.0"
-  epoch: 0
+  epoch: 1
   description: UNIX init scheme with service supervision
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - gcc-14-default
 
 pipeline:
   - uses: fetch

--- a/xtail.yaml
+++ b/xtail.yaml
@@ -3,7 +3,7 @@
 package:
   name: xtail
   version: "2.1.12"
-  epoch: 0
+  epoch: 1
   description: Like "tail -f", but works on truncated files, directories, more
   copyright:
     - license: BSD-3-Clause
@@ -22,7 +22,6 @@ environment:
       - automake
       - build-base
       - busybox
-      - gcc-14-default
       - patch
 
 pipeline:


### PR DESCRIPTION
Fixes: #54855
Fixes: #54877
Fixes: #54880
Fixes: #54892
Fixes: #54893
Fixes: #54926
Fixes: #54927
Fixes: #54928
Fixes: #54929
Fixes: #54930
Fixes: #55120
Fixes: #54941
Fixes: #54969
