### PR TITLE
fix(kubeflow-pipeline) GHSA-2xpw-w6gg-jr37 GHSA-gm62-xv2j-4w53

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.15.0"
-  epoch: 3 # GHSA-xrqc-7xgx-c9vh
+  epoch: 4 # GHSA-xrqc-7xgx-c9vh
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -85,6 +85,9 @@ subpackages:
 
             # Patch GHSA-jfmj-5v4g-7637
             sed -i 's|zipp==3.15.0|zipp==3.19.1|g' requirements.txt
+
+            # Patch GHSA-2xpw-w6gg-jr37 GHSA-gm62-xv2j-4w53
+            sed -i 's|urllib3==2.5.0|urllib3==2.6.0|g' requirements.txt
 
             # google-auth: upgrade to support urllib3 2.x (fixes dependency conflict)
             sed -i 's|google-auth==2.23.0|google-auth==2.40.3|g' requirements.txt


### PR DESCRIPTION
Updating urllib in subpackage kubeflow-pipeline-apiserver

https://github.com/chainguard-dev/CVE-Dashboard/issues/51222
https://github.com/chainguard-dev/CVE-Dashboard/issues/51266
