### PR TITLE
Add clang to -dev packages runtime

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.2"
-  epoch: 1 # CVE-2025-12084
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -357,6 +357,7 @@ subpackages:
     description: "python3.14 development headers"
     dependencies:
       runtime:
+        - clang-19
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
@@ -375,6 +376,7 @@ subpackages:
     description: "python3 development headers"
     dependencies:
       runtime:
+        - clang-19
         - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - runs: |

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -20,7 +20,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       # This is a year old. Hopefully 3.14.x updates will move this to current.
-      - clang-19
+      - clang-${{vars.clang-version}}
       - expat-dev
       - gdbm-dev
       - libcap-utils
@@ -28,7 +28,7 @@ environment:
       - libx11-dev
       - linux-headers
       # This is a year old. Hopefully 3.14.x updates will move this to current.
-      - llvm-19
+      - llvm-${{vars.clang-version}}
       - mpdecimal-dev
       - ncurses-dev
       - openssl-dev
@@ -45,6 +45,7 @@ environment:
       - zstd-dev
 
 vars:
+  clang-version: 19
   python-config: |
     --host=__host_triplet_gnu__ \
     --build=__host_triplet_gnu__ \
@@ -357,7 +358,7 @@ subpackages:
     description: "python3.14 development headers"
     dependencies:
       runtime:
-        - clang-19
+        - clang-${{vars.clang-version}}
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
@@ -376,7 +377,7 @@ subpackages:
     description: "python3 development headers"
     dependencies:
       runtime:
-        - clang-19
+        - clang-${{vars.clang-version}}
         - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - runs: |


### PR DESCRIPTION
Adds `clang` as a runtime dependency to the `-dev` subpackages.

Addresses https://github.com/chainguard-dev/customer-issues/issues/2893