### PR TITLE
gcc: Create vars.glibc-version and use it

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -49,6 +49,9 @@ var-transforms:
     replace: $1
     to: major-version
 
+vars:
+  glibc-version: "2.42"
+
 pipeline:
   - uses: git-checkout
     with:
@@ -91,7 +94,7 @@ pipeline:
         --disable-nls \
         --disable-werror \
         --with-pkgversion='Wolfi ${{package.full-version}}' \
-        --with-glibc-version=2.42 \
+        --with-glibc-version=${{vars.glibc-version}} \
         --enable-initfini-array \
         --disable-nls \
         --disable-multilib \


### PR DESCRIPTION
No need to rebuild the package, so I'm not bumping the epoch.