### PR TITLE
fix(kubeflow-pipelines-visualization-server): GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.15.0"
-  epoch: 0
+  epoch: 1
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,9 @@ pipeline:
 
       # pip-tools is not compatible with pip 25.3
       pip install -U 'pip!=25.3'
+
+      # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+      pip install "urllib3==2.6.0"
 
       # Reset and regenerate requirements.txt from our modified-requirements.in
       # Necessary to properly (and more easily) patch CVEs and resolve build failures


### PR DESCRIPTION
Bump urllib3 to 2.6.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50335, https://github.com/chainguard-dev/CVE-Dashboard/issues/50531

<!--ci-cve-scan:fail-any-->
