### PR TITLE
yara: Compile using gcc-14-default

### DIFF
--- a/yara.yaml
+++ b/yara.yaml
@@ -2,7 +2,7 @@
 package:
   name: yara
   version: "4.5.5"
-  epoch: 0
+  epoch: 1
   description: The pattern matching swiss knife for malware researchers
   copyright:
     - license: BSD-3-Clause
@@ -16,6 +16,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - flex
+      # https://github.com/chainguard-dev/customer-issues/issues/2888
+      # This is a GCC bug.
+      - gcc-14-default
       - libmagic-dev
       - libtool
       - linux-headers


### PR DESCRIPTION
yara is currently segfaulting when performing the following (inside a Wolfi container):

```console
$ apk add yara wget unzip
$ wget
https://github.com/electron/electron/releases/download/v39.2.6/chromedriver-v39.2.6-win32-ia32.zip
$ unzip chromedriver-v39.2.6-win32-ia32.zip
$ echo 'import "pe"  rule test_rule { condition:  true }' > rule.yara
yara rule.yara ffmpeg.dll
```

This is the backtrace:

```
(gdb) bt
```

And the segfault is happening because:

```
(gdb) p/x $pc
$1 = 0x55c1d209bc55
(gdb) x/i $pc
=> 0x55c1d209bc55 <pe__load+15157>:     movdqa (%rdx),%xmm0
(gdb) p/x *$rdx
$2 = 0x80007
(gdb) p/x $rdx
$3 = 0x7f6c33572a21
```

`movdqa` requires the memory to be aligned, which is not happening. This is very likely a GCC 15 bug, and I will follow up with GCC upstream.

For now, we have a few ways to workaround the issue:

- Compile using `gcc-14-default`.

- Compile with `-fno-tree-vectorize`, which disables the specific optimization responsible for generating the `movdqa` instruction.

- Compile with `-O1`, which also disables optimizations.

I believe it's better to stick with `gcc-14-default` because then we don't have to disable any optimizations.

It's important to say that Alpine's yara does not segfault because it gets compiled with `-Os`, which doesn't generate `movdqa`.

Fixes: https://github.com/chainguard-dev/customer-issues/issues/2888