### PR TITLE
fix(newrelic-nri-statsd): Remediate GHSA-4f99-4q7p-p3gh

### DIFF
--- a/newrelic-nri-statsd.yaml
+++ b/newrelic-nri-statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-statsd
   version: "2.12.0"
-  epoch: 1 # CVE-2025-61729
+  epoch: 2 # GHSA-4f99-4q7p-p3gh
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: Apache-2.0
@@ -25,9 +25,10 @@ pipeline:
       expected-commit: e89294aee902171dfd0722e712cc517ed80b7180
       repository: https://github.com/newrelic/nri-statsd
       tag: v${{package.version}}
+      cherry-picks: |
+        master/aa6bc93b71c21434bf567774b900c6cde6481e60: GHSA-4f99-4q7p-p3gh
 
   - runs: |
-      sed -i 's|40\.0\.1|41.0.2|g' Dockerfile
       mkdir -p "${{targets.destdir}}"/usr/bin
       mkdir -p "${{targets.destdir}}"/home/nonroot
       mv /usr/bin/gostatsd "${{targets.destdir}}"/usr/bin


### PR DESCRIPTION
Bump atlassianlabs/gostatsd to 41.0.4 in Dockerfile
by cherry picking an upstream commit

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-4f99-4q7p-p3gh-->
