### PR TITLE
fix(kubernetes-1.34): revert iptables-wrappers to ip6tables

### DIFF
--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.2"
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -162,7 +162,7 @@ subpackages:
     description: An agent that runs on each node in a Kubernetes cluster making sure that containers are running in a Pod
     dependencies:
       runtime:
-        - iptables-wrappers
+        - ip6tables
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -201,7 +201,7 @@ subpackages:
     description: Kubernetes network proxy that runs on each node
     dependencies:
       runtime:
-        - iptables-wrappers
+        - ip6tables
         - nftables
         - kmod
         - conntrack-tools
@@ -385,7 +385,7 @@ test:
         - iproute2
         - socat
         - conntrack-tools
-        - iptables-wrappers
+        - ip6tables
         - crictl
   pipeline:
     - uses: test/kwok/cluster


### PR DESCRIPTION
Replace iptables-wrappers dependency with ip6tables in kubelet and kube-proxy to avoid race condition during concurrent iptables execution.

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


<!--ci-cve-scan:fail-any-->
