### PR TITLE
fix(kubeflow-volumes-web-app): GHSA-2xpw-w6gg-jr37

### DIFF
--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: "1.10.0"
-  epoch: 5
+  epoch: 6
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -51,6 +51,9 @@ pipeline:
 
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip3 install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
+
+      # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+      pip3 install --upgrade "urllib3>=2.0.6" --prefix=/usr --root="${{targets.destdir}}"
 
       # Build the frontend common packages
       cd ../frontend/kubeflow-common-lib


### PR DESCRIPTION
Bump urllib3 to 2.6.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/50575

<!--ci-cve-scan:fail-any-->
