### PR TITLE
chore: update cassandra-compat-subpkg to provide missing scripts.

### DIFF
--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: "5.0.6"
-  epoch: 1
+  epoch: 2
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
@@ -125,11 +125,12 @@ subpackages:
         - gosu
         - iproute2
         - sed
+        - jemalloc
       provides:
         - cassandra-entrypoint-compat=${{package.full-version}}
     pipeline:
       - runs: |
-          ENTRYPOINT_URL="https://raw.githubusercontent.com/docker-library/cassandra/master/5.0/docker-entrypoint.sh"
+          ENTRYPOINT_URL="https://raw.githubusercontent.com/docker-library/cassandra/master/${{vars.major-minor-version}}/docker-entrypoint.sh"
           curl -o /tmp/docker-entrypoint.sh "$ENTRYPOINT_URL"
 
           EXPECTED_SHA256="9a5b895a511bd19512eb19e001196bc458d80201b98e3acca85e8792e99f4aed"
@@ -141,6 +142,11 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/local/bin/
           cp docker-entrypoint.sh ${{targets.contextdir}}/usr/local/bin/
           chmod +x ${{targets.contextdir}}/usr/local/bin/docker-entrypoint.sh
+
+          mkdir -p ${{targets.subpkgdir}}/opt/bin
+          ln -sf /bin/cassandra.in ${{targets.subpkgdir}}/opt/bin/cassandra.in
+          mkdir -p ${{targets.subpkgdir}}/opt/bin/tools
+          ln -sf /bin/tools/cassandra.in ${{targets.subpkgdir}}/opt/bin/tools/cassandra.in
     test:
       pipeline:
         - runs: |

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -143,15 +143,17 @@ subpackages:
           cp docker-entrypoint.sh ${{targets.contextdir}}/usr/local/bin/
           chmod +x ${{targets.contextdir}}/usr/local/bin/docker-entrypoint.sh
 
-          mkdir -p ${{targets.subpkgdir}}/opt/bin
-          ln -sf /bin/cassandra.in ${{targets.subpkgdir}}/opt/bin/cassandra.in
-          mkdir -p ${{targets.subpkgdir}}/opt/bin/tools
-          ln -sf /bin/tools/cassandra.in ${{targets.subpkgdir}}/opt/bin/tools/cassandra.in
+          mkdir -p ${{targets.subpkgdir}}/opt/cassandra/bin
+          ln -sf /bin/cassandra.in ${{targets.subpkgdir}}/opt/cassandra/bin/cassandra.in
+          mkdir -p ${{targets.subpkgdir}}/opt/cassandra/bin/tools
+          ln -sf /bin/tools/cassandra.in ${{targets.subpkgdir}}/opt/cassandra/bin/tools/cassandra.in
     test:
       pipeline:
         - runs: |
             # Verify the entrypoint script is executable
             test -x /usr/local/bin/docker-entrypoint.sh
+            test -x /opt/cassandra/bin/cassandra.in
+            test -x /opt/cassandra/bin/tools/cassandra.in
 
   - name: cqlsh-${{vars.major-minor-version}}
     dependencies:

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -143,17 +143,20 @@ subpackages:
           cp docker-entrypoint.sh ${{targets.contextdir}}/usr/local/bin/
           chmod +x ${{targets.contextdir}}/usr/local/bin/docker-entrypoint.sh
 
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          ln -sf /usr/bin/jemalloc.so.2 ${{targets.subpkgdir}}/usr/lib/libjemalloc.so.2
           mkdir -p ${{targets.subpkgdir}}/opt/cassandra/bin
-          ln -sf /bin/cassandra.in ${{targets.subpkgdir}}/opt/cassandra/bin/cassandra.in
+          ln -sf /bin/cassandra.in.sh ${{targets.subpkgdir}}/opt/cassandra/bin/cassandra.in.sh
           mkdir -p ${{targets.subpkgdir}}/opt/cassandra/bin/tools
-          ln -sf /bin/tools/cassandra.in ${{targets.subpkgdir}}/opt/cassandra/bin/tools/cassandra.in
+          ln -sf /bin/tools/cassandra.in.sh ${{targets.subpkgdir}}/opt/cassandra/bin/tools/cassandra.in.sh
     test:
       pipeline:
         - runs: |
             # Verify the entrypoint script is executable
             test -x /usr/local/bin/docker-entrypoint.sh
-            test -x /opt/cassandra/bin/cassandra.in
-            test -x /opt/cassandra/bin/tools/cassandra.in
+            test -x /usr/lib/libjemalloc.so.2
+            test -x /opt/cassandra/bin/cassandra.in.sh
+            test -x /opt/cassandra/bin/tools/cassandra.in.sh
 
   - name: cqlsh-${{vars.major-minor-version}}
     dependencies:


### PR DESCRIPTION
```
docker run -it --entrypoint bash cassandra:latest
root@3a583a70a758:/# find /usr/lib -name *jemalloc.so.*
/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
root@3a583a70a758:/# find / -name cassandra.in.sh
/opt/cassandra/bin/cassandra.in.sh
/opt/cassandra/tools/bin/cassandra.in.sh
```