### PR TITLE
iptables-wrappers: fix redirection error handling

### DIFF
--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables-wrappers
   version: 2
-  epoch: 5
+  epoch: 6
   description: Wrapper scripts for using iptables in containers
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,12 @@ pipeline:
       expected-commit: e139a115350974aac8a82ec4b815d2845f86997e
       cherry-picks: |
         master/680003b3c6e93b471a59ecc9ae87a8f9054b82f3: Convert iptables-wrapper to a static go program
+
+  - uses: patch
+    with:
+      patches: |
+        0001-Fix-invocation-of-iptables-if-redirection-fails.patch
+        0002-Ignore-redirection-error-if-target-already-exists.patch
 
   # This package is used in FIPS context
   - uses: go/assert-no-crypto

--- a/iptables-wrappers/0001-Fix-invocation-of-iptables-if-redirection-fails.patch
+++ b/iptables-wrappers/0001-Fix-invocation-of-iptables-if-redirection-fails.patch
@@ -1,0 +1,36 @@
+From 56800d00a90af7ab58aeaafffa2eabc99cb29ec8 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markus.boehme@chainguard.dev>
+Date: Fri, 12 Dec 2025 16:21:16 +0000
+Subject: [PATCH] Fix invocation of iptables if redirection fails
+
+Fix the invocation of iptables/nftables if the redirection fails. As
+os.Args[0] can still contain e.g. the full path of the symlink the
+wrapper was invoked as, the leading path components must be stripped for
+the actual iptables/nftables multi-call binary to know how to behave.
+---
+ main.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/main.go b/main.go
+index caebb05..d604c87 100644
+--- a/main.go
++++ b/main.go
+@@ -41,6 +41,7 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 
+ 	"github.com/kubernetes-sigs/iptables-wrappers/internal/iptables"
+ )
+@@ -71,6 +72,7 @@ func main() {
+ 		// fake it, though this will probably also fail if they aren't root
+ 		binaryPath = iptables.XtablesPath(sbinPath, mode)
+ 		args = os.Args
++		args[0] = path.Base(args[0])
+ 	}
+ 
+ 	cmdIPTables := exec.CommandContext(ctx, binaryPath, args...)
+-- 
+2.51.2
+

--- a/iptables-wrappers/0002-Ignore-redirection-error-if-target-already-exists.patch
+++ b/iptables-wrappers/0002-Ignore-redirection-error-if-target-already-exists.patch
@@ -1,0 +1,58 @@
+From 70b06c9e1915fb10391314fdca899f3def5255e7 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markus.boehme@chainguard.dev>
+Date: Fri, 12 Dec 2025 18:34:13 +0000
+Subject: [PATCH] Ignore redirection error if target already exists
+
+Do not log an error if redirection failed because the target already
+exists. This can happen when multiple iptables-wrappers processes race
+each other, or the filesystem is mounted read-only (and removing the
+existing symlink silently failed). There is nothing to be done in these
+cases and the logs are just noise.
+---
+ internal/iptables/alternatives.go | 2 +-
+ main.go                           | 9 ++++++++-
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/internal/iptables/alternatives.go b/internal/iptables/alternatives.go
+index 655ba09..12d4bad 100644
+--- a/internal/iptables/alternatives.go
++++ b/internal/iptables/alternatives.go
+@@ -98,7 +98,7 @@ func (s symlinkSelector) UseMode(ctx context.Context, mode Mode) error {
+ 		_ = os.RemoveAll(cmdPath)
+ 
+ 		if err := os.Symlink(xtablesForModePath, cmdPath); err != nil {
+-			return fmt.Errorf("creating %s symlink for mode %s: %v", cmd, modeStr, err)
++			return fmt.Errorf("creating %s symlink for mode %s: %w", cmd, modeStr, err)
+ 		}
+ 	}
+ 
+diff --git a/main.go b/main.go
+index d604c87..62f7765 100644
+--- a/main.go
++++ b/main.go
+@@ -39,6 +39,7 @@ import (
+ 	"context"
+ 	"errors"
+ 	"fmt"
++	"io/fs"
+ 	"os"
+ 	"os/exec"
+ 	"path"
+@@ -68,7 +69,13 @@ func main() {
+ 
+ 	selector := iptables.BuildAlternativeSelector(sbinPath)
+ 	if err := selector.UseMode(ctx, mode); err != nil {
+-		fmt.Fprintf(os.Stderr, "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?): %s\n", err)
++		// Ignore redirection error if target already exists. This may happen when
++		// multiple iptables-wrappers are racing each other or the filesystem is
++		// mounted read-only.
++		if !errors.Is(err, fs.ErrExist) {
++			fmt.Fprintf(os.Stderr, "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?): %s\n", err)
++		}
++
+ 		// fake it, though this will probably also fail if they aren't root
+ 		binaryPath = iptables.XtablesPath(sbinPath, mode)
+ 		args = os.Args
+-- 
+2.51.2
+


### PR DESCRIPTION
Fix a couple issues with the handling of redirection errors:

  1. Ensure the actual iptables/nftables multi-call binary knows which iptables/nftables command to invoke, by stripping the leading path components of the symlink to iptables-wrappers (e.g. /usr/bin/iptables is no proper command, iptables is).

  2. Suppress an error message about being unable to redirect the iptables/nftables symlinks away from the iptables-wrapper in conditions there is nothing to be done about the error, e.g. when multiple invocations raced one another or the underlying file system is mounted read-only.

#### For PRs that add patches

- [X] Patch source is documented: https://github.com/kubernetes-sigs/iptables-wrappers/pull/11
