### PR TITLE
fix(njs): bump epoch to rebuild modules for nginx-mainline compatibility

### DIFF
--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -2,7 +2,7 @@
 package:
   name: nginx-s3-gateway
   version: 0_git20250605
-  epoch: 5
+  epoch: 6
   description: NGINX S3 Gateway
   copyright:
     - license: Apache-2.0

--- a/nginx-s3-gateway.yaml
+++ b/nginx-s3-gateway.yaml
@@ -2,7 +2,7 @@
 package:
   name: nginx-s3-gateway
   version: 0_git20250605
-  epoch: 6
+  epoch: 5
   description: NGINX S3 Gateway
   copyright:
     - license: Apache-2.0

--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: "0.9.4"
-  epoch: 1
+  epoch: 2
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
The njs module is statically linked to nginx and performs a version check when loaded. When nginx is updated in the image, the nginx-s3-gateway package needs to be rebuilt to ensure the njs module matches the nginx version.

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


<!--ci-cve-scan:fail-any-->
