### PR TITLE
ruby3.x-net-http-persistent: avoid connection_pool v3

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,12 +1,13 @@
 package:
   name: ruby3.2-net-http-persistent
   version: "4.0.6"
-  epoch: 1
+  epoch: 2
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - "!ruby${{vars.rubyMM}}-connection_pool~3"
       - ruby${{vars.rubyMM}}-connection_pool~2.5
 
 environment:


### PR DESCRIPTION
So the resolver doesn't inject it.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
