### PR TITLE
fix(dask-kubernetes): patch kubernetes client metadata to allow urllib3 2.6.0

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.7.0"
-  epoch: 2 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 3 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"
@@ -55,6 +55,13 @@ pipeline:
       # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
       pip install --upgrade "urllib3==2.6.0"
 
+      # Patch kubernetes package metadata to allow urllib3 2.6.0
+      # kubernetes package incorrectly constrains urllib3<2.4.0 but urllib3 2.6.0 is compatible
+      KUBE_METADATA=$(find /usr/share/dask-kubernetes/lib/python${{vars.python-version}}/site-packages -path "*/kubernetes-*.dist-info/METADATA" | head -1)
+      if [ -f "$KUBE_METADATA" ]; then
+        sed -i 's/Requires-Dist: urllib3<2.4.0,>=1.24.2/Requires-Dist: urllib3>=1.24.2/' "$KUBE_METADATA"
+      fi
+
       # Remove pip to avoid accumulating CVEs
       # APK can be used instead if needed
       pip uninstall --yes pip
@@ -91,6 +98,21 @@ test:
       with:
         python: python${{vars.python-version}}
         import: ${{vars.pypi-package}}
+    - name: Verify urllib3 version and kubernetes metadata patch
+      runs: |
+        # Verify urllib3 2.6.0 is installed
+        python${{vars.python-version}} -c "import urllib3; assert urllib3.__version__ == '2.6.0', f'Expected urllib3 2.6.0, got {urllib3.__version__}'"
+
+        # Verify kubernetes metadata was patched to allow urllib3 2.6.0
+        KUBE_METADATA=$(find /usr/share/dask-kubernetes/lib/python${{vars.python-version}}/site-packages -path "*/kubernetes-*.dist-info/METADATA" | head -1)
+        if ! grep -q "Requires-Dist: urllib3>=1.24.2" "$KUBE_METADATA"; then
+          echo "Error: kubernetes metadata not patched correctly"
+          grep "urllib3" "$KUBE_METADATA"
+          exit 1
+        fi
+
+        # Verify operator controller can be imported without version conflicts
+        python${{vars.python-version}} -c "from dask_kubernetes.operator.controller import *"
 
 update:
   enabled: true


### PR DESCRIPTION
The kubernetes Python client incorrectly constrains urllib3<2.4.0, which blocks the security fixes in urllib3 2.6.0 (GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53, here https://github.com/wolfi-dev/os/pull/75541).

Upstream removed this constraint in PR #2461 (merged Oct 2025) but hasn't released it yet - it will be in kubernetes client v35. Until then, we patch the METADATA file to remove the upper bound since urllib3 2.6.0 is fully compatible.

Added tests to verify:
- urllib3 2.6.0 is installed
- kubernetes metadata is patched correctly
- operator controller imports without version conflicts

Upstream tracking:
- https://github.com/kubernetes-client/python/pull/2417
- https://github.com/kubernetes-client/python/issues/2458
- https://github.com/kubernetes-client/python/pull/2461

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>


<!--ci-cve-scan:fail-any-->
