### PR TITLE
test(kubeflow): epoch bump

### DIFF
--- a/kubeflow.yaml
+++ b/kubeflow.yaml
@@ -5,7 +5,7 @@
 package:
   name: kubeflow
   version: "1.10.0"
-  epoch: 9 # CVE-2025-61729
+  epoch: 10
   description: Kubeflow Go Components
   copyright:
     - license: Apache-2.0

--- a/kubeflow/controller-test.sh
+++ b/kubeflow/controller-test.sh
@@ -81,6 +81,7 @@ EOF
 
     
     kubectl create ns kubeflow-user-example-com
+    sleep 5
     cat <<EOF | kubectl apply -f -
   apiVersion: v1
   kind: Pod


### PR DESCRIPTION
To determine is CI errors are specific to a branch or also on tip of
main.
