### PR TITLE
microvm-init: dump dmesg output to /var/log/dmesg

### DIFF
--- a/microvm-init.yaml
+++ b/microvm-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: microvm-init
   version: 0.0.1
-  epoch: 15
+  epoch: 16
   description: Minimal busybox init for microvm workloads
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,7 @@ package:
       - kmod
       - mount
       - openssh-server
+      - umount
       - util-linux-misc
       - xfsprogs
 

--- a/microvm-init/init
+++ b/microvm-init/init
@@ -186,5 +186,8 @@ for i in $(awk -F: '$7 == "/bin/sh" {print $1}' /etc/passwd); do
 	chown -R "$i":"$group" "$home"
 done
 
+echo "[INIT] dumping dmesg to /var/log/dmesg" > /dev/console
+dmesg > /var/log/dmesg
+
 ssh-keygen -A -a 1
 exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
Do this so that future versions of melange can capture the log file's contents, for either debugging purposes or analysis over time.

Also, add the `umount` package to the installed set of packages in the microvm control environment (not the guest).
