### PR TITLE
Rem CVE: GHSA-4qg8-fj49-pxjh Update timestamp-auth

### DIFF
--- a/kyverno-notation-aws.yaml
+++ b/kyverno-notation-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-notation-aws
   version: 1.1
-  epoch: 25 # GHSA-j5w8-q4qc-rx2x
+  epoch: 26 # GHSA-4qg8-fj49-pxjh
   description: Kyverno extension service for Notation and the AWS signer
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,13 @@ pipeline:
         github.com/go-viper/mapstructure/v2@v2.4.0
         github.com/kyverno/kyverno@v1.14.2
         golang.org/x/crypto@v0.45.0
-      replaces: github.com/docker/docker=github.com/docker/docker@v26.1.5+incompatible
+      replaces: |-
+        github.com/docker/docker=github.com/docker/docker@v26.1.5+incompatible
+
+  - uses: go/bump
+    with:
+      replaces: |-
+        github.com/sigstore/timestamp-authority=github.com/sigstore/timestamp-authority/v2@v2.0.3
 
   - uses: go/build
     with:


### PR DESCRIPTION
We are using a 2nd go-bump as
Our gobump works on the replaces first and then work on deps but for this we want to replace at the end of everything Otherwise it is causing unwanted dependency update result in api mismatch

<!--ci-cve-scan:must-fix: GHSA-4qg8-fj49-pxjh-->

It was marked Pending upstrea fix previously: https://github.com/wolfi-dev/advisories/blob/52a333f84b3eb64ee304f2177171d8e2441bcff3/kyverno-notation-aws.advisories.yaml#L354-L357
