### PR TITLE
DNM: iptables-wrappers doesn't replace iptables

### DIFF
--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,16 +1,13 @@
 package:
   name: iptables-wrappers
   version: 2
-  epoch: 6
+  epoch: 7
   description: Wrapper scripts for using iptables in containers
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - xtables
-    replaces:
-      - iptables
-      - ip6tables
+      - xtables>=1.8.4
 
 vars:
   wrapped-commands: |


### PR DESCRIPTION
`iptables-wrappers` is causing havoc, and I'm trying to [figure out](https://chainguard-dev.slack.com/archives/C02NDL0EAB0/p1765896349719299) the right way to do this.

Per the `iptables-wrappers` docs, it's *supposed* to be installed alongside `iptables`, not replace it.

Pushing this up so I can do some testing to see if this works the way I hope it does via a presubmit repo.