### PR TITLE
jitsucom-jitsu: update package.json pins for GHSA-mwv6-3258-q52c, GHSA-w37m-7fhw-fmv9

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: "2.11.0"
-  epoch: 10 # GHSA-869p-cjfg-cm3x
+  epoch: 11 # GHSA-mwv6-3258-q52c
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT
@@ -51,7 +51,8 @@ pipeline:
   - name: Bump dependencies to mitigate vulnerabilities
     runs: |
       jq '.dependencies."js-yaml" = "^4.1.1"' webapps/console/package.json > temp.json && mv temp.json webapps/console/package.json
-      jq '.dependencies."next" = "^15.5.7"' webapps/console/package.json > temp.json && mv temp.json webapps/console/package.json
+      # Remediate GHSA-w37m-7fhw-fmv9 and GHSA-mwv6-3258-q52c
+      jq '.dependencies."next" = "^15.5.8"' webapps/console/package.json > temp.json && mv temp.json webapps/console/package.json
 
   - name: "delete leftover source files"
     runs: |


### PR DESCRIPTION
Bump webapp/console's `next` dependency`next^15.5.8` to remediate GHSA-mwv6-3258-q52c, GHSA-w37m-7fhw-fmv9.
