### PR TITLE
Revert "deno/2.6.1 package update (#76003)"

### DIFF
--- a/deno.yaml
+++ b/deno.yaml
@@ -1,6 +1,6 @@
 package:
   name: deno
-  version: "2.6.1"
+  version: "2.6.0"
   epoch: 0
   description: "A modern runtime for JavaScript and TypeScript."
   copyright:
@@ -29,7 +29,7 @@ pipeline:
     with:
       repository: https://github.com/denoland/deno
       tag: v${{package.version}}
-      expected-commit: 1ba09320aa4ef7362ec33ec332e6e6d38c75d2b5
+      expected-commit: d5b1548eba893d4cc26305f33739a6ca2e6e8c11
 
   - uses: rust/cargobump
 


### PR DESCRIPTION
This reverts commit c275329f8c05759d15b4dc93b3c07a9fa88a0683.

Failing with:

```
error: could not compile `deno` (bin "deno") due to 1 previous error; 1 warning emitted
```