### PR TITLE
fix(akhq): Remediate GHSA-84h7-rjj3-6jx4

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.26.0
-  epoch: 3
+  epoch: 4 # GHSA-84h7-rjj3-6jx4
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,7 @@ pipeline:
       # includes patches for GHSA-pr98-23f8-jwxv, GHSA-6v67-2wr5-gvf4, GHSA-4g8c-wm8x-jfhw, GHSA-4g8c-wm8x-jfhw, GHSA-pq2g-wx69-c263, CVE-2025-48734, GHSA-j288-q9x7-2f5v, GHSA-xwmg-2g98-w7v9 and GHSA-3p8m-j85q-pgmj
       patches: |
         cves-20250714.patch
+        GHSA-84h7-rjj3-6jx4.patch
 
   - runs: |
       ./gradlew build -x test -x startTestKafkaCluster --parallel --no-daemon

--- a/akhq/GHSA-84h7-rjj3-6jx4.patch
+++ b/akhq/GHSA-84h7-rjj3-6jx4.patch
@@ -1,0 +1,40 @@
+From bacc0f9778d7bf2359878eb7c61dcda6dde8f2a6 Mon Sep 17 00:00:00 2001
+From: Ankush Pathak <ankush.pathak@chainguard.dev>
+Date: Wed, 17 Dec 2025 08:59:08 +0000
+Subject: [PATCH] Bump io.netty:netty-codec-http to 4.2.8.Final to remediate
+ GHSA-84h7-rjj3-6jx4
+
+Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>
+---
+ build.gradle      | 1 +
+ gradle.properties | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index 350e64ac..4d7280ee 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -57,6 +57,7 @@ configurations.all {
+         force("net.minidev:json-smart:2.5.2")
+         force("org.apache.commons:commons-lang3:" + lang3Version)
+         force("com.nimbusds:nimbus-jose-jwt:" + nimbusJoseJwtVersion)
++        force("io.netty:netty-codec-http:" + nettyVersion)
+     }
+ }
+ 
+diff --git a/gradle.properties b/gradle.properties
+index 06629bac..d3632ae4 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -11,4 +11,5 @@ commonsCompressVersion=1.26.0
+ vertxVersion=4.4.8
+ nettyVersion=4.1.125.Final
+ jettyHttpVersion=12.0.12
+-beansVersion=1.11.0
+\ No newline at end of file
++beansVersion=1.11.0
++nettyVersion=4.2.8.Final
+\ No newline at end of file
+-- 
+2.52.0
+


### PR DESCRIPTION
Remediate GHSA-84h7-rjj3-6jx4 by bumping io.netty:netty-codec-http to 4.2.8.Final

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-84h7-rjj3-6jx4-->
