### PR TITLE
fix(celeborn-0.6): GHSA-84h7-rjj3-6jx4

### DIFF
--- a/celeborn-0.6.yaml
+++ b/celeborn-0.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: celeborn-0.6
   version: "0.6.2"
-  epoch: 1 # GHSA-84h7-rjj3-6jx4
+  epoch: 2
   description: "Apache Celeborn - A Remote Shuffle Service for Distributed Data Processing Engines"
   copyright:
     - license: Apache-2.0

--- a/celeborn-0.6/pombump-deps.yaml
+++ b/celeborn-0.6/pombump-deps.yaml
@@ -5,9 +5,3 @@ patches:
   - groupId: com.fasterxml.jackson.core
     artifactId: jackson-core
     version: 2.15.0
-  - groupId: io.netty
-    artifactId: netty-codec-smtp
-    version: 4.1.128.Final
-  - groupId: io.netty
-    artifactId: netty-codec-http
-    version: 4.1.129.Final

--- a/celeborn-0.6/pombump-properties.yaml
+++ b/celeborn-0.6/pombump-properties.yaml
@@ -10,7 +10,7 @@ properties:
   - property: maven.plugin.silencer.version
     value: 1.7.19
   - property: netty.version
-    value: 4.1.125.Final
+    value: 4.1.129.Final
   - property: protobuf.version
     value: 3.25.5
   - property: ratis.version


### PR DESCRIPTION
Clean up netty pombumps

Set netty version to 4.1.129.Final

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/51503

<!--ci-cve-scan:fail-any-->
