### PR TITLE
logstash-9.2: rebuild to remediate GHSA-84h7-rjj3-6jx4

### DIFF
--- a/logstash-9.2.yaml
+++ b/logstash-9.2.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.2
   version: "9.2.2"
-  epoch: 0
+  epoch: 1 # GHSA-84h7-rjj3-6jx4
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
GHSA-84h7-rjj3-6jx4 is a vulnerability introduced to this package through the plugin logstash-input-http@3.10.3.  This vulnerability has been remediated in logstash-input-http@3.10.4.  Bump epoch in logstash to trigger a rebuild using the new plugin versions.
