### PR TITLE
Add iptables-nft/iptables-legacy packages

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -149,6 +149,13 @@ pipeline:
       install -D -m644 iptables.confd "${{targets.destdir}}"/etc/conf.d/iptables
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
+  # Weirdly, iptables-xml links to /usr/bin/xtables-legacy-multi; everything
+  # else links to bare xtables-legacy-multi or xtables-nft-multi.
+  - runs: |
+      if [ "$(readlink -fv ${{targets.destdir}}/usr/bin/iptables-xml)" = "/usr/bin/xtables-legacy-multi" ] ; then
+        ln -sfv xtables-legacy-multi ${{targets.destdir}}/usr/bin/iptables-xml
+      fi
+
 subpackages:
   - name: iptables-doc
     description: iptables documentation
@@ -280,14 +287,14 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
           rm ${{targets.contextdir}}/usr/bin/*-legacy*
+      # Redirect these to xtables-nft-multi; by default they use
+      # xtables-legacy-multi.
       - runs: |
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables-restore
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables-save
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-restore
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-save
-          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-xml
+          for bin in ${{targets.contextdir}}/usr/bin/* ; do
+            if [ "$(readlink -fv $bin | grep xtables-legacy-multi)" != "" ] ; then
+              ln -sfv xtables-nft-multi $bin
+            fi
+          done
     test:
       pipeline:
         # Not listed here because they don't have a --help option:
@@ -295,34 +302,67 @@ subpackages:
         - uses: test/tw/help-check
           with:
             bins: |
-              arptables arptables-save arptables-translate \
-              arptables-nft arptables-nft-save \
-              ebtables ebtables-restore ebtables-save ebtables-translate \
-              ebtables-nft ebtables-nft-restore ebtables-nft-save \
-              iptables iptables-restore iptables-save iptables-xml \
-              iptables-translate iptables-restore-translate \
-              iptables-nft iptables-nft-restore iptables-nft-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-              xtables-monitor xtables-nft-multi
+              arptables \
+              arptables-nft \
+              arptables-nft-save \
+              arptables-save \
+              arptables-translate \
+              ebtables \
+              ebtables-nft \
+              ebtables-nft-restore \
+              ebtables-nft-save \
+              ebtables-restore \
+              ebtables-save \
+              ebtables-translate \
+              ip6tables \
+              ip6tables-nft \
+              ip6tables-nft-restore \
+              ip6tables-nft-save \
+              ip6tables-restore \
+              ip6tables-restore-translate \
+              ip6tables-save \
+              ip6tables-translate \
+              iptables \
+              iptables-nft \
+              iptables-nft-restore \
+              iptables-nft-save \
+              iptables-restore \
+              iptables-restore-translate \
+              iptables-save \
+              iptables-translate \
+              iptables-xml
         # Not listed here because they don't have a --version option:
         # arptables-restore, arptables-nft-restore, ebtables-restore,
-        # ebtables-nft-restore, iptables-xml, xtables-nft-multi
+        # ebtables-nft-restore, iptables-xml
         - uses: test/tw/ver-check
           with:
             bins: |
-              arptables arptables-save arptables-translate \
-              arptables-nft arptables-nft-save \
-              ebtables ebtables-save ebtables-translate \
-              ebtables-nft ebtables-nft-save \
-              iptables iptables-restore iptables-save \
-              iptables-translate iptables-restore-translate \
-              iptables-nft iptables-nft-restore iptables-nft-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-              xtables-monitor
+              arptables \
+              arptables-nft \
+              arptables-nft-save \
+              arptables-save \
+              arptables-translate \
+              ebtables \
+              ebtables-nft \
+              ebtables-nft-save \
+              ebtables-save \
+              ebtables-translate \
+              ip6tables \
+              ip6tables-nft \
+              ip6tables-nft-restore \
+              ip6tables-nft-save \
+              ip6tables-restore \
+              ip6tables-restore-translate \
+              ip6tables-save \
+              ip6tables-translate \
+              iptables \
+              iptables-nft \
+              iptables-nft-restore \
+              iptables-nft-save \
+              iptables-restore \
+              iptables-restore-translate \
+              iptables-save \
+              iptables-translate
         - uses: test/tw/ldd-check
         - uses: test/no-docs
 
@@ -339,45 +379,47 @@ subpackages:
         - iptables
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
-          rm ${{targets.contextdir}}/usr/bin/*-nft*
-      - runs: |
-          for name in ${{targets.contextdir}}/usr/bin/* ; do
-            if test -h $name ; then
-              ln -sfv /usr/bin/xtables-legacy-multi ${{targets.contextdir}}/usr/bin/$i
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          for bin in ${{targets.destdir}}/usr/bin/*; do
+            if [ "$(readlink -fv $bin | grep xtables-legacy-multi)" != "" ]; then
+              cp -Pp $bin ${{targets.contextdir}}/usr/bin/
             fi
           done
     test:
       pipeline:
-        # Not listed here because it doesn't have a --help option:
-        # arptables-restore
         - uses: test/tw/help-check
           with:
             bins: |
-              arptables arptables-save arptables-translate \
-              ebtables ebtables-restore ebtables-save ebtables-translate \
-              iptables iptables-restore iptables-save iptables-xml \
-              iptables-translate iptables-restore-translate \
-              iptables-legacy iptables-legacy-restore iptables-legacy-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-              xtables-legacy-multi xtables-monitor
-        # Not listed here because they don't have a --version option:
-        # arptables-restore, ebtables-restore, iptables-xml
+              ip6tables \
+              ip6tables-legacy \
+              ip6tables-legacy-restore \
+              ip6tables-legacy-save
+              ip6tables-restore
+              ip6tables-save \
+              iptables \
+              iptables-legacy \
+              iptables-legacy-restore \
+              iptables-legacy-save \
+              iptables-restore \
+              iptables-save \
+              iptables-xml
+        # Not listed here because it doesn't have a --version option:
+        # iptables-xml
         - uses: test/tw/ver-check
           with:
             bins: |
-              arptables arptables-save arptables-translate \
-              ebtables ebtables-save ebtables-translate \
-              iptables iptables-restore iptables-save \
-              iptables-translate iptables-restore-translate \
-              iptables-legacy iptables-legacy-restore iptables-legacy-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-              xtables-monitor
+              ip6tables \
+              ip6tables-legacy \
+              ip6tables-legacy-restore \
+              ip6tables-legacy-save
+              ip6tables-restore
+              ip6tables-save \
+              iptables \
+              iptables-legacy \
+              iptables-legacy-restore \
+              iptables-legacy-save \
+              iptables-restore \
+              iptables-save
         - uses: test/tw/ldd-check
         - uses: test/no-docs
 

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -150,147 +150,6 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
-  # New hotness. Everything *should* be able to use these. They all link to
-  # xtables-nft-multi.
-  - name: iptables-nft
-    description: iptables for modern kernels
-    dependencies:
-      runtime:
-        - xtables
-      replaces:
-        - ip6tables
-        - iptables
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
-          rm ${{targets.contextdir}}/usr/bin/*-legacy*
-          rm -r ${{targets.contextdir}}/usr/include
-          rm -r ${{targets.contextdir}}/usr/lib
-          rm -r ${{targets.contextdir}}/usr/share/man
-      - runs: |
-          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-nft-multi
-          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-nft-multi
-      # Remove this because it's in xtables.
-      #
-      # TODO: If nothing depends directly on xtables, we could include it
-      # here.
-      - runs: |
-          rm ${{targets.contextdir}}/usr/bin/xtables-nft-multi
-    test:
-      pipeline:
-        # Not listed here because they don't have a --help option:
-        # arptables-restore, arptables-nft-restore
-        - uses: test/tw/help-check
-          with:
-            bins: |
-              arptables arptables-save arptables-translate \
-              arptables-nft arptables-nft-save \
-              ebtables ebtables-restore ebtables-save ebtables-translate \
-              ebtables-nft ebtables-nft-restore ebtables-nft-save \
-              iptables iptables-restore iptables-save iptables-xml \
-              iptables-translate iptables-restore-translate \
-              iptables-nft iptables-nft-restore iptables-nft-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-              xtables-monitor xtables-nft-multi
-        # Not listed here because they don't have a --version option:
-        # arptables-restore, arptables-nft-restore, ebtables-restore,
-        # ebtables-nft-restore, iptables-xml, xtables-nft-multi
-        - uses: test/tw/ver-check
-          with:
-            bins: |
-              arptables arptables-save arptables-translate \
-              arptables-nft arptables-nft-save \
-              ebtables ebtables-save ebtables-translate \
-              ebtables-nft ebtables-nft-save \
-              iptables iptables-restore iptables-save \
-              iptables-translate iptables-restore-translate \
-              iptables-nft iptables-nft-restore iptables-nft-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-              xtables-monitor
-        - uses: test/tw/ldd-check
-        - uses: test/no-docs
-
-  # Old. DO NOT use this unless it's specifically required by something.
-  # Needing iptables-legacy should be viewed as a red flag! They all link to
-  # xtables-legacy-multi.
-  - name: iptables-legacy
-    description: iptables for obsolete kernels
-    dependencies:
-      runtime:
-        - xtables
-      replaces:
-        - ip6tables
-        - iptables
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/
-          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
-          rm ${{targets.contextdir}}/usr/bin/*-nft*
-          rm -r ${{targets.contextdir}}/usr/include
-          rm -r ${{targets.contextdir}}/usr/lib
-          rm -r ${{targets.contextdir}}/usr/share/man
-      - runs: |
-          for i in \
-            arptables arptables-restore arptables-save arptables-translate \
-            ebtables ebtables-restore ebtables-save ebtables-translate \
-            iptables iptables-restore iptables-save iptables-xml \
-            iptables-translate iptables-restore-translate \
-            iptables-legacy iptables-legacy-restore iptables-legacy-save \
-            ip6tables ip6tables-restore ip6tables-save \
-            ip6tables-translate ip6tables-restore-translate \
-            ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-            xtables-monitor ; do
-              ln -sfv ${{targets.contextdir}}/usr/bin/$i /usr/bin/xtables-legacy-multi
-          done
-      # Remove this because it's in xtables.
-      #
-      # TODO: If nothing depends directly on xtables, we could include it
-      # here.
-      - runs: |
-          rm ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
-    test:
-      pipeline:
-        # Not listed here because they don't have a --help option:
-        # arptables-restore
-        - uses: test/tw/help-check
-          with:
-            bins: |
-              arptables arptables-save arptables-translate \
-              ebtables ebtables-restore ebtables-save ebtables-translate \
-              iptables iptables-restore iptables-save iptables-xml \
-              iptables-translate iptables-restore-translate \
-              iptables-legacy iptables-legacy-restore iptables-legacy-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-              xtables-legacy-multi xtables-monitor
-        # Not listed here because they don't have a --version option:
-        # arptables-restore, ebtables-restore, iptables-xml
-        - uses: test/tw/ver-check
-          with:
-            bins: |
-              arptables arptables-save arptables-translate \
-              ebtables ebtables-save ebtables-translate \
-              iptables iptables-restore iptables-save \
-              iptables-translate iptables-restore-translate \
-              iptables-legacy iptables-legacy-restore iptables-legacy-save \
-              ip6tables ip6tables-restore ip6tables-save \
-              ip6tables-translate ip6tables-restore-translate \
-              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-              xtables-monitor
-        - uses: test/tw/ldd-check
-        - uses: test/no-docs
-
   - name: iptables-doc
     description: iptables documentation
     pipeline:
@@ -405,6 +264,122 @@ subpackages:
               help_version "$cmd"
             done
             no_other_commands "${{context.name}}" $cmds
+
+  # New hotness. Everything *should* be able to use these. They all link to
+  # xtables-nft-multi.
+  - name: iptables-nft
+    description: iptables for modern kernels
+    dependencies:
+      runtime:
+        - xtables
+      replaces:
+        - ip6tables
+        - iptables
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
+          rm ${{targets.contextdir}}/usr/bin/*-legacy*
+      - runs: |
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables-restore
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/ip6tables-save
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-restore
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-save
+          ln -sfv /usr/bin/xtables-nft-multi ${{targets.contextdir}}/usr/bin/iptables-xml
+    test:
+      pipeline:
+        # Not listed here because they don't have a --help option:
+        # arptables-restore, arptables-nft-restore
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              arptables-nft arptables-nft-save \
+              ebtables ebtables-restore ebtables-save ebtables-translate \
+              ebtables-nft ebtables-nft-restore ebtables-nft-save \
+              iptables iptables-restore iptables-save iptables-xml \
+              iptables-translate iptables-restore-translate \
+              iptables-nft iptables-nft-restore iptables-nft-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+              xtables-monitor xtables-nft-multi
+        # Not listed here because they don't have a --version option:
+        # arptables-restore, arptables-nft-restore, ebtables-restore,
+        # ebtables-nft-restore, iptables-xml, xtables-nft-multi
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              arptables-nft arptables-nft-save \
+              ebtables ebtables-save ebtables-translate \
+              ebtables-nft ebtables-nft-save \
+              iptables iptables-restore iptables-save \
+              iptables-translate iptables-restore-translate \
+              iptables-nft iptables-nft-restore iptables-nft-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+              xtables-monitor
+        - uses: test/tw/ldd-check
+        - uses: test/no-docs
+
+  # Old. DO NOT use this unless it's specifically required by something.
+  # Needing iptables-legacy should be viewed as a red flag! They all link to
+  # xtables-legacy-multi.
+  - name: iptables-legacy
+    description: iptables for obsolete kernels
+    dependencies:
+      runtime:
+        - xtables
+      replaces:
+        - ip6tables
+        - iptables
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
+          rm ${{targets.contextdir}}/usr/bin/*-nft*
+      - runs: |
+          for name in ${{targets.contextdir}}/usr/bin/* ; do
+            if test -L $name ; then
+              ln -sfv /usr/bin/xtables-legacy-multi ${{targets.contextdir}}/usr/bin/$i
+            fi
+          done
+    test:
+      pipeline:
+        # Not listed here because it doesn't have a --help option:
+        # arptables-restore
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              ebtables ebtables-restore ebtables-save ebtables-translate \
+              iptables iptables-restore iptables-save iptables-xml \
+              iptables-translate iptables-restore-translate \
+              iptables-legacy iptables-legacy-restore iptables-legacy-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+              xtables-legacy-multi xtables-monitor
+        # Not listed here because they don't have a --version option:
+        # arptables-restore, ebtables-restore, iptables-xml
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              ebtables ebtables-save ebtables-translate \
+              iptables iptables-restore iptables-save \
+              iptables-translate iptables-restore-translate \
+              iptables-legacy iptables-legacy-restore iptables-legacy-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+              xtables-monitor
+        - uses: test/tw/ldd-check
+        - uses: test/no-docs
 
 update:
   enabled: true

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 29
+  epoch: 30
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -30,33 +30,6 @@ vars:
     ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
     ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
     xtables-legacy-multi xtables-monitor xtables-nft-multi
-  # New hotness. Everything *should* be able to use these. They all link to
-  # xtables-nft-multi.
-  iptables-nft-cmds: |
-    arptables arptables-restore arptables-save arptables-translate \
-    arptables-nft arptables-nft-restore arptables-nft-save \
-    ebtables ebtables-restore ebtables-save ebtables-translate \
-    ebtables-nft ebtables-nft-restore ebtables-nft-save \
-    iptables iptables-restore iptables-save iptables-xml \
-    iptables-translate iptables-restore-translate \
-    iptables-nft iptables-nft-restore iptables-nft-save \
-    ip6tables ip6tables-restore ip6tables-save \
-    ip6tables-translate ip6tables-restore-translate \
-    ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-    xtables-monitor xtables-nft-multi
-  # Old. DO NOT use this unless it's specifically required by something.
-  # Needing iptables-legacy should be viewed as a red flag! They all link to
-  # xtables-legacy-multi.
-  iptables-legacy-cmds: |
-    arptables arptables-restore arptables-save arptables-translate \
-    ebtables ebtables-restore ebtables-save ebtables-translate \
-    iptables iptables-restore iptables-save iptables-xml \
-    iptables-translate iptables-restore-translate \
-    iptables-legacy iptables-legacy-restore iptables-legacy-save \
-    ip6tables ip6tables-restore ip6tables-save \
-    ip6tables-translate ip6tables-restore-translate \
-    ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
-    xtables-legacy-multi xtables-monitor
   define-test-funcs: |
     help_version() {
       cmd="$1"
@@ -177,6 +150,8 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
+  # New hotness. Everything *should* be able to use these. They all link to
+  # xtables-nft-multi.
   - name: iptables-nft
     description: iptables for modern kernels
     dependencies:
@@ -190,8 +165,9 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
           rm ${{targets.contextdir}}/usr/bin/*-legacy*
-          rm ${{targets.contextdir}}/usr/share/man/man8/*-legacy*
+          rm -r ${{targets.contextdir}}/usr/include
           rm -r ${{targets.contextdir}}/usr/lib
+          rm -r ${{targets.contextdir}}/usr/share/man
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-nft-multi
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-nft-multi
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-nft-multi
@@ -200,7 +176,47 @@ subpackages:
           ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-nft-multi
           ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-nft-multi
           rm ${{targets.contextdir}}/usr/bin/xtables-nft-multi
+    test:
+      pipeline:
+        # Not listed here because they don't have a --help option:
+        # arptables-restore, arptables-nft-restore
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              arptables-nft arptables-nft-save \
+              ebtables ebtables-restore ebtables-save ebtables-translate \
+              ebtables-nft ebtables-nft-restore ebtables-nft-save \
+              iptables iptables-restore iptables-save iptables-xml \
+              iptables-translate iptables-restore-translate \
+              iptables-nft iptables-nft-restore iptables-nft-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+              xtables-monitor xtables-nft-multi
+        # Not listed here because they don't have a --version option:
+        # arptables-restore, arptables-nft-restore, ebtables-restore,
+        # ebtables-nft-restore, iptables-xml, xtables-nft-multi
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              arptables-nft arptables-nft-save \
+              ebtables ebtables-save ebtables-translate \
+              ebtables-nft ebtables-nft-save \
+              iptables iptables-restore iptables-save \
+              iptables-translate iptables-restore-translate \
+              iptables-nft iptables-nft-restore iptables-nft-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+              xtables-monitor
+        - uses: test/tw/ldd-check
+        - uses: test/no-docs
 
+  # Old. DO NOT use this unless it's specifically required by something.
+  # Needing iptables-legacy should be viewed as a red flag! They all link to
+  # xtables-legacy-multi.
   - name: iptables-legacy
     description: iptables for obsolete kernels
     dependencies:
@@ -214,8 +230,9 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/
           cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
           rm ${{targets.contextdir}}/usr/bin/*-nft*
-          rm ${{targets.contextdir}}/usr/share/man/man8/*-nft*
+          rm -r ${{targets.contextdir}}/usr/include
           rm -r ${{targets.contextdir}}/usr/lib
+          rm -r ${{targets.contextdir}}/usr/share/man
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-legacy-multi
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-legacy-multi
           ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-legacy-multi
@@ -224,6 +241,38 @@ subpackages:
           ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-legacy-multi
           ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-legacy-multi
           rm ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
+    test:
+      pipeline:
+        # Not listed here because they don't have a --help option:
+        # arptables-restore
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              ebtables ebtables-restore ebtables-save ebtables-translate \
+              iptables iptables-restore iptables-save iptables-xml \
+              iptables-translate iptables-restore-translate \
+              iptables-legacy iptables-legacy-restore iptables-legacy-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+              xtables-legacy-multi xtables-monitor
+        # Not listed here because they don't have a --version option:
+        # arptables-restore, ebtables-restore, iptables-xml
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              arptables arptables-save arptables-translate \
+              ebtables ebtables-save ebtables-translate \
+              iptables iptables-restore iptables-save \
+              iptables-translate iptables-restore-translate \
+              iptables-legacy iptables-legacy-restore iptables-legacy-save \
+              ip6tables ip6tables-restore ip6tables-save \
+              ip6tables-translate ip6tables-restore-translate \
+              ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+              xtables-monitor
+        - uses: test/tw/ldd-check
+        - uses: test/no-docs
 
   - name: iptables-doc
     description: iptables documentation

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -14,6 +14,8 @@ package:
       - xtables
 
 vars:
+  # Original, full set of commands. In the resulting `iptables` package, most
+  # end up being links to `xtables-nft-multi`
   iptables-cmds: |
     arptables arptables-restore arptables-save arptables-translate \
     arptables-nft arptables-nft-restore arptables-nft-save \
@@ -26,8 +28,35 @@ vars:
     ip6tables ip6tables-restore ip6tables-save \
     ip6tables-translate ip6tables-restore-translate \
     ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-    ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save
+    ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
     xtables-legacy-multi xtables-monitor xtables-nft-multi
+  # New hotness. Everything *should* be able to use these. They all link to
+  # xtables-nft-multi.
+  iptables-nft-cmds: |
+    arptables arptables-restore arptables-save arptables-translate \
+    arptables-nft arptables-nft-restore arptables-nft-save \
+    ebtables ebtables-restore ebtables-save ebtables-translate \
+    ebtables-nft ebtables-nft-restore ebtables-nft-save \
+    iptables iptables-restore iptables-save iptables-xml \
+    iptables-translate iptables-restore-translate \
+    iptables-nft iptables-nft-restore iptables-nft-save \
+    ip6tables ip6tables-restore ip6tables-save \
+    ip6tables-translate ip6tables-restore-translate \
+    ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+    xtables-monitor xtables-nft-multi
+  # Old. DO NOT use this unless it's specifically required by something.
+  # Needing iptables-legacy should be viewed as a red flag! They all link to
+  # xtables-legacy-multi.
+  iptables-legacy-cmds: |
+    arptables arptables-restore arptables-save arptables-translate \
+    ebtables ebtables-restore ebtables-save ebtables-translate \
+    iptables iptables-restore iptables-save iptables-xml \
+    iptables-translate iptables-restore-translate \
+    iptables-legacy iptables-legacy-restore iptables-legacy-save \
+    ip6tables ip6tables-restore ip6tables-save \
+    ip6tables-translate ip6tables-restore-translate \
+    ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+    xtables-legacy-multi xtables-monitor
   define-test-funcs: |
     help_version() {
       cmd="$1"
@@ -148,6 +177,54 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
+  - name: iptables-nft
+    description: iptables for modern kernels
+    dependencies:
+      runtime:
+        - xtables
+      replaces:
+        - ip6tables
+        - iptables
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
+          rm ${{targets.contextdir}}/usr/bin/*-legacy*
+          rm ${{targets.contextdir}}/usr/share/man/man8/*-legacy*
+          rm -r ${{targets.contextdir}}/usr/lib
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-nft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-nft-multi
+          rm ${{targets.contextdir}}/usr/bin/xtables-nft-multi
+
+  - name: iptables-legacy
+    description: iptables for obsolete kernels
+    dependencies:
+      runtime:
+        - xtables
+      replaces:
+        - ip6tables
+        - iptables
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          cp -r ${{targets.destdir}}/* ${{targets.contextdir}}/
+          rm ${{targets.contextdir}}/usr/bin/*-nft*
+          rm ${{targets.contextdir}}/usr/share/man/man8/*-nft*
+          rm -r ${{targets.contextdir}}/usr/lib
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-legacy-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-legacy-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-legacy-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nlegacyft-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-legacy-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-legacy-multi
+          ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-legacy-multi
+          rm ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
+
   - name: iptables-doc
     description: iptables documentation
     pipeline:
@@ -231,6 +308,28 @@ subpackages:
     dependencies:
       runtime:
         - iptables
+    test:
+      pipeline:
+        - uses: test/emptypackage
+
+  - name: ip6tables-nft
+    checks:
+      disabled:
+        - empty
+    dependencies:
+      runtime:
+        - iptables-nft
+    test:
+      pipeline:
+        - uses: test/emptypackage
+
+  - name: ip6tables-legacy
+    checks:
+      disabled:
+        - empty
+    dependencies:
+      runtime:
+        - iptables-legacy
     test:
       pipeline:
         - uses: test/emptypackage

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -344,7 +344,7 @@ subpackages:
           rm ${{targets.contextdir}}/usr/bin/*-nft*
       - runs: |
           for name in ${{targets.contextdir}}/usr/bin/* ; do
-            if test -L $name ; then
+            if test -h $name ; then
               ln -sfv /usr/bin/xtables-legacy-multi ${{targets.contextdir}}/usr/bin/$i
             fi
           done

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -168,13 +168,19 @@ subpackages:
           rm -r ${{targets.contextdir}}/usr/include
           rm -r ${{targets.contextdir}}/usr/lib
           rm -r ${{targets.contextdir}}/usr/share/man
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-nft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-nft-multi
+      - runs: |
+          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-nft-multi
+          ln -sfv ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-nft-multi
+      # Remove this because it's in xtables.
+      #
+      # TODO: If nothing depends directly on xtables, we could include it
+      # here.
+      - runs: |
           rm ${{targets.contextdir}}/usr/bin/xtables-nft-multi
     test:
       pipeline:
@@ -233,13 +239,24 @@ subpackages:
           rm -r ${{targets.contextdir}}/usr/include
           rm -r ${{targets.contextdir}}/usr/lib
           rm -r ${{targets.contextdir}}/usr/share/man
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables /usr/bin/xtables-legacy-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-restore /usr/bin/xtables-legacy-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/ip6tables-save /usr/bin/xtables-legacy-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables /usr/bin/xtables-nlegacyft-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-restore /usr/bin/xtables-legacy-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-save /usr/bin/xtables-legacy-multi
-          ln -sf ${{targets.contextdir}}/usr/bin/iptables-xml /usr/bin/xtables-legacy-multi
+      - runs: |
+          for i in \
+            arptables arptables-restore arptables-save arptables-translate \
+            ebtables ebtables-restore ebtables-save ebtables-translate \
+            iptables iptables-restore iptables-save iptables-xml \
+            iptables-translate iptables-restore-translate \
+            iptables-legacy iptables-legacy-restore iptables-legacy-save \
+            ip6tables ip6tables-restore ip6tables-save \
+            ip6tables-translate ip6tables-restore-translate \
+            ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save \
+            xtables-monitor ; do
+              ln -sfv ${{targets.contextdir}}/usr/bin/$i /usr/bin/xtables-legacy-multi
+          done
+      # Remove this because it's in xtables.
+      #
+      # TODO: If nothing depends directly on xtables, we could include it
+      # here.
+      - runs: |
           rm ${{targets.contextdir}}/usr/bin/xtables-legacy-multi
     test:
       pipeline:
@@ -350,6 +367,7 @@ subpackages:
             done
             no_other_commands "${{context.name}}" $cmds
 
+  # TODO: Remove this completely and fix all packages that are using it.
   - name: ip6tables
     checks:
       disabled:
@@ -357,28 +375,6 @@ subpackages:
     dependencies:
       runtime:
         - iptables
-    test:
-      pipeline:
-        - uses: test/emptypackage
-
-  - name: ip6tables-nft
-    checks:
-      disabled:
-        - empty
-    dependencies:
-      runtime:
-        - iptables-nft
-    test:
-      pipeline:
-        - uses: test/emptypackage
-
-  - name: ip6tables-legacy
-    checks:
-      disabled:
-        - empty
-    dependencies:
-      runtime:
-        - iptables-legacy
     test:
       pipeline:
         - uses: test/emptypackage


### PR DESCRIPTION
This *adds* `iptables-nft` and `iptables-legacy` packages that could/should be used instead of `iptables`, `ip6tables`, or `iptables-wrappers`.

Note that this doesn't *remove* any packages so we can upgrade things without breaking changes.

*Ideally* everything should be able to just use `iptables-nft`; packages that require `iptables-legacy` are depending on *ancient* kernel features and may need special handling.
