### PR TITLE
fix(kserve-modelmesh): GHSA-84h7-rjj3-6jx4

### DIFF
--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -2,7 +2,7 @@
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 18 # GHSA-25qh-j22f-pwp8
+  epoch: 19
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:

--- a/kserve-modelmesh/pombump-deps.yaml
+++ b/kserve-modelmesh/pombump-deps.yaml
@@ -14,9 +14,3 @@ patches:
   - groupId: org.bouncycastle
     artifactId: bcpkix-jdk18on
     version: "1.79"
-  - groupId: io.netty
-    artifactId: netty-codec-http2
-    version: 4.1.127.Final
-  - groupId: io.netty
-    artifactId: netty-codec
-    version: 4.1.127.Final

--- a/kserve-modelmesh/pombump-properties.yaml
+++ b/kserve-modelmesh/pombump-properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - property: netty-version
-    value: "4.1.127.Final"
+    value: "4.1.129.Final"


### PR DESCRIPTION
Bump netty to 4.1.29.Final in properties

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/51478

<!--ci-cve-scan:fail-any-->
