### PR TITLE
teleport-18: ignore ldapbind tags

### DIFF
--- a/teleport-18.yaml
+++ b/teleport-18.yaml
@@ -100,6 +100,7 @@ update:
     - ".*gus.*"
     - ".*wasm.*"
     - ".*fred.*"
+    - ".*ldapbind.*"
   git:
     strip-prefix: v
     tag-filter-prefix: v18.


### PR DESCRIPTION
These don't appear to be official releases.