### PR TITLE
fix(management-api-for-apache-cassandra-5.0): GHSA-84h7-rjj3-6jx4

### DIFF
--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
   version: "0.1.111"
-  epoch: 0 # GHSA-jq43-27x9-3v86
+  epoch: 1
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
+++ b/management-api-for-apache-cassandra-5.0/2025-08-15-consolidated-cve-patches.patch
@@ -7,7 +7,7 @@ index 537f567..f1d81f8 100644
    <properties>
      <cassandra5.version>5.0.6</cassandra5.version>
 -    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
-+    <netty.http.codec.version>4.1.128.Final</netty.http.codec.version>
++    <netty.http.codec.version>4.1.129.Final</netty.http.codec.version>
    </properties>
    <dependencies>
      <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -46,6 +46,7 @@ index ab1c6e9..5c7175f 100644
 -    <logback.version>1.5.13</logback.version>
 +    <slf4j.version>2.0.16</slf4j.version>
 +    <logback.version>1.5.19</logback.version>
-     <netty.version>4.1.128.Final</netty.version>
+-    <netty.version>4.1.128.Final</netty.version>
++    <netty.version>4.1.129.Final</netty.version>
      <mockito.version>3.5.13</mockito.version>
      <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
Bump netty-codec-http to 4.1.129.Final in patch file

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/51535

<!--ci-cve-scan:fail-any-->
