### PR TITLE
erlang-{25,27,28}: switch to git-checkout

### DIFF
--- a/erlang-25.yaml
+++ b/erlang-25.yaml
@@ -2,7 +2,7 @@
 package:
   name: erlang-25
   version: "25.3.2.21"
-  epoch: 4
+  epoch: 5
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -28,10 +28,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 99296fcd97a2053c5fcde7dc0ded2ba261a3baf1491c745fca71bd9804d51443
-      uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
+      repository: https://github.com/erlang/otp
+      tag: OTP-${{package.version}}
+      expected-commit: 52199ed7e79646b73bacc47c92967ce9970b2373
 
   - runs: |
       export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"

--- a/erlang-27.yaml
+++ b/erlang-27.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-27
   version: "27.3.4.6"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -28,10 +28,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2
-      uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
+      repository: https://github.com/erlang/otp
+      tag: OTP-${{package.version}}
+      expected-commit: f1b17a1fb4d2bc74501608852547f8d9b504f7e3
 
   - runs: |
       export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"

--- a/erlang-28.yaml
+++ b/erlang-28.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-28
   version: "28.3"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -28,10 +28,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1956ad6584678b631ab4f9b8aebe2dac037cd7401abb44564a01134ff0ac5bed
-      uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
+      repository: https://github.com/erlang/otp
+      tag: OTP-${{package.version}}
+      expected-commit: 0d237f43a5ec5af62c65d9c5906fb1359bb6f516
 
   - runs: |
       export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"


### PR DESCRIPTION
erlang-26 had already been switched a while ago.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668