### PR TITLE
tileserver-gl: downgrade libvips dependency

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 6 # GHSA-mh29-5h37-fv8m
+  epoch: 7 # GHSA-mh29-5h37-fv8m
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -9,6 +9,8 @@ package:
     runtime:
       - Xvfb
       - busybox
+      # override auto-generated dep so we can force an older versioin
+      - libvips~8.17
       - mesa
       - mesa-glx
       - nodejs-20
@@ -37,7 +39,7 @@ environment:
       - libjpeg-turbo-dev
       - libpng-dev
       - libuv-dev
-      - libvips-dev
+      - libvips-dev~8.17
       - libwebp
       - libwebp-dev
       - libxft-dev


### PR DESCRIPTION
We are observing some libvips errors when using tileserver, try with a lower version
to see if it is a regression.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
