### PR TITLE
gnutar: switch to git-checkout

### DIFF
--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutar
   version: "1.35"
-  epoch: 6
+  epoch: 7
   description: "The GNU Tar program"
   copyright:
     - license: GPL-3.0-or-later
@@ -12,20 +12,37 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
+      - coreutils
+      - gettext-dev
+      - texinfo
+      - wget # for gnulib translations
       - wolfi-base
   environment:
     FORCE_UNSAFE_CONFIGURE: 1 # Needed to run configure as root
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftpmirror.gnu.org/gnu/tar/tar-${{package.version}}.tar.gz
-      expected-sha256: 14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e
+      repository: https://git.savannah.gnu.org/git/tar.git
+      tag: v${{package.version}}
+      expected-commit: e545d446dfe6564265cdf4186641ee76f4acc7fa
+
+  - name: git.savannah.gnu.org is flaky
+    runs: git submodule set-url gnulib https://github.com/coreutils/gnulib.git
+
+  - runs: echo ${{package.version}} >.tarball-version
+
+  - runs: ./bootstrap
 
   - uses: autoconf/configure
+    with:
+      opts: CFLAGS='-fno-analyzer -Wno-error=unused-parameter'
 
   - uses: autoconf/make
 

--- a/gnutar.yaml
+++ b/gnutar.yaml
@@ -54,6 +54,7 @@ subpackages:
   - name: gnutar-doc
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     test:
       pipeline:
         - uses: test/docs


### PR DESCRIPTION
For some reason this has the effect of turning on more compiler strictness, some of which fails.  But it's easy to relax that a bit.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668