### PR TITLE
FIX open-webui toship optional dependencies from toml

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -50,6 +50,8 @@ environment:
     USE_OLLAMA: false
     WHISPER_MODEL: base
     WHISPER_MODEL_DIR: backend/data/cache/whisper/models
+    # without this flag the Frontend build directory defaults to '/usr/share/open-webui/lib/python3.11/build' (https://github.com/open-webui/open-webui/blob/6f1486ffd0cb288d0e21f41845361924e0d742b3/backend/open_webui/env.py#L265)
+    FROM_INIT_PY: "true"
 
 pipeline:
   - uses: git-checkout
@@ -133,12 +135,11 @@ subpackages:
     name: ${{package.name}}-compat
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/app ${{targets.contextdir}}/app/backend ${{targets.contextdir}}/app/build
+          mkdir -p ${{targets.contextdir}}/app ${{targets.contextdir}}/app/backend
           ln -sf /usr/share/${{package.name}}/backend/start.sh ${{targets.contextdir}}/app/backend/start.sh
           ln -sf /usr/share/${{package.name}}/backend/data/ ${{targets.contextdir}}/app/backend/data
           ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui ${{targets.contextdir}}/app/backend/open_webui
-          ln -s /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/* ${{targets.contextdir}}/app/build/
-
+          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/ ${{targets.contextdir}}/app/build
           ln -sf /usr/share/${{package.name}}/package.json ${{targets.contextdir}}/app/package.json
           ln -sf /usr/share/${{package.name}}/CHANGELOG.md ${{targets.contextdir}}/app/CHANGELOG.md
     test:

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -133,14 +133,11 @@ subpackages:
     name: ${{package.name}}-compat
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/app ${{targets.contextdir}}/app/backend
+          mkdir -p ${{targets.contextdir}}/app ${{targets.contextdir}}/app/backend ${{targets.contextdir}}/app/build
           ln -sf /usr/share/${{package.name}}/backend/start.sh ${{targets.contextdir}}/app/backend/start.sh
           ln -sf /usr/share/${{package.name}}/backend/data/ ${{targets.contextdir}}/app/backend/data
           ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui ${{targets.contextdir}}/app/backend/open_webui
-          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/ ${{targets.contextdir}}/app/build
-
-          mkdir -p ${{targets.contextdir}}/usr/share/${{package.name}}/lib/python${{vars.python-version}}
-          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend ${{targets.contextdir}}/usr/share/${{package.name}}/lib/python${{vars.python-version}}/build
+          ln -s /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/* ${{targets.contextdir}}/app/build/
 
           ln -sf /usr/share/${{package.name}}/package.json ${{targets.contextdir}}/app/package.json
           ln -sf /usr/share/${{package.name}}/CHANGELOG.md ${{targets.contextdir}}/app/CHANGELOG.md

--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.41"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -65,6 +65,9 @@ pipeline:
       source .venv/bin/activate
 
       uv pip install --upgrade pip
+
+      # https://github.com/open-webui/open-webui/blob/6f1486ffd0cb288d0e21f41845361924e0d742b3/Dockerfile#L128
+      uv pip install -r backend/requirements.txt
       uv pip install .
       uv pip install torchvision torchaudio itsdangerous
 
@@ -135,6 +138,10 @@ subpackages:
           ln -sf /usr/share/${{package.name}}/backend/data/ ${{targets.contextdir}}/app/backend/data
           ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui ${{targets.contextdir}}/app/backend/open_webui
           ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend/ ${{targets.contextdir}}/app/build
+
+          mkdir -p ${{targets.contextdir}}/usr/share/${{package.name}}/lib/python${{vars.python-version}}
+          ln -sf /usr/share/${{package.name}}/lib/python${{vars.python-version}}/site-packages/open_webui/frontend ${{targets.contextdir}}/usr/share/${{package.name}}/lib/python${{vars.python-version}}/build
+
           ln -sf /usr/share/${{package.name}}/package.json ${{targets.contextdir}}/app/package.json
           ln -sf /usr/share/${{package.name}}/CHANGELOG.md ${{targets.contextdir}}/app/CHANGELOG.md
     test:


### PR DESCRIPTION
Right now the package build skips the [optional dependencies](https://github.com/open-webui/open-webui/blob/main/pyproject.toml#L131) and some are required by [backend](https://github.com/open-webui/open-webui/blob/main/backend/requirements.txt)


