### PR TITLE
fix(py3-cassandra-medusa): GHSA-w853-jp5j-5j7f

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.26.0"
-  epoch: 1
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,8 @@ pipeline:
       poetry add "requests@^2.32.4"
       # CVE-2025-53643 GHSA-9548-qrrj-x5pj
       poetry add "aiohttp@^3.12.14"
+      # GHSA-w853-jp5j-5j7f
+      poetry add "filelock@^3.20.1"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
       POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
       poetry build


### PR DESCRIPTION
Bump filelock to 3.20.1

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/51749

<!--ci-cve-scan:fail-any-->
