### PR TITLE
DNM: Use iptables-nft instead of iptables-wrappers

### DIFF
--- a/amazon-k8s-cni.yaml
+++ b/amazon-k8s-cni.yaml
@@ -1,13 +1,13 @@
 package:
   name: amazon-k8s-cni
   version: "1.21.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - iptables-wrappers
+      - iptables-nft
 
 environment:
   contents:

--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -1,7 +1,7 @@
 package:
   name: aznfs-mount
   version: "2.0.12"
-  epoch: 5
+  epoch: 6
   description: AZNFS Mount Helper
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,7 @@ package:
       - coreutils
       - findmnt
       - flock
-      - iptables-wrappers
+      - iptables-nft
       - procps
       - util-linux
 

--- a/blob-csi-1.27.yaml
+++ b/blob-csi-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: blob-csi-1.27
   version: "1.27.1"
-  epoch: 0 # GHSA-r6j8-c6r2-37rr
+  epoch: 1
   description: Azure Blob Storage CSI driver
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ environment:
       - curl
       - fuse3
       - iproute2
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - procps
       - util-linux
@@ -90,7 +90,7 @@ subpackages:
         - dash-binsh
         - e2fsprogs
         - iproute2
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - mount
         - netcat-openbsd

--- a/calico-3.31.yaml
+++ b/calico-3.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.31
   version: "3.31.3"
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -160,7 +160,7 @@ subpackages:
         - glibc
         - iproute2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - libbpf
         # listed in Dockerfile, but not sure if they're build dependencies (for iptables) or runtime
         - libelf

--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.18
   version: "1.18.5"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
       - cni-plugins-loopback
       - iproute2
       - ipset
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - llvm-17
       - merged-sbin
@@ -147,7 +147,7 @@ subpackages:
     description: iptables compatibility package for cilium
     dependencies:
       runtime:
-        - iptables-wrappers
+        - iptables-nft
         - merged-sbin
         - wolfi-baselayout
       provides:

--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-28
   version: "28.5.2"
-  epoch: 11 # GHSA-jv3w-x3r3-g6rm
+  epoch: 12
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -120,8 +120,7 @@ subpackages:
         - fuse-overlayfs
         - git
         - iproute2
-        - ip6tables
-        - iptables
+        - iptables-nft
         - openssl
         - pigz
         - procps

--- a/docker-29.yaml
+++ b/docker-29.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-29
   version: "29.1.3"
-  epoch: 1 # GHSA-jv3w-x3r3-g6rm
+  epoch: 2
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -103,7 +103,7 @@ subpackages:
         - git
         - iproute2
         - ip6tables
-        - iptables
+        - iptables-nft
         - openssl
         - pigz
         - procps

--- a/docker-29.yaml
+++ b/docker-29.yaml
@@ -103,7 +103,7 @@ subpackages:
         - git
         - iproute2
         - ip6tables
-        - iptables
+        - iptables-nft
         - openssl
         - pigz
         - procps

--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel
   version: "0.27.4"
-  epoch: 6 # GHSA-jv3w-x3r3-g6rm
+  epoch: 7
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - ca-certificates
       - coreutils
       - iproute2
-      - iptables-wrappers
+      - iptables-nft
       - nftables
       - strongswan
       - wireguard-tools
@@ -73,7 +73,7 @@ test:
         - etcd
         - jq
         - iproute2
-        - iptables-wrappers
+        - iptables-nft
   pipeline:
     - name: "Check flanneld version"
       runs: |

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,14 +1,14 @@
 package:
   name: jupyterhub-k8s-hub
   version: "4.3.2"
-  epoch: 0
+  epoch: 1
   description: Zero to JupyterHub with Kubernetes
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - configurable-http-proxy
-      - iptables-wrappers
+      - iptables-nft
       - py3-jupyterhub
       - py3-jupyterhub-firstuseauthenticator
       - py3-jupyterhub-hmacauthenticator

--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -2,13 +2,13 @@
 package:
   name: jupyterhub-k8s-network-tools
   version: "4.3.2"
-  epoch: 0
+  epoch: 1
   description: Network diagnostic tools for use within a JupyterHub Kubernetes cluster
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - iptables-wrappers
+      - iptables-nft
 
 environment:
   contents:

--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.11.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -119,7 +119,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -164,7 +164,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/k3s-1.33.yaml
+++ b/k3s-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.33
   version: "1.33.7.1"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -116,7 +116,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -161,7 +161,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.35.0.1"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -116,7 +116,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -161,7 +161,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/nerdctl.yaml
+++ b/nerdctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: nerdctl
   version: "2.2.1"
-  epoch: 0 # GHSA-jv3w-x3r3-g6rm
+  epoch: 1
   description: Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ test:
     contents:
       packages:
         - containerd
-        - iptables-wrappers
+        - iptables-nft
         - curl
         - coreutils
   pipeline:

--- a/podman.yaml
+++ b/podman.yaml
@@ -1,7 +1,7 @@
 package:
   name: podman
   version: "5.7.1"
-  epoch: 1 # GHSA-jv3w-x3r3-g6rm
+  epoch: 2
   description: "A tool for managing OCI containers and pods"
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ environment:
       - gpgme-dev
       - grep
       - iptables-dev
-      - iptables-wrappers
+      - iptables-nft
       - libassuan-dev
       - libgpg-error-dev
       - libseccomp-dev

--- a/rancher-2.13.yaml
+++ b/rancher-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.13
   version: "2.13.1"
-  epoch: 0 # GHSA-r6j8-c6r2-37rr
+  epoch: 1
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ package:
       - helm
       - iproute2
       - ipset
-      - iptables-wrappers
+      - iptables-nft
       - jq
       - k3s-multicall~${{vars.k3s-major-minor-version}}
       - kustomize

--- a/spegel.yaml
+++ b/spegel.yaml
@@ -1,7 +1,7 @@
 package:
   name: spegel
   version: "0.6.0"
-  epoch: 0
+  epoch: 1
   description: Stateless cluster local OCI registry mirror.
   copyright:
     - license: MIT
@@ -42,7 +42,7 @@ test:
     contents:
       packages:
         - containerd
-        - iptables-wrappers
+        - iptables-nft
         - curl
         - coreutils
         - distribution

--- a/ztunnel-1.28.yaml
+++ b/ztunnel-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: ztunnel-1.28
   version: "1.28.2"
-  epoch: 0
+  epoch: 1
   description: The `ztunnel` component of istio ambient mesh.
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - ztunnel=${{package.full-version}}
     runtime:
       - ca-certificates-bundle
-      - iptables-wrappers
+      - iptables-nft
       - libmnl
       - libnetfilter_conntrack
       - libnfnetlink


### PR DESCRIPTION
DO NOT MERGE - also, remove skip:package-version-check and skip:staging-package-version-check labels!

This is currently just to provide a pre-submit repo for testing the `iptables-nft` package in images.

This switches things to use `iptables-nft` (the current tech kernel firewall). See INC102 for details.