### PR TITLE
Migrate dapr-1.15 to enterprise-packages and update to 1.16.5

### DIFF
--- a/dapr-1.16.yaml
+++ b/dapr-1.16.yaml
@@ -1,7 +1,7 @@
 package:
-  name: dapr-1.15
-  version: "1.15.13"
-  epoch: 3 # GHSA-32fw-gq77-f2f2
+  name: dapr-1.16
+  version: "1.16.5"
+  epoch: 0
   description: Portable, event-driven, runtime for building distributed applications across cloud and edge.
   dependencies:
     provides:
@@ -29,7 +29,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: ae09be1066fe14add621c8c0b76f3cae882e970c
+      expected-commit: f167add0ab641afa210d61771820d0d178bc41ae
       repository: https://github.com/dapr/dapr
       tag: v${{package.version}}
 
@@ -73,7 +73,6 @@ pipeline:
     with:
       deps: |-
         github.com/choleraehyq/pid@v0.0.21
-        github.com/dvsekhvalnov/jose2go@v1.7.0
         golang.org/x/crypto@v0.45.0
         github.com/eclipse/paho.mqtt.golang@v1.5.1
 
@@ -301,7 +300,7 @@ test:
           echo "---- Check message received ----"
 
           # Extract .data field and grep it
-          if jq -r '.data' /tmp/received.log 2>/dev/null | grep -qx 'hello'; then
+          if jq -r '.data | fromjson' /tmp/received.log 2>/dev/null | grep -qx 'hello'; then
             echo "✅ Message successfully received!"
           else
             echo "❌ Message not received"
@@ -315,5 +314,5 @@ update:
   github:
     identifier: dapr/dapr
     strip-prefix: v
-    tag-filter: v1.15.
+    tag-filter: v1.16.
     use-tag: true


### PR DESCRIPTION
This PR migrates dapr-1.15 to enterprise-packages and updates to version 1.16.5.

**Migration Details:**
- Old version: 1.15.13 (epoch: 3)
- New version: 1.16.5 (epoch: 0)
- Destination repo: enterprise-packages
- Old file: dapr-1.15.yaml
- New file: dapr-1.16.yaml

The filename change (version update) effectively removes the old version from this repo.
The package has been added to enterprise-packages with an epoch bump to avoid APK sync conflicts.

**Next Steps:**
1. Wait for all images to pick up the new version from enterprise-packages
2. Optionally withdraw the old package if needed