### PR TITLE
docker: Update to v29 stream

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -14,6 +14,7 @@ package:
       - docker-init
       - dockerd
       - openssh-client # used by docker-cli
+      - nftables
   checks:
     disabled:
       # docker is a meta package pulling in several subpackages at runtime
@@ -34,13 +35,14 @@ environment:
       - libtool
       - linux-headers
       - lvm2-dev
+      - nftables-dev
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/moby/moby
-      tag: v${{package.version}}
-      expected-commit: 89c5e8fd66634b6128fc4c0e6f1236e2540e46e0
+      tag: docker-v${{package.version}}
+      expected-commit: fbf3ed25f893e6ce21336f1101590e40a13934f4 
 
   - runs: |
       # moby/moby uses a non-standard `vendor.mod` and helper scripts instead
@@ -49,7 +51,7 @@ pipeline:
       # pin to older dependencies when this package auto updates, we temp change the
       # vendor.mod file to go.mod to use go/bump so we don't have to use a tool like sed.
 
-      mv vendor.mod go.mod
+      # mv vendor.mod go.mod
       go mod tidy
 
   - uses: go/bump
@@ -59,17 +61,17 @@ pipeline:
         github.com/hashicorp/go-memdb@v1.3.5
         github.com/opencontainers/image-spec@v1.1.1
         github.com/opencontainers/runtime-spec@v1.2.1
-        github.com/rootless-containers/rootlesskit/v2@v2.3.4
-        github.com/golang-jwt/jwt/v5@v5.2.2
-        github.com/opencontainers/selinux@v1.13.0
-        github.com/containerd/containerd/v2@v2.1.5
+        github.com/rootless-containers/rootlesskit/v2@v2.3.5
+        github.com/golang-jwt/jwt/v5@v5.3.0
+        github.com/opencontainers/selinux@v1.13.1
+        github.com/containerd/containerd/v2@v2.2.0
         golang.org/x/crypto@v0.45.0
         github.com/containernetworking/plugins@v1.9.0
 
   - runs: |
       # setting back to original so we can run moby specific hack
-      mv go.mod vendor.mod
-      mv go.sum vendor.sum
+      #mv go.mod vendor.mod
+      #mv go.sum vendor.sum
       ./hack/vendor.sh
 
       # Replicate the environment setup performed by docker

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: "29.1.3"
-  epoch: 0 # GHSA-jv3w-x3r3-g6rm
+  epoch: 0
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -51,7 +51,6 @@ pipeline:
       # pin to older dependencies when this package auto updates, we temp change the
       # vendor.mod file to go.mod to use go/bump so we don't have to use a tool like sed.
 
-      # mv vendor.mod go.mod
       go mod tidy
 
   - uses: go/bump
@@ -69,9 +68,6 @@ pipeline:
         github.com/containernetworking/plugins@v1.9.0
 
   - runs: |
-      # setting back to original so we can run moby specific hack
-      #mv go.mod vendor.mod
-      #mv go.sum vendor.sum
       ./hack/vendor.sh
 
       # Replicate the environment setup performed by docker

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
-  version: "28.5.2"
-  epoch: 9 # GHSA-jv3w-x3r3-g6rm
+  version: "29.1.3"
+  epoch: 0 # GHSA-jv3w-x3r3-g6rm
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0

--- a/docker.yaml
+++ b/docker.yaml
@@ -13,8 +13,8 @@ package:
       - docker-compose
       - docker-init
       - dockerd
-      - openssh-client # used by docker-cli
       - nftables
+      - openssh-client # used by docker-cli
   checks:
     disabled:
       # docker is a meta package pulling in several subpackages at runtime
@@ -42,7 +42,7 @@ pipeline:
     with:
       repository: https://github.com/moby/moby
       tag: docker-v${{package.version}}
-      expected-commit: fbf3ed25f893e6ce21336f1101590e40a13934f4 
+      expected-commit: fbf3ed25f893e6ce21336f1101590e40a13934f4
 
   - runs: |
       # moby/moby uses a non-standard `vendor.mod` and helper scripts instead


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
