### PR TITLE
rabbitmq-server: set CPE

### DIFF
--- a/rabbitmq-server-4.2.yaml
+++ b/rabbitmq-server-4.2.yaml
@@ -1,10 +1,14 @@
 package:
   name: rabbitmq-server-4.2
   version: "4.2.2"
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
+  cpe:
+    part: a
+    vendor: broadcom
+    product: rabbitmq_server
   dependencies:
     provides:
       - rabbitmq-server=${{package.full-version}}


### PR DESCRIPTION
Set CPE on rabbitmq-server to ensure accurate CVE scan results.

CPE match is based on latest from CVE-2025-50200:
- https://nvd.nist.gov/vuln/detail/CVE-2025-50200

Fixes: OS-233