### PR TITLE
7zip: switch to git-checkout

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -1,7 +1,7 @@
 package:
   name: 7zip
   version: "2501"
-  epoch: 1
+  epoch: 2
   description: "File archiver with a high compression ratio"
   copyright:
     - license: LGPL-2.0-only
@@ -13,12 +13,18 @@ environment:
       - busybox
       - ca-certificates-bundle
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d{2})(\d{2})
+    replace: $1.$2
+    to: real-package-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://7-zip.org/a/7z${{package.version}}-src.tar.xz
-      expected-sha512: 5ee146ce993c6d12ad19333dc3545e6c3429212260c22d456390e49ca150e6fcbfc6eae45b5ec61138ae1598d7b4a79d6f2e3ff02929af38039c0ca59823e729
-      strip-components: 0
+      repository: https://github.com/ip7z/7zip
+      tag: ${{vars.real-package-version}}
+      expected-commit: 5e96a8279489832924056b1fa82f29d5837c9469
 
   - name: Configure and build
     runs: |
@@ -50,8 +56,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 372314
+  github:
+    identifier: ip7z/7zip
   version-transform:
     - match: \.
       replace: ''


### PR DESCRIPTION
It's unfortunate that we're using a mangled variant of the version that we then have to unmangle to get back to the git tag, but since 25.01 < 2501 I guess we're stuck with it.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668