### PR TITLE
fix(k8sgpt): Remediate GHSA-f6mr-38g8-39rg by bumping ollama

### DIFF
--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: "0.4.27"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1 # GHSA-f6mr-38g8-39rg
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,7 @@ pipeline:
         github.com/containerd/containerd@v1.7.29
         golang.org/x/crypto@v0.45.0
         github.com/expr-lang/expr@v1.17.7
+        github.com/ollama/ollama@v0.12.4
 
   - runs: |
       make tidy


### PR DESCRIPTION
GHSA-f6mr-38g8-39rg entry currently states latest available version v0.13.5 is also affected. But [the original CVE finding states versions <= 0.12.3 are affected](https://gist.github.com/Cristliu/48dae561696374744d9fced07a544ecd). 
[An update](https://github.com/github/advisory-database/pull/6571) to GHSA-f6mr-38g8-39rg has been proposed to correct the affected versions field, meanwhile this PR attempts to bump ollama to 0.12.4 assuming the proposed correction is merged.

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-f6mr-38g8-39rg-->
