### PR TITLE
fix(tileserver-gl): also pin libvips version in -compat package

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -153,6 +153,8 @@ subpackages:
       provides:
         - ${{package.name}}-entrypoint=${{package.full-version}}
       runtime:
+        # override auto-generated dep so we can force an older versioin
+        - libvips~8.17
         - Xvfb
         - busybox
     pipeline:

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -153,7 +153,7 @@ subpackages:
       provides:
         - ${{package.name}}-entrypoint=${{package.full-version}}
       runtime:
-        # override auto-generated dep so we can force an older versioin
+        # override auto-generated dep so we can force an older version
         - libvips~8.17
         - Xvfb
         - busybox

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.4.0"
-  epoch: 7 # GHSA-mh29-5h37-fv8m
+  epoch: 8 # GHSA-mh29-5h37-fv8m
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
The -compat package is consumed by our image, so the dep also requires pinning there.

This is a follow on from https://github.com/wolfi-dev/os/pull/76476
