### PR TITLE
zig/0.15.2-r1: migrate to codeberg

### DIFF
--- a/zig.yaml
+++ b/zig.yaml
@@ -1,7 +1,7 @@
 package:
   name: zig
   version: "0.15.2"
-  epoch: 0
+  epoch: 1
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/ziglang/zig
+      repository: https://codeberg.org/ziglang/zig
       tag: ${{package.version}}
       expected-commit: e4cbd752c8c05f131051f8c873cff7823177d7d3
 
@@ -59,9 +59,7 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: ziglang/zig
-    use-tag: true
+  git: {}
 
 test:
   environment:


### PR DESCRIPTION
Zig [recently](https://ziglang.org/news/migrating-from-github-to-codeberg/) migrated from GitHub to Codeberg.

The `0.15.2` tag commits appear equivalent so this just needed a tweak to the URI and the `update` block (which matches the other Codeberg projects we build).

GitHub: https://github.com/ziglang/zig/commit/e4cbd752c8c05f131051f8c873cff7823177d7d3
Codeberg: https://codeberg.org/ziglang/zig/src/commit/e4cbd752c8c05f131051f8c873cff7823177d7d3