### PR TITLE
freerdp, freerdp-3: use libxkbfile-dev rather than libxkb-dev

### DIFF
--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: "3.20.2"
-  epoch: 0
+  epoch: 1
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -38,8 +38,8 @@ environment:
       - libxext-dev
       - libxi-dev
       - libxinerama-dev
-      - libxkb-dev
       - libxkbcommon-dev
+      - libxkbfile-dev
       - libxrender-dev
       - libxslt
       - libxv-dev

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 8
+  epoch: 9
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -26,8 +26,8 @@ environment:
       - libxext-dev
       - libxi-dev
       - libxinerama-dev
-      - libxkb-dev
       - libxkbcommon-dev
+      - libxkbfile-dev
       - libxrender-dev
       - libxv-dev
       - linux-headers


### PR DESCRIPTION
Those packages are apparently duplicates, but `libxkbfile-dev` is more appropriately named.  See
https://github.com/wolfi-dev/os/pull/76621#discussion_r2640120423.