### PR TITLE
chromium: manually update to 143.0.7499.169

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: "143.0.7499.109"
+  version: "143.0.7499.169"
   epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
@@ -156,8 +156,12 @@ pipeline:
       # Tarballs are built using the instructions here:
       # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       # which has been automated in https://github.com/chromium-linux-tarballs/chromium-tarballs
-      uri: https://github.com/chromium-linux-tarballs/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
-      expected-sha512: 9d9a24f9e424b8121c73edc8c5ad685447ccfc67d29878cc3b248eed86273702a0f26eb91ed501d492f165de1319bfdaed7a4071f2a9e7cfd7551f845b066f65
+      #
+      # !! NOTE !! We are temporarily using my fork of `chromium-tarballs` as
+      # the `chromium-linux-tarballs` repo hasn't been updated in a few weeks:
+      # https://github.com/chromium-linux-tarballs/chromium-tarballs/issues/30
+      uri: https://github.com/OddBloke/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
+      expected-sha512: 783f5bb97e62f8866c99dfd554856192d559a9a5876ede9289e1000163a2dd6ceb0d5321e9c4298bd29a2b4b32dfed5121f106120754ccb15a9c8ac239b3510f
 
   - name: Remove binaries from source tree
     runs: |


### PR DESCRIPTION
As part of which we temporarily switch to using my fork, as the main repo hasn't published new tarballs in a few weeks.

<!--ci-cve-scan:fail-any-->