### PR TITLE
fix,kserve: remediate remaining python CVEs

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: "0.16.0"
-  epoch: 5 # GHSA-cfpf-hrx2-8rv6
+  epoch: 6 # GHSA-cfpf-hrx2-8rv6
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -96,7 +96,15 @@ subpackages:
         working-directory: ./python/storage
         runs: |
           # Install dependencies and build the package using uv
-          uv sync --locked
+          uv sync
+
+          # filelock: CVE-2025-47273 GHSA-w853-jp5j-5j7f
+          uv add \
+            "filelock>=3.20.1"
+
+          # urllib3: GHSA-gm62-xv2j-4w53 GHSA-2xpw-w6gg-jr37
+          uv add \
+            "urllib3>=2.6.0"
 
           uv pip freeze | grep -v kserve > requirements.txt
           uv build
@@ -121,6 +129,14 @@ subpackages:
           # protobuf: CVE-2025-4565 GHSA-8qvm-5x2c-j2w7
           uv add \
             "protobuf>=4.25.8"
+
+          # setuptools: CVE-2025-47273 GHSA-5rjg-fvgr-3xxf
+          uv add \
+            "setuptools>=78.1.1"
+
+          # filelock: CVE-2025-47273 GHSA-w853-jp5j-5j7f
+          uv add \
+            "filelock>=3.20.1"
 
           # urllib3: GHSA-gm62-xv2j-4w53 GHSA-2xpw-w6gg-jr37
           uv add \

--- a/kserve/bump-python-version.patch
+++ b/kserve/bump-python-version.patch
@@ -17,3 +17,16 @@ index 63befa0..3e3327a 100644
  dependencies = [
      "uvicorn[standard]<1.0.0,>=0.30.6",
      "fastapi>=0.115.3",
+diff --git a/python/storage/pyproject.toml b/python/storage/pyproject.toml
+index f48d99a07..2e45daef6 100644
+--- a/python/storage/pyproject.toml
++++ b/python/storage/pyproject.toml
+@@ -4,7 +4,7 @@ authors = [
+     {name = "The KServe Authors", email = "fspolti@redhat.com"},
+ ]
+ license = {text = "https://github.com/kserve/kserve/blob/master/LICENSE"}
+-requires-python = "<3.13,>=3.9"
++requires-python = "<3.13,>=3.11"
+ dependencies = [
+     "requests<3.0.0,>=2.32.2",
+     "google-cloud-storage<3.0.0,>=2.14.0",


### PR DESCRIPTION
This PR is a followup to https://github.com/wolfi-dev/os/pull/76706 and remediates the remaining python CVEs in the kserve package. 

- https://github.com/advisories/GHSA-w853-jp5j-5j7f
- https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
- https://github.com/advisories/GHSA-pq67-6m6q-mj2v

<!--ci-cve-scan:must-fix: GHSA-w853-jp5j-5j7f GHSA-5rjg-fvgr-3xxf GHSA-pq67-6m6q-mj2v-->
