### PR TITLE
local-static-provisioner: fix GHSA-r6j8-c6r2-37rr by cherry-picking upstream commits

### DIFF
--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -27,8 +27,8 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: bc3d8238c205d8b32fcef4330a490555d53fe232
       cherry-picks: |
-        main/2edb740e03b22a619e832176ba0d4c30ba1f9f92: fix CVE-2025-5187
-        main/fbbab741296e295136f60d1de5996ad7a9e90d02: fix CVE-2025-13281
+        master/2edb740e03b22a619e832176ba0d4c30ba1f9f92: fix CVE-2025-5187
+        master/fbbab741296e295136f60d1de5996ad7a9e90d02: fix CVE-2025-13281
 
   - uses: go/bump
     with:

--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-static-provisioner
   version: "2.8.0"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-r6j8-c6r2-37rr
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,9 @@ pipeline:
       repository: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
       tag: v${{package.version}}
       expected-commit: bc3d8238c205d8b32fcef4330a490555d53fe232
+      cherry-picks: |
+        main/2edb740e03b22a619e832176ba0d4c30ba1f9f92: fix CVE-2025-5187
+        main/fbbab741296e295136f60d1de5996ad7a9e90d02: fix CVE-2025-13281
 
   - uses: go/bump
     with:


### PR DESCRIPTION
## Summary
Fixes GHSA-r6j8-c6r2-37rr (CVE-2025-13281) by cherry-picking upstream security fixes.

## Changes
- **Epoch**: 6 → 7
- **Cherry-picked commits**:
  1. `2edb740e03b22a619e832176ba0d4c30ba1f9f92`: fix CVE-2025-5187
  2. `fbbab741296e295136f60d1de5996ad7a9e90d02`: fix CVE-2025-13281

## Upstream Commits
- **CVE-2025-5187**: Updates dependencies including k8s.io/kubernetes
- **CVE-2025-13281**: Fixes kube-controller-manager SSRF vulnerability

**Source**: [kubernetes-sigs/sig-storage-local-static-provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner)

## Verification
After rebuild, the cherry-picked security fixes will be applied to resolve the vulnerability.

## References
- CVE Dashboard Issue: #51746
- GHSA Advisory: https://github.com/advisories/GHSA-r6j8-c6r2-37rr