### PR TITLE
DNM: make Clickhouse go faster on ARM

### DIFF
--- a/clickhouse-25.11.yaml
+++ b/clickhouse-25.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.11
   version: "25.11.3.54"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  clang-version: 21
 
 var-transforms:
   - from: ${{package.version}}
@@ -32,7 +35,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-19
+      - clang-${{vars.clang-version}}
       - cmake
       - coreutils
       - findutils
@@ -40,7 +43,7 @@ environment:
       - grep
       - ini-file
       - libcxx1
-      - lld-19
+      - lld-${{vars.clang-version}}
       - nasm<3
       - ninja
       - perl
@@ -79,7 +82,6 @@ pipeline:
         -DCOMPILER_CACHE=disabled \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_BUILD_TYPE=RELEASE \
-        -DNO_ARMV81_OR_HIGHER=1 \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_CXX_FLAGS="-Wno-error=unused-result" \
         -DVERSION_STRING=${{package.version}} \


### PR DESCRIPTION
Clickhouse needs all the CPU it can get, and `-DNO_ARMV81_OR_HIGHER=1` has been throttling it.

Note that we can only do this if, in fact, our ARM target on AWS is Graviton 3.