### PR TITLE
mesosphere-vsphere-csi: fix GHSA-r6j8-c6r2-37rr by updating k8s.io/kubernetes to v1.33.6

### DIFF
--- a/mesosphere-vsphere-csi.yaml
+++ b/mesosphere-vsphere-csi.yaml
@@ -5,7 +5,7 @@
 package:
   name: mesosphere-vsphere-csi
   version: "3.5.0"
-  epoch: 5 # CVE-2025-61729
+  epoch: 6 # GHSA-r6j8-c6r2-37rr
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: |-
-        k8s.io/kubernetes@v1.33.4
+        k8s.io/kubernetes@v1.33.6
         github.com/opencontainers/selinux@v1.13.0
 
 subpackages:


### PR DESCRIPTION
## Summary
Fixes GHSA-r6j8-c6r2-37rr (CVE-2025-13281) by updating k8s.io/kubernetes from v1.33.4 to v1.33.6.

## Vulnerability Details
- **GHSA**: GHSA-r6j8-c6r2-37rr
- **CVE**: CVE-2025-13281
- **Component**: k8s.io/kubernetes
- **Type**: kube-controller-manager SSRF vulnerability
- **Severity**: Medium
- **Attack Vector**: Half-blind Server Side Request Forgery through in-tree Portworx StorageClass

## Changes
- **k8s.io/kubernetes**: v1.33.4 → v1.33.6 (via go/bump)
- **Epoch**: 5 → 6

## Fix Version
The vulnerability is fixed in:
- Kubernetes 1.32.10+
- Kubernetes 1.33.6+
- Kubernetes 1.34.2+

## Verification
After rebuild, k8s.io/kubernetes v1.33.6 will be used, resolving the vulnerability.

## References
- CVE Dashboard Issue: #51659
- GHSA Advisory: https://github.com/advisories/GHSA-r6j8-c6r2-37rr