### PR TITLE
Update CONTRIBUTING.md for clarity and support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Whether you want to add a new package, or provide a change to an existing packag
 1. Create an issue with the details about the change. Use the appropriate template for the type of change you’re making. 
 2. Create the PR referencing the issue. 
 
-To get these changes merged requires engagement from a Chainguard Engineer. On a best effort, we will help shepherd changes through our process.
+To get these changes merged requires engagement from a Chainguard Engineer. On a best effort, we will help shepherd changes through our process. If you are a Chainguard customer, reach out to your Customer Success rep for additional support.
 
 ## Criteria for packages in Wolfi
 
@@ -60,7 +60,7 @@ For example, if your package name is "foo", run `make package/foo`.
 
 This will build the package by invoking [melange](https://github.com/chainguard-dev/melange) in a particular way. This invocation is defined in the [Makefile](Makefile), if you're interested to see how this is wired up. Also, you can run Melange _directly_ without using `make` if you understand what you're doing.
 
-**Note:** The buildsystem has a cache of source files that may help reduce the time your build takes. Feel free to see if this cache helps you by adding `USE_CACHE=yes` to the command above. If you encounter issues with this approach, the best advice is to remove the `USE_CACHE=no` from your command and carry on with your builds.
+**Note:** The build system has a cache of source files that may help reduce the time your build takes. Feel free to see if this cache helps you by adding `USE_CACHE=yes` to the command above. If you encounter issues with this approach, the best advice is to remove the `USE_CACHE=no` from your command and carry on with your builds.
 
 When the build finishes, your package(s) should be found in the generated `./packages` directory.
 
@@ -76,7 +76,7 @@ Check for anything unexpected, or for any [CVEs you can patch](./HOW_TO_PATCH_CV
 
 ## Package versioning
 
-- When bumping version of a package, you will need to update the version, epoch & shasum (sha256 or sha512) in package YAML file. The version and epoch also need to be bumped in Makefile.
+- When bumping the version of a package, you will need to update the version, epoch & shasum (sha256 or sha512) in the package YAML file. The version and epoch also need to be bumped in Makefile.
 
 - `epoch` needs to be bumped when the package version remains the same but something else changes. `epoch` needs to be reset to 0 when it's a new version of the package.
 


### PR DESCRIPTION
Clarified support for Chainguard customers and improved wording for build system cache note.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: adds a comment about engaging with CS, and fixes a couple of typos.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
