### PR TITLE
Create package update request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-update-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-update-request.yml
@@ -1,0 +1,107 @@
+Package update request template
+
+name: Wolfi Package Update / Fix Request
+
+description: Request an update or fix to an existing package in Wolfi OS.
+
+title: "[Wolfi Package Update]: $PACKAGE_NAME"
+
+labels:
+  - "wolfi-package-update"
+  - "needs-triage"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Wolfi OS!  
+        Before submitting, please review our expectations around package selection and maintenance.  
+        Acceptance of updates is **not guaranteed** and requires review by the Chainguard OS team on a best-effort basis.
+
+  - type: input
+    id: package-name
+    attributes:
+      label: Package name
+      description: The name of the existing Wolfi package you are requesting an update or fix for.
+    validations:
+      required: true
+
+  - type: input
+    id: current-version
+    attributes:
+      label: Current version in Wolfi
+      description: The version currently available in Wolfi OS (if known).
+
+  - type: input
+    id: requested-version
+    attributes:
+      label: Requested version
+      description: The version you are requesting (must be the latest stable upstream release).
+
+  - type: input
+    id: upstream-url
+    attributes:
+      label: Upstream project URL
+      description: Link to the upstream source repository or project homepage.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem
+      description: Describe the problem this update or fix addresses.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide clear, minimal steps to reproduce the issue.
+
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: Root cause (if known)
+      description: Describe the suspected or confirmed root cause, if you’ve investigated it.
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change you’re proposing. Include links to draft PRs or diffs if available.
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing performed
+      description: Describe any testing you’ve done to validate the fix.
+
+  - type: checkboxes
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Please confirm the following before submitting.
+      options:
+        - label: The requested version is the **latest stable upstream release** (no pre-releases or RCs)
+          required: true
+        - label: The upstream project uses an **OSI-approved license**
+          required: true
+        - label: The change aligns with Wolfi’s packaging and security model
+          required: true
+        - label: The package can be reasonably maintained over time
+          required: true
+        - label: There are no known unresolved security or supply-chain concerns
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **Important notes**
+        - `wolfi-dev/os` is a **read-only public clone**
+        - Pull requests cannot be merged directly
+        - Changes require shepherding by a Chainguard engineer on a **best-effort basis**
+        - Acceptance and timelines are **not guaranteed**
+
+        If you are a Chainguard customer, please contact your Customer Success representative for additional support.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: We had one for new packages, but not for updates / bugs

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
