### PR TITLE
opentelemetry-collector: fix GHSA-cfpf-hrx2-8rv6 by updating expr to v1.17.7

### DIFF
--- a/opentelemetry-collector.yaml
+++ b/opentelemetry-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector
   version: "0.142.0"
-  epoch: 0 # CVE-2025-61729
+  epoch: 1 # GHSA-cfpf-hrx2-8rv6
   description: OpenTelemetry Collector
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,10 @@ pipeline:
       repository: https://github.com/open-telemetry/opentelemetry-collector
       tag: v${{package.version}}
       expected-commit: b579eb1cd7f4334b0f460eb05a81373e5635942f
+
+  - uses: go/bump
+    with:
+      deps: github.com/expr-lang/expr@v1.17.7
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
Fixes GHSA-cfpf-hrx2-8rv6 (CVE-2025-68156) by updating github.com/expr-lang/expr from v1.17.6 to v1.17.7.

## Vulnerability Details
- **GHSA**: GHSA-cfpf-hrx2-8rv6
- **CVE**: CVE-2025-68156
- **Component**: github.com/expr-lang/expr v1.17.6 (go-module)
- **Type**: Denial of Service via unbounded recursion
- **Severity**: High
- **Attack Vector**: Deeply nested or cyclic data structures in builtin functions (flatten, min, max, mean, median)

## Changes
- **github.com/expr-lang/expr**: v1.17.6 → v1.17.7 (via go/bump)
- **Epoch**: 0 → 1

## Implementation
Added go/bump step after git-checkout to update the expr dependency to the patched version.

## Verification
Remote scan confirms vulnerability present in 0.142.0-r0. After rebuild with go/bump, github.com/expr-lang/expr v1.17.7 will be used, resolving the vulnerability.

## References
- CVE Dashboard Issue: #51695
- GHSA Advisory: https://github.com/advisories/GHSA-cfpf-hrx2-8rv6