### PR TITLE
fix(sonarqube): Remediate GHSA-m9gh-789g-q5pv

### DIFF
--- a/sonarqube.yaml
+++ b/sonarqube.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube
   version: "25.12.0.117093"
-  epoch: 0
+  epoch: 1 # GHSA-m9gh-789g-q5pv
   description: SonarQube is an open source platform for continuous inspection of code quality (Community Build)
   copyright:
     - license: LGPL-3.0-or-later
@@ -41,6 +41,8 @@ pipeline:
       repository: https://github.com/SonarSource/sonarqube
       tag: ${{package.version}}
       expected-commit: bd7a1254715e0df950e61d05c9a07cb1ba42552b
+      cherry-picks: |
+        master/c6894b30d37bcfb0d093a3bffb8a31744ca2b489: GHSA-m9gh-789g-q5pv
 
   - name: build
     runs: |


### PR DESCRIPTION
Cherry pick c6894b30d37bcfb0d093a3bffb8a31744ca2b489 to bump Elasticsearch to 8.19.8
and reemdiate GHSA-m9gh-789g-q5pv

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-m9gh-789g-q5pv-->
