### PR TITLE
fix(keycloak): bump netty-http-codec

### DIFF
--- a/keycloak-26.4.yaml
+++ b/keycloak-26.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-26.4
   version: "26.4.7"
-  epoch: 1 # GHSA-84h7-rjj3-6jx4
+  epoch: 2 # GHSA-84h7-rjj3-6jx4
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0

--- a/keycloak-26.4/pombump-deps.yaml
+++ b/keycloak-26.4/pombump-deps.yaml
@@ -24,7 +24,7 @@ patches:
     version: 42.7.7
   - groupId: io.netty
     artifactId: netty-codec-http
-    version: 4.1.129.Final
+    version: 4.1.130.Final
   - groupId: io.netty
     artifactId: netty-codec-http2
     version: 4.1.125.Final
@@ -33,7 +33,7 @@ patches:
     version: 4.1.125.Final
   - groupId: io.netty
     artifactId: netty-codec-http
-    version: 4.1.129.Final
+    version: 4.1.130.Final
   - groupId: com.microsoft.sqlserver
     artifactId: mssql-jdbc
     version: 13.2.1.jre11


### PR DESCRIPTION
We [recently bumped](https://github.com/wolfi-dev/os/commit/83f6be87939d88516174c29a8e933b09e9ce81ab) `netty-http-codec` to `4.1.129.Final` in order to remediate a CVE.

However, that release of Netty [contained a regression](https://netty.io/news/2025/12/15/4-1-130-Final.html) which led to image tests failing.

This bumps the version again to `4.1.130.Final` so that the CVE is remediated and the regression fixed.
