### PR TITLE
fix(akhq): Remediate GHSA-3677-xxcr-wjqv by bumping jose4j to 0.9.6

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.26.0
-  epoch: 4 # GHSA-84h7-rjj3-6jx4
+  epoch: 5 # GHSA-3677-xxcr-wjqv
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,7 @@ pipeline:
       patches: |
         cves-20250714.patch
         GHSA-84h7-rjj3-6jx4.patch
+        GHSA-3677-xxcr-wjqv.patch
 
   - runs: |
       ./gradlew build -x test -x startTestKafkaCluster --parallel --no-daemon

--- a/akhq/GHSA-3677-xxcr-wjqv.patch
+++ b/akhq/GHSA-3677-xxcr-wjqv.patch
@@ -1,0 +1,39 @@
+From 4facdf783906f5bb2daa4196f4f8cd8306f657d3 Mon Sep 17 00:00:00 2001
+From: Ankush Pathak <ankush.pathak@chainguard.dev>
+Date: Fri, 26 Dec 2025 15:15:45 +0000
+Subject: [PATCH] Bump jose4j to 0.9.6 to remediate GHSA-3677-xxcr-wjqv
+
+Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>
+---
+ build.gradle      | 1 +
+ gradle.properties | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index 4d7280ee..f8bb5501 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -58,6 +58,7 @@ configurations.all {
+         force("org.apache.commons:commons-lang3:" + lang3Version)
+         force("com.nimbusds:nimbus-jose-jwt:" + nimbusJoseJwtVersion)
+         force("io.netty:netty-codec-http:" + nettyVersion)
++        force("org.bitbucket.b_c:jose4j:" + jose4jVersion)
+     }
+ }
+ 
+diff --git a/gradle.properties b/gradle.properties
+index d3632ae4..4bd55d28 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -12,4 +12,5 @@ vertxVersion=4.4.8
+ nettyVersion=4.1.125.Final
+ jettyHttpVersion=12.0.12
+ beansVersion=1.11.0
+-nettyVersion=4.2.8.Final
+\ No newline at end of file
++nettyVersion=4.2.8.Final
++jose4jVersion=0.9.6
+\ No newline at end of file
+-- 
+2.52.0
+


### PR DESCRIPTION
Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-3677-xxcr-wjqv-->
