### PR TITLE
spark-4.0: Bump netty

### DIFF
--- a/spark-4.0.yaml
+++ b/spark-4.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-4.0
   version: "4.0.1"
-  epoch: 4 # GHSA-vc5p-v9hr-52mj
+  epoch: 5
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-4.0/pombump-deps.yaml
+++ b/spark-4.0/pombump-deps.yaml
@@ -7,13 +7,13 @@ patches:
     version: 3.18.0
   - groupId: io.netty
     artifactId: netty-codec-http2
-    version: 4.1.125.Final
+    version: 4.1.130.Final
   - groupId: org.apache.zookeeper
     artifactId: zookeeper
     version: 3.9.4
   - groupId: io.netty
     artifactId: netty-codec-http
-    version: 4.1.129.Final
+    version: 4.1.130.Final
   - groupId: org.apache.logging.log4j
     artifactId: log4j-core
     version: 2.25.3

--- a/spark-4.0/pombump-properties.yaml
+++ b/spark-4.0/pombump-properties.yaml
@@ -4,6 +4,6 @@ properties:
   - property: hadoop.version
     value: "3.4.2"
   - property: netty.version
-    value: "4.1.125.Final"
+    value: "4.1.130.Final"
   - property: jersey.version
     value: "3.0.17"


### PR DESCRIPTION
The spark-operator was afflicted with an error about invalid URIs which
is known to be an netty 4.1.129 issue.
