### PR TITLE
fix(apache-tika-3.2): Remediate GHSA-vc5p-v9hr-52mj by bumping log4j-core

### DIFF
--- a/apache-tika-3.2.yaml
+++ b/apache-tika-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-tika-3.2
   version: "3.2.3"
-  epoch: 1
+  epoch: 2 # GHSA-vc5p-v9hr-52mj
   description: The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).
   copyright:
     - license: Apache-2.0

--- a/apache-tika-3.2/pombump-deps.yaml
+++ b/apache-tika-3.2/pombump-deps.yaml
@@ -2,3 +2,6 @@ patches:
   - groupId: org.apache.commons
     artifactId: commons-lang3
     version: 3.18.0
+  - groupId: org.apache.logging.log4j
+    artifactId: log4j-core
+    version: 2.25.3

--- a/apache-tika-3.2/pombump-properties.yaml
+++ b/apache-tika-3.2/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "3.18.0"
   - property: cxf.version
     value: "4.0.7"
+  - property: log4j2.version
+    value: "2.25.3"


### PR DESCRIPTION
Bump log4j-core to 2.25.3 to remediate GHSA-vc5p-v9hr-52mj

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-vc5p-v9hr-52mj-->
