### PR TITLE
kserve-modelmesh: update log4j-core to 2.25.3 for CVE-2025-68161

### DIFF
--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -2,7 +2,7 @@
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 19
+  epoch: 20
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:

--- a/kserve-modelmesh/pombump-deps.yaml
+++ b/kserve-modelmesh/pombump-deps.yaml
@@ -14,3 +14,6 @@ patches:
   - groupId: org.bouncycastle
     artifactId: bcpkix-jdk18on
     version: "1.79"
+  - groupId: org.apache.logging.log4j
+    artifactId: log4j-core
+    version: 2.25.3


### PR DESCRIPTION
A newer version of log4j-core is required to remediate CVE-2025-68161 in kserve-modelmesh

https://github.com/advisories/GHSA-vc5p-v9hr-52mj

<!--ci-cve-scan:fail-any-->