### PR TITLE
fix: bump Netty to remediate CVE-2025-67735

### DIFF
--- a/selenium.yaml
+++ b/selenium.yaml
@@ -51,6 +51,10 @@ pipeline:
   - runs: |
       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/usr/lib
 
+      # Upgrade netty - GHSA-84h7-rjj3-6jx4
+      sed -i 's/io.netty:netty-bom:4.2.7.Final/io.netty:netty-bom:4.2.8.Final/' MODULE.bazel
+      REPIN=1 bazel run @maven//:pin
+
       bazel build grid
       mkdir -p "${{targets.destdir}}"/usr/bin
       mkdir -p "${{targets.destdir}}"/usr/share/java/${{package.name}}/bin

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,7 +1,7 @@
 package:
   name: selenium
   version: "4.39.0"
-  epoch: 0
+  epoch: 1
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
The aim here is that it should pull in a newer version of Netty (remediating https://github.com/advisories/GHSA-84h7-rjj3-6jx4) as upstream don't appear to have pinned a version


<!--ci-cve-scan:must-fix: GHSA-84h7-rjj3-6jx4-->
