### PR TITLE
refactor(docker-28,29): use var-transforms for consistent subpackage …

### DIFF
--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -11,8 +11,8 @@ package:
       - docker-cli
       - docker-cli-buildx
       - docker-compose
-      - dockerd-${{vars.major-version}}
       - docker-init-${{vars.major-version}}
+      - dockerd-${{vars.major-version}}
       - openssh-client # used by docker-cli
     provides:
       - docker=${{package.full-version}}

--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-28
   version: "28.5.2"
-  epoch: 10 # GHSA-jv3w-x3r3-g6rm
+  epoch: 11 # GHSA-jv3w-x3r3-g6rm
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,12 @@ package:
     disabled:
       # docker is a meta package pulling in several subpackages at runtime
       - empty
+
+var-transforms:
+  - from: ${{package.name}}
+    match: docker-(\d+)
+    replace: $1
+    to: major-version
 
 environment:
   contents:
@@ -100,7 +106,7 @@ pipeline:
       # this exists to appease yam
 
 subpackages:
-  - name: ${{package.name}}-dockerd
+  - name: dockerd-${{vars.major-version}}
     description: "Docker Engine (dockerd)"
     dependencies:
       runtime:
@@ -141,7 +147,7 @@ subpackages:
             bins: dockerd docker-proxy
             version-flag: "--version"
 
-  - name: ${{package.name}}-init
+  - name: docker-init-${{vars.major-version}}
     description: "Docker init"
     dependencies:
       runtime:
@@ -158,7 +164,7 @@ subpackages:
             [ -f /usr/bin/docker-init ]
             [ -x /usr/bin/docker-init ]
 
-  - name: ${{package.name}}-oci-entrypoint
+  - name: docker-oci-entrypoint-${{vars.major-version}}
     description: "docker OCI entrypoint"
     pipeline:
       - runs: |
@@ -173,7 +179,7 @@ subpackages:
         - runs: |
             stat /usr/bin/docker-entrypoint.sh
 
-  - name: ${{package.name}}-dockerd-oci-entrypoint
+  - name: dockerd-oci-entrypoint-${{vars.major-version}}
     description: "dockerd OCI entrypoint"
     dependencies:
       runtime:
@@ -192,7 +198,7 @@ subpackages:
         - runs: |
             stat /usr/bin/dockerd-entrypoint.sh
 
-  - name: ${{package.name}}-rootless
+  - name: docker-rootless-${{vars.major-version}}
     description: "dockerd rootless"
     dependencies:
       runtime:
@@ -210,7 +216,7 @@ subpackages:
             dockerd-rootless-setuptool.sh --help
 
   # Ref: https://github.com/docker-library/docker/blob/master/Dockerfile-dind.template
-  - name: ${{package.name}}-dind
+  - name: docker-dind-${{vars.major-version}}
     description: "Docker in Docker"
     dependencies:
       provides:
@@ -224,7 +230,7 @@ subpackages:
           runs: stat /usr/bin/dind
 
   # ref: https://github.com/docker-library/docker/blob/bce646b7ffd6d126d920a3e06dd59d9192be8d9c/28/dind/dockerd-entrypoint.sh#L229-L231
-  - name: ${{package.name}}-dind-compat
+  - name: docker-dind-compat-${{vars.major-version}}
     description: compat package for docker-dind
     dependencies:
       provides:
@@ -241,7 +247,7 @@ subpackages:
       pipeline:
         - uses: test/tw/symlink-check
 
-  - name: ${{package.name}}-config-mirror-gcr
+  - name: docker-config-mirror-gcr-${{vars.major-version}}
     description: "Docker daemon config to use gcr.io to mirror docker.io"
     dependencies:
       provides:
@@ -259,7 +265,7 @@ subpackages:
           }
           EOF
 
-  - name: ${{package.name}}-dockerd-service
+  - name: dockerd-service-${{vars.major-version}}
     description: "Systemd services for docker"
     dependencies:
       runtime:

--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -7,12 +7,12 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ${{package.name}}-dockerd
-      - ${{package.name}}-init
       - busybox
       - docker-cli
       - docker-cli-buildx
       - docker-compose
+      - docker-dockerd-${{vars.major-version}}
+      - docker-init-${{vars.major-version}}
       - openssh-client # used by docker-cli
     provides:
       - docker=${{package.full-version}}
@@ -185,9 +185,9 @@ subpackages:
       runtime:
         - busybox
         # Used as a fallback in the dockerd-entrypoint.sh script
-        - ${{package.name}}-oci-entrypoint
+        - docker-oci-entrypoint-${{vars.major-version}}
         # Used as a fallback in the dockerd-entrypoint.sh script
-        - ${{package.name}}-dind
+        - docker-dind-${{vars.major-version}}
       provides:
         - dockerd-oci-entrypoint=${{package.full-version}}
     pipeline:
@@ -269,7 +269,7 @@ subpackages:
     description: "Systemd services for docker"
     dependencies:
       runtime:
-        - ${{package.name}}
+        - docker-${{vars.major-version}}
         - containerd-service
         - systemd
       provides:
@@ -286,7 +286,7 @@ subpackages:
 
           # Create docker group
           mkdir -p ${{targets.contextdir}}/usr/lib/sysusers.d/
-          cat <<EOF >${{targets.contextdir}}/usr/lib/sysusers.d/${{package.name}}.conf
+          cat <<EOF >${{targets.contextdir}}/usr/lib/sysusers.d/docker.conf
           g docker 125
           EOF
     test:

--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -11,7 +11,7 @@ package:
       - docker-cli
       - docker-cli-buildx
       - docker-compose
-      - docker-dockerd-${{vars.major-version}}
+      - dockerd-${{vars.major-version}}
       - docker-init-${{vars.major-version}}
       - openssh-client # used by docker-cli
     provides:

--- a/docker-29.yaml
+++ b/docker-29.yaml
@@ -7,12 +7,12 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ${{package.name}}-dockerd
-      - ${{package.name}}-init
       - busybox
       - docker-cli
       - docker-cli-buildx
       - docker-compose
+      - docker-init-${{vars.major-version}}
+      - dockerd-${{vars.major-version}}
       - openssh-client # used by docker-cli
   checks:
     disabled:
@@ -161,9 +161,9 @@ subpackages:
       runtime:
         - busybox
         # Used as a fallback in the dockerd-entrypoint.sh script
-        - ${{package.name}}-oci-entrypoint
+        - docker-oci-entrypoint-${{vars.major-version}}
         # Used as a fallback in the dockerd-entrypoint.sh script
-        - ${{package.name}}-dind
+        - docker-dind-${{vars.major-version}}
     pipeline:
       - runs: |
           install -Dm755 /home/docker-library/dockerd-entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/dockerd-entrypoint.sh
@@ -232,7 +232,7 @@ subpackages:
     description: "Systemd services for docker"
     dependencies:
       runtime:
-        - ${{package.name}}
+        - docker-${{vars.major-version}}
         - containerd-service
         - systemd
     pipeline:

--- a/docker-29.yaml
+++ b/docker-29.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-29
   version: "29.1.3"
-  epoch: 0 # GHSA-jv3w-x3r3-g6rm
+  epoch: 1 # GHSA-jv3w-x3r3-g6rm
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,12 @@ package:
     disabled:
       # docker is a meta package pulling in several subpackages at runtime
       - empty
+
+var-transforms:
+  - from: ${{package.name}}
+    match: docker-(\d+)
+    replace: $1
+    to: major-version
 
 environment:
   contents:
@@ -82,7 +88,7 @@ pipeline:
       # this exists to appease yam
 
 subpackages:
-  - name: ${{package.name}}-dockerd
+  - name: dockerd-${{vars.major-version}}
     description: "Docker Engine (dockerd)"
     dependencies:
       runtime:
@@ -121,7 +127,7 @@ subpackages:
             bins: dockerd docker-proxy
             version-flag: "--version"
 
-  - name: ${{package.name}}-init
+  - name: docker-init-${{vars.major-version}}
     description: "Docker init"
     dependencies:
       runtime:
@@ -136,7 +142,7 @@ subpackages:
             [ -f /usr/bin/docker-init ]
             [ -x /usr/bin/docker-init ]
 
-  - name: ${{package.name}}-oci-entrypoint
+  - name: docker-oci-entrypoint-${{vars.major-version}}
     description: "docker OCI entrypoint"
     pipeline:
       - runs: |
@@ -149,7 +155,7 @@ subpackages:
         - runs: |
             stat /usr/bin/docker-entrypoint.sh
 
-  - name: ${{package.name}}-dockerd-oci-entrypoint
+  - name: dockerd-oci-entrypoint-${{vars.major-version}}
     description: "dockerd OCI entrypoint"
     dependencies:
       runtime:
@@ -166,7 +172,7 @@ subpackages:
         - runs: |
             stat /usr/bin/dockerd-entrypoint.sh
 
-  - name: ${{package.name}}-rootless
+  - name: docker-rootless-${{vars.major-version}}
     description: "dockerd rootless"
     dependencies:
       runtime:
@@ -182,7 +188,7 @@ subpackages:
             dockerd-rootless-setuptool.sh --help
 
   # Ref: https://github.com/docker-library/docker/blob/master/Dockerfile-dind.template
-  - name: ${{package.name}}-dind
+  - name: docker-dind-${{vars.major-version}}
     description: "Docker in Docker"
     pipeline:
       - runs: |
@@ -193,7 +199,7 @@ subpackages:
           runs: stat /usr/bin/dind
 
   # ref: https://github.com/docker-library/docker/blob/bce646b7ffd6d126d920a3e06dd59d9192be8d9c/28/dind/dockerd-entrypoint.sh#L229-L231
-  - name: ${{package.name}}-dind-compat
+  - name: docker-dind-compat-${{vars.major-version}}
     description: compat package for docker-dind
     pipeline:
       - runs: |
@@ -207,7 +213,7 @@ subpackages:
       pipeline:
         - uses: test/tw/symlink-check
 
-  - name: ${{package.name}}-config-mirror-gcr
+  - name: docker-config-mirror-gcr-${{vars.major-version}}
     description: "Docker daemon config to use gcr.io to mirror docker.io"
     pipeline:
       # https://docs.docker.com/docker-hub/image-library/mirror/#configure-the-docker-daemon
@@ -222,7 +228,7 @@ subpackages:
           }
           EOF
 
-  - name: ${{package.name}}-dockerd-service
+  - name: dockerd-service-${{vars.major-version}}
     description: "Systemd services for docker"
     dependencies:
       runtime:


### PR DESCRIPTION
…naming

Extract major versions and standardize subpackage naming patterns across Docker 28 and 29. Update epochs accordingly.

This produces cleaner, more
intuitive package names by extracting the version suffix:
  docker-28-dockerd          → dockerd-28
  docker-28-dind             → docker-dind-28
  docker-28-init             → docker-init-28
  docker-28-rootless         → docker-rootless-28
  docker-28-oci-entrypoint   → docker-oci-entrypoint-28
  docker-28-dind-compat      → docker-dind-compat-28
  docker-28-config-mirror-gcr → docker-config-mirror-gcr-28
