### PR TITLE
kafka-4.1: update module pins for CVE-2025-68161

### DIFF
--- a/kafka-4.1.yaml
+++ b/kafka-4.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-4.1
   version: "4.1.1"
-  epoch: 0
+  epoch: 1 # CVE-2025-68161
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,11 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: be816b82d25370ceac697ccf7c88cea873e9b4e3
+
+  - uses: patch
+    with:
+      patches: |
+        CVE-2025-68161.patch
 
   - runs: |
       gradle clean releaseTarGz

--- a/kafka-4.1/CVE-2025-68161.patch
+++ b/kafka-4.1/CVE-2025-68161.patch
@@ -1,0 +1,59 @@
+From e5329b898171c69c1d96613a6c7df4f798e30f69 Mon Sep 17 00:00:00 2001
+From: Andrew Scribner <ca.scribner+1@gmail.com>
+Date: Mon, 29 Dec 2025 14:26:46 -0500
+Subject: [PATCH] Bump log4j to version 2.25.3 to remediate CVE-2025-68161
+
+Also removes the `-Werror` build flag, which causes builds to fail if there are any warnings during compilation.  This is required because because a log4j feature used by Kafka is deprecated (not removed) as of 2.25.x, which causes a compiler warning which fails the build if `-Werror` is set.
+---
+ LICENSE-binary             | 8 ++++----
+ build.gradle               | 1 -
+ gradle/dependencies.gradle | 2 +-
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index b601ccebfb..f375a6445a 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -238,10 +238,10 @@ License Version 2.0:
+ - jetty-util-12.0.22
+ - jose4j-0.9.6
+ - jspecify-1.0.0
+-- log4j-api-2.24.3
+-- log4j-core-2.24.3
+-- log4j-slf4j-impl-2.24.3
+-- log4j-1.2-api-2.24.3
++- log4j-api-2.25.3
++- log4j-core-2.25.3
++- log4j-slf4j-impl-2.25.3
++- log4j-1.2-api-2.25.3
+ - lz4-java-1.8.0
+ - maven-artifact-3.9.6
+ - metrics-core-2.2.0
+diff --git a/build.gradle b/build.gradle
+index 97250637b7..ca881c527b 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -129,7 +129,6 @@ ext {
+       options.compilerArgs << "-Xlint:all"
+       options.compilerArgs << "-Xlint:-serial"
+       options.compilerArgs << "-Xlint:-try"
+-      options.compilerArgs << "-Werror"
+     }
+   }
+ 
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index 10173814e5..4006493c9c 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -105,7 +105,7 @@ versions += [
+   kafka_38: "3.8.1",
+   kafka_39: "3.9.1",
+   kafka_40: "4.0.0",
+-  log4j2: "2.24.3",
++  log4j2: "2.25.3",
+   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
+   lz4: "1.8.0",
+   mavenArtifact: "3.9.6",
+-- 
+2.43.0
+


### PR DESCRIPTION
Bump:
* log4j2==2.25.3 to remediate CVE-2025-68161
