### PR TITLE
font-opensymbol: switch to git-checkout

### DIFF
--- a/font-opensymbol.yaml
+++ b/font-opensymbol.yaml
@@ -1,7 +1,7 @@
 package:
   name: font-opensymbol
   version: 102.12
-  epoch: 1
+  epoch: 2
   description: LibreOffice-compatible OpenSymbol font for technical and symbolic glyphs
   copyright:
     - license: MPL-2.0
@@ -9,35 +9,47 @@ package:
 environment:
   contents:
     packages:
-      - binutils
       - busybox
-      - curl
+      - fontforge
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: ef4a053515961170f0bbc48b30fc7a9a34c99b259a91a05e95edf8d77504bcfa
-      uri: http://ftp.de.debian.org/debian/pool/main/libr/libreoffice/fonts-opensymbol_${{package.version}}+LibO7.4.7-1+deb12u8_all.deb
-      extract: false
+      repository: https://git.libreoffice.org/core
+      tag: libreoffice-7.4.7.1
+      expected-commit: 9204137cd80881d05c679c2486e99f8e6c810710
+      sparse-paths: |
+        extras/source/truetype/symbol
+
+  # https://git.libreoffice.org/core/+/refs/heads/master/extras/CustomTarget_opensymbol.mk
+  - name: Generate TTF font
+    runs: |
+      fontforge -lang=ff -c 'Open($1); Generate($2)' \
+        extras/source/truetype/symbol/OpenSymbol.sfd opens___.ttf
+
+  # https://git.libreoffice.org/core/+/refs/heads/master/postprocess/CustomTarget_fontconfig.mk
+  - name: Generate fontconfig configuration
+    runs: |
+      (
+        printf '<?xml version="1.0"?>\n<!DOCTYPE fontconfig SYSTEM "/etc/fonts/conf.d/fonts.dtd">\n<fontconfig>\n'
+        cat extras/source/truetype/symbol/fc_local.snippet
+        printf '</fontconfig>\n'
+      ) >30-opensymbol.conf
 
   - runs: |
-      ar x fonts-opensymbol_${{package.version}}+LibO7.4.7-1+deb12u8_all.deb
-      tar -xf data.tar.xz
+      mkdir -p "${{targets.contextdir}}/usr/share/fontconfig/conf.avail"
+      mv 30-opensymbol.conf "${{targets.contextdir}}/usr/share/fontconfig/conf.avail/"
 
       mkdir -p "${{targets.contextdir}}/etc/fonts/conf.d"
-      mv ./etc/fonts/conf.d "${{targets.contextdir}}/etc/fonts/conf.d"
-
-      mkdir -p "${{targets.contextdir}}/usr/share/bug"
-      mv ./usr/share/bug/ "${{targets.contextdir}}/usr/share/bug"
-
-      mkdir -p "${{targets.contextdir}}/usr/share/fontconfig"
-      mv ./usr/share/fontconfig "${{targets.contextdir}}/usr/share/fontconfig"
+      ln -s /usr/share/fontconfig/conf.avail/30-opensymbol.conf "${{targets.contextdir}}/etc/fonts/conf.d/30-opensymbol.conf"
 
       mkdir -p "${{targets.contextdir}}/usr/share/fonts/truetype/libreoffice"
-      mv ./usr/share/fonts/truetype/libreoffice/*.ttf "${{targets.contextdir}}/usr/share/fonts/truetype/libreoffice/"
+      mv opens___.ttf "${{targets.contextdir}}/usr/share/fonts/truetype/libreoffice/"
 
 update:
   enabled: false
+  manual: true
+  exclude-reason: "See Version: field in extras/source/truetype/symbol/OpenSymbol.sfd; only updated by some LibreOffice releases"
 
 test:
   pipeline:


### PR DESCRIPTION
This also fixes some fontconfig installation paths, which previously had a spurious extra level of nesting (`/etc/fonts/conf.d/conf.d/` and `/usr/share/fontconfig/fontconfig/conf.avail/`).

Related: https://github.com/chainguard-dev/internal-dev/issues/24668