### PR TITLE
fonts: switch to git-checkout

### DIFF
--- a/font-liberation.yaml
+++ b/font-liberation.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-liberation
   version: 2.1.5
-  epoch: 1
+  epoch: 2
   description: Fonts to replace commonly used Microsoft Windows fonts
   copyright:
     - license: OFL-1.1
@@ -16,19 +16,25 @@ environment:
       - busybox
       - ca-certificates-bundle
       - fontconfig
+      - fontforge
+      - py3-supported-fonttools
+      - python3
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7191c669bf38899f73a2094ed00f7b800553364f90e2637010a69c0e268f25d0
-      uri: https://github.com/liberationfonts/liberation-fonts/files/7261482/liberation-fonts-ttf-${{package.version}}.tar.gz
+      repository: https://github.com/liberationfonts/liberation-fonts
+      tag: ${{package.version}}
+      expected-commit: 4b0192046158094654e865245832c66d2104219e
+
+  - uses: autoconf/make
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}} \
         ${{targets.destdir}}/etc/fonts/conf.avail \
         ${{targets.destdir}}/etc/fonts/conf.d
 
-      install -D -m644 ./*.ttf -t ${{targets.destdir}}/usr/share/fonts/${{package.name}}/
+      install -D -m644 liberation-fonts-ttf-${{package.version}}/*.ttf -t ${{targets.destdir}}/usr/share/fonts/${{package.name}}/
 
       for i in $(find . -name '*.conf'); do
         install -D -m644 "$i" -t ${{targets.destdir}}/etc/fonts/conf.avail/
@@ -39,8 +45,8 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 16833
+  github:
+    identifier: liberationfonts/liberation-fonts
 
 test:
   pipeline:

--- a/font-opensans.yaml
+++ b/font-opensans.yaml
@@ -1,7 +1,8 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: font-opensans
   version: 0_git20210927
-  epoch: 1
+  epoch: 2
   description: Humanist Sans Serif Typeface
   copyright:
     - license: Apache-2.0
@@ -16,10 +17,11 @@ environment:
       - mkfontscale
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: cdc1ba1f82c7a130a2c6a9def519528ec936baad08e0188bf8dc90a0718ca7f5
-      uri: https://github.com/googlefonts/opensans/archive/ebedbda589fe5bd861b02325aca98c86ad845251.tar.gz
+      repository: https://github.com/googlefonts/opensans
+      branch: main
+      expected-commit: bd7e37632246368c60fdcbd374dbf9bad11969b6
 
   - runs: |
       install -D -m644 fonts/ttf/*.ttf -t "${{targets.destdir}}"/usr/share/fonts/opensans

--- a/font-stix-otf-arm.yaml
+++ b/font-stix-otf-arm.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-stix-otf-arm
   version: 2.13
-  epoch: 0
+  epoch: 1
   description: stix-otf fonts
   copyright:
     - license: OFL-1.1
@@ -18,10 +18,11 @@ environment:
       - busybox
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/stipub/stixfonts/archive/refs/tags/v2.13b171.tar.gz
-      expected-sha256: 1e76b9ab0bb08372ff73ad5b58d9116260e9058d1fce4b83fe1e213c3b9c947f
+      repository: https://github.com/stipub/stixfonts
+      tag: v2.13b171
+      expected-commit: 744a22a4dd626cd14d75728aef34fc8ad7c85db0
 
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/share/fonts/stix-fonts/"
@@ -30,6 +31,8 @@ pipeline:
 update:
   enabled: false
   exclude-reason: We're currently fetching from the latest release, 2.13 b171, which appears to be a one-off build. We should keep an eye out for any similar builds in the future.
+  github:
+    identifier: stipub/stixfonts
 
 test:
   pipeline:


### PR DESCRIPTION
Most fonts don't seem to be usefully maintained in git, but a few are.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668