### PR TITLE
logstash 9.2: update gem pins for CVE-2025-14762

### DIFF
--- a/logstash-9.2.yaml
+++ b/logstash-9.2.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-9.2
   version: "9.2.2"
-  epoch: 1 # GHSA-84h7-rjj3-6jx4
+  epoch: 2 # CVE-2025-14762.
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -103,6 +103,8 @@ pipeline:
       sed -i "s/rack (>= 3\.1\.16)/rexml (>= 3.1.17)/" "Gemfile.jruby-3.1.lock.release"
       echo "gem 'rack', '3.1.18'" >> Gemfile.template
       echo "gem 'sinatra', '4.2.0'" >> Gemfile.template
+      # Fix CVE-2025-14762
+      sed -i 's/aws-sdk-s3 (1.199.1)/aws-sdk-s3 (1.208.0)/' Gemfile.jruby-3.1.lock.release
 
       for plugin in ${{vars.separately-packaged-plugins}}
       do


### PR DESCRIPTION
Bump to aws-sdk-s3==1.208.0 to remediate CVE-2025-14762.
