### PR TITLE
zipkin: bump log4j version to v2.25.3 in pombump-properties.yaml

### DIFF
--- a/zipkin.yaml
+++ b/zipkin.yaml
@@ -1,7 +1,7 @@
 package:
   name: zipkin
   version: "3.5.1"
-  epoch: 9 # GHSA-84h7-rjj3-6jx4
+  epoch: 10 # GHSA-vc5p-v9hr-52mj
   description: Zipkin distributed tracing system
   copyright:
     - license: Apache-2.0

--- a/zipkin/pombump-deps.yaml
+++ b/zipkin/pombump-deps.yaml
@@ -14,3 +14,6 @@ patches:
   - groupId: org.apache.commons
     artifactId: commons-lang3
     version: 3.18.0
+  - groupId: org.apache.logging.log4j
+    artifactId: log4j-core
+    version: 2.25.3

--- a/zipkin/pombump-deps.yaml
+++ b/zipkin/pombump-deps.yaml
@@ -14,6 +14,3 @@ patches:
   - groupId: org.apache.commons
     artifactId: commons-lang3
     version: 3.18.0
-  - groupId: org.apache.logging.log4j
-    artifactId: log4j-core
-    version: 2.25.3

--- a/zipkin/pombump-properties.yaml
+++ b/zipkin/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "4.2.8.Final"
   - property: spring-boot.version
     value: "3.4.10"
+  - property: log4j.version
+    value: "2.25.3"


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2025-68161-->


Fixes: https://github.com/wolfi-dev/os/pull/76550
