### PR TITLE
feat(ruby-3.2-aws-sdk-3): bump to version 1.209.0

### DIFF
--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: ruby3.2-aws-sdk-core
-  version: "3.227.0"
+  version: "3.240.0"
   epoch: 0
   description: Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby.
   copyright:
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: d31fede90259b577671ed003141b518cc14f559c
+      expected-commit: 946aefc489b6037d3fe3d680805592f178a076b9
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
       depth: -1

--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -32,6 +32,15 @@ pipeline:
       branch: version-3
       depth: -1
 
+  # verify that the version file in the checkout matches our intended version
+  - runs: |
+      VER=$(cat gems/${{vars.gem}}/VERSION)
+      if [ ! "$VER" == "${{package.version}}" ]
+      then
+        echo "Unexpected upstream version (expected: ${{package.version}}, found: $VER"
+        exit 1
+      fi
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: ruby3.2-aws-sdk-s3
-  version: 1.169.0
-  epoch: 1
+  version: 1.209.0
+  epoch: 0
   description: Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 86cccb96ed7a0ee71cd33847151b4219d30b1571
+      expected-commit: aa020cd8c3d09be074cc2b018691f0145be5802a
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
       depth: -1

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -31,6 +31,15 @@ pipeline:
       branch: version-3
       depth: -1
 
+  # verify that the version file in the checkout matches our intended version
+  - runs: |
+      VER=$(cat gems/${{vars.gem}}/VERSION)
+      if [ ! "$VER" == "${{package.version}}" ]
+      then
+        echo "Unexpected upstream version (expected: ${{package.version}}, found: $VER"
+        exit 1
+      fi
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}


### PR DESCRIPTION
This is being done primarily to bring in the change in 1.208.0 which remediates CVE-2025-14762

Have been through the [upstream changelog](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/CHANGELOG.md#12090-2025-12-23) and there are no breaking changes listed between the two versions

