### PR TITLE
fix(kube-fluentd-operator): bump aws-sdk-s3 to remediate CVE-2025-14762

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -93,6 +93,9 @@ pipeline:
       # bump webrick to mitigate GHSA-c2f4-jgmc-q2r5
       echo "gem 'rexml', '3.4.2'" >> Gemfile
 
+      # bump the s3 SDK to remediate CVE-2025-14762
+      echo "gem 'aws-sdk-s3', '~> 1.208'" >> Gemfile
+
       # bump fluent-plugin-systemd to latest version 1.1.1, which requires systemd-journal 2.1.0+
       # This resolves segmentation faults when reading systemd journal logs (issue #2393)
       sed -i "s/gem 'fluent-plugin-systemd', \"1.0.5\"/gem 'fluent-plugin-systemd', \"~> 1.1.0\"/" Gemfile
@@ -105,9 +108,6 @@ pipeline:
 
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'thor', '1.4.0'" >> Gemfile
-
-      # bump the s3 SDK to remediate CVE-2025-14762
-      echo "gem 'aws-sdk-s3', '~> 1.208'" >> Gemfile
 
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin
       mv ./plugins/* ${{targets.destdir}}/etc/fluent/plugin

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 53 # GHSA-4f99-4q7p-p3gh
+  epoch: 54 # GHSA-4f99-4q7p-p3gh
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -106,6 +106,9 @@ pipeline:
       # bump webrick to mitigate GHSA-6f62-3596-g6w7
       echo "gem 'thor', '1.4.0'" >> Gemfile
 
+      # bump the s3 SDK to remediate CVE-2025-14762
+      echo "gem 'aws-sdk-s3', '~> 1.208'" >> Gemfile
+
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin
       mv ./plugins/* ${{targets.destdir}}/etc/fluent/plugin
 


### PR DESCRIPTION
[upstream changelog entry](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/CHANGELOG.md#12080-2025-12-16)