### PR TITLE
fix(argo-events): Remove argo-events-compat subpackage

### DIFF
--- a/argo-events.yaml
+++ b/argo-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-events
   version: "1.9.9"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: Event-driven Automation Framework for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -28,19 +28,6 @@ pipeline:
         -X github.com/argoproj/argo-events.gitTreeState=clean
       output: argo-events
       packages: ./cmd
-
-subpackages:
-  - name: argo-events-compat
-    pipeline:
-      - runs: |
-          # Symlink the binary from usr/bin to /
-          mkdir -p "${{targets.subpkgdir}}"
-          ln -sf /usr/bin/argo-events ${{targets.subpkgdir}}/argo-events
-    # test added by a robot (compat)
-    test:
-      pipeline:
-        - runs: |
-            readlink -v /argo-events
 
 update:
   enabled: true


### PR DESCRIPTION
compat subpackage causes eventsources to fail to mount secrets at /argo-events/secrets/

Causes the following error:

```
Error Message: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mountin "/var/lib/kubelet/pods/a342d685-dcdd-4dad-994f-ee54e017481c/volumes/kubernetes.io~secret/my-webhook-token" to rootfs at "/argo-events/secrets/my-webhook-token": create mountpoint for /argo-events/secrets/my-webhook-token mount: lookup mountpoint target: securejoin.OpenInRoot /argo-events/secrets/my-webhook-token: openat2 /argo-events/secrets/my-webhook-token: not a directory: unknown
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
