### PR TITLE
yara-x/1.10.0-r1 build with release-lto profile

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -7,7 +7,7 @@ package:
     - license: BSD-3-Clause
   resources:
     cpu: 16
-    memory: 12Gi
+    memory: 16Gi
 
 environment:
   contents:
@@ -88,4 +88,7 @@ test:
     - runs: |
         git clone https://github.com/chainguard-dev/malcontent.git
         cd malcontent
-        time -v go run cmd/mal/mal.go --min-risk critical --min-file-risk critical scan yr /usr
+
+        go build -o out/mal ./cmd/mal
+
+        time -v out/mal --min-risk critical --min-file-risk critical scan yr /usr

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -29,6 +29,12 @@ pipeline:
       expected-commit: 04817dd2ec529b71af47722a473bbdb2db65b15d
       tag: v${{package.version}}
 
+  # mitigate a current ARM64 Rust <> wasmtime bug currently addressed by the latter
+  # while they wait for the former
+  # see: https://github.com/bytecodealliance/wasmtime/issues/11957
+  - runs: |
+      sed -i 's/wasmtime = { version = "38.0.4", default-features = false }/wasmtime = { version = "39.0.1", default-features = false }/g' Cargo.toml
+
   - uses: rust/cargobump
 
   - name: Build base yara tool

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: "1.10.0"
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -33,10 +33,20 @@ pipeline:
   - name: Build base yara tool
     uses: cargo/build
     with:
+      # Special profile that builds a release binary with link-time optimization.
+      # Compiling with this profile takes a while, but the resulting binary is
+      # smaller and better optimized.
+      #
+      # this uses lto = true which attempts to perform optimizations
+      # across all crates within the dependency graph.
+      # see: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+      # and https://github.com/VirusTotal/yara-x/blob/3c92ac0c0173ec295f9975fc46b9be2bfe0b6028/Cargo.toml#L119-L127
+      opts: --profile release-lto
+      output-dir: target/release-lto
       output: yr
 
   - runs: |
-      cargo cinstall -p yara-x-capi --features=native-code-serialization --release --prefix=${{targets.destdir}}/usr --pkgconfigdir=${{targets.destdir}}/usr/lib/pkgconfig --includedir=${{targets.destdir}}/usr/include --libdir=${{targets.destdir}}/usr/lib --manifest-path capi/Cargo.toml
+      cargo cinstall -p yara-x-capi --features=native-code-serialization --profile release-lto --prefix=${{targets.destdir}}/usr --pkgconfigdir=${{targets.destdir}}/usr/lib/pkgconfig --includedir=${{targets.destdir}}/usr/include --libdir=${{targets.destdir}}/usr/lib --manifest-path capi/Cargo.toml
 
       # this is required because the yara_x_capi.pc will end up with /home/build/melange-out/yara-x each of the paths
       # this causes an issue during install and when attempting to build using the library api.

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -6,7 +6,8 @@ package:
   copyright:
     - license: BSD-3-Clause
   resources:
-    memory: 6Gi
+    cpu: 16
+    memory: 12Gi
 
 environment:
   contents:

--- a/yara-x/cargobump-deps.yaml
+++ b/yara-x/cargobump-deps.yaml
@@ -3,5 +3,3 @@ packages:
     version: 1.44.2
   - name: crossbeam-channel
     version: 0.5.15
-  - name: wasmtime
-    version: 37.0.3


### PR DESCRIPTION
This PR builds the the yara-x CLI and the C API with the `release-lto` profile which further optimizes the build and also reduces the overall size.

I also fixed an odd bug that would have blocked the next yara-x release from passing (ARM64-specific but nevertheless).

Size reduction as seen from `ci-diff-report`:
`aarch64`:
```diff
.PKGINFO
- -rw-r--r-- 594 2025-11-20 14:05:06 .PKGINFO
+ -rw-r--r-- 593 2025-12-30 22:18:42 .PKGINFO
.melange.yaml
- -rw-r--r-- 14418 2025-11-20 14:05:06 .melange.yaml
+ -rw-r--r-- 15081 2025-12-30 22:18:42 .melange.yaml
usr/bin/yr
- -rwxr-xr-x 34820400 2025-11-20 14:05:06 yr
-   APK-TOOLS.checksum.SHA1: "da53866ec52bfb8e17ea0a82f328ca93539eac08"
+ -rwxr-xr-x 24242168 2025-12-30 22:18:42 yr
+   APK-TOOLS.checksum.SHA1: "debe188fe267b5e3613b11bef89b7aec31db08de"
usr/lib/libyara_x_capi.a
- -rw-r--r-- 118211878 2025-11-20 14:05:06 libyara_x_capi.a
-   APK-TOOLS.checksum.SHA1: "7cd8951d98da5a3c4ef21dbf5c8129e9946df19d"
+ -rw-r--r-- 43394348 2025-12-30 22:18:42 libyara_x_capi.a
+   APK-TOOLS.checksum.SHA1: "87d18691790055659c7cddbc30204ecc015da9c0"
usr/lib/libyara_x_capi.so.1.10.0
- -rwxr-xr-x 29596120 2025-11-20 14:05:06 libyara_x_capi.so.1.10.0
-   APK-TOOLS.checksum.SHA1: "b0232745233242620faca9f616863e735bb79b92"
+ -rwxr-xr-x 21072168 2025-12-30 22:18:42 libyara_x_capi.so.1.10.0
+   APK-TOOLS.checksum.SHA1: "0d85ed9b874c171f8492b4e44d5cddd38242b881"
```

`x86_64`:
```diff
.melange.yaml
- -rw-r--r-- 14382 2025-11-20 14:05:06 .melange.yaml
+ -rw-r--r-- 15045 2025-12-30 22:18:42 .melange.yaml
usr/bin/yr
- -rwxr-xr-x 37370648 2025-11-20 14:05:06 yr
-   APK-TOOLS.checksum.SHA1: "64c26895820406c2355494a05340157d498dd822"
+ -rwxr-xr-x 27178584 2025-12-30 22:18:42 yr
+   APK-TOOLS.checksum.SHA1: "eda975b4602625735c5b993880b9a7cc03e8ccb9"
usr/lib/libyara_x_capi.a
- -rw-r--r-- 123966896 2025-11-20 14:05:06 libyara_x_capi.a
-   APK-TOOLS.checksum.SHA1: "adf161e8d9c12be99fea4aad2217f1a673d8d37a"
+ -rw-r--r-- 48490818 2025-12-30 22:18:42 libyara_x_capi.a
+   APK-TOOLS.checksum.SHA1: "c1afbca853dd3a7da94c2786dc588039edf909b3"
usr/lib/libyara_x_capi.so.1.10.0
- -rwxr-xr-x 32027304 2025-11-20 14:05:06 libyara_x_capi.so.1.10.0
-   APK-TOOLS.checksum.SHA1: "7f3bcae7a5ac696afc101e47fed851d6ac901942"
+ -rwxr-xr-x 23801336 2025-12-30 22:18:42 libyara_x_capi.so.1.10.0
+   APK-TOOLS.checksum.SHA1: "6172c581b50497ec28f25e25c5df97b486610380"
```