### PR TITLE
fix: bump log4j to remediate CVE-2025-68161

### DIFF
--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -113,6 +113,9 @@ pipeline:
       # Bump netty to 4.2.8-Final: GHSA-84h7-rjj3-6jx4
       sed -i 's/^\(netty.*\)4.2.7/\14.2.8/' gradle/libs.versions.toml
 
+      # Bump log4j to 2.25.3: GHSA-vc5p-v9hr-52mj
+      sed -i 's/^\(log4j.*\)2.21.0/\12.25.3/' gradle/libs.versions.toml
+
   - runs: |
       echo "org.gradle.daemon=false" >> gradle.properties
       gradle localDistro --parallel -Dbuild.snapshot="false" -Dbuild.version_qualifier=""

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.4.0"
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Increase the log4j version to help with https://github.com/advisories/GHSA-vc5p-v9hr-52mj