### PR TITLE
fix(confluent-kafka): remediate CVE-2025-68161

### DIFF
--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -9,7 +9,7 @@ package:
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
   version: "8.3.0.96"
-  epoch: 0
+  epoch: 1
   description: Community edition of Confluent Kafka.
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,9 @@ pipeline:
 
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+      # Remediate https://github.com/advisories/GHSA-vc5p-v9hr-52mj
+      sed -i 's/log4j2: "2.25.1"/log4j2: "2.25.3"/' gradle/dependencies.gradle
 
       gradle clean releaseTarGz
 


### PR DESCRIPTION
Bumps the log4j version (from 2.25.1 to 2.25.3) to remediate GHSA-vc5p-v9hr-52mj