### PR TITLE
confluent-common-docker: update to 7.6.9 to resolve GHSA-3677-xxcr-wjqv

### DIFF
--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-common-docker
-  version: 7.6.0
-  epoch: 21
+  version: 7.6.9
+  epoch: 0
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 1517960f490072414719d11cdb66e5a183ee45dc
+      expected-commit: dda142cc7499fba34fd46d54d103f5d9e5f6d3b9
       repository: https://github.com/confluentinc/common-docker
       tag: v${{package.version}}
 


### PR DESCRIPTION
## Summary
Updates confluent-common-docker from version 7.6.0 to 7.6.9.

## Changes
- Updated version from 7.6.0 to 7.6.9
- Updated expected-commit to match v7.6.9 tag
- Reset epoch to 0 for new version

## Upstream Reference
- Tag: v7.6.9
- Commit: dda142cc7499fba34fd46d54d103f5d9e5f6d3b9
- Repository: https://github.com/confluentinc/common-docker

## Verification
Build and scan will verify the package builds correctly with the new version.