### PR TITLE
openssl: Build oldglibc builds w/ no-module

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: "3.6.0"
-  epoch: 6
+  epoch: 7
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -51,6 +51,7 @@ pipeline:
 
   - name: Perform throw-away canary tests of jitter and non-validated fips
     runs: |
+      [ ! -d /usr/lib/oldglibc ] || exit 0
       mkdir -p build-jitter-fips-tests/
       cd build-jitter-fips-tests/
       ../Configure --with-rand-seed=none enable-jitter enable-fips -DOPENSSL_DEFAULT_SEED_SRC=JITTER --debug
@@ -68,6 +69,7 @@ pipeline:
          --openssldir=/etc/ssl \
          enable-ktls \
          $([ -d /usr/lib/oldglibc ] || echo enable-jitter) \
+         $([ ! -d /usr/lib/oldglibc ] || echo no-module) \
          shared \
          enable-pie \
          no-zlib \
@@ -187,6 +189,10 @@ subpackages:
     description: "OpenSSL legacy provider"
     pipeline:
       - runs: |
+          if [ -d /usr/lib/oldglibc ]; then
+            # this is a no-module build
+            exit 0
+          fi
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/ossl-modules
           mv "${{targets.destdir}}"/usr/lib/ossl-modules/legacy.so "${{targets.subpkgdir}}"/usr/lib/ossl-modules/
     test:


### PR DESCRIPTION
Build the legacy code into libcrypto and make the openssl-provider-legacy
package empty so that builds of the cryptography python library can link
the legacy code statically.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
