### PR TITLE
airflow-3: update marshmallow to v3.26.2 to remediate CVE-2025-68480

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.5"
-  epoch: 0 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 1 # GHSA-428g-f7cq-pgp5
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -76,6 +76,7 @@ pipeline:
         cryptography==44.0.1 # GHSA-79v4-65xg-pq4g, GHSA-h4gh-qq45-vh27
         filelock==3.20.1
         commons-lang3==3.18.0 # GHSA-j288-q9x7-2f5v
+        marshmallow==3.26.2 # GHSA-428g-f7cq-pgp5
 
   - runs: |
       # ZIP doesn't handle the SDE we set correctly, so set it to 1980-01-01


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2025-68480-->
