### PR TITLE
infinispan-15.2: fix GHSA-vc5p-v9hr-52mj by updating log4j-core to 2.25.3

### DIFF
--- a/infinispan-15.2.yaml
+++ b/infinispan-15.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: infinispan-15.2
   version: "15.2.6"
-  epoch: 2 # GHSA-84h7-rjj3-6jx4
+  epoch: 3 # CVE fix: GHSA-vc5p-v9hr-52mj (log4j-core 2.24.3 -> 2.25.3)
   description: Infinispan is an open source data grid platform and highly scalable NoSQL cloud data store.
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,15 @@ pipeline:
       expected-commit: c5dd3a4c57c605eb0667b7225732fef39aac0f03
 
   - uses: maven/pombump
+    with:
+      properties-file: pombump-properties.yaml
+      patch-file: pombump-deps.yaml
+      pom: pom.xml
+
+  - uses: maven/pombump
+    with:
+      properties-file: pombump-properties-configuration.yaml
+      pom: build/configuration/pom.xml
 
   - name: Create dirs
     runs: |

--- a/infinispan-15.2/pombump-deps.yaml
+++ b/infinispan-15.2/pombump-deps.yaml
@@ -11,3 +11,6 @@ patches:
   - groupId: io.netty
     artifactId: netty-codec-http
     version: 4.1.129.Final
+  - groupId: org.apache.logging.log4j
+    artifactId: log4j-core
+    version: 2.25.3

--- a/infinispan-15.2/pombump-properties-configuration.yaml
+++ b/infinispan-15.2/pombump-properties-configuration.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: version.log4j
+    value: 2.25.3

--- a/infinispan-15.2/pombump-properties.yaml
+++ b/infinispan-15.2/pombump-properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: version.log4j
+    value: 2.25.3


### PR DESCRIPTION
## Summary
Fixes GHSA-vc5p-v9hr-52mj by updating log4j-core from 2.24.3 to 2.25.3 across all Infinispan modules.

## Vulnerability Details
- **CVE**: GHSA-vc5p-v9hr-52mj / CVE-2025-68161
- **Component**: log4j-core @ 2.24.3
- **Severity**: Medium
- **Issue**: Apache Log4j does not verify the TLS hostname in its Socket Appender
- **Vulnerable range**: >= 2.0-beta9, < 2.25.3
- **Fix version**: 2.25.3

## Root Cause Analysis
Infinispan has a separate configuration module with its own pom.xml that explicitly declares log4j dependencies:
- `build/configuration/pom.xml`

This module doesn't inherit log4j versions from the root pom.xml, so we must apply pombump to both pom files.

## Changes
### New Files Created
1. `infinispan-15.2/pombump-properties.yaml` - Root log4j version property
2. `infinispan-15.2/pombump-properties-configuration.yaml` - Configuration module property

### Files Modified
3. `infinispan-15.2/pombump-deps.yaml` - Added log4j-core direct dependency override
4. `infinispan-15.2.yaml` - Added pombump steps for root and configuration modules, incremented epoch from 2 to 3

### Pombump Strategy
Applied to **2 different pom.xml files** with both property and dependency overrides:
1. `pom.xml` (root build) - properties + deps
2. `build/configuration/pom.xml` (configuration module) - properties only

## Method
We use a **dual approach**:
- **Property override**: Set `version.log4j` property to 2.25.3
- **Direct dependency override**: Force `log4j-core` artifact to 2.25.3

This ensures complete coverage across all Infinispan modules including the configuration module.

## Verification Steps
After build:
```bash
wolfictl scan packages/*/*/infinispan-15.2-15.2.6-r3.apk
```

Should show log4j-core 2.25.3 with no GHSA-vc5p-v9hr-52mj vulnerability.

## References
- **GitHub Advisory**: https://github.com/advisories/GHSA-vc5p-v9hr-52mj
- **CVE Dashboard Issue**: Referenced in bot PR https://github.com/wolfi-dev/os/pull/76548
- **Upstream configuration pom.xml**: https://github.com/infinispan/infinispan/blob/15.2.6.Final/build/configuration/pom.xml

## Note
This PR replaces the bot-created PR #76548 which was missing the necessary pombump configuration files.