### PR TITLE
fix(sonarqube): Remediate GHSA-qf7c-7r9h-mm92

### DIFF
--- a/sonarqube.yaml
+++ b/sonarqube.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube
   version: "25.12.0.117093"
-  epoch: 1 # GHSA-m9gh-789g-q5pv
+  epoch: 2 # GHSA-qf7c-7r9h-mm92, GHSA-vc5p-v9hr-52mj
   description: SonarQube is an open source platform for continuous inspection of code quality (Community Build)
   copyright:
     - license: LGPL-3.0-or-later
@@ -43,6 +43,10 @@ pipeline:
       expected-commit: bd7a1254715e0df950e61d05c9a07cb1ba42552b
       cherry-picks: |
         master/c6894b30d37bcfb0d093a3bffb8a31744ca2b489: GHSA-m9gh-789g-q5pv
+
+  - name: Bump elasticsearch to 8.19.9 to remediate GHSA-qf7c-7r9h-mm92 and GHSA-vc5p-v9hr-52mj
+    runs: |
+      sed -i "s|elasticSearchServerVersion=8\.19\.8|elasticSearchServerVersion=8.19.9|" gradle.properties
 
   - name: build
     runs: |


### PR DESCRIPTION
Bump Elasticsearch server to 8.19.9

Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-vc5p-v9hr-52mj-->
<!--ci-cve-scan:must-fix: GHSA-qf7c-7r9h-mm92-->
