### PR TITLE
code-server: add patch to bump qs to v6.14.1

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.106.3"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,7 @@ pipeline:
         fix-CVE-2025-47279.patch
         GHSA-76c9-3jph-rj3q.patch
         GHSA-mh29-5h37-fv8m.patch
+        GHSA-6rw7-vpxm-498p.patch
 
   - runs: |
       mkdir -p "${{targets.contextdir}}"/usr/lib/code-server

--- a/code-server/GHSA-6rw7-vpxm-498p.patch
+++ b/code-server/GHSA-6rw7-vpxm-498p.patch
@@ -1,0 +1,26 @@
+From 976f7f583d8c33eff15afd64a843598c9fc7a033 Mon Sep 17 00:00:00 2001
+From: Brian Carey <brian.carey@chainguard.dev>
+Date: Fri, 2 Jan 2026 15:21:47 +0000
+Subject: [PATCH] deps: update qs to v6.41.1 to remediate CVE-2025-15284
+
+Signed-off-by: Brian Carey <brian.carey@chainguard.dev>
+---
+ package.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 8bd1c71b..c0107a35 100644
+--- a/package.json
++++ b/package.json
+@@ -81,7 +81,7 @@
+     "limiter": "^2.1.0",
+     "pem": "^1.14.8",
+     "proxy-agent": "^6.3.1",
+-    "qs": "6.14.0",
++    "qs": "6.14.1",
+     "rotating-file-stream": "^3.1.1",
+     "safe-compare": "^1.1.4",
+     "semver": "^7.5.4",
+-- 
+2.52.0
+


### PR DESCRIPTION
qs v6.14.1 remediates CVE-2025-15284

<!--ci-cve-scan:must-fix: CVE-2025-15284-->
