### PR TITLE
fix: cherrypick to fix CVE-2025-13836 CVE-2025-12084 CVE-2025-13837

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -57,6 +57,9 @@ pipeline:
       tag: v${{package.version}}
       cherry-picks: |
         3.12/c8a5f3435c342964e0a432cc9fb448b7dbecd1ba: [CVE-2025-6075]
+        3.12/14b1fdb0a94b96f86fc7b86671ea9582b8676628: [CVE-2025-13836]
+        3.12/9c9dda6625a2a90d2a06c657eee021d6be19842d: [CVE-2025-12084]
+        3.12/5a8b19677d818fb41ee55f310233772e15aa1a2b: [CVE-2025-13837]
 
   - name: Force use of system libraries
     runs: |

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: "3.12.12"
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0


### PR DESCRIPTION
Upstream merged fixes earlier in December

[CVE-2025-13836](https://images.chainguard.dev/security/CVE-2025-13836#/package/python-3.12/CVE-2025-13836): https://github.com/python/cpython/pull/142140 merged December 22nd
[CVE-2025-12084](https://images.chainguard.dev/security/CVE-2025-12084#/package/python-3.12/CVE-2025-12084): https://github.com/python/cpython/pull/142211 merged December 22nd
[CVE-2025-13837](https://images.chainguard.dev/security/CVE-2025-13837#/package/python-3.12/CVE-2025-13837): https://github.com/python/cpython/pull/142149 merged December 22nd

Cherrypick to remediate