### PR TITLE
seaweedfs: add iamguarded subpkg

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,13 +1,19 @@
 package:
   name: seaweedfs
   version: "4.05"
-  epoch: 0 # GHSA-g754-hx8w-x2g6
+  epoch: 1
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - fuse2
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 environment:
   environment:
@@ -63,6 +69,63 @@ subpackages:
             test -x /entrypoint.sh
             /entrypoint.sh help | grep -F "SeaweedFS"
 
+  - name: ${{package.name}}-iamguarded-compat
+    description: Compatibility package for iamguarded variant of SeaweedFS
+    dependencies:
+      runtime:
+        - bash
+        - busybox
+        - procps
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: ${{package.name}}
+          version: ${{vars.major-version}}
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/iamguarded/seaweedfs/bin
+          mkdir -p ${{targets.contextdir}}/data
+          mkdir -p ${{targets.contextdir}}/tmp
+          chmod g+rwX ${{targets.contextdir}}/opt/iamguarded
+          chmod g+rwX ${{targets.contextdir}}/data
+          ln -sf /usr/bin/weed ${{targets.contextdir}}/opt/iamguarded/seaweedfs/bin/weed
+      - uses: iamguarded/finalize-compat
+        with:
+          package: ${{package.name}}
+          version: ${{vars.major-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - curl
+            - jq
+            - wait-for-it
+        environment:
+          MASTER_PORT: "9333"
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: ${{package.name}}
+            version: ${{vars.major-version}}
+        - uses: test/tw/symlink-check
+          with:
+            allow-absolute: true
+        - name: "Test master server startup and API"
+          uses: test/daemon-check-output
+          with:
+            start: /opt/iamguarded/seaweedfs/bin/weed master -ip=0.0.0.0 -port="${MASTER_PORT}" -mdir=/tmp/seaweedfs-test
+            timeout: 45
+            expected_output: |
+              Start Seaweed Master
+              No existing leader found!
+              Initializing new cluster
+            post: |
+              wait-for-it "localhost:${MASTER_PORT}" -t 30
+
+              curl -sf "http://localhost:${MASTER_PORT}/cluster/status" | grep -F "Leader"
+              curl -sf "http://localhost:${MASTER_PORT}/dir/assign" | jq -e ".fid and .url"
+              curl -sf "http://localhost:${MASTER_PORT}/dir/status" | jq -e ".Topology"
+
 test:
   environment:
     contents:
@@ -73,10 +136,13 @@ test:
     environment:
       MASTER_PORT: "9333"
   pipeline:
-    - name: "Version and help commands"
-      runs: |
-        weed version |  grep -F "${{package.version}}"
-        weed help | grep -F "SeaweedFS"
+    - uses: test/tw/ldd-check
+    - uses: test/tw/help-check
+      with:
+        bins: weed
+    - uses: test/tw/ver-check
+      with:
+        bins: weed
     - name: "Test master server startup and API"
       uses: test/daemon-check-output
       with:


### PR DESCRIPTION
Adds `-iamguarded-compat` subpkg to `seaweedfs`.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
