### PR TITLE
Refractor/terragrunt

### DIFF
--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,19 +1,19 @@
 package:
   name: terragrunt
   version: "0.96.1"
-  epoch: 0
+  epoch: 1
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - busybox # Provides shell utilities (echo, etc.) for scaffold templates and hooks
+      # other runtime deps (terraform or opentofu) can be added on the basis of requirement and licesnes constraints
       - git # https://github.com/gruntwork-io/terragrunt/blob/main/internal/cas/git.go#L27
-      - terraform
 
 environment:
   contents:
     packages:
-      - busybox
       - mockgen
 
 pipeline:
@@ -48,6 +48,7 @@ test:
       packages:
         - curl
         - posix-libc-utils
+        - terraform # added for testing
   pipeline:
     # Verify terragrunt reports correct version
     - uses: test/tw/ver-check


### PR DESCRIPTION
`terragrunt`: runtime dep either `opentofu` and `terraform` can be added depending upon license constraint 
`busybox`: is added because it is present in the upstream image