### PR TITLE
fix(langfuse-3): Bump qs to 6.14.1 to remediate GHSA-6rw7-vpxm-498p

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
   version: "3.143.0"
-  epoch: 0
+  epoch: 1 # GHSA-6rw7-vpxm-498p
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -88,7 +88,8 @@ pipeline:
         "pnpm.overrides.js-yaml=^4.1.1" \
         "pnpm.overrides.mdast-util-to-hast=^13.2.1" \
         "pnpm.overrides.@modelcontextprotocol/sdk=^1.24.0" \
-        "pnpm.overrides.jws=^4.0.1"
+        "pnpm.overrides.jws=^4.0.1" \
+        "pnpm.overrides.qs=^6.14.1"
 
       pnpm install --ignore-scripts --no-frozen-lockfile
 


### PR DESCRIPTION
Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-6rw7-vpxm-498p-->
