### PR TITLE
Use iptables-nft instead of iptables-wrappers (1 of 2)

### DIFF
--- a/amazon-k8s-cni.yaml
+++ b/amazon-k8s-cni.yaml
@@ -1,13 +1,13 @@
 package:
   name: amazon-k8s-cni
   version: "1.21.1"
-  epoch: 0 # CVE-2025-47907
+  epoch: 1
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - iptables-wrappers
+      - iptables-nft
 
 environment:
   contents:

--- a/aznfs-mount.yaml
+++ b/aznfs-mount.yaml
@@ -1,7 +1,7 @@
 package:
   name: aznfs-mount
   version: "2.0.12"
-  epoch: 5
+  epoch: 6
   description: AZNFS Mount Helper
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,7 @@ package:
       - coreutils
       - findmnt
       - flock
-      - iptables-wrappers
+      - iptables-nft
       - procps
       - util-linux
 

--- a/blob-csi-1.27.yaml
+++ b/blob-csi-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: blob-csi-1.27
   version: "1.27.1"
-  epoch: 0 # GHSA-r6j8-c6r2-37rr
+  epoch: 1
   description: Azure Blob Storage CSI driver
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ environment:
       - curl
       - fuse3
       - iproute2
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - procps
       - util-linux
@@ -90,7 +90,7 @@ subpackages:
         - dash-binsh
         - e2fsprogs
         - iproute2
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - mount
         - netcat-openbsd

--- a/calico-3.31.yaml
+++ b/calico-3.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.31
   version: "3.31.3"
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -160,7 +160,7 @@ subpackages:
         - glibc
         - iproute2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - libbpf
         # listed in Dockerfile, but not sure if they're build dependencies (for iptables) or runtime
         - libelf

--- a/cilium-1.18.yaml
+++ b/cilium-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.18
   version: "1.18.5"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
       - cni-plugins-loopback
       - iproute2
       - ipset
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - llvm-17
       - merged-sbin
@@ -147,7 +147,7 @@ subpackages:
     description: iptables compatibility package for cilium
     dependencies:
       runtime:
-        - iptables-wrappers
+        - iptables-nft
         - merged-sbin
         - wolfi-baselayout
       provides:

--- a/docker-28.yaml
+++ b/docker-28.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-28
   version: "28.5.2"
-  epoch: 11 # GHSA-jv3w-x3r3-g6rm
+  epoch: 12
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -120,8 +120,7 @@ subpackages:
         - fuse-overlayfs
         - git
         - iproute2
-        - ip6tables
-        - iptables
+        - iptables-nft
         - openssl
         - pigz
         - procps

--- a/docker-29.yaml
+++ b/docker-29.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-29
   version: "29.1.4"
-  epoch: 0 # GHSA-jv3w-x3r3-g6rm
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -98,7 +98,7 @@ subpackages:
         - git
         - iproute2
         - ip6tables
-        - iptables
+        - iptables-nft
         - openssl
         - pigz
         - procps

--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel
   version: "0.27.4"
-  epoch: 6 # GHSA-jv3w-x3r3-g6rm
+  epoch: 7
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - ca-certificates
       - coreutils
       - iproute2
-      - iptables-wrappers
+      - iptables-nft
       - nftables
       - strongswan
       - wireguard-tools
@@ -73,7 +73,7 @@ test:
         - etcd
         - jq
         - iproute2
-        - iptables-wrappers
+        - iptables-nft
   pipeline:
     - name: "Check flanneld version"
       runs: |

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,14 +1,14 @@
 package:
   name: jupyterhub-k8s-hub
   version: "4.3.2"
-  epoch: 0
+  epoch: 1
   description: Zero to JupyterHub with Kubernetes
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - configurable-http-proxy
-      - iptables-wrappers
+      - iptables-nft
       - py3-jupyterhub
       - py3-jupyterhub-firstuseauthenticator
       - py3-jupyterhub-hmacauthenticator

--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -2,13 +2,13 @@
 package:
   name: jupyterhub-k8s-network-tools
   version: "4.3.2"
-  epoch: 0
+  epoch: 1
   description: Network diagnostic tools for use within a JupyterHub Kubernetes cluster
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - iptables-wrappers
+      - iptables-nft
 
 environment:
   contents:


### PR DESCRIPTION
To clean up the `iptables-wrappers` mess, we should use the `iptables-nft` package instead; new packages should also use `iptables-nft` and we should deprecate `iptables` and/or make it an alias for `iptables-nft`.