### PR TITLE
Use iptables-nft instead of iptables-wrappers (2 of 2)

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.11.1"
-  epoch: 1 # CVE 2025-68156
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -120,7 +120,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -165,7 +165,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/k3s-1.33.yaml
+++ b/k3s-1.33.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.33
   version: "1.33.7.1"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -116,7 +116,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -161,7 +161,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: "1.35.0.1"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,7 @@ package:
       - conntrack-tools
       - containerd-shim-runc-v2
       - ipset # required for network policy controller
-      - iptables-wrappers
+      - iptables-nft
       - kmod
       - libseccomp
       - merged-bin
@@ -116,7 +116,7 @@ subpackages:
         - conntrack-tools
         - containerd-shim-runc-v2
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - libseccomp
         - merged-bin
@@ -161,7 +161,7 @@ subpackages:
         - busybox
         - conntrack-tools
         - ipset
-        - iptables-wrappers
+        - iptables-nft
         - kmod
         - merged-bin
         - mount

--- a/nerdctl.yaml
+++ b/nerdctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: nerdctl
   version: "2.2.1"
-  epoch: 0 # GHSA-jv3w-x3r3-g6rm
+  epoch: 1
   description: Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ test:
     contents:
       packages:
         - containerd
-        - iptables-wrappers
+        - iptables-nft
         - curl
         - coreutils
   pipeline:

--- a/podman.yaml
+++ b/podman.yaml
@@ -1,7 +1,7 @@
 package:
   name: podman
   version: "5.7.1"
-  epoch: 1 # GHSA-jv3w-x3r3-g6rm
+  epoch: 2
   description: "A tool for managing OCI containers and pods"
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ environment:
       - gpgme-dev
       - grep
       - iptables-dev
-      - iptables-wrappers
+      - iptables-nft
       - libassuan-dev
       - libgpg-error-dev
       - libseccomp-dev

--- a/rancher-2.13.yaml
+++ b/rancher-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-2.13
   version: "2.13.1"
-  epoch: 0 # GHSA-r6j8-c6r2-37rr
+  epoch: 1
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ package:
       - helm
       - iproute2
       - ipset
-      - iptables-wrappers
+      - iptables-nft
       - jq
       - k3s-multicall~${{vars.k3s-major-minor-version}}
       - kustomize

--- a/rancher-2.13.yaml
+++ b/rancher-2.13.yaml
@@ -5,6 +5,9 @@ package:
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 16
+    memory: 24Gi
   dependencies:
     provides:
       - rancher=${{package.full-version}}

--- a/spegel.yaml
+++ b/spegel.yaml
@@ -1,7 +1,7 @@
 package:
   name: spegel
   version: "0.6.0"
-  epoch: 0
+  epoch: 1
   description: Stateless cluster local OCI registry mirror.
   copyright:
     - license: MIT
@@ -42,7 +42,7 @@ test:
     contents:
       packages:
         - containerd
-        - iptables-wrappers
+        - iptables-nft
         - curl
         - coreutils
         - distribution

--- a/ztunnel-1.28.yaml
+++ b/ztunnel-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: ztunnel-1.28
   version: "1.28.2"
-  epoch: 1 # GHSA-rhfx-m35p-ff5j
+  epoch: 2
   description: The `ztunnel` component of istio ambient mesh.
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - ztunnel=${{package.full-version}}
     runtime:
       - ca-certificates-bundle
-      - iptables-wrappers
+      - iptables-nft
       - libmnl
       - libnetfilter_conntrack
       - libnfnetlink


### PR DESCRIPTION
To clean up the `iptables-wrappers` mess, we should use the `iptables-nft` package instead; new packages should also use `iptables-nft` and we should deprecate `iptables` and/or make it an alias for `iptables-nft`.