### PR TITLE
ruby4.0-elasticsearch: Install minitest-mock when testing

### DIFF
--- a/ruby4.0-elasticsearch.yaml
+++ b/ruby4.0-elasticsearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby4.0-elasticsearch
   version: "9.2.0"
-  epoch: 0
+  epoch: 1
   description: |
     Ruby integrations for Elasticsearch (client, API, etc.)
   copyright:
@@ -61,30 +61,28 @@ test:
         elastic_ruby_console --help
     # Test the Elasticsearch client library
     - runs: ruby -e "require 'elasticsearch'; puts 'Elasticsearch library loaded successfully!'"
+    - runs: |
+        gem install minitest-mock
+        ruby <<-EOF
+        require 'elasticsearch'
+        require 'minitest/mock'
 
-#######
-# Disable until https://github.com/minitest/minitest/issues/1051 is fixed
-#######
-#    - runs: |
-#        ruby <<-EOF
-#        require 'elasticsearch'
-#        require 'minitest/mock'
-#
-#        # Mock the Elasticsearch client
-#        client = Elasticsearch::Client.new(log: true)
-#        mock_response = { "cluster_name" => "mock_cluster", "version" => { "number" => "8.0.0" } }
-#
-#        client.stub :info, mock_response do
-#          response = client.info
-#
-#          # Validate the response
-#          unless response["cluster_name"] == "mock_cluster" && response["version"]["number"] == "8.0.0"
-#            raise "Mocked Elasticsearch response validation failed: \#{response.inspect}"
-#          end
-#
-#          puts "Mocked Elasticsearch client functionality verified successfully!"
-#        end
-#        EOF
+        # Mock the Elasticsearch client
+        client = Elasticsearch::Client.new(log: true)
+        mock_response = { "cluster_name" => "mock_cluster", "version" => { "number" => "8.0.0" } }
+
+        client.stub :info, mock_response do
+          response = client.info
+
+          # Validate the response
+          unless response["cluster_name"] == "mock_cluster" && response["version"]["number"] == "8.0.0"
+            raise "Mocked Elasticsearch response validation failed: \#{response.inspect}"
+          end
+
+          puts "Mocked Elasticsearch client functionality verified successfully!"
+        end
+        EOF
+
 var-transforms:
   - from: ${{package.name}}
     match: ^ruby(\d\.\d+)-.*


### PR DESCRIPTION
`minitest-mock` was extracted from `minitest` into a separate gem, so we need to install it explicitly now.