### PR TITLE
ruby4.0-activerecord: Reenable test

### DIFF
--- a/ruby4.0-activerecord.yaml
+++ b/ruby4.0-activerecord.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby4.0-activerecord
   version: "8.1.1"
-  epoch: 0
+  epoch: 1
   description: Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in.
   copyright:
     - license: MIT
@@ -45,63 +45,60 @@ test:
   pipeline:
     - name: Validate import
       runs: ruby -e "require 'active_record'"
+    - name: Basic example
+      runs: |
+        gem install sqlite3
 
-#########
-# Disable test until https://github.com/sparklemotion/sqlite3-ruby/issues/663 is fixed
-#########
-# - name: Basic example
-#   runs: |
-#     gem install sqlite3
-#
-#     cat > example.rb <<EOF
-#     # Test db CRUD operations
-#
-#     require 'active_record'
-#
-#     ActiveRecord::Base.establish_connection(
-#       :adapter => "sqlite3",
-#       :database => ":memory:"
-#     )
-#
-#     ActiveRecord::Schema.define do
-#       create_table :tests do |table|
-#           table.column :name, :string
-#           table.column :foo, :string
-#       end
-#     end
-#
-#     class Test < ActiveRecord::Base
-#     end
-#
-#     # Test record creation / reading
-#     test_thing = Test.new(name: "Linky", foo: "bar")
-#     id = test_thing.save
-#
-#     test_thing = Test.find(id)
-#     raise 'ActiveRecord#new failed' unless test_thing.name == "Linky"
-#
-#     # Test record updating
-#     test_thing.foo = "baz"
-#     id = test_thing.save
-#
-#     test_thing = Test.find(id)
-#     raise 'ActiveRecord#exec_update failed' unless test_thing.foo == "baz"
-#
-#     # Test record deletion
-#     test_thing.destroy
-#
-#     begin
-#       test_thing = Test.find(id)
-#     rescue ActiveRecord::RecordNotFound
-#       test_thing = nil
-#     end
-#
-#     raise 'ActiveRecord#destroy failed' unless test_thing.nil?
-#
-#     puts 'ActiveRecord tests passed.'
-#     EOF
-#
-#     ruby example.rb
+        cat > example.rb <<EOF
+        # Test db CRUD operations
+
+        require 'active_record'
+
+        ActiveRecord::Base.establish_connection(
+          :adapter => "sqlite3",
+          :database => ":memory:"
+        )
+
+        ActiveRecord::Schema.define do
+          create_table :tests do |table|
+              table.column :name, :string
+              table.column :foo, :string
+          end
+        end
+
+        class Test < ActiveRecord::Base
+        end
+
+        # Test record creation / reading
+        test_thing = Test.new(name: "Linky", foo: "bar")
+        id = test_thing.save
+
+        test_thing = Test.find(id)
+        raise 'ActiveRecord#new failed' unless test_thing.name == "Linky"
+
+        # Test record updating
+        test_thing.foo = "baz"
+        id = test_thing.save
+
+        test_thing = Test.find(id)
+        raise 'ActiveRecord#exec_update failed' unless test_thing.foo == "baz"
+
+        # Test record deletion
+        test_thing.destroy
+
+        begin
+          test_thing = Test.find(id)
+        rescue ActiveRecord::RecordNotFound
+          test_thing = nil
+        end
+
+        raise 'ActiveRecord#destroy failed' unless test_thing.nil?
+
+        puts 'ActiveRecord tests passed.'
+        EOF
+
+        ruby example.rb
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
`sqlite3` gems for Ruby 4.0 have been published in the meanwhile, so we can reenable the more extensive test.