### PR TITLE
iptables-nft for all your iptables needs

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.11
-  epoch: 30
+  epoch: 31
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -282,6 +282,7 @@ subpackages:
       replaces:
         - ip6tables
         - iptables
+        - iptables-wrappers
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/


### PR DESCRIPTION
Make `iptables-nft` replace `iptables-wrappers` as well. The idea being that this will make it easier to migrate packages to `iptables-nft` without explosions.

Source of *that* theory is `rancher-2.13` failing in https://github.com/wolfi-dev/os/pull/77192 due to *something* down in the dependency tree pulling in `iptables-wrappers` while `iptables-nft` was already there.