### PR TITLE
Log the SHA256 of the Octo STS token

### DIFF
--- a/pipelines/auth/github.yaml
+++ b/pipelines/auth/github.yaml
@@ -39,6 +39,7 @@ pipeline:
         echo "Using OctoSTS to get a token for ${{inputs.repo}} as ${{inputs.identity}}"
         idtoken=$(curl --fail-with-body -sSL -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=octo-sts.dev)
         ghtoken=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${idtoken}" "https://octo-sts.dev/sts/exchange?scope=${{inputs.repo}}&identity=${{inputs.identity}}" | jq -r .token)
+        echo "OctoSTS token SHA256: $(echo -n "${ghtoken}" | sha256sum | cut -d' ' -f1)"
       fi
 
       git config --global credential.helper store


### PR DESCRIPTION
We do the same thing in our `octo-sts/action` here: https://github.com/octo-sts/action/blob/f603d3be9d8dd9871a265776e625a27b00effe05/index.js#L113-L115

This will let us correlate the hashes of failed builds with exchanges on the server side.
