### PR TITLE
zlib: enforce full package version when using -dev package

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,4 @@
-audit-4.0.2-r3.apk
-audit-4.0.3-r0.apk
-audit-4.0.3-r1.apk
+zlib-static-1.3.1.2-r0.apk
+zlib-dev-1.3.1.2-r0.apk
+zlib-doc-1.3.1.2-r0.apk
+zlib-1.3.1.2-r0.apk

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1.2
-  epoch: 0
+  epoch: 1
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -9,6 +9,12 @@ package:
     runtime:
       - merged-lib
       - wolfi-baselayout
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\..*$
+    replace: ${1}
+    to: soversion
 
 environment:
   contents:
@@ -48,6 +54,10 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libz${{vars.soversion}}
+    pipeline:
+      - uses: split/lib
+
   - name: "zlib-static"
     description: "zlib static library"
     pipeline:
@@ -63,9 +73,9 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - libz${{vars.soversion}}=${{package.full-version}}
         - merged-lib
         - wolfi-baselayout
-        - zlib
     test:
       environment:
         contents:

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -57,6 +57,9 @@ subpackages:
   - name: libz${{vars.soversion}}
     pipeline:
       - uses: split/lib
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
 
   - name: "zlib-static"
     description: "zlib static library"

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -7,6 +7,8 @@ package:
     - license: MPL-2.0 AND MIT
   dependencies:
     runtime:
+      # Compat link as there is alot of direct usage of "zlib" as a runtime dependency
+      - libz${{vars.soversion}}=${{package.full-version}}
       - merged-lib
       - wolfi-baselayout
 

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -7,16 +7,8 @@ package:
     - license: MPL-2.0 AND MIT
   dependencies:
     runtime:
-      # Compat link as there is alot of direct usage of "zlib" as a runtime dependency
-      - libz${{vars.soversion}}=${{package.full-version}}
       - merged-lib
       - wolfi-baselayout
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+)\..*$
-    replace: ${1}
-    to: soversion
 
 environment:
   contents:
@@ -56,13 +48,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: libz${{vars.soversion}}
-    pipeline:
-      - uses: split/lib
-    test:
-      pipeline:
-        - uses: test/tw/ldd-check
-
   - name: "zlib-static"
     description: "zlib static library"
     pipeline:
@@ -78,7 +63,7 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - libz${{vars.soversion}}=${{package.full-version}}
+        - zlib=${{package.full-version}}
         - merged-lib
         - wolfi-baselayout
     test:


### PR DESCRIPTION
Ensure tight coupling between -dev and main package using package full version.

The unversioned .so in the -dev package will always link to the fully versioned so in the main package so mixing different versions will break.

Withdraw the -r0 versions that don't enforce this to fix issues seen by end users.
