### PR TITLE
fix(kubeflow-centraldashboard): GHSA-6rw7-vpxm-498p

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: "1.10.0"
-  epoch: 7
+  epoch: 8
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ pipeline:
         "node-fetch": "^2.6.7",
         "node-forge": "^1.3.2",
         "axios": "^1.12.0",
-        "qs": "^6.7.3",
+        "qs": "^6.14.1",
         "underscore": "^1.12.1",
         "minimatch": "^3.0.5",
         "path-parse": "^1.0.7",


### PR DESCRIPTION
Bump qs to 6.14.1

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/52319

<!--ci-cve-scan:fail-any-->
