### PR TITLE
remove gnutls dep

### DIFF
--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: "3.0.4"
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later
@@ -18,13 +18,11 @@ environment:
       - cmake-3
       - gawk
       - git
-      - gnutls-dev
       - grep
       - icu
       - icu-dev
       - jemalloc-dev
       - libevent-dev
-      - libgcrypt-dev
       - libtool
       - m4
       - openssl
@@ -43,6 +41,13 @@ pipeline:
       repository: https://github.com/sysown/proxysql
       tag: v${{package.version}}
       expected-commit: faa64a570d19fe35af43494db0babdee3e3cdc89
+
+  # Build libmicrohttpd without gnutls - the embedded HTTP server will not support HTTPS
+  - uses: patch
+    with:
+      patches: |
+        libmicrohttpd-disable-https.patch
+        remove-gnutls-linking.patch
 
   - runs: make -j$(nproc) GIT_VERSION=${{package.version}}-r${{package.epoch}}
 

--- a/proxysql/libmicrohttpd-disable-https.patch
+++ b/proxysql/libmicrohttpd-disable-https.patch
@@ -1,0 +1,11 @@
+--- a/deps/Makefile
++++ b/deps/Makefile
+@@ -130,7 +130,7 @@ curl: curl/curl/lib/.libs/libcurl.a
+ libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
+ 	cd libmicrohttpd && rm -rf libmicrohttpd-*/ || true
+ 	cd libmicrohttpd && tar -zxf libmicrohttpd-*.tar.gz
+-	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
++	cd libmicrohttpd/libmicrohttpd && ./configure --without-gnutls && CC=${CC} CXX=${CXX} ${MAKE}
+
+ microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
+

--- a/proxysql/remove-gnutls-linking.patch
+++ b/proxysql/remove-gnutls-linking.patch
@@ -1,0 +1,25 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -106,18 +106,18 @@ ifeq ($(UNAME_S),Linux)
+ 	STATICMYLIBS += -lcoredumper
+ endif
+
+-MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread -lssl -lcrypto -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
++MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lpthread -lssl -lcrypto -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
+ ifeq ($(DISTRO),almalinux)
+ ifeq ($(CENTOSVER),8)
+-	MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH) -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
++	MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lpthread $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH) -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
+ endif
+ endif
+
+ ifeq ($(UNAME_S),Darwin)
+-	MYLIBS :=-lre2 -lmariadbclient -lpq -lpthread -lm -lz -liconv -lgnutls -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
++	MYLIBS :=-lre2 -lmariadbclient -lpq -lpthread -lm -lz -liconv -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
+ else
+ 	CURL_DIR := $(DEPS_PATH)/curl/curl
+ 	IDIRS += -L$(CURL_DIR)/include
+ 	LDIRS += -L$(CURL_DIR)/lib/.libs
+ endif
+ ifeq ($(UNAME_S),Linux)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
