### PR TITLE
cinc-auditor: new package + ruby 3.4 ed25519 and bcrypt_pbkdf gems

### DIFF
--- a/cinc-auditor.yaml
+++ b/cinc-auditor.yaml
@@ -1,0 +1,113 @@
+# cinc-auditor is a free distribution of the open source Chef Software
+# Inc. inspec tool. See https://cinc.sh/start/auditor/
+package:
+  name: cinc-auditor
+  version: 7.0.95
+  epoch: 0
+  description: cinc-auditor is an OSS tool for applying inspec profiles
+  copyright:
+    - license: Apache-2.0
+      license-path: LICENSE
+    - license: LicenseRef-Third-Party
+      license-path: NOTICE.TXT
+  dependencies:
+    runtime:
+      # additional gem dependencies added in the upstream cinc-auditor
+      # habitat/plan.sh script that can't be listed as part of the Gemfile
+      # for some reason
+      - ruby${{vars.ruby-version}}-bcrypt_pbkdf
+      - ruby${{vars.ruby-version}}-ed25519
+
+vars:
+  ruby-version: 3.4
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - gcc
+      - make
+      - ruby${{vars.ruby-version}}-bcrypt_pbkdf
+      - ruby${{vars.ruby-version}}-ed25519
+      - ruby-${{vars.ruby-version}}
+      - ruby-${{vars.ruby-version}}-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: http://downloads.cinc.sh/source/stable/cinc-auditor/cinc-auditor-${{package.version}}.tar.xz
+      expected-sha512: c85a295988d35ca7d2df7757d3ce2c9266159c5494714020175760a5f674b309a7211fe3f8eef74a1f2d08c55509fdc66385cbd186b59d861f72ec880d468a93
+
+  - name: build inspec gem
+    uses: ruby/build
+    with:
+      gem: inspec
+
+  - name: build inspec-core gem
+    uses: ruby/build
+    with:
+      gem: inspec-core
+
+  - name: build conc-auditor-bin gem
+    uses: ruby/build
+    with:
+      dir: inspec-bin
+      gem: cinc-auditor-bin
+
+  # cinc-auditor needs around 260 gems as dependencies, which is too
+  # much to package. Instead, vender the needed gems under
+  # /usr/lib/cinc-auditor/gems/
+  - name: install inspec gems
+    runs: |
+      INSTALLED_BIN_DIR="/usr/lib/cinc-auditor/bin"
+      INSTALLED_GEMS_DIR="$(ruby -e 'puts Gem.default_dir.sub("\/ruby\/", "\/cinc-auditor\/")')/"
+      TARGET_DIR_BIN="${{targets.contextdir}}${INSTALLED_BIN_DIR}"
+      TARGET_DIR_INSTALL="${{targets.contextdir}}${INSTALLED_GEMS_DIR}"
+      mkdir -p "${TARGET_DIR_BIN}"
+      mkdir -p "${TARGET_DIR_INSTALL}"
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+
+      export GEM_PATH="$(ruby -e 'puts Gem.default_dir')"
+
+      gem install inspec*.gem \
+        --install-dir "${TARGET_DIR_INSTALL}"  \
+        --bindir "${TARGET_DIR_BIN}" \
+        --no-document
+
+      (cd inspec-bin && gem install cinc-auditor-bin-${{package.version}}.gem \
+        --install-dir "${TARGET_DIR_INSTALL}"  \
+        --bindir "${TARGET_DIR_BIN}" \
+        --no-document )
+
+      # create a wrapper script around cinc-auditor that sets the
+      # gem path correctly for the vendered dependencies
+      cat <<EOF > "cinc-auditor"
+      #!/bin/sh
+      set -e
+
+      # Set Ruby paths defined from 'do_setup_environment()'
+      export GEM_HOME="${INSTALLED_GEMS_DIR}"
+      export GEM_PATH="$(ruby -e 'puts Gem.default_dir'):\$GEM_HOME"
+
+      exec /usr/bin/ruby "${INSTALLED_BIN_DIR}/cinc-auditor" "\$@"
+      EOF
+      install -m755 cinc-auditor -t "${{targets.contextdir}}/usr/bin/"
+
+      # Pre-populate Chef UUID to suppress runtime warning from Cinc Auditor
+      mkdir -p "${{targets.contextdir}}/etc/chef"
+      echo "00000000-0000-0000-0000-000000000000" > "${{targets.contextdir}}/etc/chef/chef_guid"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 387942
+
+test:
+  pipeline:
+    - runs: |
+        cinc-auditor --help
+        cinc-auditor version
+        cinc-auditor shell --backend local -c 'describe file("/etc/passwd") do it { should exist } end'
+        cinc-auditor shell --backend local -c \
+           'describe passwd("/etc/passwd") do its("count") { should_not eq 0 } ; its("users") { should_not be_empty } end'

--- a/ruby3.4-bcrypt_pbkdf.yaml
+++ b/ruby3.4-bcrypt_pbkdf.yaml
@@ -1,0 +1,128 @@
+package:
+  name: ruby3.4-bcrypt_pbkdf
+  version: "1.1.2"
+  epoch: 0
+  description: Ruby gem implementing bcrypt_pbkdf
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e52088f9a28e34321a9b359f30d472097f1d7f01
+      repository: https://github.com/net-ssh/bcrypt_pbkdf-ruby
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: bcrypt_pbkdf
+
+update:
+  enabled: true
+  github:
+    identifier: net-ssh/bcrypt_pbkdf-ruby
+    tag-filter-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+  pipeline:
+    - uses: test/tw/ldd-check
+    - uses: test/tw/gem-check
+    - name: simple bcrypt_bpkfd smoke test
+      runs: |
+        cat <<EOF > example.rb
+        require 'bcrypt_pbkdf'
+
+        password = "my_secure_password"
+        salt = "random_salt_value"
+        key_len = 32
+        rounds = 100
+
+        # Test 1: Basic functionality
+        puts "\nTest 1: Basic functionality"
+        begin
+          derived_key = BCryptPbkdf.key(password, salt, key_len, rounds)
+          puts "✓ Successfully derived key"
+          puts "  Key length: #{derived_key.bytesize} bytes"
+          puts "  Key (hex): #{derived_key.unpack1('H*')}"
+        rescue => e
+          puts "✗ Failed: #{e.message}"
+          exit 1
+        end
+
+        # Test 2: Consistency check
+        puts "\nTest 2: Consistency check (same inputs = same output)"
+        derived_key2 = BCryptPbkdf.key(password, salt, key_len, rounds)
+        if derived_key == derived_key2
+          puts "✓ Consistent output verified"
+        else
+          puts "✗ Inconsistent output"
+          exit 1
+        end
+
+        # Test 3: Different passwords produce different keys
+        puts "\nTest 3: Different passwords produce different keys"
+        different_key = BCryptPbkdf.key("different_password", salt, key_len, rounds)
+        if derived_key != different_key
+          puts "✓ Different passwords produce different keys"
+        else
+          puts "✗ Same key produced for different passwords"
+          exit 1
+        end
+
+        # Test 4: Different salts produce different keys
+        puts "\nTest 4: Different salts produce different keys"
+        different_salt_key = BCryptPbkdf.key(password, "different_salt", key_len, rounds)
+        if derived_key != different_salt_key
+          puts "✓ Different salts produce different keys"
+        else
+          puts "✗ Same key produced for different salts"
+          exit 1
+        end
+
+        # Test 5: Variable key lengths
+        puts "\nTest 5: Variable key lengths"
+        [16, 32, 64].each do |length|
+          key = BCryptPbkdf.key(password, salt, length, rounds)
+          if key.bytesize == length
+            puts "✓ Generated #{length}-byte key successfully"
+          else
+            puts "✗ Expected #{length} bytes, got #{key.bytesize}"
+            exit 1
+          end
+        end
+        EOF
+
+        ruby example.rb

--- a/ruby3.4-ed25519.yaml
+++ b/ruby3.4-ed25519.yaml
@@ -1,0 +1,130 @@
+package:
+  name: ruby3.4-ed25519
+  version: "1.4.0"
+  epoch: 0
+  description: Ed25519 high-performance public-key signature system as a RubyGem
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 79d7b8aed5753ce294933ce290985300aeace5c1
+      repository: https://github.com/RubyCrypto/ed25519
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: ed25519
+
+update:
+  enabled: true
+  github:
+    identifier: RubyCrypto/ed25519
+    tag-filter-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+  pipeline:
+    - uses: test/tw/ldd-check
+    - uses: test/tw/gem-check
+    - runs: |
+        cat <<EOF > example.rb
+        require 'ed25519'
+
+        puts "ED25519 Gem Smoke Test"
+
+        # Test 1: Generate a signing key
+        puts "\n1. Generating signing key..."
+        signing_key = Ed25519::SigningKey.generate
+        puts "✓ Signing key generated"
+
+        # Test 2: Extract verify key
+        puts "\n2. Extracting verify key..."
+        verify_key = signing_key.verify_key
+        puts "✓ Verify key extracted"
+
+        # Test 3: Sign a message
+        puts "\n3. Signing a message..."
+        message = "Hello, ED25519!"
+        signature = signing_key.sign(message)
+        puts "✓ Message signed"
+        puts "   Message: #{message}"
+        puts "   Signature (hex): #{signature.unpack1('H*')}"
+
+        # Test 4: Verify the signature
+        puts "\n4. Verifying signature..."
+        begin
+          verify_key.verify(signature, message)
+          puts "✓ Signature verified successfully"
+        rescue Ed25519::VerifyError
+          puts "✗ Signature verification failed"
+          exit 1
+        end
+
+        # Test 5: Verify with wrong message (should fail)
+        puts "\n5. Testing verification with wrong message..."
+        wrong_message = "Wrong message"
+        begin
+          verify_key.verify(signature, wrong_message)
+          puts "✗ Verification should have failed but didn't"
+          exit 1
+        rescue Ed25519::VerifyError
+          puts "✓ Verification correctly failed for wrong message"
+        end
+
+        # Test 6: Export and import keys
+        puts "\n6. Testing key serialization..."
+        signing_key_bytes = signing_key.to_bytes
+        verify_key_bytes = verify_key.to_bytes
+
+        restored_signing_key = Ed25519::SigningKey.new(signing_key_bytes)
+        restored_verify_key = Ed25519::VerifyKey.new(verify_key_bytes)
+
+        puts "✓ Keys serialized and restored"
+
+        # Test 7: Verify with restored key
+        puts "\n7. Verifying with restored key..."
+        begin
+          restored_verify_key.verify(signature, message)
+          puts "✓ Signature verified with restored key"
+        rescue Ed25519::VerifyError
+          puts "✗ Verification with restored key failed"
+          exit 1
+        end
+
+        puts "All tests passed! ✓"
+        EOF
+        ruby example.rb


### PR DESCRIPTION
Add the cinc-auditor package: https://cinc.sh/start/auditor/

This package is an open source distribution of the Chef Software, Inc.  Inspec utility for testing and auditing infrastructure: https://docs.chef.io/inspec/

The cinc-auditor package depends on ~260 gems, many of which are not already packaged; this is why gem install is used to pull gems remotely into a vendored location (`/usr/lib/cinc-auditor/gems`).

Also include two ruby gems, bcrypt_pbkdf and ed25519, that are not included as dependencies in the gemspec files, but end up getting included as part of the cinc build process.

Because of the way the cinc project works, they do not publish a git repo of the upstream inspec repo with their changes applied but instead only distribute release tarballs.

v2:
- add cinc-auditor update info from release-monitoring.org
- fix ruby3.4-bcrypt-pbkdf test script

Ref: https://github.com/chainguard-dev/prodsec/issues/588

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
