### PR TITLE
busybox: add patch for CVE-2025-60876

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.37.0
-  epoch: 50
+  epoch: 51
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only
@@ -67,6 +67,10 @@ pipeline:
   - uses: patch
     with:
       patches: CVE-2025-46394.patch
+
+  - uses: patch
+    with:
+      patches: CVE-2025-60876.patch
 
   - name: Configure
     runs: |

--- a/busybox/CVE-2025-60876.patch
+++ b/busybox/CVE-2025-60876.patch
@@ -1,0 +1,37 @@
+From: Radoslav Kolev <radoslav.kolev@suse.com>
+Date: Wed, 12 Nov 2025 17:50:54 +0000
+Subject: [PATCH] wget: don't allow control characters or spaces in the URL
+
+Fixes CVE-2025-60876 malicious URL can be used to inject
+HTTP headers in the request.
+
+Original discussion: https://lists.busybox.net/pipermail/busybox/2025-August/091704.html
+CVE: https://www.cve.org/CVERecord?id=CVE-2025-60876
+
+Signed-off-by: Radoslav Kolev <radoslav.kolev@suse.com>
+---
+ networking/wget.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/networking/wget.c b/networking/wget.c
+index ec3767793..b8a6d02bb 100644
+--- a/networking/wget.c
++++ b/networking/wget.c
+@@ -536,6 +536,15 @@ static void parse_url(const char *src_url, struct host_info *h)
+ {
+ 	char *url, *p, *sp;
+
++	/* Fix for CVE-2025-60876 - don't allow control characters or spaces in the URL */
++	/* otherwise a malicious URL can be used to inject HTTP headers in the request */
++	unsigned char *u = (void *) src_url;
++	while (*u) {
++		if (*u <= ' ')
++			bb_simple_error_msg_and_die("Unencoded control character found in the URL!");
++		u++;
++	}
++
+ 	free(h->allocated);
+ 	h->allocated = url = xstrdup(src_url);
+
+--
+2.51.1


### PR DESCRIPTION
Adds patch to fix HTTP header injection vulnerability in wget.


POC: https://gist.github.com/subyumatest/41554af6a72aedaacaec026adc311092
Original Discussion: https://lists.busybox.net/pipermail/busybox/2025-August/091704.html
Patch Source: https://lists.busybox.net/pipermail/busybox/2025-November/091818.html

Fixes: [CVE-2025-60876](https://www.cve.org/CVERecord?id=CVE-2025-60876)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

The recommended `wolfictl adv create` in HOW_TO_PATCH_CVES.md is deprecated.

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode).
<!--ci-cve-scan:must-fix: CVE-2025-60876-->
<!--ci-cve-scan:fail-any-->

#### For PRs that add patches
- [x] Patch source is documented
