### PR TITLE
cinc-auditor: switch to using git repo as origin

### DIFF
--- a/cinc-auditor.yaml
+++ b/cinc-auditor.yaml
@@ -1,9 +1,10 @@
 # cinc-auditor is a free distribution of the open source Chef Software
 # Inc. inspec tool. See https://cinc.sh/start/auditor/
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: cinc-auditor
-  version: 7.0.95
-  epoch: 0
+  version: "7.0.95"
+  epoch: 1
   description: cinc-auditor is an OSS tool for applying inspec profiles
   copyright:
     - license: Apache-2.0
@@ -34,10 +35,11 @@ environment:
       - ruby-${{vars.ruby-version}}-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: http://downloads.cinc.sh/source/stable/cinc-auditor/cinc-auditor-${{package.version}}.tar.xz
-      expected-sha512: c85a295988d35ca7d2df7757d3ce2c9266159c5494714020175760a5f674b309a7211fe3f8eef74a1f2d08c55509fdc66385cbd186b59d861f72ec880d468a93
+      expected-commit: 588ebe3baf241c11a6a4d2827964bb72e9063edc
+      repository: https://gitlab.com/cinc-project/upstream/inspec/
+      branch: stable/cinc-v${{package.version}}
 
   - name: build inspec gem
     uses: ruby/build
@@ -49,7 +51,7 @@ pipeline:
     with:
       gem: inspec-core
 
-  - name: build conc-auditor-bin gem
+  - name: build cinc-auditor-bin gem
     uses: ruby/build
     with:
       dir: inspec-bin
@@ -100,6 +102,8 @@ pipeline:
 
 update:
   enabled: true
+  # cinc-auditor repo doesn't use git tags, but instead a versioned
+  # branch, so rely on the release-monitor of the release tarballs.
   release-monitor:
     identifier: 387942
 


### PR DESCRIPTION
Upstream repo uses versioned branches and not tags or releases, so use that, and silence the linter warning about not using a tag.

Ref: https://github.com/chainguard-dev/prodsec/issues/588
Fixes: e77b27cda6 ("cinc-auditor: new package + ruby 3.4 ed25519 and
       bcrypt_pbkdf gems (#77322)")
