### PR TITLE
fix(test): enable proper shebang injection in daemon-check-output

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -279,8 +279,7 @@ pipeline:
 
       if [ -n "$setup" ]; then
           shbang="#!"
-          # correct/documented behavior is disabled for now so that scripts do not run with set -e
-          if false FIXME see pr-44792 && [ "${setup#${shbang}}" != "$setup" ]; then
+          if [ "${setup#${shbang}}" = "$setup" ]; then
               printf "%s\n" '#!/bin/sh -ex' > "${SETUP_F}"
           fi
           printf "%s\n" "$setup" >> "${SETUP_F}"
@@ -295,8 +294,7 @@ pipeline:
 
       if [ -n "$post" ]; then
           shbang="#!"
-          # correct/documented behavior is disabled for now so that scripts do not run with set -e
-          if false FIXME see pr-44792 && [ "${post#${shbang}}" = "$post" ]; then
+          if [ "${post#${shbang}}" = "$post" ]; then
               printf "%s\n" '#!/bin/sh -ex' > "${POST_F}"
           fi
           printf "%s\n" "$post" >> "${POST_F}"


### PR DESCRIPTION
Remove FIXME workaround and fix logic to correctly add #!/bin/sh -ex to setup/post scripts that lack shebangs. Changes condition from != to = to properly detect scripts without shebang lines.

cc @smoser 