### PR TITLE
daemon-check-output(cass-operator): fix post-test to use correct health probe port

### DIFF
--- a/cass-operator.yaml
+++ b/cass-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-operator
   version: "1.28.0"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Manages Cassandra cluster as standalone product or as part of the k8ssandra-operator
   copyright:
     - license: Apache-2.0
@@ -112,7 +112,7 @@ test:
           Starting EventSource
           Starting Controller
         post: |
-          wait-for-it -t 3 --strict localhost:8080 -- echo "Server is up"
-          echo "Verifying metrics endpoint"
-          curl -sf http://127.0.0.1:8080/metrics
-          echo "Metrics endpoint is serving as expected"
+          wait-for-it -t 3 --strict localhost:8081 -- echo "Server is up"
+          echo "Verifying health endpoint"
+          curl -sf http://127.0.0.1:8081/healthz && echo "Health endpoint working"
+          curl -sf http://127.0.0.1:8081/readyz && echo "Ready endpoint working"


### PR DESCRIPTION
The operator serves health endpoints (/healthz, /readyz) on port 8081, not metrics on port 8080. Update post script to check the correct endpoints.

Ref: https://github.com/wolfi-dev/os/pull/77372
