### PR TITLE
daemon-check-output(cerbos): fix swagger schema endpoint test to use correct field

### DIFF
--- a/cerbos.yaml
+++ b/cerbos.yaml
@@ -1,7 +1,7 @@
 package:
   name: cerbos
   version: "0.50.0"
-  epoch: 0 # CVE-2025-47910
+  epoch: 1 # CVE-2025-47910
   description: Cerbos is the open core, language-agnostic, scalable authorization solution that makes user permissions and authorization simple to implement and manage by writing context-aware access control policies for your application resources.
   copyright:
     - license: Apache-2.0

--- a/cerbos.yaml
+++ b/cerbos.yaml
@@ -104,10 +104,11 @@ test:
           Starting HTTP server at
           Starting admin service
         post: |-
+          wait-for-it -t 3 --strict localhost:3592 -- echo "Server is up"
           curl -sf http://localhost:3592/_cerbos/health | grep -i "SERVING"
 
-          # Check OpenAPI schema endpoint
-          curl -sf http://localhost:3592/schema/swagger.json | jq -e ".openapi != null"
+          # Check Swagger schema endpoint (Swagger 2.0 format)
+          curl -sf http://localhost:3592/schema/swagger.json | jq -e ".swagger != null"
 
           # Check main page returns 200
           curl -sf -o /dev/null -w "%{http_code}" http://localhost:3592 | grep "200"


### PR DESCRIPTION
The /schema/swagger.json endpoint returns Swagger 2.0 format which uses the 'swagger' field, not 'openapi' (OpenAPI 3.x). Update the jq check accordingly. Also add wait-for-it before health check.

Cerbos uses grpc-gateway which generates Swagger 2.0 specs.
upstream Ref: https://github.com/cerbos/cerbos/blob/main/schema/schema.go\#L17-L18

Test change Ref: https://github.com/wolfi-dev/os/pull/77372
