### PR TITLE
daemon-check-output(custom-pod-autoscaler-operator): fix test CRD installation

### DIFF
--- a/custom-pod-autoscaler-operator.yaml
+++ b/custom-pod-autoscaler-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: custom-pod-autoscaler-operator
   version: "1.4.2"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: Operator for managing Kubernetes Custom Pod Autoscalers (CPA).
   copyright:
     - license: Apache-2.0
@@ -129,9 +129,7 @@ test:
               name: cpa
               namespace: default
           EOF
-          helm show crds https://github.com/jthomperoo/custom-pod-autoscaler-operator/releases/download/v${{package.version}}/custom-pod-autoscaler-operator-v${{package.version}}.tgz \
-            | kubectl apply --server-side -f -
-          kubectl wait --for=condition=Established crd/custompodautoscalers.custompodautoscaler.com --timeout=60s
+          # Install the operator with helm - CRDs are included in the chart templates
           helm install custom-pod-autoscaler-operator \
             https://github.com/jthomperoo/custom-pod-autoscaler-operator/releases/download/v${{package.version}}/custom-pod-autoscaler-operator-v${{package.version}}.tgz \
             -n default --create-namespace \
@@ -139,6 +137,7 @@ test:
             --set serviceAccount.name=cpa \
             --set rbac.create=false \
             --wait
+          kubectl wait --for=condition=Established crd/custompodautoscalers.custompodautoscaler.com --timeout=60s
         start: "/operator"
         timeout: 10
         expected_output: |


### PR DESCRIPTION
The chart stores CRDs in templates/ rather than crds/, so 'helm show crds' returns empty. Let helm install handle CRD installation directly since template-based CRDs are applied as normal resources.

Test change ref: https://github.com/wolfi-dev/os/pull/77372