### PR TITLE
airflow-3: update aiohttp to v3.13.3 to remediate several CVEs

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.5"
-  epoch: 1 # GHSA-428g-f7cq-pgp5
+  epoch: 2 # GHSA-428g-f7cq-pgp5
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -73,6 +73,7 @@ pipeline:
       constraints-file: constraints-${{vars.python-version}}.txt
       only-replace: false
       packages: |
+        aiohttp==3.13.3 # GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq GHSA-jj3x-wxrx-4x23
         cryptography==44.0.1 # GHSA-79v4-65xg-pq4g, GHSA-h4gh-qq45-vh27
         filelock==3.20.1
         commons-lang3==3.18.0 # GHSA-j288-q9x7-2f5v


### PR DESCRIPTION
aiohttp v3.13.3 addresses:
- GHSA-54jq-c3m8-4m76
- GHSA-54jq-c3m8-4m76
- GHSA-6jhg-hg63-jvvf
- GHSA-6mq8-rvhq-8wgg
- GHSA-fh55-r93g-j68g
- GHSA-g84x-mcqj-x9qq
- GHSA-jj3x-wxrx-4x23
- GHSA-mqqc-3gqh-h2x8

<!--ci-cve-scan:must-fix: GHSA-54jq-c3m8-4m76 GHSA-54jq-c3m8-4m76 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq  GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8-->