### PR TITLE
Migrate git.kernel.org -> kernel.googlesource.com

### DIFF
--- a/dash.yaml
+++ b/dash.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://git.kernel.org/pub/scm/utils/dash/dash.git
+      repository: https://kernel.googlesource.com/pub/scm/utils/dash/dash.git
       tag: v${{package.version}}
       expected-commit: 1365bb36a92656eb52b64cb04d249c47a1d3c4cf
       cherry-picks: |

--- a/dash.yaml
+++ b/dash.yaml
@@ -3,7 +3,7 @@
 package:
   name: dash
   version: "0.5.13"
-  epoch: 2
+  epoch: 3
   description: Small and fast POSIX-compliant shell
   copyright:
     - license: BSD-3-Clause AND GPL-2.0-or-later

--- a/erofs-utils.yaml
+++ b/erofs-utils.yaml
@@ -21,10 +21,11 @@ environment:
       - zstd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://kernel.googlesource.com/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${{package.version}}.tar.gz
-      expected-sha512: 8c7afd3db55fd4c4f7aa9fbd7ed40fa40de0bfffcee601a3f5dce823d406a32b5e939e24cd6dc336e3033e940fb16ee93f8821f627f90b10e6137113949933dd
+      repository: https://kernel.googlesource.com/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+      tag: v${{package.version}}
+      expected-commit: 51b5939b5f783221310d25146e6a2019ba8129b6
 
   - uses: autoconf/configure
     with:

--- a/erofs-utils.yaml
+++ b/erofs-utils.yaml
@@ -2,7 +2,7 @@
 package:
   name: erofs-utils
   version: "1.8.10"
-  epoch: 2
+  epoch: 3
   description: userspace utilities for erofs filesystem
   copyright:
     - license: Apache-2.0 AND GPL-2.0-or-later
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${{package.version}}.tar.gz
+      uri: https://kernel.googlesource.com/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${{package.version}}.tar.gz
       expected-sha512: 8c7afd3db55fd4c4f7aa9fbd7ed40fa40de0bfffcee601a3f5dce823d406a32b5e939e24cd6dc336e3033e940fb16ee93f8821f627f90b10e6137113949933dd
 
   - uses: autoconf/configure

--- a/ipvsadm.yaml
+++ b/ipvsadm.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://git.kernel.org/pub/scm/utils/kernel/ipvsadm/ipvsadm.git
+      repository: https://kernel.googlesource.com/pub/scm/utils/kernel/ipvsadm/ipvsadm.git
       tag: v${{package.version}}
       expected-commit: a0e3834fbe85754dd221bc0d1c0c1eb46e12aa51
 

--- a/ipvsadm.yaml
+++ b/ipvsadm.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipvsadm
   version: "1.31"
-  epoch: 43
+  epoch: 44
   description: The IP Virtual Server administration utility
   copyright:
     - license: GPL-2.0-or-later

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -34,7 +34,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
+      repository: https://kernel.googlesource.com/pub/scm/utils/kernel/kmod/kmod.git
       tag: v${{package.version}}
       expected-commit: 13330c958deef15c227a9c83d8ba72106152fd7f
 

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "34.2"
-  epoch: 42
+  epoch: 43
   description: Linux kernel module management utilities
   copyright:
     - license: LGPL-2.1

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: git://git.kernel.org/pub/scm/libs/libcap/libcap.git
+      repository: https://kernel.googlesource.com/pub/scm/libs/libcap/libcap.git
       tag: v1.${{package.version}}
       expected-commit: 3b2513a1ba696f01d31edfa93f35c30b379cc70e
 

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.77"
-  epoch: 0
+  epoch: 1
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libtraceevent.yaml
+++ b/libtraceevent.yaml
@@ -15,10 +15,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-${{package.version}}.tar.gz
-      expected-sha256: cec7167e885d2f022bc5a2b0f2c0c58110fa0575e5dba49d7b694f0a6fd7fa0c
+      repository: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtraceevent.git
+      tag: libtraceevent-${{package.version}}
+      expected-commit: 7a8fee57d87aa61c9d578cd67e99d2677b894772
 
   - uses: autoconf/make
 

--- a/libtraceevent.yaml
+++ b/libtraceevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtraceevent
   version: "1.8.7"
-  epoch: 0
+  epoch: 1
   description: "Linux kernel trace event library"
   copyright:
     - license: "LGPL-2.1-or-later AND GPL-2.0-or-later"
@@ -17,7 +17,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-${{package.version}}.tar.gz
+      uri: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-${{package.version}}.tar.gz
       expected-sha256: cec7167e885d2f022bc5a2b0f2c0c58110fa0575e5dba49d7b694f0a6fd7fa0c
 
   - uses: autoconf/make

--- a/libtracefs.yaml
+++ b/libtracefs.yaml
@@ -16,10 +16,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtracefs.git/snapshot/libtracefs-${{package.version}}.tar.gz
-      expected-sha256: a9cd9cbae81b7fff71b3f72d2b819e49cec0402529e5f252e1d9319a62a356cb
+      repository: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtracefs.git
+      tag: libtracefs-${{package.version}}
+      expected-commit: 6fad6a14ba0d4c4b437d9e4eed7098d4bb07b4fc
 
   - uses: autoconf/make
 

--- a/libtracefs.yaml
+++ b/libtracefs.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtracefs
   version: "1.8.3"
-  epoch: 0
+  epoch: 1
   description: "Linux kernel trace file system library"
   copyright:
     - license: "LGPL-2.1-or-later"
@@ -18,7 +18,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/libtracefs-${{package.version}}.tar.gz
+      uri: https://kernel.googlesource.com/pub/scm/libs/libtrace/libtracefs.git/snapshot/libtracefs-${{package.version}}.tar.gz
       expected-sha256: a9cd9cbae81b7fff71b3f72d2b819e49cec0402529e5f252e1d9319a62a356cb
 
   - uses: autoconf/make


### PR DESCRIPTION
Update packages that use git.kernel.org to use kernel.googlesource.com; we see sporadic network issues connecting to git.kernel.org which may be related to our usage patterns.