### PR TITLE
seaweedfs: backport s3 hotfix

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: seaweedfs
   version: "4.05"
-  epoch: 1
+  epoch: 2
   description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,8 @@ pipeline:
       repository: https://github.com/seaweedfs/seaweedfs
       tag: ${{package.version}}
       expected-commit: 87b71029f75efc2fe6f1bcf12a3f129127f04e90
+      cherry-picks: |
+        master/6a9860098f75787fc1773f823d19cbf15d5671e2: fix: correcting S3 nil cipher dereference in filer init
 
   - uses: go/build
     with:


### PR DESCRIPTION
Fixes panic error related with S3.

```
I0107 10:34:17.237489 s3.go:275 Starting S3 API Server with standard IAM

panic: runtime error: invalid memory address or nil pointer dereference

[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2d84130]


goroutine 101 [running]:

github.com/seaweedfs/seaweedfs/weed/command.(*S3Options).startS3Server(0x70190a0)

  github.com/seaweedfs/seaweedfs/weed/command/s3.go:295 +0x560

github.com/seaweedfs/seaweedfs/weed/command.runFiler.func1(...)

  github.com/seaweedfs/seaweedfs/weed/command/filer.go:244

created by github.com/seaweedfs/seaweedfs/weed/command.runFiler in goroutine 1

  github.com/seaweedfs/seaweedfs/weed/command/filer.go:242 +0x340
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
