### PR TITLE
fluent-bit: de-vendor

### DIFF
--- a/fluent-bit-4.2.yaml
+++ b/fluent-bit-4.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-4.2
   version: "4.2.2"
-  epoch: 1
+  epoch: 2
   description: Fast and Lightweight Log processor and forwarder
   resources:
     cpu: 40
@@ -26,6 +26,10 @@ environment:
       - flex
       - gcc-14-default
       - glibc
+      - jemalloc-dev
+      - librdkafka-dev
+      - luajit-dev
+      - msgpack-c-dev
       - openssl-dev
       - postgresql-dev
       - systemd-dev
@@ -52,6 +56,7 @@ pipeline:
       cmake -DFLB_RELEASE=On \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
+        -DFLB_PREFER_SYSTEM_LIBS=On \
         -DFLB_JEMALLOC=On \
         -DFLB_TLS=On \
         -DFLB_EXAMPLES=Off \


### PR DESCRIPTION
Unfortunately fluent-bit is vendoring a lot of it's dependencies even when we include the system version.

This adds some missing builddeps as well as telling CMAKE to prefer the system deps.
