### PR TITLE
open-webui: update aiohttp to v3.13.3 to remediate several CVEs

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.6.43"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause
@@ -84,6 +84,9 @@ pipeline:
 
       # GHSA-9h52-p55h-vw2f
       uv pip install --upgrade mcp>=1.23.0
+
+      # GHSA-54jq-c3m8-4m76 GHSA-69f9-5gxw-wvc2 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8
+      uv pip install --upgrade aiohttp==3.13.3
 
       uv pip uninstall pip
 


### PR DESCRIPTION
aiohttp v3.13.3 addresses:
- GHSA-54jq-c3m8-4m76
- GHSA-54jq-c3m8-4m76
- GHSA-6jhg-hg63-jvvf
- GHSA-6mq8-rvhq-8wgg
- GHSA-fh55-r93g-j68g
- GHSA-g84x-mcqj-x9qq
- GHSA-jj3x-wxrx-4x23
- GHSA-mqqc-3gqh-h2x8

<!--ci-cve-scan:must-fix: GHSA-54jq-c3m8-4m76 GHSA-54jq-c3m8-4m76 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq  GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8-->
