### PR TITLE
dask-kubernetes: update aiohttp to v3.13.3 to remediate several CVEs

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.7.0"
-  epoch: 3 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 4
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"
@@ -49,8 +49,9 @@ pipeline:
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip install --upgrade "requests>=2.32.4"
 
-      # Upgrade requests to fix GHSA-9548-qrrj-x5pj
-      pip install --upgrade "aiohttp==3.12.14"
+      # Upgrade aiohttp to fix:
+      # GHSA-54jq-c3m8-4m76 GHSA-69f9-5gxw-wvc2 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8
+      pip install --upgrade "aiohttp==3.13.3"
 
       # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
       pip install --upgrade "urllib3==2.6.0"


### PR DESCRIPTION
aiohttp v3.13.3 addresses:
- GHSA-54jq-c3m8-4m76
- GHSA-54jq-c3m8-4m76
- GHSA-6jhg-hg63-jvvf
- GHSA-6mq8-rvhq-8wgg
- GHSA-fh55-r93g-j68g
- GHSA-g84x-mcqj-x9qq
- GHSA-jj3x-wxrx-4x23
- GHSA-mqqc-3gqh-h2x8

<!--ci-cve-scan:must-fix: GHSA-54jq-c3m8-4m76 GHSA-54jq-c3m8-4m76 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq  GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8-->