### PR TITLE
kubeflow-pipelines-visualization-server: update aiohttp to v3.13.3 to remediate several CVEs

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: "2.15.0"
-  epoch: 0
+  epoch: 1
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0

--- a/kubeflow-pipelines-visualization-server/modified-requirements.in
+++ b/kubeflow-pipelines-visualization-server/modified-requirements.in
@@ -23,3 +23,4 @@ jupyterlab>=4.4.8
 numpy==1.23.5
 pillow>=11.3.0
 pyarrow-hotfix==0.*
+aiohttp==3.13.3


### PR DESCRIPTION
aiohttp v3.13.3 addresses:
- GHSA-54jq-c3m8-4m76
- GHSA-54jq-c3m8-4m76
- GHSA-6jhg-hg63-jvvf
- GHSA-6mq8-rvhq-8wgg
- GHSA-fh55-r93g-j68g
- GHSA-g84x-mcqj-x9qq
- GHSA-jj3x-wxrx-4x23
- GHSA-mqqc-3gqh-h2x8

<!--ci-cve-scan:must-fix: GHSA-54jq-c3m8-4m76 GHSA-54jq-c3m8-4m76 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq  GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8-->