### PR TITLE
py3-cassandra-medusa: update aiohttp to v3.13.3 to remediate several CVEs

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: "0.26.0"
-  epoch: 2
+  epoch: 3
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -44,8 +44,8 @@ pipeline:
       poetry add "setuptools@^78.1.1"
       # GHSA-9hjg-9r4m-mvj7: requests
       poetry add "requests@^2.32.4"
-      # CVE-2025-53643 GHSA-9548-qrrj-x5pj
-      poetry add "aiohttp@^3.12.14"
+      # GHSA-54jq-c3m8-4m76 GHSA-69f9-5gxw-wvc2 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8
+      poetry add "aiohttp@^3.13.3"
       # GHSA-w853-jp5j-5j7f
       poetry add "filelock@^3.20.1"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt


### PR DESCRIPTION
aiohttp v3.13.3 addresses:
- GHSA-54jq-c3m8-4m76
- GHSA-54jq-c3m8-4m76
- GHSA-6jhg-hg63-jvvf
- GHSA-6mq8-rvhq-8wgg
- GHSA-fh55-r93g-j68g
- GHSA-g84x-mcqj-x9qq
- GHSA-jj3x-wxrx-4x23
- GHSA-mqqc-3gqh-h2x8

<!--ci-cve-scan:must-fix: GHSA-54jq-c3m8-4m76 GHSA-54jq-c3m8-4m76 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq  GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8-->