### PR TITLE
Address CVE 2025-68156

### DIFF
--- a/k3s-1.32.yaml
+++ b/k3s-1.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s-1.32
   version: "1.32.11.1"
-  epoch: 0
+  epoch: 1 # CVE 2025-68156
   description:
   copyright:
     - license: Apache-2.0
@@ -69,6 +69,7 @@ pipeline:
         github.com/quic-go/quic-go@v0.54.1
         github.com/libp2p/go-libp2p@v0.44.0
         golang.org/x/crypto@v0.45.0
+        github.com/expr-lang/expr@v1.17.7
       replaces: gopkg.in/go-jose/go-jose.v2=gopkg.in/go-jose/go-jose.v2@v2.6.3
 
   # Build things (almost) identical to upstream, with the k3s components


### PR DESCRIPTION
Address CVE 2025-68156 by updating `github.com/expr-lang/expr` to v1.17.7.