### PR TITLE
ruby-3.2: cherry-pick update of uri to 0.12.5

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: "3.2.9"
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -59,6 +59,7 @@ pipeline:
       expected-commit: 8f611e0c46012e321b39efd629eb5f4f53976863
       cherry-picks: |
         ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
+        ruby_3_2/2c01a34978b104113025d45d85eb30c1dbbea0cb: Merge URI-0.12.5
 
   - runs: |
       # Don't bundle the gems we have separate packages for


### PR DESCRIPTION
As uri is a default gem that comes with ruby we can't just update it ourselves.

Cherrypicking the commit that makes the update to uri 0.12.5 in the ruby_3_2 upstream branch[1]

This remediates CVE-2025-61594

[1] https://github.com/ruby/ruby/commit/2c01a34978b104113025d45d85eb30c1dbbea0cb

<!--ci-cve-scan:must-fix: CVE-2025-61594-->
