### PR TITLE
Rebuild packages reporting unknown/unknown/unknown

### DIFF
--- a/addon-resizer.yaml
+++ b/addon-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: addon-resizer
   version: "1.8.23"
-  epoch: 10 # CVE-2025-47906
+  epoch: 11 # CVE-2025-47906
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/argo-rollouts.yaml
+++ b/argo-rollouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-rollouts
   version: "1.8.3"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Progressive Delivery for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/argocd-extension-installer.yaml
+++ b/argocd-extension-installer.yaml
@@ -4,7 +4,7 @@ package:
   # in the beginning there were no releases, so we were using the commit hash as the version
   # now we are using the latest release version
   version: "0.0.9"
-  epoch: 0
+  epoch: 1
   description: Install Argo CD extensions using init-containers
   copyright:
     - license: Apache-2.0

--- a/aws-eks-pod-identity-agent.yaml
+++ b/aws-eks-pod-identity-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-eks-pod-identity-agent
   version: "0.1.36"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: EKS Pod Identity is a feature of Amazon EKS that simplifies the process for cluster administrators to configure Kubernetes applications with AWS IAM permissions
   copyright:
     - license: Apache-2.0

--- a/aws-node-termination-handler.yaml
+++ b/aws-node-termination-handler.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-node-termination-handler
   version: "1.25.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Gracefully handle EC2 instance shutdown within Kubernetes
   copyright:
     - license: Apache-2.0

--- a/aws-signer-notation-plugin.yaml
+++ b/aws-signer-notation-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-signer-notation-plugin
   version: "1.0.2292"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: AWS Signer Plugin for Notation
   copyright:
     - license: Apache-2.0

--- a/aws-sigv4-proxy.yaml
+++ b/aws-sigv4-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-sigv4-proxy
   version: "1.10"
-  epoch: 4 # CVE-2025-61725
+  epoch: 5 # CVE-2025-61725
   description: This project signs and proxies HTTP requests with Sigv4
   copyright:
     - license: Apache-2.0

--- a/bento.yaml
+++ b/bento.yaml
@@ -1,7 +1,7 @@
 package:
   name: bento
   version: "1.13.1"
-  epoch: 0 # GHSA-32fw-gq77-f2f2
+  epoch: 1 # GHSA-32fw-gq77-f2f2
   description: Bento is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
   copyright:
     - license: MIT

--- a/cass-operator.yaml
+++ b/cass-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-operator
   version: "1.28.0"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: Manages Cassandra cluster as standalone product or as part of the k8ssandra-operator
   copyright:
     - license: Apache-2.0

--- a/cert-manager-cmctl.yaml
+++ b/cert-manager-cmctl.yaml
@@ -3,7 +3,7 @@ package:
   # This got pulled from the cert-manager repo in the 1.15 release, prior to
   # that it was in the cert-manager/cert-manager repo.
   version: "2.4.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: "1.3.2"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0

--- a/cfssl.yaml
+++ b/cfssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cfssl
   version: 1.6.5
-  epoch: 25 # GHSA-j5w8-q4qc-rx2x
+  epoch: 26 # GHSA-j5w8-q4qc-rx2x
   description: Cloudflare's PKI and TLS toolkit
   copyright:
     - license: BSD-2-Clause

--- a/chart-testing.yaml
+++ b/chart-testing.yaml
@@ -1,7 +1,7 @@
 package:
   name: chart-testing
   version: "3.14.0"
-  epoch: 2 # CVE-2025-58187
+  epoch: 3 # CVE-2025-58187
   description: Tool for testing Helm charts, used for linting and testing pull requests.
   copyright:
     - license: Apache-2.0

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: "0.16.3"
-  epoch: 11 # GHSA-j5w8-q4qc-rx2x
+  epoch: 12 # GHSA-j5w8-q4qc-rx2x
   description: helm chart repository server
   copyright:
     - license: Apache-2.0

--- a/cilium-certgen-0.2.yaml
+++ b/cilium-certgen-0.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-certgen-0.2
   version: "0.2.4"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: A convenience tool to generate and store certificates for Hubble Relay mTLS.
   copyright:
     - license: Apache-2.0

--- a/cloud-provider-aws-1.34.yaml
+++ b/cloud-provider-aws-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-aws-1.34
   version: "1.34.1"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs.
   copyright:
     - license: Apache-2.0

--- a/cloud-provider-azure-1.34.yaml
+++ b/cloud-provider-azure-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-provider-azure-1.34
   version: "1.34.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Cloud provider for Azure
   copyright:
     - license: Apache-2.0

--- a/cloud-sql-proxy-2.18.yaml
+++ b/cloud-sql-proxy-2.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy-2.18
   version: "2.18.3"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudflared
   version: "2025.11.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Cloudflare Tunnel client
   copyright:
     - license: Apache-2.0

--- a/cloudprober.yaml
+++ b/cloudprober.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudprober
   version: "0.14.1"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: An active monitoring software to detect failures before your customers do.
   copyright:
     - license: Apache-2.0

--- a/cluster-api-aws-controller.yaml
+++ b/cluster-api-aws-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-aws-controller
   version: "2.10.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Kubernetes Cluster API Provider AWS provides consistent deployment and day 2 operations of "self-managed" and EKS Kubernetes clusters on AWS
   copyright:
     - license: Apache-2.0

--- a/cluster-api-azure-controller.yaml
+++ b/cluster-api-azure-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-azure-controller
   version: "1.21.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Cluster API implementation for Microsoft Azure
   copyright:
     - license: Apache-2.0

--- a/cluster-api-ipam-provider-in-cluster.yaml
+++ b/cluster-api-ipam-provider-in-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-ipam-provider-in-cluster
   version: "1.0.3"
-  epoch: 3 # CVE-2025-47907
+  epoch: 4 # CVE-2025-47907
   description: IPAM provider for Kubernetes Cluster API that manages IP address pools using Kubernetes resources
   copyright:
     - license: Apache-2.0

--- a/cluster-autoscaler-1.34.yaml
+++ b/cluster-autoscaler-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.34
   version: "1.34.2"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: "1.10.2"
-  epoch: 8 # CVE-2025-61725
+  epoch: 9 # CVE-2025-61725
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0

--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -1,7 +1,7 @@
 package:
   name: configmap-reload
   version: "0.15.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: Simple binary to trigger a reload when a Kubernetes ConfigMap is updated
   copyright:
     - license: Apache-2.0

--- a/confluent-kafka-images.yaml
+++ b/confluent-kafka-images.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-kafka-images
   version: "8.3.0.3"
-  epoch: 0
+  epoch: 1
   description: Provides build files for Apache Kafka and Confluent Docker images
   copyright:
     - license: Apache-2.0

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -1,7 +1,7 @@
 package:
   name: cortex
   version: "1.20.1"
-  epoch: 0 # CVE-2025-58187
+  epoch: 1 # CVE-2025-58187
   description: A horizontally scalable, highly available, multi-tenant, long term Prometheus.
   copyright:
     - license: Apache-2.0

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: "0.20.7"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0

--- a/cups.yaml
+++ b/cups.yaml
@@ -1,7 +1,7 @@
 package:
   name: cups
   version: "2.4.16"
-  epoch: 0
+  epoch: 1
   description: The CUPS Printing System
   copyright:
     - license: Apache-2.0

--- a/dataplaneapi.yaml
+++ b/dataplaneapi.yaml
@@ -1,7 +1,7 @@
 package:
   name: dataplaneapi
   version: "3.2.7"
-  epoch: 1 # CVE-2025-58187
+  epoch: 2 # CVE-2025-58187
   description: HAProxy Data Plane API
   copyright:
     - license: Apache-2.0

--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -1,7 +1,7 @@
 package:
   name: descheduler
   version: "0.34.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Descheduler for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/dfc.yaml
+++ b/dfc.yaml
@@ -1,7 +1,7 @@
 package:
   name: dfc
   version: "0.9.5"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Convert Dockerfiles to use Chainguard
   copyright:
     - license: Apache-2.0

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,7 +1,7 @@
 package:
   name: distribution
   version: 3.0.0
-  epoch: 44 # GHSA-j5w8-q4qc-rx2x
+  epoch: 45 # GHSA-j5w8-q4qc-rx2x
   description: The toolkit to pack, ship, store, and deliver container content
   copyright:
     - license: Apache-2.0

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: "0.13.1"
-  epoch: 10 # CVE-2025-61725
+  epoch: 11 # CVE-2025-61725
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT

--- a/docker-machine-driver-linode.yaml
+++ b/docker-machine-driver-linode.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-machine-driver-linode
   version: 0.1.15
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: Linode Driver Plugin for Docker Machine using Linode APIv4
   copyright:
     - license: MIT

--- a/dynamic-localpv-provisioner.yaml
+++ b/dynamic-localpv-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: dynamic-localpv-provisioner
   version: "4.4.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Dynamic Local Volumes for Kubernetes Stateful workloads.
   copyright:
     - license: Apache-2.0

--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: "2.4.1"
-  epoch: 1 # GHSA-qx2v-8332-m4fv
+  epoch: 2 # GHSA-qx2v-8332-m4fv
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT

--- a/envconsul.yaml
+++ b/envconsul.yaml
@@ -1,7 +1,7 @@
 package:
   name: envconsul
   version: "0.13.4"
-  epoch: 4 # GHSA-j5w8-q4qc-rx2x
+  epoch: 5 # GHSA-j5w8-q4qc-rx2x
   description: "Launch a subprocess with environment variables using data from @hashicorp Consul and Vault."
   copyright:
     - license: MPL-2.0

--- a/falco-exporter.yaml
+++ b/falco-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-exporter
   version: 0.8.7
-  epoch: 11 # CVE-2025-61725
+  epoch: 12 # CVE-2025-61725
   description: Prometheus Metrics Exporter for Falco output events
   copyright:
     - license: Apache-2.0

--- a/falcoctl.yaml
+++ b/falcoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcoctl
   version: "0.11.4"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: Administrative tooling for Falco
   copyright:
     - license: Apache-2.0

--- a/fixuid.yaml
+++ b/fixuid.yaml
@@ -1,7 +1,7 @@
 package:
   name: fixuid
   version: "0.6.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 6 # CVE-2025-61725
   description: Go tool to change a Docker container's user/group and file permissions.
   copyright:
     - license: MIT

--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: "3.5.0"
-  epoch: 2 # CVE-2025-47907
+  epoch: 3 # CVE-2025-47907
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: "1.4.5"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: "1.7.4"
-  epoch: 3 # GHSA-j5w8-q4qc-rx2x
+  epoch: 4 # GHSA-j5w8-q4qc-rx2x
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: "2.1.7"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/gatekeeper-3.21.yaml
+++ b/gatekeeper-3.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.21
   version: "3.21.0"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: "3.7.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/gpgme.yaml
+++ b/gpgme.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpgme
   version: "2.0.1"
-  epoch: 1
+  epoch: 2
   description: GNU - GnuPG Made Easy
   copyright:
     - license: GPL-3.0-or-later

--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: "1.25.5"
-  epoch: 3 # GHSA-pwhc-rpq9-4c8w
+  epoch: 4 # GHSA-pwhc-rpq9-4c8w
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kube-arangodb-1.3.yaml
+++ b/kube-arangodb-1.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-arangodb-1.3
   version: "1.3.4"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  epoch: 1 # GHSA-pwhc-rpq9-4c8w
   description: ArangoDB Kubernetes Operator - manages deployments of the ArangoDB database in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: "1.10.6"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubo.yaml
+++ b/kubo.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubo
   version: "0.39.0"
-  epoch: 1 # GHSA-j5w8-q4qc-rx2x
+  epoch: 2 # GHSA-j5w8-q4qc-rx2x
   description: An IPFS implementation in Go
   copyright:
     - license: MIT

--- a/kyverno-policy-reporter-kyverno-plugin.yaml
+++ b/kyverno-policy-reporter-kyverno-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-kyverno-plugin
   version: 1.6.4
-  epoch: 14 # CVE-2025-47907
+  epoch: 15 # CVE-2025-47907
   description: Policy Reporter Kyverno Plugin
   copyright:
     - license: MIT

--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: "1.18.1"
-  epoch: 1 # CVE-2025-47910
+  epoch: 2 # CVE-2025-47910
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0

--- a/libxkbcommon.yaml
+++ b/libxkbcommon.yaml
@@ -2,7 +2,7 @@
 package:
   name: libxkbcommon
   version: "1.13.1"
-  epoch: 0
+  epoch: 1
   description: keyboard handling library
   copyright:
     - license: MIT

--- a/libxslt.yaml
+++ b/libxslt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxslt
   version: "1.1.45"
-  epoch: 0
+  epoch: 1
   description: XML stylesheet transformation library
   copyright:
     - license: MIT

--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-static-provisioner
   version: "2.8.0"
-  epoch: 6 # GHSA-j5w8-q4qc-rx2x
+  epoch: 7 # GHSA-j5w8-q4qc-rx2x
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0

--- a/logstash-exporter.yaml
+++ b/logstash-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: logstash-exporter
   version: "1.9.1"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Prometheus exporter for Logstash written in Go
   copyright:
     - license: MIT

--- a/lvm-driver.yaml
+++ b/lvm-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: lvm-driver
   version: "1.8.0"
-  epoch: 1 # CVE-2025-47906
+  epoch: 2 # CVE-2025-47906
   description: Dynamically provision Stateful Persistent Node-Local Volumes & Filesystems for Kubernetes that is integrated with a backend LVM2 data storage stack.
   copyright:
     - license: Apache-2.0

--- a/mcp-grafana.yaml
+++ b/mcp-grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: mcp-grafana
   version: "0.7.10"
-  epoch: 1 # CVE-2025-47907
+  epoch: 2 # CVE-2025-47907
   description: MCP server for grafana
   dependencies:
     runtime:

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: "0.15.4"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: "4.12.5"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Writing kubernetes controllers can be simple
   copyright:
     - license: Apache-2.0

--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: "2.27.4"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fsspec
   version: "2025.12.0"
-  epoch: 0
+  epoch: 1
   description: File-system specification
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.2-excon.yaml
+++ b/ruby3.2-excon.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-excon
   version: "1.3.2"
-  epoch: 0
+  epoch: 1
   description: EXtended http(s) CONnections
   copyright:
     - license: MIT

--- a/ruby3.2-io-stream.yaml
+++ b/ruby3.2-io-stream.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-io-stream
   version: "0.11.1"
-  epoch: 0
+  epoch: 1
   description: A Ruby gem providing stream abstractions for input and output.
   copyright:
     - license: MIT

--- a/step-issuer.yaml
+++ b/step-issuer.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-issuer
   version: "0.9.11"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: A certificate issuer for cert-manager using step certificates CA
   copyright:
     - license: Apache-2.0

--- a/tetragon.yaml
+++ b/tetragon.yaml
@@ -1,7 +1,7 @@
 package:
   name: tetragon
   version: "1.6.0"
-  epoch: 1
+  epoch: 2
   description: "eBPF-based Security Observability and Runtime Enforcement"
   copyright:
     - license: Apache-2.0

--- a/timoni.yaml
+++ b/timoni.yaml
@@ -1,7 +1,7 @@
 package:
   name: timoni
   version: "0.25.2"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Timoni is a package manager for Kubernetes, powered by CUE and inspired by Helm.
   copyright:
     - license: Apache-2.0

--- a/tkn.yaml
+++ b/tkn.yaml
@@ -1,7 +1,7 @@
 package:
   name: tkn
   version: "0.43.0"
-  epoch: 1 # GHSA-72c7-4g63-hpw5
+  epoch: 2 # GHSA-72c7-4g63-hpw5
   description: A CLI for interacting with Tekton!
   copyright:
     - license: Apache-2.0

--- a/tofu-controller.yaml
+++ b/tofu-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: tofu-controller
   version: "0.16.0_rc5"
-  epoch: 8 # GHSA-j5w8-q4qc-rx2x
+  epoch: 9 # GHSA-j5w8-q4qc-rx2x
   description: A GitOps OpenTofu and Terraform controller for Flux
   copyright:
     - license: Apache-2.0

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: "1.7.2"
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0

--- a/trivy-operator.yaml
+++ b/trivy-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy-operator
   version: "0.29.0"
-  epoch: 5 # GHSA-j5w8-q4qc-rx2x
+  epoch: 6 # GHSA-j5w8-q4qc-rx2x
   description: "Kubernetes-native security toolkit that finds and reports vulnerabilities and misconfigurations"
   copyright:
     - license: Apache-2.0

--- a/velero-plugin-for-microsoft-azure.yaml
+++ b/velero-plugin-for-microsoft-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero-plugin-for-microsoft-azure
   version: "1.13.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Plugins to support Velero on microsoft-azure
   copyright:
     - license: Apache-2.0

--- a/velero.yaml
+++ b/velero.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero
   version: "1.17.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3 # GHSA-j5w8-q4qc-rx2x
   description: Backup and migrate Kubernetes applications and their persistent volumes
   copyright:
     - license: Apache-2.0

--- a/vendir.yaml
+++ b/vendir.yaml
@@ -1,7 +1,7 @@
 package:
   name: vendir
   version: "0.45.0"
-  epoch: 1 # CVE-2025-61725
+  epoch: 2 # CVE-2025-61725
   description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
   copyright:
     - license: Apache-2.0

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: "1.5.1"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/vt-cli.yaml
+++ b/vt-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: vt-cli
   version: "1.2.0"
-  epoch: 2 # CVE-2025-61725
+  epoch: 3 # CVE-2025-61725
   description: "VirusTotal Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/wait-for-port.yaml
+++ b/wait-for-port.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-port
   version: "1.0.10"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: CLI tool for waiting until a TCP port reaches the desired state
   copyright:
     - license: Apache-2.0

--- a/wave.yaml
+++ b/wave.yaml
@@ -1,7 +1,7 @@
 package:
   name: wave
   version: 0.10.0
-  epoch: 13 # CVE-2025-61725
+  epoch: 14 # CVE-2025-61725
   description: Kubernetes configuration tracking controller
   copyright:
     - license: Apache-2.0

--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: whereabouts
   version: "0.9.2"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: A CNI IPAM plugin that assigns IP addresses cluster-wide
   copyright:
     - license: Apache-2.0

--- a/x509-certificate-exporter.yaml
+++ b/x509-certificate-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: x509-certificate-exporter
   version: "3.19.1"
-  epoch: 7 # GHSA-j5w8-q4qc-rx2x
+  epoch: 8 # GHSA-j5w8-q4qc-rx2x
   description: A Prometheus exporter to monitor x509 certificates expiration in Kubernetes clusters or standalone.
   copyright:
     - license: MIT

--- a/xeol.yaml
+++ b/xeol.yaml
@@ -1,7 +1,7 @@
 package:
   name: xeol
   version: "0.10.8"
-  epoch: 20 # GHSA-j5w8-q4qc-rx2x
+  epoch: 21 # GHSA-j5w8-q4qc-rx2x
   description: A scanner for end-of-life (EOL) software
   dependencies:
     runtime:

--- a/yace.yaml
+++ b/yace.yaml
@@ -1,7 +1,7 @@
 package:
   name: yace
   version: "0.63.0"
-  epoch: 3 # CVE-2025-58187
+  epoch: 4 # CVE-2025-58187
   description: Prometheus exporter for AWS CloudWatch.
   copyright:
     - license: Apache-2.0

--- a/yunikorn-web.yaml
+++ b/yunikorn-web.yaml
@@ -1,7 +1,7 @@
 package:
   name: yunikorn-web
   version: "1.7.0"
-  epoch: 3 # CVE-2025-61725
+  epoch: 4 # CVE-2025-61725
   description: Apache YuniKorn Web UI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
When we rolled out changes to the build process, we accidentally broke the git repo detection for some packages. When this happens, melange reports the repo as `pkg:github/https%3A/%2Funknown%2Funknown%2Funknown@unknown`. Example: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/git-lfs-3.7.1-r2.apk@sha1:f81ce220f17541a15ecad72e949f939d7ed961a5/var/lib/db/sbom/git-lfs-3.7.1-r2.spdx.json

The root cause for this problem has been fixed, but we need to rebuild packages that were affected. This change bumps the epoch for all affected packages.