### PR TITLE
daemon-check-output(kong): fix failing test by removing invalid jq database check

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong
   version: "3.9.1"
-  epoch: 2
+  epoch: 3
   description: "The Kong Gateway - an API Gateway built on Nginx and OpenResty"
   copyright:
     - license: Apache-2.0
@@ -131,6 +131,6 @@ test:
         expected_output: "Kong started"
         post: |
           wait-for-it 127.0.0.1:8001 -t 30
-          curl -sf http://127.0.0.1:8001/status | jq -e '.database=="off"'
+          curl -sf http://127.0.0.1:8001/ | jq -e '.configuration.database == "off"'
           curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/ | grep -E "(404|502)"
     - uses: test/tw/ldd-check

--- a/kong.yaml
+++ b/kong.yaml
@@ -131,6 +131,7 @@ test:
         expected_output: "Kong started"
         post: |
           wait-for-it 127.0.0.1:8001 -t 30
+          curl -sf http://127.0.0.1:8001/status | jq -e '.server'
           curl -sf http://127.0.0.1:8001/ | jq -e '.configuration.database == "off"'
           curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/ | grep -E "(404|502)"
     - uses: test/tw/ldd-check


### PR DESCRIPTION
The /status endpoint in Kong 3.9.1 does not return a `database` field at the root level, causing `jq -e '.database=="off"'` to fail. The DBless mode is already verified by the KONG_DATABASE=off environment variable and successful startup. Remove the unnecessary check to fix the test.

test change ref: https://github.com/wolfi-dev/os/pull/77372