### PR TITLE
DNM: Fixing ClickHouse ARM builds

### DIFF
--- a/clickhouse-25.11.yaml
+++ b/clickhouse-25.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.11
   version: "25.11.5.8"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  clang-version: 19
 
 var-transforms:
   - from: ${{package.version}}
@@ -32,7 +35,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-19
+      - clang-${{vars.clang-version}}
       - cmake
       - coreutils
       - findutils
@@ -40,7 +43,7 @@ environment:
       - grep
       - ini-file
       - libcxx1
-      - lld-19
+      - lld-${{vars.clang-version}}
       - nasm<3
       - ninja
       - perl

--- a/clickhouse-25.11.yaml
+++ b/clickhouse-25.11.yaml
@@ -32,6 +32,7 @@ environment:
   contents:
     packages:
       - bash
+      - binutils
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -88,6 +89,17 @@ pipeline:
         -DVERSION_STRING=${{package.version}} \
         -DCLICKHOUSE_OFFICIAL_BUILD=1 \
         ..
+
+  # Checking for CPU instructions not supported by Graviton 2.
+  - pipeline:
+      - if: ${{build.arch}} == "aarch64"
+        runs: |
+          objdump -d ${{targets.destdir}}/usr/bin/clickhouse | grep -E " z[0-9]| p[0-9]" | head > bad-instructions.txt
+          if test -s bad-instructions.txt ; then
+            echo "Bad aarch64 instructions found:" ;
+            cat bad-instructions.txt ;
+            exit 666
+          fi
 
   - runs: |
       cd build

--- a/clickhouse-25.12.yaml
+++ b/clickhouse-25.12.yaml
@@ -32,6 +32,7 @@ environment:
   contents:
     packages:
       - bash
+      - binutils
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -90,6 +91,17 @@ pipeline:
         -DVERSION_STRING=${{package.version}} \
         -DCLICKHOUSE_OFFICIAL_BUILD=1 \
         ..
+
+  # Checking for CPU instructions not supported by Graviton 2.
+  - pipeline:
+      - if: ${{build.arch}} == "aarch64"
+        runs: |
+          objdump -d ${{targets.destdir}}/usr/bin/clickhouse | grep -E " z[0-9]| p[0-9]" | head > bad-instructions.txt
+          if test -s bad-instructions.txt ; then
+            echo "Bad aarch64 instructions found:" ;
+            cat bad-instructions.txt ;
+            exit 666
+          fi
 
   - runs: |
       cd build

--- a/clickhouse-25.12.yaml
+++ b/clickhouse-25.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.12
   version: "25.12.1.649"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  clang-version: 19
 
 var-transforms:
   - from: ${{package.version}}
@@ -32,17 +35,17 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-19
+      - clang-${{vars.clang-version}}
       - cmake
-      - compiler-rt-19
+      - compiler-rt-${{vars.clang-version}}
       - coreutils
       - findutils
       - git
       - grep
       - ini-file
       - libcxx1
-      - lld-19
-      - llvm-19
+      - lld-${{vars.clang-version}}
+      - llvm-${{vars.clang-version}}
       - nasm<3
       - ninja
       - perl

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: "3.2.9"
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -59,6 +59,7 @@ pipeline:
       expected-commit: 8f611e0c46012e321b39efd629eb5f4f53976863
       cherry-picks: |
         ruby_3_2/c38243e2c4e874d67b63431f9489f47ddfecdefd: [ruby/openssl] ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store
+        ruby_3_2/2c01a34978b104113025d45d85eb30c1dbbea0cb: Merge URI-0.12.5
 
   - runs: |
       # Don't bundle the gems we have separate packages for


### PR DESCRIPTION
Hunting a problem with ARM builds of ClickHouse using CPU instructions not present on Graviton 2 processors. <https://github.com/chainguard-dev/customer-issues/issues/2909>
