### PR TITLE
DNM: Hunting aarch64 CPU instruction issue

### DIFF
--- a/clickhouse-25.11.yaml
+++ b/clickhouse-25.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.11
   version: "25.11.6.11"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  clang-version: 19
 
 var-transforms:
   - from: ${{package.version}}
@@ -29,10 +32,11 @@ environment:
   contents:
     packages:
       - bash
+      - binutils
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-19
+      - clang-${{vars.clang-version}}
       - cmake
       - coreutils
       - findutils
@@ -40,7 +44,7 @@ environment:
       - grep
       - ini-file
       - libcxx1
-      - lld-19
+      - lld-${{vars.clang-version}}
       - nasm<3
       - ninja
       - perl
@@ -85,6 +89,24 @@ pipeline:
         -DVERSION_STRING=${{package.version}} \
         -DCLICKHOUSE_OFFICIAL_BUILD=1 \
         ..
+
+  # Checking for CPU instructions not supported by Graviton 2.
+  #
+  # If this fails, the aarch64 binaries have CPU instructions in them that
+  # aren't available on Graviton 2 style CPUs; instructions we *haven't*
+  # enabled have been generated. Fixing this may require adjustments to the
+  # Rust toolchain we're using.
+  - pipeline:
+      - if: ${{build.arch}} == "aarch64"
+        runs: |
+          objdump -d ${{targets.destdir}}/usr/bin/clickhouse | grep -E " z[0-9]| p[0-9]" | head > bad-instructions.txt
+          if test -s bad-instructions.txt ; then \
+            echo "Bad aarch64 instructions found:" ; \
+            cat bad-instructions.txt ; \
+            exit 666 ; \
+          else \
+            echo "No bad aarch64 instructions found!" ; \
+          fi
 
   - runs: |
       cd build

--- a/clickhouse-25.12.yaml
+++ b/clickhouse-25.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-25.12
   version: "25.12.2.54"
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
     runtime:
       - merged-usrsbin
       - wolfi-baselayout
+
+vars:
+  clang-version: 19
 
 var-transforms:
   - from: ${{package.version}}
@@ -29,20 +32,21 @@ environment:
   contents:
     packages:
       - bash
+      - binutils
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-19
+      - clang-${{vars.clang-version}}
       - cmake
-      - compiler-rt-19
+      - compiler-rt-${{vars.clang-version}}
       - coreutils
       - findutils
       - git
       - grep
       - ini-file
       - libcxx1
-      - lld-19
-      - llvm-19
+      - lld-${{vars.clang-version}}
+      - llvm-${{vars.clang-version}}
       - nasm<3
       - ninja
       - perl
@@ -87,6 +91,24 @@ pipeline:
         -DVERSION_STRING=${{package.version}} \
         -DCLICKHOUSE_OFFICIAL_BUILD=1 \
         ..
+
+  # Checking for CPU instructions not supported by Graviton 2.
+  #
+  # If this fails, the aarch64 binaries have CPU instructions in them that
+  # aren't available on Graviton 2 style CPUs; instructions we *haven't*
+  # enabled have been generated. Fixing this may require adjustments to the
+  # Rust toolchain we're using.
+  - pipeline:
+      - if: ${{build.arch}} == "aarch64"
+        runs: |
+          objdump -d ${{targets.destdir}}/usr/bin/clickhouse | grep -E " z[0-9]| p[0-9]" | head > bad-instructions.txt
+          if test -s bad-instructions.txt ; then \
+            echo "Bad aarch64 instructions found:" ; \
+            cat bad-instructions.txt ; \
+            exit 666 ; \
+          else \
+            echo "No bad aarch64 instructions found!" ; \
+          fi
 
   - runs: |
       cd build


### PR DESCRIPTION
Hunting down https://github.com/chainguard-dev/customer-issues/issues/2909 by aligning our aarch64 builds with upstream.