### PR TITLE
fix(opensearch-dashboards-3): GHSA-6rw7-vpxm-498p

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.2.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 2
+  epoch: 3
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -93,6 +93,10 @@ pipeline:
       devDependencies='{"cypress": "^13.5.1"}'
       jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
 
+      # fix GHSA-6rw7-vpxm-498p
+      dependencies='{"qs": "^6.14.1"}'
+      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
+
       # fix CVE-2025-9288
       devDependencies='{"sha.js": "^2.4.12"}'
       jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
@@ -158,6 +162,10 @@ subpackages:
 
           # fix CVE-2025-29907
           dependencies='{"jspdf": "^3.0.1"}'
+          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
+
+          # fix GHSA-6rw7-vpxm-498p
+          dependencies='{"qs": "^6.14.1"}'
           jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
 
           yarn osd bootstrap --allow-root 2>/dev/null


### PR DESCRIPTION
Bump qs to 6.14.1

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/52326

<!--ci-cve-scan:fail-any-->
