### PR TITLE
cinc-auditor: add runtime dependency on busybox for /bin/sh

### DIFF
--- a/cinc-auditor.yaml
+++ b/cinc-auditor.yaml
@@ -4,7 +4,7 @@
 package:
   name: cinc-auditor
   version: "7.0.95"
-  epoch: 1
+  epoch: 2
   description: cinc-auditor is an OSS tool for applying inspec profiles
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,8 @@ package:
       license-path: NOTICE.TXT
   dependencies:
     runtime:
+      # needed for the shell wrapper script in /usr/bin
+      - busybox
       # additional gem dependencies added in the upstream cinc-auditor
       # habitat/plan.sh script that can't be listed as part of the Gemfile
       # for some reason


### PR DESCRIPTION
The cinc-auditor script includes a shell script wrapper that sets ruby environment variables so that the vendored ruby gems can be found by it. Add a runtime dependency on busybox to get a /bin/sh for the script. so that images that include the cinc-auditor package automatically get the dependency.
