### PR TITLE
Fix script execution in certhash update

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20251003"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -56,8 +56,8 @@ pipeline:
       EOF
 
       cat > "${{targets.destdir}}"/etc/ca-certificates/update.d/certhash <<-EOF
-        #!/bin/sh
-        exec /usr/bin/c_rehash /etc/ssl/certs
+      #!/bin/sh
+      exec /usr/bin/c_rehash /etc/ssl/certs
       EOF
 
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/certhash


### PR DESCRIPTION
`certhash` script in the `ca-certificates` package has leading whitespace, results in "Error while loading /etc/ca-certificates/update.d/certhash: Exec format error"

should solve https://github.com/chainguard-dev/customer-issues/issues/2962