### PR TITLE
az: update pynacl to v1.6.2 and urllib3 to v2.6.3 to remediate CVE-2025-69277,CVE-2026-21441

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.81.0"
-  epoch: 2
+  epoch: 2 # GHSA-38jv-5279-wg99 GHSA-mrfv-m5wm-5w6w
   description: Azure CLI
   copyright:
     - license: MIT
@@ -41,8 +41,8 @@ pipeline:
       # Install the built wheels directly into the package filesystem
       pip install --prefix=${{targets.destdir}}/usr --no-compile src/azure-cli/dist/*.whl src/azure-cli-core/dist/*.whl
 
-      # Remediate GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
-      pip install --prefix=${{targets.destdir}}/usr --upgrade "urllib3==2.6.0"
+      # Remediate GHSA-38jv-5279-wg99
+      pip install --prefix=${{targets.destdir}}/usr --upgrade "urllib3==2.6.3"
 
   - uses: strip
 

--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.81.0"
-  epoch: 1
+  epoch: 2
   description: Azure CLI
   copyright:
     - license: MIT
@@ -26,6 +26,8 @@ pipeline:
       repository: https://github.com/Azure/azure-cli/
       tag: azure-cli-${{package.version}}
       expected-commit: e1fdb81cc99a69670fe3f9771f9af171ac0741af
+      cherry-picks: |
+        dev/319e9c41caf66b6dd6841bb529637df3e399092c: {Packaging} Bump pynacl to1.6.2, cffi to 2.0.0
 
   - name: Python Build
     runs: |


### PR DESCRIPTION
pynacl updated to v1.6.2 using a cherry-pick from upstream az - CVE-2025-69277

urllib3 upgraded to v2.6.3 using pip - CVE-2026-21441

<!--ci-cve-scan:must-fix: CVE-2025-69277 CVE-2026-21441-->
