### PR TITLE
kubeflow-pipelines: update urllib3 to v2.6.3 to remediate CVE-2026-21441

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: "2.15.0"
-  epoch: 5 # GHSA-cfpf-hrx2-8rv6
+  epoch: 6 # GHSA-38jv-5279-wg99
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -87,8 +87,8 @@ subpackages:
             # Patch GHSA-jfmj-5v4g-7637
             sed -i 's|zipp==3.15.0|zipp==3.19.1|g' requirements.txt
 
-            # Patch GHSA-2xpw-w6gg-jr37 GHSA-gm62-xv2j-4w53
-            sed -i 's|urllib3==2.5.0|urllib3==2.6.0|g' requirements.txt
+            # Patch GHSA-38jv-5279-wg99
+            sed -i 's|urllib3==2.5.0|urllib3==2.6.3|g' requirements.txt
 
             # google-auth: upgrade to support urllib3 2.x (fixes dependency conflict)
             sed -i 's|google-auth==2.23.0|google-auth==2.40.3|g' requirements.txt


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-21441-->

