### PR TITLE
apache2: Vendor httpd-foreground script

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: "2.4.66"
-  epoch: 0
+  epoch: 1
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -104,12 +104,6 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
-
-  - uses: fetch
-    with:
-      uri: https://raw.githubusercontent.com/docker-library/httpd/master/${{vars.build-version}}/alpine/httpd-foreground
-      expected-sha256: 003f4ca165cf0daa9721c907259d3ef6a7fd9017453079780c1ae91de96fa777
-      extract: false
 
 subpackages:
   - name: ${{package.name}}-dev
@@ -275,7 +269,8 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
 
-          # Install the `httpd-foreground` script from the fetch step above to the compat subpackage
+          # Install the `httpd-foreground` script to the compat subpackage
+          # Vendored from https://raw.githubusercontent.com/docker-library/httpd/master/2.4/alpine/httpd-foreground
           install -Dm755 /home/build/httpd-foreground ${{targets.contextdir}}/usr/local/bin/httpd-foreground
           # Create symlinks
           ln -s /etc/apache2/httpd.conf "${{targets.subpkgdir}}"/usr/local/apache2/conf/

--- a/apache2/httpd-foreground
+++ b/apache2/httpd-foreground
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Apache gets grumpy about PID files pre-existing
+rm -f /usr/local/apache2/logs/httpd.pid
+
+exec httpd -DFOREGROUND "$@"


### PR DESCRIPTION
We're trying to reduce our use of `fetch`.  The `httpd-foreground` script in docker-library/httpd hasn't changed since 2019 and is very simple, so it doesn't seem too unreasonable to just vendor it.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668