### PR TITLE
dnssec-root: Switch to git-checkout

### DIFF
--- a/dnssec-root.yaml
+++ b/dnssec-root.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnssec-root
   version: "20190225"
-  epoch: 3
+  epoch: 4
   description: The DNSSEC root key(s)
   copyright:
     - license: CC-PDDC
@@ -17,10 +17,11 @@ environment:
       - python3
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6c704b7b3f13e828d87de8b971b99721e46586fd3a8a547cf4e7b748cbe3d493
-      uri: https://github.com/iana-org/get-trust-anchor/archive/67c11662510f5e2db6e6517228e80b794950c43f.tar.gz
+      repository: https://github.com/iana-org/get-trust-anchor
+      branch: master
+      expected-commit: 179765e80ebde71594b0e14cc6d6a506d911699a
 
   - runs: |
       python3 get_trust_anchor.py
@@ -34,5 +35,7 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # no releases or tags, commit sha is used, not auto updatable
-  git: {}
+  exclude-reason: "no releases or tags, commit sha is used, not auto updatable"
+  manual: true
+  github:
+    identifier: iana-org/get-trust-anchor


### PR DESCRIPTION
This does mean that the package will fail to build when upstream changes (perhaps `git-checkout` needs a mode to check out a specific commit for this sort of case?).  However, we were previously using a commit from 2017-02-05 without a very clear reason, so this might be better than silently falling behind.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668