### PR TITLE
airflow-3: update urllib3 to v2.6.3 to remediate CVE-2026-21441

### DIFF
--- a/airflow-3.yaml
+++ b/airflow-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow-3
   version: "3.1.5"
-  epoch: 2 # GHSA-428g-f7cq-pgp5
+  epoch: 3 # GHSA-38jv-5279-wg99
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -78,6 +78,7 @@ pipeline:
         filelock==3.20.1
         commons-lang3==3.18.0 # GHSA-j288-q9x7-2f5v
         marshmallow==3.26.2 # GHSA-428g-f7cq-pgp5
+        urllib3==2.6.3 # GHSA-38jv-5279-wg99
 
   - runs: |
       # ZIP doesn't handle the SDE we set correctly, so set it to 1980-01-01


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-21441-->
