### PR TITLE
libdaemon, libdbi: Switch to git-checkout

### DIFF
--- a/libdaemon.yaml
+++ b/libdaemon.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdaemon
   version: 0.14
-  epoch: 4
+  epoch: 5
   description: A lightweight C library which eases the writing of UNIX daemons
   copyright:
     - license: LGPL-2.1-or-later
@@ -9,24 +9,21 @@ package:
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - lynx
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: fd23eb5f6f986dcc7e708307355ba3289abe03cc381fc47a80bca4a50aa6b834
-      uri: https://dev.alpinelinux.org/archive/libdaemon/libdaemon-${{package.version}}.tar.gz
+      repository: https://git.0pointer.net/clone/libdaemon.git
+      depth: -1 # repository does not support shallow clones
+      tag: v${{package.version}}
+      expected-commit: 9fcc28e0e8f84968d1fb8b6d544a42efb13803ec
 
   - uses: autoconf/configure
-    with:
-      opts: |
-        --prefix=/usr \
-        --localstatedir=/var
 
   - uses: autoconf/make
 

--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libdbi
   version: 0.9.0
-  epoch: 4
+  epoch: 5
   description: "Database independent abstraction layer for C"
   copyright:
     - license: LGPL-2.1-or-later
@@ -14,14 +14,21 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://downloads.sourceforge.net/project/libdbi/libdbi/libdbi-${{package.version}}/libdbi-${{package.version}}.tar.gz
-      expected-sha512: ee8777195af43057409d051a6055ec0467cd926d48da076458b09f91d2f0995a1cc4bc071762e401b7bdcd8a4173fd8ea3472db3a1518e34b4c5b5ed24e4e2ce
+      repository: https://git.code.sf.net/p/libdbi/libdbi
+      tag: libdbi-${{package.version}}
+      expected-commit: 046b649e15a39e37d4112ad3538f32eb66bf9811
+
+  - runs: autoreconf -vfi
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-docs
 
   - uses: autoconf/make
 


### PR DESCRIPTION
This loses libdbi's documentation since `openjade` isn't packaged, but we probably didn't want that in the library package anyway.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668