### PR TITLE
python-3.14: Move JIT build to subpackage

### DIFF
--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.14
   version: "3.14.2"
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -19,7 +19,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
-      # This is a year old. Hopefully 3.14.x updates will move this to current.
+      # clang, llvm and python-3.13 are required for the JIT subpackage build
       - clang-${{vars.clang-version}}
       - expat-dev
       - gdbm-dev
@@ -27,14 +27,10 @@ environment:
       - libffi-dev
       - libx11-dev
       - linux-headers
-      # This is a year old. Hopefully 3.14.x updates will move this to current.
       - llvm-${{vars.clang-version}}
       - mpdecimal-dev
       - ncurses-dev
       - openssl-dev
-      # This is required for the JIT-enabled build. Hopefully 3.14.x updates
-      # will remove this requirement, or it will vanish when the JIT version
-      # becomes the default.
       - python-3.13
       - readline-dev
       - sqlite-dev
@@ -105,22 +101,16 @@ pipeline:
     with:
       patches: gh-118224.patch gh-127301.patch
 
-  - name: Clone patched source for no-GIL build
+  - name: Clone patched source for no-GIL and JIT builds
     runs: |
-      mkdir no-gil
-      tar -cf - --exclude=no-gil . | (cd no-gil; tar -xf -)
+      mkdir no-gil build-jit
+      tar -cf - --exclude=no-gil --exclude=build-jit . | (cd no-gil; tar -xf -)
+      tar -cf - --exclude=no-gil --exclude=build-jit . | (cd build-jit; tar -xf -)
 
-  # Experimental JIT support
-  #
-  # --enable-optimizations with clang requires PGO support (in particular,
-  # we're missing libclang_rt.profile). This build configuration won't be
-  # optimal and might not produce any performance gains.
   - uses: autoconf/configure
     with:
       opts: |
-        CC=clang \
-        --enable-experimental-jit=yes-off \
-        --with-tail-call-interp \
+        --enable-optimizations \
         ${{vars.python-config}}
 
   - uses: autoconf/make
@@ -231,6 +221,94 @@ subpackages:
             - name: Verify no-GIL build
               runs: |
                 ${{vars.python-t}} -c 'import sysconfig; assert(sysconfig.get_config_var("Py_GIL_DISABLED"))'
+
+  - name: "${{package.name}}-jit"
+    description: "Python with experimental JIT support"
+    dependencies:
+      provides:
+        - python3-jit=${{package.full-version}}
+        - python-3-jit=${{package.full-version}}
+      runtime:
+        # 'import _tkinter' will fail with ImportError on 'libtcl9tk9.0.so'
+        # which is provided by tk.  melange SCA does not find this dependency.
+        - tk
+    pipeline:
+      - working-directory: build-jit
+        pipeline:
+          # Experimental JIT support
+          #
+          # --enable-optimizations with clang requires PGO support (in particular,
+          # we're missing libclang_rt.profile). This build configuration won't be
+          # optimal and might not produce any performance gains.
+          - runs: |
+              export PATH="/usr/lib/llvm-${{vars.clang-version}}/bin:$PATH"
+          - uses: autoconf/configure
+            with:
+              opts: |
+                CC=clang-${{vars.clang-version}} \
+                --enable-experimental-jit=yes-off \
+                --with-tail-call-interp \
+                ${{vars.python-config}}
+          - uses: autoconf/make
+          - uses: autoconf/make-install
+          - name: "Clean out base items"
+            runs: |
+              find ${{targets.subpkgdir}}/usr/lib -type f -name 'libpython*.a' -exec rm -rf '{}' +
+              find ${{targets.subpkgdir}}/usr/lib -type d -name 'test' -exec rm -rf '{}' +
+              find ${{targets.subpkgdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
+
+              cd ${{targets.subpkgdir}}/usr/bin
+              rm idle3*
+              rm ${{targets.subpkgdir}}/usr/lib/libpython3.so
+
+              # add dubious python -> python3 link
+              ln -s python3 ${{targets.subpkgdir}}/usr/bin/python
+
+              # Drop site-packages README.txt to avoid SCA dep on python3~3.M
+              rm -R ${{targets.subpkgdir}}/usr/lib/${{vars.python}}/site-packages
+
+              rm -R ${{targets.subpkgdir}}/usr/lib/${{vars.python}}/idlelib
+              rm -R ${{targets.subpkgdir}}/usr/lib/${{vars.python}}/ensurepip/_bundled/
+
+              rm ${{targets.subpkgdir}}/usr/bin/pydoc3*
+              rm -R ${{targets.subpkgdir}}/usr/include
+              rm -R ${{targets.subpkgdir}}/usr/share
+              rm ${{targets.subpkgdir}}/usr/lib/pkgconfig/python-3.14-*.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig/python3-*.pc
+          - name: "Precompile .py files"
+            runs: |
+              find ${{targets.subpkgdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
+              find ${{targets.subpkgdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
+
+              export LD_LIBRARY_PATH="${{targets.subpkgdir}}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+              ${{targets.subpkgdir}}/usr/bin/${{vars.python}} -m compileall --invalidation-mode=unchecked-hash \
+                  -r100 ${{targets.subpkgdir}}/usr/lib/
+          - uses: strip
+    test:
+      pipeline:
+        - working-directory: build-jit
+          pipeline:
+            - uses: test/tw/ldd-check
+            - uses: test/tw/symlink-check
+            - uses: test/tw/ver-check
+              with:
+                bins: python ${{vars.python}}
+            - uses: test/tw/help-check
+              with:
+                bins: python ${{vars.python}}
+            - name: Verify functioning JIT
+              runs: |
+                export PYTHON_JIT=1
+                ${{vars.python}} -c "
+                import sys
+                def fib(n):
+                    if n < 2:
+                        return n
+                    return fib(n-1) + fib(n-2)
+                result = fib(20)
+                print(f'JIT test: fib(20) = {result}')
+                assert result == 6765, f'Expected 6765, got {result}'
+                print('JIT test passed!')
+                "
 
   - name: "${{package.name}}-base"
     description: "${{package.name}} without /usr/bin/python3"
@@ -358,7 +436,6 @@ subpackages:
     description: "python3.14 development headers"
     dependencies:
       runtime:
-        - clang-${{vars.clang-version}}
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
@@ -377,7 +454,6 @@ subpackages:
     description: "python3 development headers"
     dependencies:
       runtime:
-        - clang-${{vars.clang-version}}
         - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - runs: |
@@ -406,18 +482,6 @@ test:
         python3 version-check.py ${{package.version}}
     - name: Verify working python3 -m venv
       runs: |
-        d=$(mktemp -d)
-        python3 -m venv "$d"
-        $d/bin/pip list
-        $d/bin/pip check
-        rm -Rf "$d"
-    - name: Verify functioning JIT
-      runs: |
-        export PYTHON_JIT=1
-        python3 jit-check.py
-    - name: (free-threaded) Verify working python3 -m venv
-      runs: |
-        export PYTHON_JIT=1
         d=$(mktemp -d)
         python3 -m venv "$d"
         $d/bin/pip list

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -41,7 +41,7 @@ environment:
       - zstd-dev
 
 vars:
-  clang-version: 19
+  clang-version: 21
   python-config: |
     --host=__host_triplet_gnu__ \
     --build=__host_triplet_gnu__ \
@@ -246,7 +246,7 @@ subpackages:
             with:
               opts: |
                 CC=clang-${{vars.clang-version}} \
-                --enable-experimental-jit=yes-off \
+                --enable-experimental-jit=yes \
                 --with-tail-call-interp \
                 ${{vars.python-config}}
           - uses: autoconf/make
@@ -297,7 +297,6 @@ subpackages:
                 bins: python ${{vars.python}}
             - name: Verify functioning JIT
               runs: |
-                export PYTHON_JIT=1
                 ${{vars.python}} -c "
                 import sys
                 def fib(n):

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -41,7 +41,7 @@ environment:
       - zstd-dev
 
 vars:
-  clang-version: 21
+  clang-version: 19
   python-config: |
     --host=__host_triplet_gnu__ \
     --build=__host_triplet_gnu__ \

--- a/python-3.14.yaml
+++ b/python-3.14.yaml
@@ -104,8 +104,8 @@ pipeline:
   - name: Clone patched source for no-GIL and JIT builds
     runs: |
       mkdir no-gil build-jit
-      tar -cf - --exclude=no-gil --exclude=build-jit . | (cd no-gil; tar -xf -)
-      tar -cf - --exclude=no-gil --exclude=build-jit . | (cd build-jit; tar -xf -)
+      tar -cf - --exclude=no-gil --exclude=build-jit . | tar -xC no-gil
+      tar -cf - --exclude=no-gil --exclude=build-jit . | tar -xC build-jit
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Make the default package build GCC based (removing the need for clang as
a dependency in the dev packages) and push the JIT enabled build into a
subpackage so that interested users can still try it.
