### PR TITLE
Return to iptables-wrappers due to evil "kubelets"

### DIFF
--- a/amazon-k8s-cni.yaml
+++ b/amazon-k8s-cni.yaml
@@ -1,13 +1,13 @@
 package:
   name: amazon-k8s-cni
   version: "1.21.1"
-  epoch: 1
+  epoch: 2
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - iptables-nft
+      - iptables-wrappers # amazon-k8s-cni *assumes* this, do not change
 
 environment:
   contents:


### PR DESCRIPTION
Reverting out of concern for breaking customers running on ancient, unsupported host systems in AWS.