### PR TITLE
daemon-check-output(fix(minio-operator): fix test by disabling STS an…

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -110,17 +110,20 @@ test:
     - name: Launch operator with dummy kubeconfig
       uses: test/daemon-check-output
       with:
-        setup: kubectl config view --minify --raw > /tmp/kubeconfig.yaml
-        start: ${{package.name}} controller --kubeconfig=/tmp/kubeconfig.yaml
+        setup: |
+          kubectl create namespace minio-operator
+          kubectl config view --minify --raw > /tmp/kubeconfig.yaml
+        start: env OPERATOR_STS_ENABLED=off ${{package.name}} controller --kubeconfig=/tmp/kubeconfig.yaml
         timeout: 30
         expected_output: |
           Starting MinIO Operator
           Setting up event handlers
           Using Kubernetes CSR Version: v1
-          Waiting for STS API to start
+          STS Api server is not enabled, not starting
           attempting to acquire leader lease minio-operator/minio-operator-lock...
-          Starting STS API server
+          Starting HTTP Upgrade Tenant Image server
         post: |
-          echo "Verifying metrics endpoint"
-          curl -sf http://127.0.0.1:8080/metrics > ${{package.name}}.log 2>&1
-          echo "Metrics endpoint is serving as expected"
+          echo "Verifying upgrade server endpoint"
+          wait-for-it -t 10 localhost:4221
+          # Curl the webhook endpoint - it will return 404 it will return a 404 (since we're not providing proper update data) but proves the server is responding
+          curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4221/webhook/v1/update | grep -q "404" && echo "Upgrade server is responding as expected"

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio-operator
   version: "7.1.1"
-  epoch: 6 # CVE-2025-61729
+  epoch: 7 # CVE-2025-61729
   description: Minio Operator creates/configures/manages Minio on Kubernetes
   copyright:
     - license: AGPL-3.0-only


### PR DESCRIPTION
…d checking correct port

The minio-operator test was failing because:

1. The test was trying to curl a metrics endpoint on port 8080 that doesn't exist - the MinIO operator doesn't expose a /metrics endpoint

2. The STS API server (port 4223) was blocking startup waiting for TLS certificates that would never be issued in the test environment

3. The minio-operator namespace was missing, causing leader election to fail

