### PR TITLE
daemon-check-output: fix(kubernetes-csi-external-health-monitor): remove unreachable metri…

### DIFF
--- a/kubernetes-csi-external-health-monitor.yaml
+++ b/kubernetes-csi-external-health-monitor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-health-monitor
   version: "0.16.0"
-  epoch: 3 # CVE-2025-61729
+  epoch: 4 # CVE-2025-61729
   description: CSI external health monitor controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -76,8 +76,3 @@ test:
           Failed to connect to the CSI driver
         error_strings: |
           Error:
-        post: |
-          echo "Verifying metrics endpoint"
-          wait-for-it http://127.0.0.1:8080 -t 5
-          curl -sf http://127.0.0.1:8080/metrics
-          echo "Metrics endpoint is serving as expected"


### PR DESCRIPTION
…cs endpoint test

The post script checking the metrics endpoint on port 8080 could never succeed because:

1. The metrics/HTTP endpoint is disabled by default - it requires explicitly passing --http-endpoint or --metrics-address flag

2. Even if enabled, the HTTP server only starts AFTER successfully connecting to a CSI driver socket at /run/csi/socket

3. The controller exits immediately when it fails to connect to the CSI driver, so no HTTP server ever starts in the test environment


