### PR TITLE
deamon-check-output: fix(pg_timetable): remove non-existent log file check

### DIFF
--- a/pg_timetable.yaml
+++ b/pg_timetable.yaml
@@ -1,7 +1,7 @@
 package:
   name: pg_timetable
   version: "6.2.0"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3 # CVE-2025-61729
   description: Advanced scheduling for PostgreSQL
   copyright:
     - license: PostgreSQL
@@ -155,9 +155,6 @@ test:
           Chain executed successfully
         post: |
           echo "Checking if task executed..."
-
-          # Print pg_timetable logs for debugging
-          cat /tmp/pg_timetable.log
 
           # Check execution log count
           RESULT=$(psql -U scheduler -d timetable -t -A -c "SELECT count(*) FROM timetable.execution_log;" | tr -d '[:space:]')


### PR DESCRIPTION
The test was failing trying to cat /tmp/pg_timetable.log which doesn't exist because pg_timetable logs to stdout, not to a file.

The log file check was unnecessary since the test already verifies task execution via expected_output and the database query on timetable.execution_log.
