### PR TITLE
deamon-check-output: fix(pgpool2_exporter): fix race condition in metrics check

### DIFF
--- a/pgpool2_exporter.yaml
+++ b/pgpool2_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgpool2_exporter
   version: "1.2.2"
-  epoch: 8 # CVE-2025-61729
+  epoch: 9 # CVE-2025-61729
   description: Prometheus exporter for Pgpool-II metrics.
   copyright:
     - license: MIT
@@ -113,7 +113,7 @@ test:
           Listening on address
         timeout: 10
         post: |
-          curl -sf http://localhost:${EXPORTER_PORT}/metrics > metrics.txt 2>&1 &
+          curl -sf http://localhost:${EXPORTER_PORT}/metrics > metrics.txt 2>&1
           grep -q "pgpool2_backend_used 1" metrics.txt
           grep -q "pgpool2_frontend_total 32" metrics.txt
           grep -q "pgpool2_up 1" metrics.txt


### PR DESCRIPTION
The curl command was running in the background with & which caused grep to run before the metrics.txt file was fully written.

Removed the background operator so curl completes before grep runs.
