### PR TITLE
deamon-check-output: fix(prometheus-pushgateway): add proper metric format for promtool va…

### DIFF
--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-pushgateway
   version: "1.11.2"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3 # CVE-2025-61729
   description: Push acceptor for ephemeral and batch jobs.
   copyright:
     - license: Apache-2.0
@@ -82,6 +82,7 @@ test:
       packages:
         - curl
         - wait-for-it
+        - prometheus
   pipeline:
     - name: "Basic binary verification"
       runs: |
@@ -102,12 +103,20 @@ test:
           wait-for-it localhost:9091 -t 30 -- curl -fsSL http://localhost:9091/-/ready | grep -q "OK"
           curl -fsSL http://localhost:9091/-/healthy | grep -q "OK"
 
-          # basic metrics push and verify
-          echo "test_metric 42" | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/test_job
+          # basic metrics push and verify (with proper HELP and TYPE for promtool)
+          cat <<EOF | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/test_job
+          # HELP test_metric A test metric for pushgateway
+          # TYPE test_metric gauge
+          test_metric 42
+          EOF
           curl -fsSL http://localhost:9091/metrics | promtool check metrics
 
           # pushing with labels and verify
-          echo "test_metric{label=\"value\"} 43" | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/test_job/instance/test_instance
+          cat <<EOF | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/test_job/instance/test_instance
+          # HELP test_metric A test metric for pushgateway
+          # TYPE test_metric gauge
+          test_metric{label="value"} 43
+          EOF
           curl -fsSL http://localhost:9091/metrics | promtool check metrics
 
           # DELETE functionality
@@ -115,7 +124,11 @@ test:
           curl -fsSL http://localhost:9091/metrics | grep -qv "test_metric{instance=\"test_instance\",job=\"test_job\",label=\"value\"}"
 
           # Test persistence
-          echo "persistent_metric 123" | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/persistent_job
+          cat <<EOF | curl -fsSL --data-binary @- http://localhost:9091/metrics/job/persistent_job
+          # HELP persistent_metric A persistent test metric
+          # TYPE persistent_metric gauge
+          persistent_metric 123
+          EOF
           curl -fsSL http://localhost:9091/metrics | promtool check metrics
 
           # Wait for persistence file to be created


### PR DESCRIPTION
…lidation

The test was failing because promtool check metrics requires proper HELP and TYPE comments for metrics.

Added proper Prometheus exposition format with HELP and TYPE comments to test metrics so promtool can validate the pushgateway output correctly.

Also added prometheus package dependency to provide promtool binary.
