### PR TITLE
deamon-check-output: fix(spicedb): use correct health endpoint path /healthz

### DIFF
--- a/spicedb.yaml
+++ b/spicedb.yaml
@@ -1,7 +1,7 @@
 package:
   name: spicedb
   version: "1.48.0"
-  epoch: 0 # CVE-2025-61729
+  epoch: 1 # CVE-2025-61729
   description: Open Source, Google Zanzibar-inspired fine-grained permissions database
   copyright:
     - license: Apache-2.0
@@ -135,7 +135,7 @@ test:
           http server started serving
         post: |
           wait-for-it "localhost:${HTTP_PORT}" -t 30
-          curl -fsSL "http://localhost:${HTTP_PORT}/health"
+          curl -fsSL "http://localhost:${HTTP_PORT}/healthz"
 
           wait-for-it "localhost:${METRICS_PORT}" -t 30
           curl -fsSL "http://localhost:${METRICS_PORT}/metrics" | grep -F -q "go_gc_duration_seconds"


### PR DESCRIPTION
The test was failing because SpiceDB exposes its health endpoint at /healthz, not /health.
