### PR TITLE
dask-kubernetes: update urllib3 to v2.6.3 to remediate CVE-2026-21441

### DIFF
--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -101,8 +101,8 @@ test:
         import: ${{vars.pypi-package}}
     - name: Verify urllib3 version and kubernetes metadata patch
       runs: |
-        # Verify urllib3 2.6.0 is installed
-        python${{vars.python-version}} -c "import urllib3; assert urllib3.__version__ == '2.6.0', f'Expected urllib3 2.6.0, got {urllib3.__version__}'"
+        # Verify urllib3 2.6.3 is installed
+        python${{vars.python-version}} -c "import urllib3; assert urllib3.__version__ == '2.6.3', f'Expected urllib3 2.6.0, got {urllib3.__version__}'"
 
         # Verify kubernetes metadata was patched to allow urllib3 2.6.0
         KUBE_METADATA=$(find /usr/share/dask-kubernetes/lib/python${{vars.python-version}}/site-packages -path "*/kubernetes-*.dist-info/METADATA" | head -1)

--- a/dask-kubernetes.yaml
+++ b/dask-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-kubernetes
   version: "2025.7.0"
-  epoch: 4
+  epoch: 5
   description: "Native Kubernetes integration for Dask"
   copyright:
     - license: "BSD-3-Clause"
@@ -53,8 +53,8 @@ pipeline:
       # GHSA-54jq-c3m8-4m76 GHSA-69f9-5gxw-wvc2 GHSA-6jhg-hg63-jvvf GHSA-6mq8-rvhq-8wgg GHSA-fh55-r93g-j68g GHSA-g84x-mcqj-x9qq GHSA-jj3x-wxrx-4x23 GHSA-mqqc-3gqh-h2x8
       pip install --upgrade "aiohttp==3.13.3"
 
-      # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37 and GHSA-gm62-xv2j-4w53
-      pip install --upgrade "urllib3==2.6.0"
+      # Upgrade urllib3 to fix GHSA-38jv-5279-wg99
+      pip install --upgrade "urllib3==2.6.3"
 
       # Patch kubernetes package metadata to allow urllib3 2.6.0
       # kubernetes package incorrectly constrains urllib3<2.4.0 but urllib3 2.6.0 is compatible


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-21441-->

