### PR TITLE
kube-proxy needs iptables-wrapper

### DIFF
--- a/kubernetes-1.34.yaml
+++ b/kubernetes-1.34.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.34
   version: "1.34.3"
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -201,8 +201,7 @@ subpackages:
     description: Kubernetes network proxy that runs on each node
     dependencies:
       runtime:
-        - ip6tables
-        - nftables
+        - iptables-wrappers
         - kmod
         - conntrack-tools
     pipeline:

--- a/kubernetes-1.35.yaml
+++ b/kubernetes-1.35.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.35
   version: "1.35.0"
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -195,8 +195,7 @@ subpackages:
     description: Kubernetes network proxy that runs on each node
     dependencies:
       runtime:
-        - ip6tables
-        - nftables
+        - iptables-wrappers
         - kmod
         - conntrack-tools
     pipeline:


### PR DESCRIPTION
Per discussion 2026-01-12, `kubes-proxy` needs `iptables-wrappers`.