### PR TITLE
kubeflow-katib: fix GHSA-38jv-5279-wg99 by updating urllib3 to 2.6.3

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-katib
   version: "0.19.0"
-  epoch: 2 # CVE-2025-61729
+  epoch: 3 # GHSA-38jv-5279-wg99
   description: Kubeflow Katib services
   copyright:
     - license: Apache-2.0
@@ -90,8 +90,8 @@ subpackages:
 
           export SUGGESTION_DIR="cmd/earlystopping/medianstop/v1beta1"
           .venv-earlystopping/bin/pip install -r $SUGGESTION_DIR/requirements.txt
-          # Fix GHSA-9hjg-9r4m-mvj7
-          .venv-earlystopping/bin/pip install --upgrade "requests>=2.32.4"
+          # Fix GHSA-9hjg-9r4m-mvj7, GHSA-38jv-5279-wg99
+          .venv-earlystopping/bin/pip install --upgrade "requests>=2.32.4" "urllib3>=2.6.3"
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR


### PR DESCRIPTION
## Summary
Fixes GHSA-38jv-5279-wg99 by updating urllib3 from 2.3.0 to 2.6.3 in the katib-earlystopping subpackage.

## Changes
- Updated katib-earlystopping pip install to explicitly upgrade urllib3 to >=2.6.3
- Incremented epoch to 3

## Vulnerability Details
**GHSA-38jv-5279-wg99**: Decompression-bomb safeguards bypassed when following HTTP redirects (streaming API)
- **Severity**: High
- **Component**: urllib3
- **Vulnerable**: >= 1.22, < 2.6.3
- **Fixed in**: 2.6.3

## Verification
Build and scan will confirm the vulnerability is resolved.

## References
- GHSA Advisory: https://github.com/advisories/GHSA-38jv-5279-wg99
- CVE Dashboard Issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/52866