### PR TITLE
kubeflow-volumes-web-app: fix GHSA-38jv-5279-wg99 by updating urllib3 to 2.6.3

### DIFF
--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: "1.10.0"
-  epoch: 6
+  epoch: 7
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -52,8 +52,8 @@ pipeline:
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip3 install --upgrade "requests>=2.32.4" --prefix=/usr --root="${{targets.destdir}}"
 
-      # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
-      pip3 install --upgrade "urllib3>=2.0.6" --prefix=/usr --root="${{targets.destdir}}"
+      # Upgrade urllib3 to fix GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53, GHSA-38jv-5279-wg99
+      pip3 install --upgrade "urllib3>=2.6.3" --prefix=/usr --root="${{targets.destdir}}"
 
       # Build the frontend common packages
       cd ../frontend/kubeflow-common-lib


### PR DESCRIPTION
## Summary
Fixes GHSA-38jv-5279-wg99 by updating urllib3 from 2.6.2 to 2.6.3.

## Changes
- Updated urllib3 version constraint from `>=2.0.6` to `>=2.6.3`
- Added GHSA-38jv-5279-wg99 to the comment listing fixed CVEs
- Incremented epoch to 7

## Vulnerability Details
**GHSA-38jv-5279-wg99**: Decompression-bomb safeguards bypassed when following HTTP redirects (streaming API)
- **Severity**: High
- **Component**: urllib3
- **Vulnerable**: >= 1.22, < 2.6.3
- **Fixed in**: 2.6.3

## Verification
Build and scan will confirm the vulnerability is resolved.

## References
- GHSA Advisory: https://github.com/advisories/GHSA-38jv-5279-wg99
- CVE Dashboard Issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/52902