### PR TITLE
fix(confluent-docker-utils): GHSA-38jv-5279-wg99

### DIFF
--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-docker-utils
   version: "0.0.163"
-  epoch: 0 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 1
   description: This package provides Docker Utility Belt (dub) and Confluent Platform Utility Belt (cub).
   copyright:
     - license: Apache-2.0
@@ -40,8 +40,8 @@ pipeline:
       # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638587228
       echo 'PyYAML==6.0.1' >> requirements.txt
 
-      # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v, GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
-      echo 'urllib3==2.6.0' >> requirements.txt
+      # urllib3: CVE-2025-50182 GHSA-48p4-8xcf-vxj5, CVE-2025-50181 GHSA-pq67-6m6q-mj2v, GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53 GHSA-38jv-5279-wg99
+      echo 'urllib3==2.6.3' >> requirements.txt
 
   - runs: |
       python3=python${{vars.python-version}}


### PR DESCRIPTION
Bump urllib3 to 2.6.3

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/52908

<!--ci-cve-scan:fail-any-->
