### PR TITLE
fix(emissary): GHSA-38jv-5279-wg99

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: "3.10.0"
-  epoch: 15 # GHSA-r6j8-c6r2-37rr
+  epoch: 16
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ pipeline:
       depth: -1 # Full history is required for version determination
 
   - runs: |
-      sed -i 's/^urllib3==2\.3\.0$/urllib3==2.6.0/' python/requirements.txt
+      sed -i 's/^urllib3==2\.3\.0$/urllib3==2.6.3/' python/requirements.txt
 
   # Go binaries
   - uses: go/bump


### PR DESCRIPTION
Bump urllib3 to 2.6.3

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/52886

<!--ci-cve-scan:fail-any-->
