### PR TITLE
chore(victoriametrics-operator): refactor output and symlinks

### DIFF
--- a/victoriametrics-operator.yaml
+++ b/victoriametrics-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-operator
   version: "0.66.1"
-  epoch: 1 # GHSA-66jq-2c23-2xh5
+  epoch: 2 # GHSA-66jq-2c23-2xh5
   description: Kubernetes operator for Victoria Metrics
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          output: config-reloader
+          output: app
           packages: ./cmd/config-reloader
     test:
       pipeline:
@@ -41,8 +41,8 @@ subpackages:
     description: compatibility symlinks package for victoriametrics-operator config-reloader Dockerfile
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}/app"
-          ln -sf ../usr/bin/config-reloader "${{targets.contextdir}}/app/config-reloader"
+          mkdir -p "${{targets.contextdir}}"
+          ln -sf ./usr/bin/app "${{targets.contextdir}}/app"
     test:
       environment:
         contents:
@@ -55,8 +55,8 @@ subpackages:
     description: compatibility symlinks package for victoriametrics-operator Dockerfile
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}/app"
-          ln -sf ../usr/bin/app "${{targets.contextdir}}/app/app"
+          mkdir -p "${{targets.contextdir}}"
+          ln -sf ./usr/bin/app "${{targets.contextdir}}/app"
     test:
       environment:
         contents:


### PR DESCRIPTION
```bash
$ crane config cgr.dev/chainguard-private/victoriametrics-operator | jq .config.Entrypoint
[
  "/app"
]

$ crane config victoriametrics/operator:config-reloader-v0.66.1 | jq .config.Entrypoint -r
[
  "/app"
]
```

matches the entrypoint per upstream and modifies the symlinks.
we want a mkdir over contextdir and then symlink at right place.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
