### PR TITLE
fix(pixi): Remediate GHSA-rhfx-m35p-ff5j by bumping lru

### DIFF
--- a/pixi.yaml
+++ b/pixi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pixi
   version: "0.62.2"
-  epoch: 0 # GHSA-j5gw-2vrg-8fgx
+  epoch: 1 # GHSA-rhfx-m35p-ff5j
   description: "Package management made easy"
   dependencies:
     runtime:
@@ -19,6 +19,10 @@ pipeline:
   - name: change the tracing-subscriber version to 0.3.19 instead of =0.3.19
     runs: |
       sed -E -i 's/^([[:space:]]*tracing-subscriber[[:space:]]*=[[:space:]]*")=([^"]*)"/\1\2"/' Cargo.toml
+
+  - name: Remediate GHSA-rhfx-m35p-ff5j
+    runs: |
+      cargo add lru@=0.16.3
 
   - uses: rust/cargobump
 


### PR DESCRIPTION
Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-rhfx-m35p-ff5j-->
