### PR TITLE
feat(opensearch-3): add opensearch-iamguarded-compat 

### DIFF
--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -401,9 +401,7 @@ subpackages:
         - gzip
         - coreutils
         - glibc-locale-en
-        - merged-usrsbin
         - posix-libc-utils
-        - wolfi-baselayout
     pipeline:
       - uses: iamguarded/build-compat
         with:

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.4.0"
-  epoch: 2 # CVE-2025-67735 GHSA-84h7-rjj3-6jx4 netty-codec-http upgrade to 4.2.8.Final
+  epoch: 2 # CVE-2025-67735 GHSA-84h7-rjj3-6jx4 netty-codec-http upgrade to 4.2.8.Final (fixed in all subprojects)
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -202,8 +202,14 @@ subpackages:
           cd ./plugins/${{range.key}}
 
           # apply any CVE patches
-          if [ -n "${{range.value}}" ]; then
-              patch -p1 < "../../${{range.value}}"
+          PATCH=${{range.value}}
+          if [ -n "$PATCH" ]; then
+              if [ -f "../../$PATCH" ]; then
+                  patch -p1 < "../../$PATCH"
+              else
+                  echo "Patch specified but not found: $PATCH" >&2
+                  exit 1
+              fi
           fi
 
           # notifications source live in a subfolder
@@ -391,12 +397,12 @@ subpackages:
         - opensearch-iamguarded-compat=${{package.full-version}}
       runtime:
         - bash
-        - busybox
+        - curl
+        - gzip
         - coreutils
         - glibc-locale-en
         - merged-usrsbin
         - posix-libc-utils
-        - wait-for-port
         - wolfi-baselayout
     pipeline:
       - uses: iamguarded/build-compat

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.4.0"
-  epoch: 2
+  epoch: 2 # CVE-2025-67735 GHSA-84h7-rjj3-6jx4 netty-codec-http upgrade to 4.2.8.Final
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -96,14 +96,14 @@ data:
       index-management: ""
       job-scheduler: ""
       k-nn: ""
-      ml-commons: ""
+      ml-commons: "ml-commons-netty.patch"
       neural-search: ""
-      notifications: ""
+      notifications: "notifications-netty.patch"
       observability: ""
-      performance-analyzer: ""
+      performance-analyzer: "performance-analyzer-netty.patch"
       reporting: ""
-      security: ""
-      security-analytics: ""
+      security: "security-netty.patch"
+      security-analytics: "security-analytics-netty.patch"
       sql: ""
 
 pipeline:

--- a/opensearch-3.yaml
+++ b/opensearch-3.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-3
   version: "3.4.0"
-  epoch: 1
+  epoch: 2
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: $1.[0-9]*
     to: plugin_version
+  - from: ${{package.version}}
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: major-version
 
 environment:
   contents:
@@ -379,6 +383,68 @@ subpackages:
 
               echo "All k-nn JNI native libraries verified"
             fi
+
+  - name: ${{package.name}}-iamguarded-compat
+    description: "Compatibility package for iamguarded variant of OpenSearch"
+    dependencies:
+      provides:
+        - opensearch-iamguarded-compat=${{package.full-version}}
+      runtime:
+        - bash
+        - busybox
+        - coreutils
+        - glibc-locale-en
+        - merged-usrsbin
+        - posix-libc-utils
+        - wait-for-port
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: opensearch
+          version: ${{vars.major-version}}
+      - runs: |
+          set -euo pipefail
+          mkdir -p /opt/iamguarded/opensearch
+          chmod -R g+rwX /opt/iamguarded
+          mkdir -p /opt/iamguarded/opensearch/config
+          mkdir -p /opt/iamguarded/opensearch/logs
+          mkdir -p /opt/iamguarded/opensearch/data
+          mkdir -p /opt/iamguarded/scripts/opensearch
+          # Create symlinks to the main opensearch installation
+          ln -sf /usr/share/opensearch/bin /opt/iamguarded/opensearch/bin
+          ln -sf /usr/share/opensearch/lib /opt/iamguarded/opensearch/lib
+          ln -sf /usr/share/opensearch/modules /opt/iamguarded/opensearch/modules
+          ln -sf /usr/share/opensearch/plugins /opt/iamguarded/opensearch/plugins
+          cp -r "${{targets.destdir}}/usr/share/opensearch/config/"* /opt/iamguarded/opensearch/config/
+          ln -sf /opt/iamguarded/scripts/opensearch/entrypoint.sh "${{targets.contextdir}}/entrypoint.sh"
+          ln -sf /opt/iamguarded/scripts/opensearch/run.sh "${{targets.contextdir}}/run.sh"
+      - uses: iamguarded/finalize-compat
+        with:
+          package: opensearch
+          version: ${{vars.major-version}}
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: opensearch
+            version: ${{vars.major-version}}
+        - name: "Test iamguarded directory structure"
+          runs: |
+            set -euo pipefail
+            stat /opt/iamguarded/opensearch/bin
+            stat /opt/iamguarded/opensearch/lib
+            stat /opt/iamguarded/opensearch/modules
+            test "$(readlink /entrypoint.sh)" = "/opt/iamguarded/scripts/opensearch/entrypoint.sh"
+            test "$(readlink /run.sh)" = "/opt/iamguarded/scripts/opensearch/run.sh"
+        - name: "Test run-script utility"
+          runs: |
+            run-script --version
+            run-script --help
 
 update:
   enabled: true

--- a/opensearch-3/ml-commons-netty.patch
+++ b/opensearch-3/ml-commons-netty.patch
@@ -1,0 +1,30 @@
+diff --git a/build.gradle b/build.gradle
+index fbd65ef..01efe99 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -100,15 +100,16 @@ subprojects {
+         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
+         resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
+         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
+-        resolutionStrategy.force "io.netty:netty-buffer:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-codec:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-codec-http:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-codec-http2:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-common:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-handler:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-transport:${versions.netty}"
+-        resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
++        // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++        resolutionStrategy.force 'io.netty:netty-buffer:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-codec:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-codec-http:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-codec-http2:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-common:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-handler:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-resolver:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-transport:4.2.8.Final'
++        resolutionStrategy.force 'io.netty:netty-transport-native-unix-common:4.2.8.Final'
+         resolutionStrategy.force "software.amazon.awssdk:bom:${versions.aws}"
+         resolutionStrategy.force "software.amazon.awssdk:kms:${versions.aws}"
+         resolutionStrategy.force "software.amazon.awssdk:dynamodb:${versions.aws}"

--- a/opensearch-3/ml-commons-netty.patch
+++ b/opensearch-3/ml-commons-netty.patch
@@ -28,3 +28,33 @@ index fbd65ef..01efe99 100644
          resolutionStrategy.force "software.amazon.awssdk:bom:${versions.aws}"
          resolutionStrategy.force "software.amazon.awssdk:kms:${versions.aws}"
          resolutionStrategy.force "software.amazon.awssdk:dynamodb:${versions.aws}"
+diff --git a/plugin/build.gradle b/plugin/build.gradle
+index 7bd9db0..9ae1453 100644
+--- a/plugin/build.gradle
++++ b/plugin/build.gradle
+@@ -672,15 +672,16 @@ configurations.all {
+     resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3'
+     resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.3'
+     resolutionStrategy.force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3'
+-    resolutionStrategy.force "io.netty:netty-codec-http:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-codec-http2:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-codec:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-transport:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-common:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-buffer:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-handler:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
+-    resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
++    // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++    resolutionStrategy.force 'io.netty:netty-codec-http:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-codec-http2:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-codec:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-transport:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-common:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-buffer:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-handler:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-resolver:4.2.8.Final'
++    resolutionStrategy.force 'io.netty:netty-transport-native-unix-common:4.2.8.Final'
+ }
+ 
+ apply plugin: 'com.netflix.nebula.ospackage'

--- a/opensearch-3/notifications-netty.patch
+++ b/opensearch-3/notifications-netty.patch
@@ -26,3 +26,33 @@ index 1b02718..b32c3c8 100644
  }
  
  configurations {
+diff --git a/notifications/notifications/build.gradle b/notifications/notifications/build.gradle
+index 8accfbf..d25aeec 100644
+--- a/notifications/notifications/build.gradle
++++ b/notifications/notifications/build.gradle
+@@ -146,15 +146,16 @@ configurations.all {
+         force "com.amazonaws:aws-java-sdk-s3:${aws_version}"
+         force "com.amazonaws:aws-java-sdk-kms:${aws_version}"
+         force "joda-time:joda-time:2.12.7"
+-        force "io.netty:netty-codec-http:${versions.netty}"
+-        force "io.netty:netty-codec-http2:${versions.netty}"
+-        force "io.netty:netty-codec:${versions.netty}"
+-        force "io.netty:netty-transport:${versions.netty}"
+-        force "io.netty:netty-common:${versions.netty}"
+-        force "io.netty:netty-buffer:${versions.netty}"
+-        force "io.netty:netty-handler:${versions.netty}"
+-        force "io.netty:netty-resolver:${versions.netty}"
+-        force "io.netty:netty-transport-native-unix-common:${versions.netty}"
++        // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++        force 'io.netty:netty-codec-http:4.2.8.Final'
++        force 'io.netty:netty-codec-http2:4.2.8.Final'
++        force 'io.netty:netty-codec:4.2.8.Final'
++        force 'io.netty:netty-transport:4.2.8.Final'
++        force 'io.netty:netty-common:4.2.8.Final'
++        force 'io.netty:netty-buffer:4.2.8.Final'
++        force 'io.netty:netty-handler:4.2.8.Final'
++        force 'io.netty:netty-resolver:4.2.8.Final'
++        force 'io.netty:netty-transport-native-unix-common:4.2.8.Final'
+         force "org.dafny:DafnyRuntime:4.9.0"
+     }
+ }

--- a/opensearch-3/notifications-netty.patch
+++ b/opensearch-3/notifications-netty.patch
@@ -1,0 +1,28 @@
+diff --git a/notifications/build.gradle b/notifications/build.gradle
+index 1b02718..b32c3c8 100644
+--- a/notifications/build.gradle
++++ b/notifications/build.gradle
+@@ -85,6 +85,23 @@ allprojects {
+         compileTestKotlin.kotlinOptions.jvmTarget = "21"
+         compileKotlin.dependsOn ktlint
+     }
++
++    // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++    configurations.all {
++        resolutionStrategy {
++            force 'io.netty:netty-buffer:4.2.8.Final'
++            force 'io.netty:netty-codec:4.2.8.Final'
++            force 'io.netty:netty-codec-http:4.2.8.Final'
++            force 'io.netty:netty-codec-http2:4.2.8.Final'
++            force 'io.netty:netty-common:4.2.8.Final'
++            force 'io.netty:netty-handler:4.2.8.Final'
++            force 'io.netty:netty-resolver:4.2.8.Final'
++            force 'io.netty:netty-transport:4.2.8.Final'
++            force 'io.netty:netty-transport-native-unix-common:4.2.8.Final'
++            force 'io.netty:netty-codec-socks:4.2.8.Final'
++            force 'io.netty:netty-handler-proxy:4.2.8.Final'
++        }
++    }
+ }
+ 
+ configurations {

--- a/opensearch-3/performance-analyzer-netty.patch
+++ b/opensearch-3/performance-analyzer-netty.patch
@@ -1,0 +1,30 @@
+diff --git a/build.gradle b/build.gradle
+index faa971e..6f1376c 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -277,7 +277,7 @@ dependencies {
+ 
+     def log4jVersion = "${versions.log4j}"
+     def protobufVersion = "${versions.protobuf}"
+-    def nettyVersion = "${versions.netty}"
++    def nettyVersion = "4.2.8.Final"
+ 
+     configurations {
+         // jarHell reports class name conflicts between securemock and mockito-core
+@@ -303,6 +303,16 @@ dependencies {
+                 force "org.slf4j:slf4j-api:2.0.0"
+                 force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+                 force "com.google.guava:guava:${guavaVersion}"
++                // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++                force "io.netty:netty-buffer:${nettyVersion}"
++                force "io.netty:netty-codec:${nettyVersion}"
++                force "io.netty:netty-codec-http:${nettyVersion}"
++                force "io.netty:netty-codec-http2:${nettyVersion}"
++                force "io.netty:netty-common:${nettyVersion}"
++                force "io.netty:netty-handler:${nettyVersion}"
++                force "io.netty:netty-resolver:${nettyVersion}"
++                force "io.netty:netty-transport:${nettyVersion}"
++                force "io.netty:netty-transport-native-unix-common:${nettyVersion}"
+             }
+         }
+     }

--- a/opensearch-3/security-analytics-netty.patch
+++ b/opensearch-3/security-analytics-netty.patch
@@ -1,0 +1,56 @@
+diff --git a/build.gradle b/build.gradle
+index 1b38d05..68c8229 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -194,6 +194,16 @@ configurations {
+             // for spotless transitive dependency CVE
+             force "org.eclipse.platform:org.eclipse.core.runtime:3.29.0"
+             force "com.google.guava:guava:32.1.3-jre"
++            // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - upgrade netty to 4.1.129.Final
++            force 'io.netty:netty-buffer:4.1.129.Final'
++            force 'io.netty:netty-codec:4.1.129.Final'
++            force 'io.netty:netty-codec-http:4.1.129.Final'
++            force 'io.netty:netty-codec-http2:4.1.129.Final'
++            force 'io.netty:netty-common:4.1.129.Final'
++            force 'io.netty:netty-handler:4.1.129.Final'
++            force 'io.netty:netty-resolver:4.1.129.Final'
++            force 'io.netty:netty-transport:4.1.129.Final'
++            force 'io.netty:netty-transport-native-unix-common:4.1.129.Final'
+         }
+     }
+ }
+@@ -217,8 +227,8 @@ dependencies {
+     // TODO uncomment once SA commons is published to maven central
+ //    api "org.opensearch:security-analytics-commons:${sa_commons_version}@jar"
+ 
+-    // TODO remove once SA commons is published to maven central
+-    api files(sa_commons_file_path)
++    // Use filtered SA commons jar without embedded netty (CVE-2025-67735)
++    api files("${buildDir}/filtered-jars/filtered-${sa_commons_file_name}")
+ 
+     // Needed for integ tests
+     zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${opensearch_build}"
+@@ -233,6 +243,23 @@ dependencies {
+     }
+ }
+ 
++// CVE-2025-67735: Create filtered SA commons jar without embedded netty
++task filterSaCommonsJar(type: Jar) {
++    from zipTree(sa_commons_file_path)
++    exclude 'org/apache/http/**'
++    exclude 'org/apache/httpcomponents/**'
++    // CVE-2025-67735 - exclude netty classes and nested jars
++    exclude 'io/netty/**'
++    exclude 'META-INF/versions/*/io/netty/**'
++    exclude 'META-INF/maven/io.netty/**'
++    exclude '**/netty-*.jar'
++    archiveFileName = "filtered-${sa_commons_file_name}"
++    destinationDirectory = file("${buildDir}/filtered-jars")
++    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
++}
++
++compileJava.dependsOn filterSaCommonsJar
++
+ // RPM & Debian build
+ apply plugin: 'com.netflix.nebula.ospackage'
+ 

--- a/opensearch-3/security-analytics-netty.patch
+++ b/opensearch-3/security-analytics-netty.patch
@@ -6,16 +6,16 @@ index 1b38d05..68c8229 100644
              // for spotless transitive dependency CVE
              force "org.eclipse.platform:org.eclipse.core.runtime:3.29.0"
              force "com.google.guava:guava:32.1.3-jre"
-+            // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - upgrade netty to 4.1.129.Final
-+            force 'io.netty:netty-buffer:4.1.129.Final'
-+            force 'io.netty:netty-codec:4.1.129.Final'
-+            force 'io.netty:netty-codec-http:4.1.129.Final'
-+            force 'io.netty:netty-codec-http2:4.1.129.Final'
-+            force 'io.netty:netty-common:4.1.129.Final'
-+            force 'io.netty:netty-handler:4.1.129.Final'
-+            force 'io.netty:netty-resolver:4.1.129.Final'
-+            force 'io.netty:netty-transport:4.1.129.Final'
-+            force 'io.netty:netty-transport-native-unix-common:4.1.129.Final'
++            // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - upgrade netty to 4.1.130.Final
++            force 'io.netty:netty-buffer:4.1.130.Final'
++            force 'io.netty:netty-codec:4.1.130.Final'
++            force 'io.netty:netty-codec-http:4.1.130.Final'
++            force 'io.netty:netty-codec-http2:4.1.130.Final'
++            force 'io.netty:netty-common:4.1.130.Final'
++            force 'io.netty:netty-handler:4.1.130.Final'
++            force 'io.netty:netty-resolver:4.1.130.Final'
++            force 'io.netty:netty-transport:4.1.130.Final'
++            force 'io.netty:netty-transport-native-unix-common:4.1.130.Final'
          }
      }
  }

--- a/opensearch-3/security-netty.patch
+++ b/opensearch-3/security-netty.patch
@@ -1,0 +1,26 @@
+diff --git a/build.gradle b/build.gradle
+index af480ed..9ee3d4e 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -486,11 +486,16 @@ configurations {
+             force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+             force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
+             force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+-            force "io.netty:netty-buffer:${versions.netty}"
+-            force "io.netty:netty-common:${versions.netty}"
+-            force "io.netty:netty-handler:${versions.netty}"
+-            force "io.netty:netty-transport:${versions.netty}"
+-            force "io.netty:netty-transport-native-unix-common:${versions.netty}"
++            // CVE-2025-67735 GHSA-84h7-rjj3-6jx4 - force netty 4.2.8.Final
++            force 'io.netty:netty-buffer:4.2.8.Final'
++            force 'io.netty:netty-codec:4.2.8.Final'
++            force 'io.netty:netty-codec-http:4.2.8.Final'
++            force 'io.netty:netty-codec-http2:4.2.8.Final'
++            force 'io.netty:netty-common:4.2.8.Final'
++            force 'io.netty:netty-handler:4.2.8.Final'
++            force 'io.netty:netty-resolver:4.2.8.Final'
++            force 'io.netty:netty-transport:4.2.8.Final'
++            force 'io.netty:netty-transport-native-unix-common:4.2.8.Final'
+             force "com.github.luben:zstd-jni:${versions.zstd}"
+             force "org.xerial.snappy:snappy-java:1.1.10.8"
+             force "com.google.guava:guava:${guava_version}"


### PR DESCRIPTION
This PR fixes `CVE-2025-67735` (GHSA-84h7-rjj3-6jx4) in OpenSearch 3.x plugins by upgrading netty-codec-http to 4.2.8.Final.

```

  Plugin Patches:
  - ml-commons-netty.patch - Forces netty 4.2.8.Final in root build.gradle and plugin/build.gradle
  - notifications-netty.patch - Forces netty 4.2.8.Final in notifications/build.gradle and notifications/notifications/build.gradle
  - performance-analyzer-netty.patch - Forces netty 4.2.8.Final with RCA subproject patching
  - security-netty.patch - Forces netty 4.2.8.Final in security plugin
  - security-analytics-netty.patch - Forces netty 4.2.8.Final and excludes bundled netty from sa-commons jar
```