### PR TITLE
glibc: split posix-libc-utils to remove bash dependency

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -383,6 +383,8 @@ subpackages:
           with:
             bins: ldd
 
+  # splitting posix-libc-utils binaries that don't require bash into their own subpackage
+  # lets us use these binaries without adding an unnecessary bash dependency
   - name: "posix-libc-utils-bin"
     description: "POSIX XCU utilities included with the C library (excluding ldd)"
     dependencies:

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.42"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 4
+  epoch: 5
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -365,6 +365,29 @@ subpackages:
       runtime:
         - bash
         - glibc=${{package.full-version}}
+        - posix-libc-utils-bin
+        - merged-lib
+        - merged-sbin
+        - merged-usrsbin
+        - wolfi-baselayout
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/ldd "${{targets.subpkgdir}}"/usr/bin
+    test:
+      pipeline:
+        - uses: test/tw/help-check
+          with:
+            bins: ldd
+        - uses: test/tw/ver-check
+          with:
+            bins: ldd
+
+  - name: "posix-libc-utils-bin"
+    description: "POSIX XCU utilities included with the C library (excluding ldd)"
+    dependencies:
+      runtime:
+        - glibc=${{package.full-version}}
         - merged-lib
         - merged-sbin
         - merged-usrsbin
@@ -376,27 +399,29 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/getconf "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/getent "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/iconv "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/ldd "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/locale "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/pldd "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/libexec "${{targets.subpkgdir}}"/usr
     test:
       pipeline:
-        - runs: |
-            gencat --version
-            gencat --help
-            getconf --version
-            getconf --help
-            getent --version
-            getent --help
-            iconv --version
-            iconv --help
-            ldd --version
-            ldd --help
-            locale --version
-            locale --help
-            pldd --version
-            pldd --help
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              gencat
+              getconf
+              getent
+              iconv
+              locale
+              pldd
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              gencat
+              getconf
+              getent
+              iconv
+              locale
+              pldd
 
   - name: "localedef"
     description: "Tool for defining GLIBC locales"

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -365,7 +365,7 @@ subpackages:
       runtime:
         - bash
         - glibc=${{package.full-version}}
-        - posix-libc-utils-bin
+        - posix-libc-utils-bin=${{package.full-version}}
         - merged-lib
         - merged-sbin
         - merged-usrsbin


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

- Related: https://github.com/chainguard-dev/internal-dev/issues/25114

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
