### PR TITLE
llvm-19: Create llvm-19-bpf subpackage

### DIFF
--- a/llvm-19.yaml
+++ b/llvm-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-19
   version: "19.1.7"
-  epoch: 14
+  epoch: 15
   description: Low-level virtual machine ${{vars.major-version}} - core frameworks
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,11 @@ pipeline:
       patches: |
         fix-build-glibc-2.42-01.patch
         fix-build-glibc-2.42-02.patch
+
+  - name: Clone patched source for BPF build
+    runs: |
+      mkdir bpf-build
+      tar cf - --exclude=bpf-build . | tar xC bpf-build
 
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
@@ -426,6 +431,96 @@ subpackages:
             clang-pseudo --help
             nvptx-arch --version
             nvptx-arch --help
+
+  - name: ${{package.name}}-bpf
+    description: Low-level virtual machine ${{vars.major-version}} - core frameworks - BPF variant
+    pipeline:
+      - working-directory: bpf-build
+        pipeline:
+          - name: Configure and compile BPF build
+            runs: |
+              cmake -B output -G Ninja -S llvm -Wno-dev \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=${{vars.llvm-prefix}} \
+              -DCMAKE_PREFIX_PATH=${{vars.llvm-prefix}} \
+              -DENABLE_LINKER_BUILD_ID=ON \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DLLVM_BUILD_DOCS=OFF \
+              -DLLVM_BUILD_EXAMPLES=OFF \
+              -DLLVM_BUILD_EXTERNAL_COMPILER_RT=OFF \
+              -DLLVM_BUILD_LLVM_DYLIB=OFF \
+              -DLLVM_BUILD_TESTS=OFF \
+              -DLLVM_INCLUDE_TESTS=OFF \
+              -DLLVM_DEFAULT_TARGET_TRIPLE="${{build.arch}}-unknown-linux-gnu" \
+              -DLLVM_BUILD_STATIC=ON \
+              -DLLVM_BUILD_RUNTIME=OFF \
+              -DLLVM_ENABLE_ASSERTIONS=OFF \
+              -DLLVM_ENABLE_FFI=OFF \
+              -DLLVM_ENABLE_LIBCXX=OFF \
+              -DLLVM_ENABLE_PIC=OFF \
+              -DLLVM_ENABLE_PROJECTS="clang" \
+              -DLLVM_TARGETS_TO_BUILD="BPF" \
+              -DLLVM_ENABLE_RTTI=OFF \
+              -DLLVM_ENABLE_SPHINX=OFF \
+              -DLLVM_ENABLE_TERMINFO=OFF \
+              -DLLVM_ENABLE_ZLIB=ON \
+              -DLLVM_INSTALL_UTILS=OFF \
+              -DLLVM_HOST_TRIPLE="${{build.arch}}-unknown-linux-gnu" \
+              -DLLVM_INCLUDE_EXAMPLES=OFF \
+              -DLLVM_LINK_LLVM_DYLIB=OFF \
+              -DLLVM_APPEND_VC_REV=OFF \
+              -DLLVM_INCLUDE_BENCHMARKS=OFF \
+              -DCLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang-${{vars.major-version}} \
+              -DCLANG_ENABLE_ARCMT=OFF \
+              -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+              -DCLANG_LINK_CLANG_DYLIB=OFF \
+              -DCLANG_PLUGIN_SUPPORT=OFF \
+              -DCLANG_VENDOR=Wolfi
+
+              cd output
+              ninja clang llc llvm-objcopy llvm-strip
+          - name: Install BPF toolchaing
+            runs: |
+              mkdir -p ${{targets.contextdir}}/usr/bin
+              mkdir -p ${{targets.contextdir}}/${{vars.llvm-prefix}}/bin
+              mkdir -p ${{targets.contextdir}}/${{vars.clang-prefix}}/bin
+
+              # Install the LLVM binaries
+              for llvm_bin in llc llvm-objcopy llvm-strip; do
+                mv output/bin/"${llvm_bin}" ${{targets.contextdir}}/${{vars.llvm-prefix}}/bin/
+                ln -s ../lib/llvm-${{vars.major-version}}/bin/"${llvm_bin}" ${{targets.contextdir}}/usr/bin/"${llvm_bin}"
+              done
+
+              # Install the clang binaries
+              for clang_bin in clang; do
+                mv output/bin/"${clang_bin}-${{vars.major-version}}" ${{targets.contextdir}}/${{vars.clang-prefix}}/bin
+                ln -s "${clang_bin}-${{vars.major-version}}" ${{targets.contextdir}}/${{vars.clang-prefix}}/bin/"${clang_bin}"
+
+                ln -s ../lib/llvm-${{vars.major-version}}/lib/clang/${{vars.major-version}}/bin/"${clang_bin}-${{vars.major-version}}" ${{targets.contextdir}}/usr/bin/"${clang_bin}-${{vars.major-version}}"
+                ln -s ../lib/llvm-${{vars.major-version}}/lib/clang/${{vars.major-version}}/bin/"${clang_bin}" ${{targets.contextdir}}/usr/bin/"${clang_bin}"
+              done
+
+              # Create symlinks for the clang variants
+              for clang_ext in "++" "-cl" "-cpp"; do
+                ln -s "clang-${{vars.major-version}}" ${{targets.contextdir}}/${{vars.clang-prefix}}/bin/"clang${clang_ext}"
+              done
+          - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/ver-check
+          with:
+            bins: |
+              clang
+              llc
+              llvm-objcopy
+              llvm-strip
+        - uses: test/tw/help-check
+          with:
+            bins: |
+              clang
+              llc
+              llvm-objcopy
+              llvm-strip
 
   - name: lld-${{vars.major-version}}
     description: LLVM linker


### PR DESCRIPTION
This subpackage is a stripped down build of LLVM with only the BPF
target enabled.  Some of our images require only a BPF-capable LLVM,
which doesn't need to ship with standard libs and other tooling.
Having a BPF-only variant of LLVM allows us to decrease image sizes
substantially.