### PR TITLE
chore: remove argocd-repo-server subpackage

### DIFF
--- a/argo-cd-3.2.yaml
+++ b/argo-cd-3.2.yaml
@@ -13,10 +13,10 @@ package:
       - gnupg
       - gpg
       - gpg-agent
-      - tzdata
       - helm~3
       - kustomize
       - openssh
+      - tzdata
     provides:
       - argo-cd=${{package.full-version}}
 

--- a/argo-cd-3.2.yaml
+++ b/argo-cd-3.2.yaml
@@ -6,6 +6,17 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
+    runtime:
+      - ${{package.name}}-compat
+      - git
+      - git-lfs
+      - gnupg
+      - gpg
+      - gpg-agent
+      - tzdata
+      - helm~3
+      - kustomize
+      - openssh
     provides:
       - argo-cd=${{package.full-version}}
 
@@ -61,40 +72,16 @@ pipeline:
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-commit-server
 
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      cp hack/gpg-wrapper.sh "${{targets.contextdir}}"/usr/bin/gpg-wrapper.sh
+      cp hack/git-verify-wrapper.sh "${{targets.contextdir}}"/usr/bin/git-verify-wrapper.sh
+      cp entrypoint.sh "${{targets.contextdir}}"/usr/bin/uid_entrypoint.sh
+      mkdir -p "${{targets.contextdir}}"/etc/ssh
+      touch "${{targets.contextdir}}"/etc/ssh/ssh_known_hosts
+
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-repo-server
-    description: "ArgoCD repo server"
-    dependencies:
-      runtime:
-        - ${{package.name}}-compat
-        - git
-        - git-lfs
-        - gnupg
-        - gpg
-        - gpg-agent
-        - tzdata
-        - helm~3
-        - kustomize
-        - openssh
-      provides:
-        - argo-cd-repo-server=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
-          cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
-          cp entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/uid_entrypoint.sh
-          mkdir -p "${{targets.contextdir}}"/etc/ssh
-          touch "${{targets.contextdir}}"/etc/ssh/ssh_known_hosts
-    test:
-      pipeline:
-        - uses: test/virtualpackage
-          with:
-            virtual-pkg-name: argo-cd-repo-server
-            real-pkg-name: ${{subpkg.name}}
-
   - name: ${{package.name}}-compat
     description: "Compatibility package for locating binaries according to upstream helm charts"
     pipeline:

--- a/argo-cd-3.2.yaml
+++ b/argo-cd-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-3.2
   version: "3.2.4"
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
follow-up after images, this removes argocd-repo-server
subpackage and then moves the runs steps to main package
including the runtime dependencies.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
