### PR TITLE
langfuse-3: update @smithy/config-resolver to v4.4.0 to remediate GHSA-6475-r3vj-m8vf

### DIFF
--- a/langfuse-3.yaml
+++ b/langfuse-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: langfuse-3
   version: "3.146.0"
-  epoch: 0 # GHSA-6rw7-vpxm-498p
+  epoch: 1 # GHSA-6475-r3vj-m8vf
   description: "Langfuse webapp"
   copyright:
     - license: "MIT"
@@ -88,6 +88,7 @@ pipeline:
         "pnpm.overrides.js-yaml=^4.1.1" \
         "pnpm.overrides.mdast-util-to-hast=^13.2.1" \
         "pnpm.overrides.@modelcontextprotocol/sdk=^1.25.2" \
+        "pnpm.overrides.@smithy/config-resolver=^4.4.0" \
         "pnpm.overrides.jws=^4.0.1" \
         "pnpm.overrides.qs=^6.14.1"
 


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: GHSA-6475-r3vj-m8vf->

