### PR TITLE
ffmpeg-8.0: bump epoch to 1

### DIFF
--- a/ffmpeg-8.0.yaml
+++ b/ffmpeg-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ffmpeg-8.0
   version: "8.0.1"
-  epoch: 0
+  epoch: 1
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later


### PR DESCRIPTION
Must be bumped in lock-step with the ffmpeg-fips-8.0 package.