### PR TITLE
fix(emissary): Remediate GHSA-87hc-h4r5-73f7 by bumping werkzeug

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: "3.10.0"
-  epoch: 16
+  epoch: 17 # GHSA-87hc-h4r5-73f7
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -41,8 +41,11 @@ pipeline:
       expected-commit: d25610acbea3cd0e57f924f9f6bd9df99a7e33a3
       depth: -1 # Full history is required for version determination
 
-  - runs: |
+  - name: Bump dependencies to resolve vulnerabilities
+    runs: |
       sed -i 's/^urllib3==2\.3\.0$/urllib3==2.6.3/' python/requirements.txt
+      # GHSA-87hc-h4r5-73f7
+      sed -i 's/^werkzeug==3\.1\.3$/werkzeug==3.1.5/' python/requirements.txt
 
   # Go binaries
   - uses: go/bump


### PR DESCRIPTION
Signed-off-by: Ankush Pathak <ankush.pathak@chainguard.dev>

<!--ci-cve-scan:must-fix: GHSA-87hc-h4r5-73f7-->
