### PR TITLE
chore(opensearch-dashboards-3): refactor dep version bumps

### DIFF
--- a/opensearch-dashboards-3.yaml
+++ b/opensearch-dashboards-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-3
   version: "3.4.0" # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 0
+  epoch: 1
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -85,28 +85,14 @@ pipeline:
       resolutions='{"node-forge": "^1.3.2"}'
       jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
-      # fix CVE-2023-28155
-      devDependencies='{"cypress": "^13.17.0"}'
+      # devDependencies block
+      # fix CVE-2023-28155, CVE-2025-9288, CVE-2025-9287
+      devDependencies='{"cypress": "^13.17.0", "sha.js": "^2.4.12", "cipher-base": "^1.0.5"}'
       jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
 
-      # fix CVE-2025-9288
-      devDependencies='{"sha.js": "^2.4.12"}'
-      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
-
-      # fix CVE-2025-9287
-      devDependencies='{"cipher-base": "^1.0.5"}'
-      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
-
-      # fix High CVE-2025-15284 (GHSA-6rw7-vpxm-498p)
-      dependencies='{"qs": "^6.14.1"}'
-      jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-      # fix CVE-2025-54798 (GHSA-52f5-9888-hmc6)
-      dependencies='{"tmp": "^0.2.4"}'
-      jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-      # fix CVE-2025-57352 (GHSA-rx8g-88g5-qh64)
-      dependencies='{"min-document": "^2.19.1"}'
+      # dependencies block
+      # fix CVE-2025-54798 (GHSA-52f5-9888-hmc6), CVE-2025-57352 (GHSA-rx8g-88g5-qh64)
+      dependencies='{"tmp": "^0.2.4", "min-document": "^2.19.1", "@smithy/config-resolver": "^4.4.0"}'
       jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
 
       yarn osd bootstrap --allow-root
@@ -154,30 +140,18 @@ subpackages:
       - runs: |
           cd ./plugins/${{range.value}}
 
+          # resolutions block
           # fix CVE-2025-27789, CVE-2025-25977, CVE-2025-5889, CVE-2025-6545, CVE-2025-7783
           resolutions='{"@babel/runtime": "^7.26.10", "canvg": "^4.0.3", "brace-expansion": "1.1.12", "pbkdf2": "3.1.3", "form-data": "4.0.4"}'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
 
+          # already existing dependencies
           # CVE-2025-7783
           jq '.dependencies["form-data"] = "4.0.4"' package.json > temp.json && mv temp.json package.json
 
-          dependencies='{"cypress": "^13.17.0"}'
-          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-          # fix CVE-2025-68428 (GHSA-f8cm-6447-x5h2)
-          dependencies='{"jspdf": "^4.0.0"}'
-          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-          # fix CVE-2025-15284 (GHSA-6rw7-vpxm-498p)
-          dependencies='{"qs": "^6.14.1"}'
-          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-          # fix CVE-2025-54798 (GHSA-52f5-9888-hmc6)
-          dependencies='{"tmp": "^0.2.4"}'
-          jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
-
-          # fix CVE-2025-57352 (GHSA-rx8g-88g5-qh64)
-          dependencies='{"min-document": "^2.19.1"}'
+          # add dependencies
+          # bump cypress, fix CVE-2025-68428 (GHSA-f8cm-6447-x5h2), CVE-2025-15284 (GHSA-6rw7-vpxm-498p), fix CVE-2025-54798 (GHSA-52f5-9888-hmc6), CVE-2025-57352 (GHSA-rx8g-88g5-qh64)
+          dependencies='{"cypress": "^13.17.0", "jspdf": "^4.0.0", "qs": "^6.14.1", "tmp": "^0.2.4", "min-document": "^2.19.1"}'
           jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
 
           yarn osd bootstrap --allow-root 2>/dev/null


### PR DESCRIPTION
For easier reading, group package version bumps by where they're located or added.

<!--ci-cve-scan:fail-any-->
