### PR TITLE
mlflow: update werkzeug to v3.1.5 to remediate CVE-2026-21860

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: "3.8.1"
-  epoch: 1 # GHSA-38jv-5279-wg99
+  epoch: 2 # GHSA-87hc-h4r5-73f7
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -83,8 +83,8 @@ pipeline:
       # Upgrade fonttools to fix GHSA-768j-98cg-p3fv
       pip install --upgrade "fonttools>=4.60.2"
 
-      # Upgrade werkzeug to fix GHSA-hgf8-39gv-g3f2
-      pip install --upgrade "werkzeug>=3.1.4"
+      # Upgrade werkzeug to fix GHSA-87hc-h4r5-73f7
+      pip install --upgrade "werkzeug>=3.1.5"
 
       # Upgrade urllib3 to fix GHSA-38jv-5279-wg99
       pip install --upgrade "urllib3>=2.6.3"


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-21860-->
