### PR TITLE
Bump abseil-cpp epoch to build 2.28 package

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20260107.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We added abseil-cpp to the 2.28 builder in https://github.com/chainguard-dev/mono/pull/30336 ... now we need to build it for 2.28.