### PR TITLE
strimzi-kafka-operator: fix GHSA-3677-xxcr-wjqv

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: "0.49.1"
-  epoch: 4 # GHSA-84h7-rjj3-6jx4
+  epoch: 5 # GHSA-3677-xxcr-wjqv
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/strimzi-kafka-operator/pombump-deps-cc.yaml
+++ b/strimzi-kafka-operator/pombump-deps-cc.yaml
@@ -31,7 +31,7 @@ patches:
     version: 3.9.4
   - groupId: org.bitbucket.b_c
     artifactId: jose4j
-    version: 0.9.5
+    version: 0.9.6
   - groupId: org.apache.logging.log4j
     artifactId: log4j-core
     version: 2.25.3

--- a/strimzi-kafka-operator/pombump-deps.yaml
+++ b/strimzi-kafka-operator/pombump-deps.yaml
@@ -11,3 +11,6 @@ patches:
   - groupId: io.netty
     artifactId: netty-codec-http
     version: 4.2.8.Final
+  - groupId: org.bitbucket.b_c
+    artifactId: jose4j
+    version: 0.9.6


### PR DESCRIPTION
## Summary
- Bump jose4j to 0.9.6 to fix GHSA-3677-xxcr-wjqv

This is a re-creation of #77926 which was closed.