### PR TITLE
ruby-4.0: Fix tag-filter-prefix

### DIFF
--- a/ruby-4.0.yaml
+++ b/ruby-4.0.yaml
@@ -145,14 +145,11 @@ subpackages:
 
 update:
   enabled: true
-  version-transform:
-    - match: "_"
-      replace: .
   github:
     identifier: ruby/ruby
     strip-prefix: v
     use-tag: true
-    tag-filter-prefix: v4_0_
+    tag-filter-prefix: v4.0
 
 test:
   environment:


### PR DESCRIPTION
Upstream uses `v4.0...` instead of `v4_0_...`.