### PR TITLE
Add MCP subpackage to DFC

### DIFF
--- a/dfc.yaml
+++ b/dfc.yaml
@@ -1,7 +1,7 @@
 package:
   name: dfc
   version: "0.10.0"
-  epoch: 0 # CVE-2025-61725
+  epoch: 1 # CVE-2025-61725
   description: Convert Dockerfiles to use Chainguard
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,32 @@ test:
     - runs: |
         dfc --version
         dfc --help
+
+subpackages:
+  - name: dfc-mcp-server
+    description: DFC MCP Server - Convert Dockerfiles to Chainguard via MCP
+    pipeline:
+      # Remove the replace directive and use the actual dfc module version
+      - runs: |
+          cd mcp-server
+          sed -i '/^replace github.com\/chainguard-dev\/dfc/d' go.mod
+          go mod edit -require github.com/chainguard-dev/dfc@v${{package.version}}
+          go mod tidy
+      - uses: go/build
+        with:
+          modroot: ./mcp-server
+          packages: .
+          output: dfc-mcp-server
+          ldflags: |
+            -X main.Version=v${{package.version}}
+    test:
+      pipeline:
+        - name: Test MCP server starts
+          runs: |
+            # MCP servers run via stdio - verify it initializes then terminate
+            output=$(timeout 2 dfc-mcp-server 2>&1 || true)
+            echo "$output"
+            echo "$output" | grep -q "MCP server initialization complete"
 
 update:
   enabled: true


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/issues/78234

Related: https://github.com/chainguard-dev/dfc/issues/114

  ## Summary
  Adds `dfc-mcp-server` as a subpackage to the existing `dfc` package. This packages the MCP server component from the `mcp-server/` directory in the dfc repository.

  ## Changes
  - Added `dfc-mcp-server` subpackage
  - Incremented epoch (0 → 1) for adding subpackage without version bump
  - Subpackage removes the `replace` directive in go.mod and builds against the released dfc module

  ## Test plan
  - [x] Built successfully with QEMU
  - [x] Built successfully with Docker
  - [x] Tests pass (verifies MCP server initializes correctly)

  ## Checklist
  None of the special-case checklists apply - this is a subpackage addition to an existing package.


**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

