### PR TITLE
feat(datadog-agent): add msodbcsql18 to datadog-agent

### DIFF
--- a/datadog-agent-7.72.yaml
+++ b/datadog-agent-7.72.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.72.4"
-  epoch: 5
+  epoch: 6
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -18,9 +18,11 @@ package:
       - blkid
       - findutils
       - grep
+      - krb5 # Required by msodbcsql18 for Kerberos authentication
       - libpcap
       - libseccomp
       - shadow
+      - unixodbc # ODBC driver manager required by msodbcsql18
 
 capabilities:
   add:
@@ -29,6 +31,10 @@ capabilities:
 vars:
   python-version: "3.12"
   destd: /opt/datadog-agent
+  # Microsoft ODBC Driver 18 for SQL Server - required for SQL Server integration
+  # When upgrading datadog-agent, check the version used in the omnibus build:
+  # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  msodbcsql18-version: "18.3.3.1-1"
 
 var-transforms:
   - from: ${{package.version}}
@@ -46,6 +52,16 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  # Transform msodbcsql18-version (e.g., "18.3.3.1-1") to library suffix (e.g., "18.3.so.3.1")
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.(\d+\.\d+)-\d+$
+    replace: "$1.so.$2"
+    to: msodbcsql18-libsuffix
+  # Extract major.minor version (e.g., "18.3.3.1-1" -> "18.3") for symlink naming
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.\d+\.\d+-\d+$
+    replace: "$1"
+    to: msodbcsql18-major-minor
 
 environment:
   contents:
@@ -63,6 +79,7 @@ environment:
       # - clang-16-dev
       - cmake
       - coreutils
+      - curl
       - dpkg
       - elfutils-dev
       - findutils
@@ -82,10 +99,12 @@ environment:
       - linux-headers
       - ninja
       - openssf-compiler-options
+      - patchelf # Required to patch RPATH of msodbcsql18 library
       - procps-dev
       - py${{vars.python-version}}-build-base-dev
       - py${{vars.python-version}}-semver
       - systemd-dev
+      - unixodbc-dev # Required to build with ODBC support for SQL Server integration
       - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian
   environment:
@@ -341,6 +360,48 @@ pipeline:
       # Install trace-loader binary
       install -Dm755 bin/trace-loader/trace-loader ${{targets.contextdir}}${{vars.destd}}/embedded/bin/trace-loader
 
+  # Install Microsoft ODBC Driver 18 for SQL Server integration
+  # Version and SHA256 hashes sourced from the omnibus build configuration.
+  # When upgrading, check: https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb
+      expected-sha256: 37e692b1517f1229042c743d0f2a7191e0dcb956bbc3785a895aaa6dc328467e
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb
+      expected-sha256: f91004ce72fcd92e686154f90e2a80f4f86469e7cb5f42ef79cba79dc6727890
+      extract: false
+
+  - name: Install msodbcsql18 ODBC driver
+    runs: |
+      mkdir -p /tmp/msodbcsql18
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib
+
+      # Extract the deb package
+      if [ "${{build.arch}}" = "aarch64" ]; then
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb /tmp/msodbcsql18
+      else
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb /tmp/msodbcsql18
+      fi
+
+      # Patch RPATH to use the agent's embedded lib directory
+      patchelf --force-rpath --set-rpath '${{vars.destd}}/embedded/lib' /tmp/msodbcsql18/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}}
+
+      # Install the driver to the embedded directory
+      cp -r /tmp/msodbcsql18/opt/microsoft/msodbcsql18/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/
+
+      # Create symlink for library compatibility
+      ln -sf ${{vars.destd}}/embedded/msodbcsql/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}} ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib/libmsodbcsql-${{vars.msodbcsql18-major-minor}}.so
+
+      # Install license and documentation
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share
+      cp -r /tmp/msodbcsql18/usr/share/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share/
+
   - uses: strip
 
 subpackages:
@@ -403,7 +464,7 @@ subpackages:
             with:
               repository: https://github.com/DataDog/integrations-core
               branch: ${{vars.datadog-major-minor-x}} # 7.x.y
-              expected-commit: 0d5325a4b9f0a26203afb457d13771963dc9a488 # needs to be updated with each new release
+              expected-commit: 139780a5241d97a819966d3d6d70099eb3db1ef0 # needs to be updated with each new release
           - name: Verify expected-commit is latest
             runs: |
               # Check if the expected-commit matches the latest commit on the branch

--- a/datadog-agent-7.72/urlib3-GHSA-2xpw-w6gg-jr37.patch
+++ b/datadog-agent-7.72/urlib3-GHSA-2xpw-w6gg-jr37.patch
@@ -1,0 +1,60 @@
+From 9569aff1c93eb8d1cfd6c9d5c64a43ca42bbf220 Mon Sep 17 00:00:00 2001
+From: Kyle Neale <kyle.neale@datadoghq.com>
+Date: Wed, 10 Dec 2025 10:01:52 -0500
+Subject: [PATCH] Bump `urllib3` to `2.6.0` (#22076)
+
+* Bump urllib3 to 2.6.0
+
+* Add changelog
+---
+ .builders/images/runner_dependencies.txt       | 2 +-
+ agent_requirements.in                          | 2 +-
+ datadog_checks_base/changelog.d/22076.security | 1 +
+ datadog_checks_base/pyproject.toml             | 2 +-
+ 4 files changed, 4 insertions(+), 3 deletions(-)
+ create mode 100644 datadog_checks_base/changelog.d/22076.security
+
+diff --git a/.builders/images/runner_dependencies.txt b/.builders/images/runner_dependencies.txt
+index 18295cc266e2e..3e70f6196970f 100644
+--- a/.builders/images/runner_dependencies.txt
++++ b/.builders/images/runner_dependencies.txt
+@@ -1,5 +1,5 @@
+ python-dotenv==1.0.0
+-urllib3==2.2.0
++urllib3==2.6.0
+ auditwheel==6.0.0; sys_platform == 'linux'
+ delvewheel==1.5.2; sys_platform == 'win32'
+ delocate==0.13.0; sys_platform == 'darwin'
+diff --git a/agent_requirements.in b/agent_requirements.in
+index 85e944b3e8db6..22a1b49fa31f0 100644
+--- a/agent_requirements.in
++++ b/agent_requirements.in
+@@ -64,6 +64,6 @@ simplejson==3.20.1
+ snowflake-connector-python==3.17.2
+ supervisor==4.3.0
+ tuf==4.0.0
+-urllib3==2.5.0
++urllib3==2.6.0
+ vertica-python==1.4.0
+ wrapt==1.17.3
+diff --git a/datadog_checks_base/changelog.d/22076.security b/datadog_checks_base/changelog.d/22076.security
+new file mode 100644
+index 0000000000000..00d326646970d
+--- /dev/null
++++ b/datadog_checks_base/changelog.d/22076.security
+@@ -0,0 +1 @@
++Bump urllib3 version to 2.6.0
+\ No newline at end of file
+diff --git a/datadog_checks_base/pyproject.toml b/datadog_checks_base/pyproject.toml
+index f7df545e0fa96..b52c148aa760b 100644
+--- a/datadog_checks_base/pyproject.toml
++++ b/datadog_checks_base/pyproject.toml
+@@ -50,7 +50,7 @@ deps = [
+     "requests-unixsocket2==1.0.0",
+     "requests==2.32.5",
+     "simplejson==3.20.1",
+-    "urllib3==2.5.0",
++    "urllib3==2.6.0",
+     "wrapt==1.17.3",
+ ]
+ http = [

--- a/datadog-agent-7.73.yaml
+++ b/datadog-agent-7.73.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.73.3"
-  epoch: 0 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
+  epoch: 1 # GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -18,9 +18,11 @@ package:
       - blkid
       - findutils
       - grep
+      - krb5 # Required by msodbcsql18 for Kerberos authentication
       - libpcap
       - libseccomp
       - shadow
+      - unixodbc # ODBC driver manager required by msodbcsql18
 
 capabilities:
   add:
@@ -29,6 +31,10 @@ capabilities:
 vars:
   python-version: "3.13"
   destd: /opt/datadog-agent
+  # Microsoft ODBC Driver 18 for SQL Server - required for SQL Server integration
+  # When upgrading datadog-agent, check the version used in the omnibus build:
+  # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  msodbcsql18-version: "18.3.3.1-1"
 
 var-transforms:
   - from: ${{package.version}}
@@ -46,6 +52,16 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  # Transform msodbcsql18-version (e.g., "18.3.3.1-1") to library suffix (e.g., "18.3.so.3.1")
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.(\d+\.\d+)-\d+$
+    replace: "$1.so.$2"
+    to: msodbcsql18-libsuffix
+  # Extract major.minor version (e.g., "18.3.3.1-1" -> "18.3") for symlink naming
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.\d+\.\d+-\d+$
+    replace: "$1"
+    to: msodbcsql18-major-minor
 
 environment:
   contents:
@@ -84,10 +100,12 @@ environment:
       - linux-headers
       - ninja
       - openssf-compiler-options
+      - patchelf # Required to patch RPATH of msodbcsql18 library
       - procps-dev
       - py${{vars.python-version}}-build-base-dev
       - py${{vars.python-version}}-semver
       - systemd-dev
+      - unixodbc-dev # Required to build with ODBC support for SQL Server integration
       - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian
   environment:
@@ -344,6 +362,48 @@ pipeline:
 
       # Install trace-loader binary
       install -Dm755 bin/trace-loader/trace-loader ${{targets.contextdir}}${{vars.destd}}/embedded/bin/trace-loader
+
+  # Install Microsoft ODBC Driver 18 for SQL Server integration
+  # Version and SHA256 hashes sourced from the omnibus build configuration.
+  # When upgrading, check: https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb
+      expected-sha256: 37e692b1517f1229042c743d0f2a7191e0dcb956bbc3785a895aaa6dc328467e
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb
+      expected-sha256: f91004ce72fcd92e686154f90e2a80f4f86469e7cb5f42ef79cba79dc6727890
+      extract: false
+
+  - name: Install msodbcsql18 ODBC driver
+    runs: |
+      mkdir -p /tmp/msodbcsql18
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib
+
+      # Extract the deb package
+      if [ "${{build.arch}}" = "aarch64" ]; then
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb /tmp/msodbcsql18
+      else
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb /tmp/msodbcsql18
+      fi
+
+      # Patch RPATH to use the agent's embedded lib directory
+      patchelf --force-rpath --set-rpath '${{vars.destd}}/embedded/lib' /tmp/msodbcsql18/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}}
+
+      # Install the driver to the embedded directory
+      cp -r /tmp/msodbcsql18/opt/microsoft/msodbcsql18/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/
+
+      # Create symlink for library compatibility
+      ln -sf ${{vars.destd}}/embedded/msodbcsql/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}} ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib/libmsodbcsql-${{vars.msodbcsql18-major-minor}}.so
+
+      # Install license and documentation
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share
+      cp -r /tmp/msodbcsql18/usr/share/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share/
 
   - uses: strip
 

--- a/datadog-agent-7.74.yaml
+++ b/datadog-agent-7.74.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.74.1"
-  epoch: 2 # GHSA-mrfv-m5wm-5w6w
+  epoch: 3 # GHSA-mrfv-m5wm-5w6w, GHSA-xrwg-mqj6-6m22
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -16,9 +16,11 @@ package:
       - blkid
       - findutils
       - grep
+      - krb5 # Required by msodbcsql18 for Kerberos authentication
       - libpcap
       - libseccomp
       - shadow
+      - unixodbc # ODBC driver manager required by msodbcsql18
     provides:
       - datadog-agent=${{package.full-version}}
 
@@ -29,6 +31,10 @@ capabilities:
 vars:
   python-version: "3.13"
   destd: /opt/datadog-agent
+  # Microsoft ODBC Driver 18 for SQL Server - required for SQL Server integration
+  # When upgrading datadog-agent, check the version used in the omnibus build:
+  # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  msodbcsql18-version: "18.3.3.1-1"
 
 var-transforms:
   - from: ${{package.version}}
@@ -46,6 +52,16 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  # Transform msodbcsql18-version (e.g., "18.3.3.1-1") to library suffix (e.g., "18.3.so.3.1")
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.(\d+\.\d+)-\d+$
+    replace: "$1.so.$2"
+    to: msodbcsql18-libsuffix
+  # Extract major.minor version (e.g., "18.3.3.1-1" -> "18.3") for symlink naming
+  - from: ${{vars.msodbcsql18-version}}
+    match: ^(\d+\.\d+)\.\d+\.\d+-\d+$
+    replace: "$1"
+    to: msodbcsql18-major-minor
 
 environment:
   contents:
@@ -84,10 +100,12 @@ environment:
       - linux-headers
       - ninja
       - openssf-compiler-options
+      - patchelf # Required to patch RPATH of msodbcsql18 library
       - procps-dev
       - py${{vars.python-version}}-build-base-dev
       - py${{vars.python-version}}-semver
       - systemd-dev
+      - unixodbc-dev # Required to build with ODBC support for SQL Server integration
       - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian
   environment:
@@ -340,6 +358,48 @@ pipeline:
 
       # Install trace-loader binary
       install -Dm755 bin/trace-loader/trace-loader ${{targets.contextdir}}${{vars.destd}}/embedded/bin/trace-loader
+
+  # Install Microsoft ODBC Driver 18 for SQL Server integration
+  # Version and SHA256 hashes sourced from the omnibus build configuration.
+  # When upgrading, check: https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb
+      expected-sha256: 37e692b1517f1229042c743d0f2a7191e0dcb956bbc3785a895aaa6dc328467e
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb
+      expected-sha256: f91004ce72fcd92e686154f90e2a80f4f86469e7cb5f42ef79cba79dc6727890
+      extract: false
+
+  - name: Install msodbcsql18 ODBC driver
+    runs: |
+      mkdir -p /tmp/msodbcsql18
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib
+
+      # Extract the deb package
+      if [ "${{build.arch}}" = "aarch64" ]; then
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_arm64.deb /tmp/msodbcsql18
+      else
+        dpkg-deb -R msodbcsql18_${{vars.msodbcsql18-version}}_amd64.deb /tmp/msodbcsql18
+      fi
+
+      # Patch RPATH to use the agent's embedded lib directory
+      patchelf --force-rpath --set-rpath '${{vars.destd}}/embedded/lib' /tmp/msodbcsql18/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}}
+
+      # Install the driver to the embedded directory
+      cp -r /tmp/msodbcsql18/opt/microsoft/msodbcsql18/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/
+
+      # Create symlink for library compatibility
+      ln -sf ${{vars.destd}}/embedded/msodbcsql/lib64/libmsodbcsql-${{vars.msodbcsql18-libsuffix}} ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/lib/libmsodbcsql-${{vars.msodbcsql18-major-minor}}.so
+
+      # Install license and documentation
+      mkdir -p ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share
+      cp -r /tmp/msodbcsql18/usr/share/* ${{targets.contextdir}}${{vars.destd}}/embedded/msodbcsql/share/
 
   - uses: strip
 


### PR DESCRIPTION
Adds Microsoft ODBC Driver 18 (msodbcsql18) required for SQL Server integration. The official Datadog Agent uses invoke omnibus.build which automatically includes msodbcsql18 via Ruby software definitions. 

Our Wolfi build uses invoke agent.build (Go binaries only) and cannot invoke omnibus without adding heavy Ruby dependencies. We replicate the upstream [msodbcsql18.rb](https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/msodbcsql18.rb) logic directly in the melange pipeline. Note: When upgrading datadog-agent, check the upstream msodbcsql18.rb for version/SHA256 changes.

```
tar tvf  packages/aarch64/datadog-agent-7.74-7.74.0-r0.apk |  grep -i msodbc
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/etc
-rwxr-xr-x  0 root   root       149 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/etc/odbcinst.ini
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/include
-rw-r--r--  0 root   root     44040 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/include/msodbcsql.h
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/lib
lrwxrwxrwx  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/lib/libmsodbcsql-18.3.so -> /opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/lib64
-rwxr-xr-x  0 root   root   2048280 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/doc
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/doc/msodbcsql18
-rw-r--r--  0 root   root     12135 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/doc/msodbcsql18/LICENSE.txt
-rw-r--r--  0 root   root     17740 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/doc/msodbcsql18/RELEASE_NOTES
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/resources
drwxr-xr-x  0 root   root         0 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/resources/en_US
-rw-r--r--  0 root   root    200704 Jan 15 19:53 opt/datadog-agent/embedded/msodbcsql/share/resources/en_US/msodbcsqlr18.rll
```

### Verification against official Datadog Agent Docker image

Confirmed that the APK contains all msodbc files present in the official Docker image:

```
$ docker container run --rm --platform linux/arm64 --entrypoint="bash" datadog/agent:latest -c "find / 2>/dev/null | grep -i msodbc"
/opt/datadog-agent/embedded/msodbcsql
/opt/datadog-agent/embedded/msodbcsql/include
/opt/datadog-agent/embedded/msodbcsql/include/msodbcsql.h
/opt/datadog-agent/embedded/msodbcsql/lib
/opt/datadog-agent/embedded/msodbcsql/lib/libmsodbcsql-18.3.so
/opt/datadog-agent/embedded/msodbcsql/lib64
/opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1
/opt/datadog-agent/embedded/msodbcsql/etc
/opt/datadog-agent/embedded/msodbcsql/etc/odbcinst.ini
/opt/datadog-agent/embedded/msodbcsql/share
/opt/datadog-agent/embedded/msodbcsql/share/resources
/opt/datadog-agent/embedded/msodbcsql/share/resources/en_US
/opt/datadog-agent/embedded/msodbcsql/share/resources/en_US/msodbcsqlr18.rll
```

All files match. The APK additionally includes documentation files (LICENSE.txt, RELEASE_NOTES) which are not present in the official image.