### PR TITLE
feat(argo-workflows-3): Add version streamed iamguarded compats

### DIFF
--- a/argo-workflows-3.7.yaml
+++ b/argo-workflows-3.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows-3.7
   version: "3.7.7"
-  epoch: 0 # GHSA-cfpf-hrx2-8rv6
+  epoch: 1 # GHSA-cfpf-hrx2-8rv6
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -108,6 +108,35 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/workflow-controller ${{targets.subpkgdir}}/workflow-controller
 
+  - name: argo-workflow-controller-${{vars.major-minor-version}}-iamguarded-compat
+    description: "compat package for iamguarded argo-workflow-controller image"
+    dependencies:
+      provides:
+        - argo-workflow-controller-iamguarded-compat=${{package.full-version}}
+      runtime:
+        - argo-workflow-controller-${{vars.major-minor-version}}
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: argo-workflow-controller
+          version: ${{vars.major-minor-version}}
+      - runs: |
+          mkdir -p /opt/iamguarded/argo-workflow-controller/bin/
+          chmod g+rwX /opt/iamguarded
+          ln -sf /usr/bin/workflow-controller /opt/iamguarded/argo-workflow-controller/bin/workflow-controller
+      - uses: iamguarded/finalize-compat
+        with:
+          package: argo-workflow-controller
+          version: ${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - runs: stat /opt/iamguarded/argo-workflow-controller/bin/workflow-controller
+        - uses: iamguarded/test-compat
+          with:
+            package: argo-workflow-controller
+            version: ${{vars.major-minor-version}}
+
   - name: argo-workflow-executor-${{vars.major-minor-version}}
     description: "Argo workflow executor"
     dependencies:
@@ -142,6 +171,35 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/argoexec ${{targets.subpkgdir}}/argoexec
 
+  - name: argo-workflow-executor-${{vars.major-minor-version}}-iamguarded-compat
+    description: "compat package for iamguarded argo-workflow-exec image"
+    dependencies:
+      provides:
+        - argo-workflow-executor-iamguarded-compat=${{package.full-version}}
+      runtime:
+        - argo-workflow-executor-${{vars.major-minor-version}}
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: argo-workflow-exec
+          version: ${{vars.major-minor-version}}
+      - runs: |
+          mkdir -p /opt/iamguarded/argo-workflow-exec/bin/
+          chmod g+rwX /opt/iamguarded
+          ln -sf /usr/bin/argoexec /opt/iamguarded/argo-workflow-exec/bin/argoexec
+      - uses: iamguarded/finalize-compat
+        with:
+          package: argo-workflow-exec
+          version: ${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - runs: stat /opt/iamguarded/argo-workflow-exec/bin/argoexec
+        - uses: iamguarded/test-compat
+          with:
+            package: argo-workflow-exec
+            version: ${{vars.major-minor-version}}
+
   - name: argo-workflow-cli-${{vars.major-minor-version}}
     dependencies:
       provides:
@@ -154,6 +212,35 @@ subpackages:
           # Argocli serves the server https://github.com/argoproj/argo-workflows/blob/master/Dockerfile#L110
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/argo ${{targets.subpkgdir}}/argo
+
+  - name: argo-workflow-cli-${{vars.major-minor-version}}-iamguarded-compat
+    description: "compat package for iamguarded argo-workflow-cli image"
+    dependencies:
+      provides:
+        - argo-workflow-cli-iamguarded-compat=${{package.full-version}}
+      runtime:
+        - argo-workflows-${{vars.major-minor-version}}
+        - wolfi-baselayout
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: argo-workflow-cli
+          version: ${{vars.major-minor-version}}
+      - runs: |
+          mkdir -p /opt/iamguarded/argo-workflow-cli/bin/
+          chmod g+rwX /opt/iamguarded
+          ln -sf /usr/bin/argo /opt/iamguarded/argo-workflow-cli/bin/argo
+      - uses: iamguarded/finalize-compat
+        with:
+          package: argo-workflow-cli
+          version: ${{vars.major-minor-version}}
+    test:
+      pipeline:
+        - runs: stat /opt/iamguarded/argo-workflow-cli/bin/argo
+        - uses: iamguarded/test-compat
+          with:
+            package: argo-workflow-cli
+            version: ${{vars.major-minor-version}}
 
   - name: argo-workflows-ui-${{vars.major-minor-version}}
     description: "Argo workflows embedded UI"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
