### PR TITLE
add configmap iamguarded compat

### DIFF
--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -1,7 +1,7 @@
 package:
   name: configmap-reload
   version: "0.15.0"
-  epoch: 5 # CVE-2025-61725
+  epoch: 7
   description: Simple binary to trigger a reload when a Kubernetes ConfigMap is updated
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,12 @@ environment:
       - ca-certificates-bundle
       - go
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1"
+    to: major-version
+
 pipeline:
   - uses: git-checkout
     with:
@@ -28,6 +34,29 @@ pipeline:
       packages: configmap-reload.go
       output: configmap-reload
       ldflags: -extldflags '-static'
+
+subpackages:
+  - name: ${{package.name}}-iamguarded-compat
+    options:
+      no-provides: true
+    pipeline:
+      - uses: iamguarded/build-compat
+        with:
+          package: configmap-reload
+          version: ${{vars.major-version}}
+      - runs: |
+          mkdir -p "/opt/iamguarded/configmap-reload/bin/"
+          ln -s "/usr/bin/configmap-reload" "/opt/iamguarded/configmap-reload/bin/configmap-reload"
+      - uses: iamguarded/finalize-compat
+        with:
+          package: configmap-reload
+          version: ${{vars.major-version}}
+    test:
+      pipeline:
+        - uses: iamguarded/test-compat
+          with:
+            package: configmap-reload
+            version: ${{vars.major-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Adds iamguarded compat to configmap-reloader, as required by iamguarded-loki chart.