### PR TITLE
chore(chainguard-source): pkg update to 1.6

### DIFF
--- a/chainguard-source.yaml
+++ b/chainguard-source.yaml
@@ -1,6 +1,6 @@
 package:
   name: chainguard-source
-  version: "1.5"
+  version: "1.6"
   epoch: 0
   description: "Fetch all sources referenced by a Chainguard Package or Image SBOM"
   copyright:
@@ -30,7 +30,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/chainguard-source
-      expected-commit: 6f09545036716db527d05cf22cf0465f9228d64a
+      expected-commit: 6a6810e7a7dbe1e4595e8a64d2872514dff9f239
       tag: ${{package.version}}
 
   - runs: |


### PR DESCRIPTION
bump to v1.6, which includes a fix that prevents an infinite loop while processing wolfi pkg refs:

https://github.com/chainguard-dev/chainguard-source/releases/tag/1.6