### PR TITLE
cinc-auditor: add train-k8s-container-mitre plugin and kubectl dep

### DIFF
--- a/cinc-auditor.yaml
+++ b/cinc-auditor.yaml
@@ -4,7 +4,7 @@
 package:
   name: cinc-auditor
   version: "7.0.95"
-  epoch: 2
+  epoch: 3
   description: cinc-auditor is an OSS tool for applying inspec profiles
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,8 @@ package:
     runtime:
       # needed for the shell wrapper script in /usr/bin
       - busybox
+      # both kubernetes transport (train-) plugins need kubectl installed
+      - kubectl
       # additional gem dependencies added in the upstream cinc-auditor
       # habitat/plan.sh script that can't be listed as part of the Gemfile
       # for some reason
@@ -84,6 +86,12 @@ pipeline:
         --bindir "${TARGET_DIR_BIN}" \
         --no-document )
 
+      # this is an additional plugin useful for querying containers in k8s.
+      gem install train-k8s-container-mitre \
+        --install-dir "${TARGET_DIR_INSTALL}"  \
+        --bindir "${TARGET_DIR_BIN}" \
+        --no-document
+
       # create a wrapper script around cinc-auditor that sets the
       # gem path correctly for the vendered dependencies
       cat <<EOF > "cinc-auditor"
@@ -112,8 +120,26 @@ update:
 test:
   pipeline:
     - runs: |
+        set -o pipefail
         cinc-auditor --help
         cinc-auditor version
         cinc-auditor shell --backend local -c 'describe file("/etc/passwd") do it { should exist } end'
         cinc-auditor shell --backend local -c \
            'describe passwd("/etc/passwd") do its("count") { should_not eq 0 } ; its("users") { should_not be_empty } end'
+
+        # Ensure the k8s-container transport plugin can be found.
+        # The cinc-auditor command will fail because it doesn't have a
+        # valid kube configuration configuration, hence the complex test
+        # check.
+        if cinc-auditor detect -t k8s-container:// > k8s-test-output 2>&1 ; then
+            echo "cinc-auditor suceeded when it should have failed" > /dev/stderr
+            cat k8s-test-output
+            exit 1
+        fi
+        if ! grep 'Missing Parameter `pod`' k8s-test-output ; then
+            cat k8s-test-output
+            exit 1
+        fi
+
+        # both k8s train backends need kubectl installed
+        kubectl version --client


### PR DESCRIPTION
Add the train-k8s-container-mitre gem as part of the package because it provides a functioning mechanism for querying containers in k8s environments. Unfortunately, due to the inconsistency of the gem name with the plugin name (the mitre version is a functional fork of the unpublished-as-a-gem and unmaintained inspec/train-k8s-container repo), this does not show up when one does:

```
cinc-auditor plugin list
```

The train-k8s-container plugin needs the kubectl utility available in the runtime environment to work, so include it as a runtime dependency.

Add an additional check to ensure the k8s-container plugin is actually available to cinc-auditor without actually having a k8s environment set up.

(The included-by-default gem plugin train-kubernetes does not seem to be functional as shipped:
https://github.com/inspec/train-kubernetes/issues/24 which matches the behavior I experienced in testing)

Ref: https://github.com/chainguard-dev/prodsec/issues/588