### PR TITLE
chore(tileserver-gl): bump epoch for new libpng 1.6.54

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: "5.5.0"
-  epoch: 0 # GHSA-mh29-5h37-fv8m
+  epoch: 1
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
We need to bump the epoch in order to grab the latest libpng lib version
out of https://github.com/wolfi-dev/os/pull/78174

Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

<!--ci-cve-scan:fail-any-->
