### PR TITLE
fix(cloudflared): GHSA-527x-5wrf-22m2

### DIFF
--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudflared
   version: "2025.11.1"
-  epoch: 2 # GHSA-j5w8-q4qc-rx2x
+  epoch: 3
   description: Cloudflare Tunnel client
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,7 @@ pipeline:
     with:
       deps: |-
         golang.org/x/crypto@v0.45.0
+        github.com/coredns/coredns@v1.14.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump coredns to 1.14.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/52938

<!--ci-cve-scan:fail-any-->
