### PR TITLE
apache-activemq-artemis: Fix path

### DIFF
--- a/apache-activemq-artemis.yaml
+++ b/apache-activemq-artemis.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-activemq-artemis
   version: "2.50.0"
-  epoch: 0 # GHSA-vc5p-v9hr-52mj
+  epoch: 1
   description: ActiveMQ Artemis is the next generation message broker from Apache ActiveMQ.
   copyright:
     - license: Apache-2.0
@@ -47,8 +47,8 @@ pipeline:
   - runs: |
       rm pombump-deps.yaml pombump-properties.yaml
       mvn -Prelease package -DskipTests -Drat.excludesFile=rat-exclusions.txt
-      mkdir -p "${{targets.contextdir}}"/opt/activemq-artemis
-      cp -r artemis-distribution/target/apache-artemis-${{package.version}}-bin/apache-artemis-${{package.version}}/* "${{targets.contextdir}}"/opt/activemq-artemis/
+      mkdir -p "${{targets.contextdir}}"/opt/artemis
+      cp -r artemis-distribution/target/apache-artemis-${{package.version}}-bin/apache-artemis-${{package.version}}/* "${{targets.contextdir}}"/opt/artemis/
 
 subpackages:
   - name: "${{package.name}}-compat"
@@ -85,7 +85,7 @@ test:
         export BROKER_HOME=/var/lib/
         export CONFIG_PATH=$BROKER_HOME/etc
         cd /var/lib/artemis-instance
-        /opt/activemq-artemis/bin/artemis create --user artemis --password artemis --allow-anonymous .
+        /opt/artemis/bin/artemis create --user artemis --password artemis --allow-anonymous .
         /var/lib/artemis-instance/bin/artemis-service start
     - name: "Clone official apache activemq-artemis examples"
       runs: |


### PR DESCRIPTION
The upstream changed the path.  Our package test failed locally, as if
it was not picking up my change.  I can't explain that.
