### PR TITLE
fix(chromium): CVE-2026-0628

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: "143.0.7499.169"
+  version: "143.0.7499.192"
   epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
@@ -156,12 +156,8 @@ pipeline:
       # Tarballs are built using the instructions here:
       # https://wiki.gentoo.org/wiki/Project:Chromium/How_to_make_a_Chromium_tarball
       # which has been automated in https://github.com/chromium-linux-tarballs/chromium-tarballs
-      #
-      # !! NOTE !! We are temporarily using my fork of `chromium-tarballs` as
-      # the `chromium-linux-tarballs` repo hasn't been updated in a few weeks:
-      # https://github.com/chromium-linux-tarballs/chromium-tarballs/issues/30
-      uri: https://github.com/OddBloke/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
-      expected-sha512: 783f5bb97e62f8866c99dfd554856192d559a9a5876ede9289e1000163a2dd6ceb0d5321e9c4298bd29a2b4b32dfed5121f106120754ccb15a9c8ac239b3510f
+      uri: https://github.com/chromium-linux-tarballs/chromium-tarballs/releases/download/${{package.version}}/chromium-${{package.version}}-linux.tar.xz
+      expected-sha512: 5eb97b8559c6a141c93020f8b9a5835a926dd0ed3360ba975ba71c4bc9e1d97376332eac1eadaf224edfc9ab27c0c82ee74c6078e338aa8d0024fe4bf4353f9b
 
   - name: Remove binaries from source tree
     runs: |


### PR DESCRIPTION
Switch back to upstream tarballs.

Bump chromium version.

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/53301

<!--ci-cve-scan:fail-any-->
