### PR TITLE
fix(apicurio-registry): replace s2i with nginx in entrypoint script

### DIFF
--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -137,8 +137,11 @@ subpackages:
     description: nginx configuration files for upstream configuration
     dependencies:
       runtime:
-        - docker-nginx
-        - nginx
+        - nginx-mime-types
+      provides:
+        - nginx-config=0.${{package.full-version}}
+      replaces:
+        - nginx-mainline-config
     pipeline:
       - working-directory: ui
         runs: |
@@ -148,10 +151,27 @@ subpackages:
           install -Dm644 .docker-scripts/update-base-href.cjs "${config_dest}/update-base-href.cjs"
           install -Dm644 .docker-scripts/nginx.conf "${{targets.contextdir}}/etc/nginx/nginx.conf"
 
+          # Fix SSL cipher configuration - PROFILE=SYSTEM is Red Hat specific and not supported on Wolfi
+          sed -i 's|ssl_ciphers PROFILE=SYSTEM;|# ssl_ciphers removed - using nginx defaults|' "${{targets.contextdir}}/etc/nginx/nginx.conf"
+
+          # Fix deprecated http2 directive (nginx 1.25.1+) - change "listen ... http2" to "listen ..." with separate "http2 on;"
+          sed -i 's|listen\s\+\([0-9]\+\)\s\+ssl\s\+http2;|listen \1 ssl;\n        http2 on;|' "${{targets.contextdir}}/etc/nginx/nginx.conf"
+
+          # Remove TLS server block - it requires certificates that don't exist by default
+          # TLS should be handled by ingress/sidecar if needed
+          sed -i '/^# Settings for a TLS enabled server/,$d' "${{targets.contextdir}}/etc/nginx/nginx.conf"
+          echo "}" >> "${{targets.contextdir}}/etc/nginx/nginx.conf"
+
           # NOTE: copy entrypoint and replace s2i/run with direct nginx exec. we don't want to maintain
           # the whole s2i related scripts so we simplify the entrypoint here
           install -Dm755 .docker-scripts/entrypoint.sh "${config_dest}/entrypoint.sh"
           sed -i 's|source /usr/libexec/s2i/run|exec nginx -g "daemon off;"|' "${config_dest}/entrypoint.sh"
+    test:
+      pipeline:
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: nginx-config
+            real-pkg-name: ${{subpkg.name}}
 
 update:
   enabled: true

--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apicurio-registry
   version: "3.1.6"
-  epoch: 2
+  epoch: 3
   description: An API/Schema registry - stores APIs and Schemas
   copyright:
     - license: Apache-2.0
@@ -147,7 +147,11 @@ subpackages:
           install -Dm644 .docker-scripts/create-config.cjs "${config_dest}/create-config.cjs"
           install -Dm644 .docker-scripts/update-base-href.cjs "${config_dest}/update-base-href.cjs"
           install -Dm644 .docker-scripts/nginx.conf "${{targets.contextdir}}/etc/nginx/nginx.conf"
+
+          # NOTE: copy entrypoint and replace s2i/run with direct nginx exec. we don't want to maintain
+          # the whole s2i related scripts so we simplify the entrypoint here
           install -Dm755 .docker-scripts/entrypoint.sh "${config_dest}/entrypoint.sh"
+          sed -i 's|source /usr/libexec/s2i/run|exec nginx -g "daemon off;"|' "${config_dest}/entrypoint.sh"
 
 update:
   enabled: true


### PR DESCRIPTION
So the whole s2i scripts don't have to be copied & maintained from the upstream image.