### PR TITLE
Strimzi-kafka-operator: new version needs JDK update to 21

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -41,7 +41,7 @@ environment:
     DEST_DIR: opt/strimzi
 
 vars:
-  java-version: '17' # https://github.com/strimzi/strimzi-kafka-operator/blob/0.48.0/development-docs/DEV_GUIDE.md#java-versions
+  java-version: '21' # https://github.com/strimzi/strimzi-kafka-operator/blob/0.50.0/development-docs/DEV_GUIDE.md#java-versions
   shellcheck_version: 0.10.0
   shellcheck_aarch64_shasum512: 77abeaa8bee293264ebfd94a2021bd490695ed5518f2da7c0f9ec4b402cd1e5da6642a0e9f953961510cef7351cc9afae7c7a528a597d1befd1867b8c69e15b1
   shellcheck_x86_64_shasum512: 31006830087c2b9ffe9fa36c1ab4a8b11c85078cac8203265d0cfd630c70a4a506e66dd9d7ccde964360ad95045894149de457db34f10cad76708c7a4aa544ca


### PR DESCRIPTION


Fixes:
https://github.com/wolfi-dev/os/pull/78403/files failing to build