### PR TITLE
prism: update diff and tar modules to remediate GHSA-73rr-hh4g-fpgx, CVE-2026-23745 

### DIFF
--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: "5.14.3"
-  epoch: 1
+  epoch: 2
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:
@@ -47,6 +47,9 @@ pipeline:
 
       # Fix js-yaml CVE GHSA-mh29-5h37-fv8m
       npm pkg set resolutions.js-yaml=3.14.2
+
+      # Bump diff to remediate GHSA-73rr-hh4g-fpgx
+      npm pkg set resolutions.diff=8.0.3
 
       # See 'compiler' build stage of prism/Dockerfile (https://github.com/stoplightio/prism/blob/master/Dockerfile)
       yarn && yarn build

--- a/prism.yaml
+++ b/prism.yaml
@@ -51,6 +51,9 @@ pipeline:
       # Bump diff to remediate GHSA-73rr-hh4g-fpgx
       npm pkg set resolutions.diff=8.0.3
 
+      # Bump tar to remediate GHSA-8qq5-rm4j-mr97
+      npm pkg set resolutions.tar=7.5.3
+
       # See 'compiler' build stage of prism/Dockerfile (https://github.com/stoplightio/prism/blob/master/Dockerfile)
       yarn && yarn build
 


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-2374 GHSA-73rr-hh4g-fpgx-->

