### PR TITLE
glibc: remediate CVEs

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -2,7 +2,7 @@ package:
   name: glibc
   version: "2.42"
   # Every glibc update causes build disruption; always announce on #eng-psa
-  epoch: 5
+  epoch: 6
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -85,6 +85,8 @@ pipeline:
         release/2.42/master/6de12fc9ad56bc19fa6fcbd8ee502f29b5170d47: aarch64: define macro for calling __libc_arm_za_disable
         release/2.42/master/256030b9842a10b1f22851b1de0c119761417544: aarch64: clear ZA state of SME before clone and clone3 syscalls
         release/2.42/master/71874f167aa5bb1538ff7e394beaacee28ebe65f: aarch64: tests for SME
+        release/2.42/master/b0ec8fb689df862171f0f78994a3bdeb51313545: memalign: reinstate alignment overflow check (CVE-2026-0861)
+        release/2.42/master/453e6b8dbab935257eb0802b0c97bca6b67ba30e: resolv: Fix NSS DNS backend for getnetbyaddr (CVE-2026-0915)
 
   - name: "Set up build directory"
     runs: |


### PR DESCRIPTION
Remediate CVE-2026-0861
Cherry pick commit from upstream:
https://sourceware.org/cgit/glibc/commit/?h=release/2.42/master&id=b0ec8fb689df862171f0f78994a3bdeb51313545
Upstream advisory:
https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0001

Remediate CVE-2026-0915
Cherry-pick commit from upstream:
https://sourceware.org/cgit/glibc/commit/?h=release/2.42/master&id=453e6b8dbab935257eb0802b0c97bca6b67ba30e
Upstream advisory:
https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0002

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
