### PR TITLE
akhq: update vertx-core to v4.5.24 to remediate CVE-2026-1002

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.26.0
-  epoch: 5 # GHSA-3677-xxcr-wjqv
+  epoch: 6 # GHSA-cphf-4846-3xx9
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,7 @@ pipeline:
         cves-20250714.patch
         GHSA-84h7-rjj3-6jx4.patch
         GHSA-3677-xxcr-wjqv.patch
+        GHSA-cphf-4846-3xx9.patch
 
   - runs: |
       ./gradlew build -x test -x startTestKafkaCluster --parallel --no-daemon

--- a/akhq/GHSA-cphf-4846-3xx9.patch
+++ b/akhq/GHSA-cphf-4846-3xx9.patch
@@ -1,0 +1,32 @@
+diff --git a/build.gradle b/build.gradle
+index f8bb5501..952ef65a 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -59,6 +59,7 @@ configurations.all {
+         force("com.nimbusds:nimbus-jose-jwt:" + nimbusJoseJwtVersion)
+         force("io.netty:netty-codec-http:" + nettyVersion)
+         force("org.bitbucket.b_c:jose4j:" + jose4jVersion)
++        force("io.vertx:vertx-core:" + vertxcoreVersion)
+     }
+ }
+ 
+@@ -307,4 +308,4 @@ shadowJar {
+ 
+ processResources.dependsOn ":client:installFrontend"
+ processResources.dependsOn ":client:assembleFrontend"
+-processResources.dependsOn ":client:copyClientResources"
++processResources.dependsOn ":client:copyClientResources"
+\ No newline at end of file
+diff --git a/gradle.properties b/gradle.properties
+index 4bd55d28..b8de517d 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -13,4 +13,5 @@ nettyVersion=4.1.125.Final
+ jettyHttpVersion=12.0.12
+ beansVersion=1.11.0
+ nettyVersion=4.2.8.Final
+-jose4jVersion=0.9.6
+\ No newline at end of file
++jose4jVersion=0.9.6
++vertxcoreVersion=4.5.24
+\ No newline at end of file


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-1002-->

