### PR TITLE
nginx: create mime-type subpackage

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.4"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -149,12 +149,34 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: nginx-mainline-mime-types
+    description: Nginx mime.types file
+    dependencies:
+      provides:
+        - nginx-mime-types=${{package.full-version}}
+    pipeline:
+      - working-directory: nginx-mainline
+        runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx
+          cp ./pkg-config/nginx/mime.types ${{targets.subpkgdir}}/etc/nginx/
+          cp ./pkg-config/nginx/mime.types.default ${{targets.subpkgdir}}/etc/nginx/
+    test:
+      pipeline:
+        - runs: |
+            test -f /etc/nginx/mime.types
+            test -f /etc/nginx/mime.types.default
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: nginx-mime-types
+            real-pkg-name: ${{subpkg.name}}
+
   - name: nginx-mainline-config
     description: Creates nginx config step that can then be overridden by users
     dependencies:
       runtime:
         - merged-usrsbin
         - nginx-mainline
+        - nginx-mainline-mime-types
         - wolfi-baselayout
       provides:
         - nginx-config=${{package.full-version}}
@@ -165,6 +187,9 @@ subpackages:
           # subpackage directory here.
           mkdir -p ${{targets.subpkgdir}}/etc/nginx
           cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # Remove mime.types files as they're now in their own subpackage
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types.default
           # default error logs to standard error
           sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
           # and both access logs to stdout
@@ -181,6 +206,7 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
+        - ${{package.name}}-mime-types
       provides:
         - nginx-config=${{package.full-version}}
     pipeline:
@@ -190,6 +216,9 @@ subpackages:
           # subpackage directory here.
           mkdir -p ${{targets.subpkgdir}}/etc/nginx
           cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # Remove mime.types files as they're now in their own subpackage
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types.default
           # default error logs to syslog
           sed -i 's/#error_log  logs\/error.log;$/error_log  syslog:server=unix:\/dev\/log  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
           # and both access logs to syslog
@@ -207,6 +236,7 @@ subpackages:
       runtime:
         - merged-usrsbin
         - nginx-mainline
+        - nginx-mainline-mime-types
         - wolfi-baselayout
       provides:
         - nginx-package-config=${{package.full-version}}

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-stable
   # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
   version: "1.28.1"
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -151,12 +151,34 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-mime-types
+    description: Nginx mime.types file
+    dependencies:
+      provides:
+        - nginx-mime-types=${{package.full-version}}
+    pipeline:
+      - working-directory: nginx-stable
+        runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx
+          cp ./pkg-config/nginx/mime.types ${{targets.subpkgdir}}/etc/nginx/
+          cp ./pkg-config/nginx/mime.types.default ${{targets.subpkgdir}}/etc/nginx/
+    test:
+      pipeline:
+        - runs: |
+            test -f /etc/nginx/mime.types
+            test -f /etc/nginx/mime.types.default
+        - uses: test/virtualpackage
+          with:
+            virtual-pkg-name: nginx-mime-types
+            real-pkg-name: ${{subpkg.name}}
+
   - name: ${{package.name}}-config
     description: Creates nginx config step that can then be overridden by users
     dependencies:
       runtime:
         - merged-usrsbin
         - nginx-stable
+        - ${{package.name}}-mime-types
         - wolfi-baselayout
       provides:
         - nginx-config=${{package.full-version}}
@@ -167,6 +189,9 @@ subpackages:
           # subpackage directory here.
           mkdir -p ${{targets.subpkgdir}}/etc/nginx
           cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # Remove mime.types files as they're now in their own subpackage
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types.default
           # default error logs to standard error
           sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
           # and both access logs to stdout
@@ -183,6 +208,7 @@ subpackages:
     dependencies:
       runtime:
         - nginx-stable
+        - ${{package.name}}-mime-types
       provides:
         - nginx-config=${{package.full-version}}
     pipeline:
@@ -192,6 +218,9 @@ subpackages:
           # subpackage directory here.
           mkdir -p ${{targets.subpkgdir}}/etc/nginx
           cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # Remove mime.types files as they're now in their own subpackage
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types
+          rm ${{targets.subpkgdir}}/etc/nginx/mime.types.default
           # default error logs to syslog
           sed -i 's/#error_log  logs\/error.log;$/error_log  syslog:server=unix:\/dev\/log  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
           # and both access logs to syslog
@@ -209,6 +238,7 @@ subpackages:
       runtime:
         - merged-usrsbin
         - nginx-stable
+        - ${{package.name}}-mime-types
         - wolfi-baselayout
       provides:
         - nginx-package-config=${{package.full-version}}


### PR DESCRIPTION
Add nginx-*-mime-types subpackages containing /etc/nginx/mime.types and
mime.types.default. Config subpackages now depend on mime-types for
backwards compatibility.
This is required for packages which contain a nginx.conf that includes
/etc/nginx/mime.types but that file gets currently removed when the
package does replace the nginx-mainline-config package to provide its
own config.