### PR TITLE
datadog-agent-7.74: update pynacl to v1.6.2 to remediate CVE-2025-69277

### DIFF
--- a/datadog-agent-7.74.yaml
+++ b/datadog-agent-7.74.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: "7.74.1"
-  epoch: 1 # GHSA-xrwg-mqj6-6m22
+  epoch: 2 # GHSA-mrfv-m5wm-5w6w
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -466,6 +466,9 @@ subpackages:
 
               # Remediate GHSA-5rjg-fvgr-3xxf
               .venv/bin/pip${{vars.python-version}} install --upgrade setuptools==78.1.1 protobuf==5.29.5
+
+              # Remediate GHSA-mrfv-m5wm-5w6w
+              .venv/bin/pip${{vars.python-version}} install --upgrade pynacl==1.6.2
 
               find .venv -name "*.pyc" -delete
               find .venv -name "__pycache__" -exec rm -rf {} +


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2025-69277 -->