### PR TITLE
code-server: remediate CVEs

### DIFF
--- a/code-server.yaml
+++ b/code-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: code-server
   version: "4.106.3"
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -74,6 +74,9 @@ pipeline:
 
       # Set npm overrides for security vulnerabilities
       npm pkg set "overrides.tar-fs=3.1.1" "overrides.node-addon-api=7.1.0" "overrides.body-parser=2.2.1"
+
+      # GHSA-8qq5-rm4j-mr97
+      npm pkg set "overrides.tar=7.5.3"
 
       # Install modules and build backend/frontend
       npm install

--- a/code-server.yaml
+++ b/code-server.yaml
@@ -61,10 +61,10 @@ pipeline:
       patches: |
         node-memory.patch
         GHSA-pq67-2wwv-3xjx.patch
-        fix-CVE-2025-47279.patch
         GHSA-76c9-3jph-rj3q.patch
         GHSA-mh29-5h37-fv8m.patch
         GHSA-6rw7-vpxm-498p.patch
+        CVE-2026-22036.patch
 
   - runs: |
       mkdir -p "${{targets.contextdir}}"/usr/lib/code-server

--- a/code-server/CVE-2026-22036.patch
+++ b/code-server/CVE-2026-22036.patch
@@ -1,7 +1,7 @@
 From 4e9587796fb8be34231b9f8e5c37f86ffdd1ac87 Mon Sep 17 00:00:00 2001
 From: David Negreira <david.negreira@chainguard.dev>
 Date: Tue, 20 May 2025 17:06:55 +0000
-Subject: [PATCH] bump undici to 7.5.0 to remediate CVE-2025-47279
+Subject: [PATCH] bump undici to 7.9.0 to remediate CVE-2026-22036
 
 ---
  lib/vscode/package-lock.json        | 2 +-
@@ -17,7 +17,7 @@ index d7d07d301e1..1a6e3befb48 100644
          "https-proxy-agent": "^7.0.2",
          "socks-proxy-agent": "^8.0.1",
 -        "undici": "^7.2.0"
-+        "undici": "^7.5.0"
++        "undici": "^7.18.2"
        },
        "optionalDependencies": {
          "@vscode/windows-ca-certs": "^0.3.1"
@@ -30,7 +30,7 @@ index a99aa799f69..137ed7c593a 100644
          "https-proxy-agent": "^7.0.2",
          "socks-proxy-agent": "^8.0.1",
 -        "undici": "^7.2.0"
-+        "undici": "^7.5.0"
++        "undici": "^7.18.2"
        },
        "optionalDependencies": {
          "@vscode/windows-ca-certs": "^0.3.1"


### PR DESCRIPTION
Remediate GHSA-8qq5-rm4j-mr97
override tar to 7.5.3

Remediate GHSA-g9mf-h72j-4rw9
override undici to 7.18.2

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
