### PR TITLE
az: add cherrypick of update to azure-core to remediate CVE-2026-21226

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: "2.82.0"
-  epoch: 0 # GHSA-38jv-5279-wg99 GHSA-mrfv-m5wm-5w6w
+  epoch: 1 # GHSA-jm66-cg57-jjv5
   description: Azure CLI
   copyright:
     - license: MIT
@@ -28,6 +28,7 @@ pipeline:
       expected-commit: 70c3eb6bc1bd6a21a7319f0bc8ebf5cd4e09ca2a
       cherry-picks: |
         dev/319e9c41caf66b6dd6841bb529637df3e399092c: {Packaging} Bump pynacl to1.6.2, cffi to 2.0.0
+        dev/9fbcb2f34b4ee7b30dfafd9e7d34e82759262913: {Packaging} Bump azure-core to 1.38.0
 
   - name: Python Build
     runs: |


### PR DESCRIPTION
https://github.com/Azure/azure-cli/commit/9fbcb2f34b4ee7b30dfafd9e7d34e82759262913

<!--ci-cve-scan:must-fix: CVE-2026-21226-->

