### PR TITLE
Adds new trust-package subpackage to trust manager

### DIFF
--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -43,7 +43,7 @@ pipeline:
 
 subpackages:
   - name: "trust-package"
-    description: "Utility for copying trust packages from debian bundles"
+    description: "Utility for copying trust packages from bundles"
     pipeline:
       - uses: go/build
         with:
@@ -52,9 +52,9 @@ subpackages:
           modroot: trust-manager/trust-packages/debian
     test:
       pipeline:
-        - name: Test debian-trust-package help
+        - name: Test trust-package help
           runs: |
-            debian-trust-package 2>&1 | grep -q "usage: debian-trust-package"
+            trust-package 2>&1 | grep -q "usage: trust-package"
         - name: Test file copying functionality
           runs: |
             # Create test directories
@@ -67,8 +67,8 @@ subpackages:
             # Create non-JSON file (should be ignored)
             echo "not json" > /tmp/test-input/file.txt
 
-            # Run the debian-trust-package
-            debian-trust-package /tmp/test-input /tmp/test-output
+            # Run the trust-package
+            trust-package /tmp/test-input /tmp/test-output
 
             # Verify JSON files were copied
             [ -f /tmp/test-output/file1.json ]

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -48,13 +48,13 @@ subpackages:
       - uses: go/build
         with:
           packages: .
-          output: trust-package
+          output: copyandmaybepause
           modroot: trust-manager/trust-packages/debian
     test:
       pipeline:
-        - name: Test trust-package help
+        - name: Test copyandmaybepause help
           runs: |
-            trust-package 2>&1 | grep -q "usage: trust-package"
+            copyandmaybepause 2>&1 | grep -q "usage: copyandmaybepause"
         - name: Test file copying functionality
           runs: |
             # Create test directories
@@ -67,8 +67,8 @@ subpackages:
             # Create non-JSON file (should be ignored)
             echo "not json" > /tmp/test-input/file.txt
 
-            # Run the trust-package
-            trust-package /tmp/test-input /tmp/test-output
+            # Run copyandmaybepause
+            copyandmaybepause /tmp/test-input /tmp/test-output
 
             # Verify JSON files were copied
             [ -f /tmp/test-output/file1.json ]

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -52,9 +52,9 @@ subpackages:
           modroot: trust-manager/trust-packages/debian
     test:
       pipeline:
-        - name: Test copyandmaybepause help
-          runs: |
-            copyandmaybepause 2>&1 | grep -q "usage: copyandmaybepause"
+        - uses: test/tw/help-check
+          with:
+            bins: /usr/bin/copyandmaybepause
         - name: Test file copying functionality
           runs: |
             # Create test directories

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: "0.20.3"
-  epoch: 0 # GHSA-j5w8-q4qc-rx2x
+  epoch: 1 # GHSA-j5w8-q4qc-rx2x
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,46 @@ pipeline:
       go build -ldflags="-w" -o ./bin/trust-manager ./cmd/trust-manager
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/trust-manager ${{targets.destdir}}/usr/bin/trust-manager
+
+subpackages:
+  - name: "debian-trust-package"
+    description: "Utility for copying trust packages from debian bundles"
+    pipeline:
+      - uses: go/build
+        with:
+          packages: .
+          output: debian-trust-package
+          modroot: trust-manager/trust-packages/debian
+    test:
+      pipeline:
+        - name: Test debian-trust-package help
+          runs: |
+            debian-trust-package 2>&1 | grep -q "usage: debian-trust-package"
+        - name: Test file copying functionality
+          runs: |
+            # Create test directories
+            mkdir -p /tmp/test-input /tmp/test-output
+
+            # Create test JSON files
+            echo '{"test": "data1"}' > /tmp/test-input/file1.json
+            echo '{"test": "data2"}' > /tmp/test-input/file2.json
+
+            # Create non-JSON file (should be ignored)
+            echo "not json" > /tmp/test-input/file.txt
+
+            # Run the debian-trust-package
+            debian-trust-package /tmp/test-input /tmp/test-output
+
+            # Verify JSON files were copied
+            [ -f /tmp/test-output/file1.json ]
+            [ -f /tmp/test-output/file2.json ]
+
+            # Verify non-JSON file was not copied
+            [ ! -f /tmp/test-output/file.txt ]
+
+            # Verify content matches
+            grep -q '"test": "data1"' /tmp/test-output/file1.json
+            grep -q '"test": "data2"' /tmp/test-output/file2.json
 
 update:
   enabled: true

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -140,8 +140,8 @@ test:
           Starting workers
         timeout: 30
         post: |
-          curl -f http://localhost:6060/readyz | grep -q "ok"
-          curl -s http://localhost:9402/metrics | grep -q trust_manager
+          curl -fsS http://localhost:6060/readyz | grep -q "ok"
+          curl -fsS http://localhost:9402/metrics | grep -q "controller_runtime"
 
           kubectl create namespace cert-manager
 

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -42,13 +42,13 @@ pipeline:
       install -Dm755 ./bin/trust-manager ${{targets.destdir}}/usr/bin/trust-manager
 
 subpackages:
-  - name: "debian-trust-package"
+  - name: "trust-package"
     description: "Utility for copying trust packages from debian bundles"
     pipeline:
       - uses: go/build
         with:
           packages: .
-          output: debian-trust-package
+          output: trust-package
           modroot: trust-manager/trust-packages/debian
     test:
       pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
