### PR TITLE
chore(melange): Bump to v0.39.0

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
-  version: "0.38.1"
-  epoch: 0 # GHSA-pwhc-rpq9-4c8w
+  version: "0.39.0"
+  epoch: 0
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 017bceff95746e8caafa409c82355278f7dc3c02
+      expected-commit: 3942cd9a018273b6fbbebc4597fdba081c3d750c
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
 


### PR DESCRIPTION
To pickup retries with backoff in git-checkout
