### PR TITLE
open-webui: bump epoch to take new azure-core version to remediate CVE-2026-21226

### DIFF
--- a/open-webui.yaml
+++ b/open-webui.yaml
@@ -1,7 +1,7 @@
 package:
   name: open-webui
   version: "0.7.2"
-  epoch: 0
+  epoch: 1
   description: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
<!--ci-cve-scan:must-fix: CVE-2026-21226-->

