### PR TITLE
py3-l*: switch to git-checkout

### DIFF
--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-libarchive-c
   version: "5.3"
-  epoch: 1
+  epoch: 2
   description: Python interface to libarchive
   copyright:
     - license: CC0-1.0
@@ -15,25 +15,16 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - libarchive-dev # For scanelf hack
+      - libarchive-dev
       - py3-supported-pip
-      - scanelf
       - wolfi-base
 
-# The build checks for a clean build env when built from github
-# which doesn't pass with our scanelf hack
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://files.pythonhosted.org/packages/source/l/libarchive-c/libarchive_c-${{package.version}}.tar.gz
-      expected-sha256: 5ddb42f1a245c927e7686545da77159859d5d4c6d00163c59daff4df314dae82
-
-  # Use the correct library soname
-  # NOTE: find_library is broken on aarch64, so just hardcode it for now.
-  # https://github.com/python/cpython/issues/57717
-  - runs: |
-      soname=$(scanelf --quiet --soname /usr/lib/libarchive.so | awk '{print $1}')
-      sed -i -e "s:find_library('archive'):'/usr/lib/$soname':" libarchive/ffi.py
+      repository: https://github.com/Changaco/python-libarchive-c
+      tag: ${{package.version}}
+      expected-commit: 7e8cb8556e45d4b22ba7b0726fb640ef6253cfcc
 
 subpackages:
   - range: py-versions
@@ -82,8 +73,8 @@ data:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 9954
+  github:
+    identifier: Changaco/python-libarchive-c
 
 vars:
   module_name: libarchive

--- a/py3-llhttp.yaml
+++ b/py3-llhttp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-llhttp
   version: "9.3.0.0"
-  epoch: 0
+  epoch: 1
   description: llhttp in python
   copyright:
     - license: MIT
@@ -27,10 +27,11 @@ environment:
       - py3-supported-build-base-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 0d989363e7fb6f270b9d49956e7a3945c26778f8c70a166815264309ac6a8295
-      uri: https://files.pythonhosted.org/packages/source/l/llhttp/llhttp-${{package.version}}.tar.gz
+      repository: https://github.com/pallas/pyllhttp
+      tag: v${{package.version}}
+      expected-commit: 57b8568373583f239c03643bc8ec5b490ebad94b
 
 subpackages:
   - range: py-versions
@@ -73,5 +74,8 @@ test:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 201061
+  github:
+    identifier: pallas/pyllhttp
+    use-tag: true
+    tag-filter-prefix: v
+    strip-prefix: v

--- a/py3-llhttp.yaml
+++ b/py3-llhttp.yaml
@@ -15,11 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      ## https://github.com/pallas/pyllhttp/issues/5
-      # 3.13: '313'
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
@@ -61,6 +60,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: test/metapackage

--- a/py3-lockfile.yaml
+++ b/py3-lockfile.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lockfile
   version: 0.12.2
-  epoch: 4
+  epoch: 5
   description: Platform-independent file locking module
   copyright:
     - license: MIT
@@ -26,10 +26,11 @@ environment:
       - py3-supported-build-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799
-      uri: https://files.pythonhosted.org/packages/source/l/lockfile/lockfile-${{package.version}}.tar.gz
+      repository: https://opendev.org/openstack/pylockfile
+      tag: ${{package.version}}
+      expected-commit: c8798cedfbc4d738c99977a07cde2de54687ac6c
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
The `scanelf` hack doesn't seem to be needed any more.

I also noticed that Python 3.13 support could be enabled in `py3-llhttp` now, so I did that.

Related: https://github.com/chainguard-dev/internal-dev/issues/24668