### PR TITLE
libsemanage: disable expand-check for semanage commands

### DIFF
--- a/libsemanage.yaml
+++ b/libsemanage.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsemanage
   version: "3.9"
-  epoch: 1
+  epoch: 2
   description: "SELinux library and simple utilities"
   copyright:
     - license: LGPL-2.1-only
@@ -42,6 +42,17 @@ pipeline:
       repository: https://github.com/SELinuxProject/selinux.git
       tag: ${{package.name}}-${{package.version}}
       expected-commit: 919e9e64cc4b20f5a1e4df1e38cce1bfe15aff09
+
+  - working-directory: ${{package.name}}
+    runs: |
+      {
+        echo
+        echo '# Whether or not to check "neverallow" rules when executing all commands.'
+        echo '# It can be set to either "0" (disabled) or "1" (enabled).'
+        echo '# There might be a large penalty in execution time if this option is enabled.'
+        echo 'expand-check = 0'
+      } >>src/semanage.conf
+      [ "$(grep -Fc expand-check src/semanage.conf)" = 1 ]
 
   - working-directory: ${{package.name}}
     pipeline:


### PR DESCRIPTION
Disable expand-check in semanage.conf for all semanage commands to improve compatibility with the SELinux policy of Fedora and its derivatives. This change aligns with semanage.conf on these distributions.