### PR TITLE
py3-wheel/0.46.2 package update: fix CVE-2026-24049

### DIFF
--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-wheel
-  version: "0.46.1"
+  version: "0.46.2"
   epoch: 5
   description: "built-package format for Python"
   copyright:
@@ -30,7 +30,7 @@ pipeline:
     with:
       repository: https://github.com/pypa/wheel
       tag: ${{package.version}}
-      expected-commit: 7a0ea7f7c3dd73747e37368bb074cd0d9fb49259
+      expected-commit: eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b
 
   - runs: |
       # Fix license metadata to avoid flit-core exception

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: "0.46.2"
-  epoch: 5
+  epoch: 0
   description: "built-package format for Python"
   copyright:
     - license: MIT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Addresses [CVE-2026-24049](https://nvd.nist.gov/vuln/detail/CVE-2026-24049)

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
