### PR TITLE
fix: postgresql-{16,17,18}-oci-entrypoint build silently produced broken packages

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -340,9 +340,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/16/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/16/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-entrypoint.sh
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/16/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/16/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh
           sed -i "s|/docker-entrypoint-initdb.d|/var/lib/postgres/initdb|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
           sed -i "s|/usr/local|/usr|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -16,7 +16,7 @@ package:
 environment:
   environment:
     # Used to fetch docker scripts
-    ALPINE_VERSION: "3.21"
+    ALPINE_VERSION: "3.23"
   contents:
     packages:
       - autoconf

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.11"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -24,7 +24,7 @@ data:
 environment:
   environment:
     # Used to fetch docker scripts
-    ALPINE_VERSION: "3.21"
+    ALPINE_VERSION: "3.23"
     # Common configure flags for both main package and plpython builds
     CONFIGURE_FLAGS: >-
       --bindir=/usr/libexec/${{vars.mangled-package-name}} --datadir=/usr/share/${{vars.mangled-package-name}} --docdir=/usr/share/doc/${{vars.mangled-package-name}} --mandir=/usr/share/${{vars.mangled-package-name}}/man --with-openssl --with-libedit-preferred --with-uuid=e2fs --with-libxml --with-libxslt --with-icu --with-lz4 --with-zstd --with-gssapi --with-ldap --with-llvm --with-pam --enable-thread-safety

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -336,9 +336,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/17/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/17/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-entrypoint.sh
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/17/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/17/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh
           sed -i "s|/docker-entrypoint-initdb.d|/var/lib/postgres/initdb|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
           sed -i "s|/usr/local|/usr|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.7"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-18.yaml
+++ b/postgresql-18.yaml
@@ -24,7 +24,7 @@ data:
 environment:
   environment:
     # Used to fetch docker scripts
-    ALPINE_VERSION: "3.21"
+    ALPINE_VERSION: "3.23"
     # Common configure flags for both main package and plpython builds
     CONFIGURE_FLAGS: >-
       --bindir=/usr/libexec/${{vars.mangled-package-name}} --datadir=/usr/share/${{vars.mangled-package-name}} --docdir=/usr/share/doc/${{vars.mangled-package-name}} --mandir=/usr/share/${{vars.mangled-package-name}}/man --with-openssl --with-libedit-preferred --with-uuid=e2fs --with-libxml --with-libxslt --with-icu --with-lz4 --with-zstd --with-gssapi --with-ldap --with-llvm --with-pam  --enable-thread-safety

--- a/postgresql-18.yaml
+++ b/postgresql-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-18
   version: "18.1"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-18.yaml
+++ b/postgresql-18.yaml
@@ -336,9 +336,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/18/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/18/alpine"${ALPINE_VERSION}"/docker-entrypoint.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-entrypoint.sh
-          curl https://raw.githubusercontent.com/docker-library/postgres/master/18/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
+          curl --fail-with-body https://raw.githubusercontent.com/docker-library/postgres/master/18/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh
           sed -i "s|/docker-entrypoint-initdb.d|/var/lib/postgres/initdb|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
           sed -i "s|/usr/local|/usr|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh


### PR DESCRIPTION
Fixes: #78604

Related:

### Summary

The builds for all postgresql oci-entrypoint-base packages are broken without this PR. The entrypoint files downloaded from the Docker, Inc. upstream repository during build time only contain the text "404: Not found." See linked issue for more details.

### Pre-review Checklist

Note: To the best of my understanding, none of the checklists from the template apply to this PR, as it strictly fixes an issue with existing build files without bumping any version fields. ~~The only thing I assume might be necessary is actually *increasing* the epoch field for these packages.~~ Yep, as per epoch-bot's complaints, I've bumped the epoch fields to force rebuilds across the board.

#### For new package PRs only
- not applicable

#### For new version streams
- not applicable

#### For package updates (renames) in the base images
- not applicable

#### For security-related PRs
- not applicable

#### For version bump PRs
- not applicable

#### For PRs that add patches
- not applicable
