### PR TITLE
wolfi-baselayout: set /var/tmp permissions to 1777

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 26
+  epoch: 27
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -53,9 +53,11 @@ pipeline:
         mkdir -p "${{targets.destdir}}"/${i}
       done
 
-      # be explicit here, and create tmp as 1777 (drwxrwxrwt) even though
-      # apko does this itself in its baseDirectories / initDB
+      # be explicit here, and create tmp and var/tmp as 1777 (drwxrwxrwt).
+      # apko also sets /tmp to 1777 in its baseDirectories / initDB,
+      # but does not handle /var/tmp.
       chmod 1777 "${{targets.destdir}}/tmp"
+      chmod 1777 "${{targets.destdir}}/var/tmp"
 
       # usr-merge
       ln -sf usr/bin ${{targets.destdir}}/sbin


### PR DESCRIPTION
## Summary
- `/var/tmp` was being created via `mkdir -p` with default `0755` permissions, but every major distro (Alpine, Ubuntu, Debian, Fedora, Arch) sets it to `1777` (`drwxrwxrwt`), same as `/tmp`.
- This was already fixed for `/tmp` in 0744eb9723 but `/var/tmp` was missed.
- The incorrect permissions caused failures in images like `selenium-standalone-chromium` where Xvfb uses `-fbdir /var/tmp` and the non-root `seluser` could not write to it, resulting in a cascade of failures (Xvfb → VNC → ChromeDriver → Selenium `GuardedRunnable` exception).

## Test plan
- [ ] Verify `/var/tmp` has `1777` permissions in a rebuilt image
- [ ] Verify `selenium-standalone-chromium` starts without the `GuardedRunnable` error

Fixes: https://github.com/chainguard-dev/customer-issues/issues/3131

🤖 Generated with [Claude Code](https://claude.com/claude-code)