### PR TITLE
Fix sync octo-sts policy

### DIFF
--- a/.github/chainguard/stereo.sts.yaml
+++ b/.github/chainguard/stereo.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:chainguard-dev/stereo:ref:refs/heads/main
 
 claim_pattern:
-  job_workflow_ref: chainguard-dev/stereo/.github/workflows/(export|publish)-wolfi.yaml@refs/heads/main
+  workflow_ref: chainguard-dev/stereo/.github/workflows/(export|publish)-wolfi.yaml@refs/heads/main
 
 permissions:
   contents: write


### PR DESCRIPTION
Meant for this to be workflow_ref not job_workflow_ref.