### PR TITLE
zookeeper: remove config in root `/` directory

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -61,7 +61,7 @@ pipeline:
       # Install Zookeeper
       mv apache-zookeeper-${{package.version}}-bin/bin ${{targets.destdir}}/usr/share/java/zookeeper
       mv apache-zookeeper-${{package.version}}-bin/lib ${{targets.destdir}}/usr/share/java/zookeeper
-      mv apache-zookeeper-${{package.version}}-bin/conf ${{targets.destdir}}/
+      mv apache-zookeeper-${{package.version}}-bin/conf ${{targets.destdir}}/usr/share/java/zookeeper
 
 subpackages:
   - name: ${{package.name}}-compat
@@ -168,8 +168,8 @@ subpackages:
 
           cp -r ${{targets.destdir}}/usr/share/java/zookeeper/bin/* /opt/iamguarded/zookeeper/bin
           ln -s /usr/share/java/zookeeper/lib /opt/iamguarded/zookeeper/lib
-          cp -r conf/* /opt/iamguarded/zookeeper/conf/
-          cp -r conf/* /opt/iamguarded/zookeeper/conf.default
+          cp -r ${{targets.destdir}}/usr/share/java/zookeeper/conf/* /opt/iamguarded/zookeeper/conf/
+          cp -r ${{targets.destdir}}/usr/share/java/zookeeper/conf/* /opt/iamguarded/zookeeper/conf.default
 
           # create symlinks for both /entrypoint.sh and /run.sh to make it compatible with iamguarded/zookeeper helm chart
           ln -sf /opt/iamguarded/scripts/zookeeper/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
@@ -207,7 +207,7 @@ test:
         cd "${ZK_HOME}"
 
         # Use sample config
-        cp /conf/zoo_sample.cfg conf/zoo.cfg
+        cp conf/zoo_sample.cfg conf/zoo.cfg
 
         # Start Zookeeper
         bin/zkServer.sh start-foreground > /dev/null 2>&1 &

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: "3.9.4"
-  epoch: 2 # GHSA-qqpg-mvqg-649v
+  epoch: 3
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION



Fixes:
A bug where newer zk packages from wolfi have a `/conf` folder which should be in `/usr/share/java/zookeeper/conf` as older packages were. Creating new directories in root is not a standard practice.

Related:

commit for blame:
https://github.com/wolfi-dev/os/commit/b6871dc15d3d12cf1dc0bc4a7e4e3982e53b68ff


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
