### PR TITLE
feat(sts): add elastic-build trust policy for wolfi cron build jobs

### DIFF
--- a/.github/chainguard/elastic-build.sts.yaml
+++ b/.github/chainguard/elastic-build.sts.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://accounts.google.com
+
+# prod-wolfi-os (elastic builds):
+#   109346087047205543085: elastic-pre-wolfi@prod-wolfi-os.iam.gserviceaccount.com
+#   112424580575185915161: elastic-post-wolfi@prod-wolfi-os.iam.gserviceaccount.com
+#   118033315711644274455: elastic-world-wolfi@prod-wolfi-os.iam.gserviceaccount.com
+# prod-images-c6e5 (enterprise/extras elastic builds):
+#   105145109555390460193: elastic-pre-enterprise@prod-images-c6e5.iam.gserviceaccount.com
+#   106994789063784552437: elastic-post-enterprise@prod-images-c6e5.iam.gserviceaccount.com
+#   116941247155554911907: elastic-world-enterprise@prod-images-c6e5.iam.gserviceaccount.com
+#   115648790681078835347: elastic-pre-extras@prod-images-c6e5.iam.gserviceaccount.com
+#   104393601869145083802: elastic-post-extras@prod-images-c6e5.iam.gserviceaccount.com
+#   118026773584156459849: elastic-world-extras@prod-images-c6e5.iam.gserviceaccount.com
+# staging-images-183e:
+#   102924494745947278887: elastic-pre-extras@staging-images-183e.iam.gserviceaccount.com
+#   117407589438042601705: elastic-pre-wolfi@staging-images-183e.iam.gserviceaccount.com
+#   101632433693147449676: elastic-post-extras@staging-images-183e.iam.gserviceaccount.com
+#   116916648757620956877: elastic-post-wolfi@staging-images-183e.iam.gserviceaccount.com
+# prod-enforce-fabc (wolfi cron build jobs):
+#   114870839879105817572: ebuild-zasv64d5x1oc4m3epw39yod@prod-enforce-fabc.iam.gserviceaccount.com (build-pre-wolfi-cron)
+#   118124811908286464886: ebuild-ckhudf69he6dfl1xy83uuke@prod-enforce-fabc.iam.gserviceaccount.com (build-post-wolfi-cron)
+#   100027593799559093519: ebuild-n0ppcbm8uzc6ew2wy4gesfg@prod-enforce-fabc.iam.gserviceaccount.com (build-world-wolfi-cron)
+# staging-enforce-cd1e (wolfi cron build jobs):
+#   116478844699827634314: ebuild-tho0c6rsknlo655tnyjlifi@staging-enforce-cd1e.iam.gserviceaccount.com (build-pre-wolfi-cron)
+#   115457633213442188328: ebuild-m2wshgog0q6xjkbz7j8swed@staging-enforce-cd1e.iam.gserviceaccount.com (build-post-wolfi-cron)
+#   118305965159726888964: ebuild-i74lfrzfboxqsa518b5p3qi@staging-enforce-cd1e.iam.gserviceaccount.com (build-world-wolfi-cron)
+subject_pattern: "(109346087047205543085|112424580575185915161|118033315711644274455|105145109555390460193|106994789063784552437|116941247155554911907|115648790681078835347|104393601869145083802|118026773584156459849|102924494745947278887|117407589438042601705|101632433693147449676|116916648757620956877|114870839879105817572|118124811908286464886|100027593799559093519|116478844699827634314|115457633213442188328|118305965159726888964)"
+
+permissions:
+  contents: read


### PR DESCRIPTION
## Summary

Adds `.github/chainguard/elastic-build.sts.yaml` to authorize the
`prod-enforce-fabc` and `staging-enforce-cd1e` ebuild cron job service
accounts (`build-pre/post/world-wolfi-cron`) to assume the `elastic-build`
identity when accessing this repo via OctoSTS.

Without this file, the cron jobs get:
```
unable to find trust policy for "elastic-build"
```
...because OctoSTS looks for the trust policy in the target repo and `wolfi-dev/os`
had no `elastic-build.sts.yaml` at all (only `stereo.sts.yaml`).

## What's included

The `subject_pattern` covers:
- All existing `elastic-*` SAs from the central policy in `iamguarded-tools` (wolfi, enterprise, extras — prod + staging)
- The three `ebuild-*` cron job SAs from `prod-enforce-fabc` (pre/post/world-wolfi-cron)
- The three `ebuild-*` cron job SAs from `staging-enforce-cd1e` (pre/post/world-wolfi-cron)

Mirrors the pattern established in chainguard-dev/stereo#13505.

## References

- CUS-177: kube-state-metrics CVE go/bump blocked by this OctoSTS failure
- chainguard-dev/stereo#13505: prior art for repo-local elastic-build STS expansion