### PR TITLE
perl-yaml-syck: fix git tag prefix in checkout

### DIFF
--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yaml-syck
   version: "1.36"
-  epoch: 2 # go/wolfi-rsc/perl-yaml-syck
+  epoch: 3 # go/wolfi-rsc/perl-yaml-syck
   description: Fast, lightweight YAML loader and dumper
   copyright:
     - license: MIT
@@ -25,7 +25,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/toddr/YAML-Syck
-      tag: v${{package.version}}
+      tag: ${{package.version}}
       expected-commit: 5240a54e6afb0bdabbaf11714475dd9b3d8f16fa
 
   - runs: |
@@ -54,8 +54,6 @@ update:
   enabled: true
   github:
     identifier: toddr/YAML-Syck
-    strip-prefix: v
-    tag-filter-prefix: v
     use-tag: true
 
 test:

--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-yaml-syck
-  version: "1.36"
-  epoch: 3 # go/wolfi-rsc/perl-yaml-syck
+  version: "1.42"
+  epoch: 0 # go/wolfi-rsc/perl-yaml-syck
   description: Fast, lightweight YAML loader and dumper
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/toddr/YAML-Syck
       tag: ${{package.version}}
-      expected-commit: 5240a54e6afb0bdabbaf11714475dd9b3d8f16fa
+      expected-commit: 378950cc93cbf1740d259d67c9a98c500ae8b463
 
   - runs: |
       export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')


### PR DESCRIPTION
## Summary

- Fix `git-checkout` tag template: `v${{package.version}}` → `${{package.version}}`
- Remove `strip-prefix: v` and `tag-filter-prefix: v` from update config
- Bump epoch to 3

The upstream `toddr/YAML-Syck` repo uses tags without a `v` prefix (e.g. `1.36`, not `v1.36`). The `git-checkout` pipeline was failing with `fatal: Remote branch v1.36 not found in upstream origin` because of the incorrect prefix.

This was causing `perl-yaml-syck` builds to fail in melange CI (chainguard-dev/melange#2394) and likely in other pipelines too.

## Test plan

- [ ] Verify `git ls-remote --tags https://github.com/toddr/YAML-Syck.git` shows `1.36` (no `v` prefix)
- [ ] Verify package builds successfully with the corrected tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)