### PR TITLE
  go-sqlcmd: new package v1.10.0

### DIFF
--- a/go-sqlcmd.yaml
+++ b/go-sqlcmd.yaml
@@ -1,0 +1,44 @@
+package:
+  name: go-sqlcmd
+  version: 1.10.0
+  epoch: 0
+  description: "A command-line tool for interacting with Microsoft SQL Server and Azure SQL"
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/microsoft/go-sqlcmd
+      expected-commit: affbc17e1e0e97b0bb625ef8185afea3d746067f
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      tags: enterprise
+      packages: ./cmd/modern
+      output: sqlcmd
+      ldflags: -X main.version=v${{package.version}}
+
+subpackages:
+  - name: go-sqlcmd-doc
+    description: go-sqlcmd documentation
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/doc/go-sqlcmd
+          cp README.md LICENSE ${{targets.subpkgdir}}/usr/share/doc/go-sqlcmd/
+
+update:
+  enabled: true
+  github:
+    identifier: microsoft/go-sqlcmd
+    strip-prefix: v


### PR DESCRIPTION
  Adds the Microsoft go-sqlcmd CLI tool for interacting with SQL Server
  and Azure SQL. Pure Go build from cmd/modern, produces a single
  /usr/bin/sqlcmd binary.

Request #8580 submitted through console.

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug[Request #8580]
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
https://github.com/microsoft/go-sqlcmd