### PR TITLE
helm-4: fix version string to include `v` prefix

### DIFF
--- a/helm-4.yaml
+++ b/helm-4.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-4
   version: "4.1.3"
-  epoch: 2 # CVE-2026-27139
+  epoch: 3
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
       packages: ./cmd/helm
       output: helm
       ldflags: |
-        -X helm.sh/helm/v4/internal/version.version=${{package.version}}
+        -X helm.sh/helm/v4/internal/version.version=v${{package.version}}
         -X helm.sh/helm/v4/internal/version.metadata=""
         -X helm.sh/helm/v4/internal/version.gitCommit=$(git rev-parse HEAD)
         -X helm.sh/helm/v4/internal/version.gitTreeState=$(test -n "`git status --porcelain`" && echo "dirty" || echo "clean")


### PR DESCRIPTION
Fixes:
* https://github.com/wolfi-dev/os/issues/78665

### Pre-review Checklist

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode). To customize:
- **Must-fix specific CVEs only:** Add `<!--ci-cve-scan:must-fix: CVE-ID-->` markers and remove the line below
- **Fail on any CVEs (default):** Keep the marker below
```
<!--ci-cve-scan:fail-any-->
```

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
