### PR TITLE
fix ICU locale data down to English-only issue

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: "78.3"
-  epoch: 0
+  epoch: 1
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -16,8 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - python3
-  environment:
-    ICU_DATA_FILTER_FILE: "./data-filter-en.json"
 
 var-transforms:
   - from: ${{package.version}}
@@ -39,10 +37,6 @@ pipeline:
       repository: https://github.com/unicode-org/icu
       tag: release-${{package.version}}
       expected-commit: 21d1eb0f306e1141c10931e914dfc038c06121da
-
-  - runs: |
-      # JSON-ified version of https://git.alpinelinux.org/aports/plain/main/icu/data-filter-en.yml?id=8db8f1a746ebc18ac3b56c91ed14224e424f57ec
-      echo '{"localeFilter":{"filterType":"locale","includeChildren":false,"includelist":["en_US","en_GB"]},"featureFilters":{"brkitr_dictionaries":"exclude","brkitr_rules":{"filterType":"regex","excludelist":["^.*_cj$"]},"coll_tree":{"filterType":"language","includelist":["be","cs","de","el","en","es","ff","fr","ha","hu","ig","it","kk","ms","nl","pl","pt","ro","ru","tr","uk","xh","zu"]},"conversion_mappings":"exclude","stringprep":{"excludelist":["rfc3722","rfc3920node","rfc3920res"]}},"resourceFilters":[{"categories":["coll_tree"],"rules":["-/collations/emoji","-/collations/private-unihan"]},{"categories":["translit"],"rules":["-/","+/%%Parent","+/%%ALIAS","+/*/ASCII-Latin","+/*/Latin-ASCII","+/*/Accents-Any","+/*/Any-Accents","+/*/Publishing-Any","+/*/Any-Publishing","+/*/Cyrillic-Latin","+/*/Cyrl-Latn","+/*/Latin-Cyrillic","+/*/Latn-Cyrl","+/*/Greek-Latin","+/*/Grek-Latn","+/*/Greek-Latin/BGN","+/*/el-el_Latn/BGN","+/*/Latin-Greek","+/*/Latn-Grek","+/*/Russian-Latin/BGN","+/*/ru-ru_Latn/BGN","+/*/Latin-Russian/BGN","+/*/ru_Latn-ru/BGN","+/*/Ukrainian-Latin/BGN","+/*/uk-uk_Latn/BGN","+/*/de-ASCII","+/*/de-t-de-d0-ascii"]}],"collationUCAData":"implicithan"}' > ./icu4c/source/data-filter-en.json
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
- The build was filtering ICU locale data down to English-only, so the `icu78-data-full` package shipped with only 4 English locales instead of hundreds.
 
- The fix removes the locale filter from the build entirely, so `icu78-data-full` now contains the full locale dataset as its name implies.
- The fix restores full ICU functionality across the board.
- It is to fix #78668.

Test performed:
```
make package/icu MELANGE_RUNNER=docker
docker run --rm -it \
    -v -v $(pwd)/packages:/packages \
    cgr.dev/chainguard/wolfi-base \
    sh -c "
      apk add --allow-untrusted \
        /packages/aarch64/icu78-data-full-78.3-r1.apk \
        /packages/aarch64/libicu78-78.3-r1.apk
      apk add php-8.3-intl php-8.3
      php -r \"var_dump(ResourceBundle::getLocales(''));\"
    "
```
Output:
```
array(906) {
  [0]=>
  string(2) "af"
  [1]=>
  string(5) "af_NA"
  [2]=>
  string(5) "af_ZA"
  [3]=>
  string(3) "agq"
  [4]=>
  string(6) "agq_CM"
  [5]=>
  string(2) "ak"
  [6]=>
  string(5) "ak_GH"
... ...
  string(10) "zh_Hant_MY"
  [903]=>
  string(10) "zh_Hant_TW"
  [904]=>
  string(2) "zu"
  [905]=>
  string(5) "zu_ZA"
}
```