### PR TITLE
ngx_brotli + nginx-mainline, nginx-stable: add brotli dynamic module

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -3,7 +3,7 @@ package:
   # MAINLINE VERSIONS MUST USE ODD MINOR VERSIONS (e.g., 1.27.x, 1.29.x)
   # Must also bump njs at the same time
   version: "1.29.8"
-  epoch: 1
+  epoch: 2
   # HEY YOU! If you update/bump this package you NEED to go and update the equivilent nginx-otel package
   description: HTTP and reverse proxy server (mainline version)
   copyright:
@@ -42,6 +42,7 @@ environment:
       - libxml2-dev
       - libxslt-dev
       - luajit-dev
+      - ngx_brotli
       - openssl-hardened-dev
       - pcre2-dev
       - perl-dev
@@ -58,6 +59,8 @@ var-transforms:
 data:
   - name: modules
     items:
+      http_brotli_filter: "10"
+      http_brotli_static: "10"
       http_geoip: "10"
       http_image_filter: "10"
       http_perl: "10"
@@ -139,7 +142,8 @@ pipeline:
           --with-stream_ssl_module \
           --with-stream_realip_module \
           --with-stream_geoip_module=dynamic \
-          --with-stream_ssl_preread_module
+          --with-stream_ssl_preread_module \
+          --add-dynamic-module=/usr/src/ngx_brotli
 
   - working-directory: nginx-mainline
     runs: |

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-stable
   # STABLE VERSIONS MUST USE EVEN MINOR VERSIONS (e.g., 1.26.x, 1.28.x)
   version: "1.28.3"
-  epoch: 1
+  epoch: 2
   # HEY YOU! If you update/bump this package you NEED to go and update the equivilent nginx-otel package
   description: HTTP and reverse proxy server (stable version)
   copyright:
@@ -38,6 +38,7 @@ environment:
       - libxml2-dev
       - libxslt-dev
       - luajit-dev
+      - ngx_brotli
       - openssl-hardened-dev
       - pcre-dev
       - perl-dev
@@ -54,6 +55,8 @@ var-transforms:
 data:
   - name: modules
     items:
+      http_brotli_filter: "10"
+      http_brotli_static: "10"
       http_geoip: "10"
       http_image_filter: "10"
       http_perl: "10"
@@ -138,7 +141,8 @@ pipeline:
           --with-stream_ssl_module \
           --with-stream_realip_module \
           --with-stream_geoip_module=dynamic \
-          --with-stream_ssl_preread_module
+          --with-stream_ssl_preread_module \
+          --add-dynamic-module=/usr/src/ngx_brotli
 
   - working-directory: nginx-stable
     runs: |

--- a/ngx_brotli.yaml
+++ b/ngx_brotli.yaml
@@ -1,0 +1,41 @@
+package:
+  name: ngx_brotli
+  version: "1.0.0_p20231009"
+  epoch: 0
+  description: Nginx module for Brotli compression (source tree for dynamic module builds)
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - wolfi-baselayout
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/google/ngx_brotli.git
+      branch: master
+      expected-commit: a71f9312c2deb28875acc7bacfdd5695a111aa53
+      destination: ngx_brotli
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/src/ngx_brotli
+      cp -r ngx_brotli/. ${{targets.destdir}}/usr/src/ngx_brotli/
+      # drop git metadata; consumers only need the source tree
+      rm -rf ${{targets.destdir}}/usr/src/ngx_brotli/.git
+
+test:
+  pipeline:
+    - uses: test/tw/srcpackage
+
+update:
+  enabled: false
+  exclude-reason: >
+    Upstream google/ngx_brotli is effectively frozen; last commit
+    was in October 2023. Pin is bumped manually when a newer nginx
+    release requires it.


### PR DESCRIPTION
## What this adds

A new `ngx_brotli` source-only package, plus Brotli support in the `nginx-mainline` and `nginx-stable` builds. Produces four new module subpackages:

- `nginx-{mainline,stable}-mod-http_brotli_filter` (runtime compression, `brotli on;`)
- `nginx-{mainline,stable}-mod-http_brotli_static` (serves precompressed `.br`, `brotli_static on;`)

## Why this approach

Revives #8771 (stale-closed) and addresses @rawlingsj's review feedback on that PR: **package ngx_brotli separately** rather than fetching it inline in each nginx build. This lets `nginx-mainline`, `nginx-stable`, and downstream consumers (e.g. `ingress-nginx-controller-*`, which currently fetches ngx_brotli inline too) share a single pin via `environment.contents.packages: ngx_brotli` + `--add-dynamic-module=/usr/src/ngx_brotli`. Follows the canonical pattern in this repo where `njs.yaml` consumes `nginx-src-main`.

## Key decisions

| Decision | Rationale |
|---|---|
| Pin `a71f9312` (master HEAD, Oct 2023) over tag `v1.0.0rc` | `v1.0.0rc` (2021) predates [PR #157](https://github.com/google/ngx_brotli/pull/157) which fixed the build against nginx 1.25+. Required for mainline 1.29.x. |
| Two subpackages (`_filter` + `_static`), not one combined | Fits the existing `range: modules` pattern verbatim. Also lets consumers install only `_static` without pulling `libbrotlienc1` (~800 KB encoder) — that dep is only needed by the filter. |
| System brotli via `brotli-dev` (no submodule init) | `brotli-dev` is already in both nginx build envs. ngx_brotli's `config` script detects it via `pkg-config` and links against system libbrotli. Matches Alpine/Debian behavior. |
| `update.enabled: false` on `ngx_brotli` | Upstream inactive since Oct 2023 with no tag cadence to track. `exclude-reason` documents the rationale; pin is bumped manually when needed. |
| Package name uses an underscore | Matches the upstream repo name (`google/ngx_brotli`) exactly. Consistent with existing wolfi precedents: `libatomic_ops`, `libnetfilter_queue`, `pg_cron`, `pg_timetable`, `resolv_wrapper`, `k8s_gateway`, `php-fpm_exporter`, … |

## Testing

- `test/tw/srcpackage` validates the `ngx_brotli` source package contents
- `test/tw/ldd-check` validates each of the four module subpackages' shared-library linkage

Local melange build was not possible on the author's machine (Apple Silicon with no amd64 emulation in Docker Desktop). Relying on the post-merge build pipeline for full verification.

## Consumer usage after merge

```yaml
# image apko.yaml
contents:
  packages:
    - nginx
    - nginx-mod-http_brotli_static   # serves precompressed .br files
    - nginx-mod-http_brotli_filter   # optional: runtime compression
```

```nginx
brotli_static on;
brotli on;                    # only if the filter module is installed
brotli_comp_level 4;
brotli_types text/css application/javascript application/json ...;
```

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license (BSD-2-Clause, [upstream LICENSE](https://github.com/google/ngx_brotli/blob/master/LICENSE))
- [x] REQUIRED - The version of the package is still receiving security updates — the module is API-complete and has no known CVEs; the underlying `libbrotli` is actively maintained in wolfi; the module is shipped by Alpine, Debian, Ubuntu, and Fedora.
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`) — **N/A**: upstream `google/ngx_brotli` has been inactive since October 2023 with no formal support policy. Documented in-package via `update.enabled: false` + `exclude-reason` in `ngx_brotli.yaml`.

Refs: #8771