### PR TITLE
bun: disable canary flag for release builds

### DIFF
--- a/bun.yaml
+++ b/bun.yaml
@@ -69,7 +69,7 @@ pipeline:
       cd /home/build/ && /usr/bin/bun install --frozen-lockfile
 
   - runs: |
-      VERBOSE=1 bun run build:release
+      VERBOSE=1 bun run build:release -- --canary=off
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -89,6 +89,8 @@ test:
   pipeline:
     - runs: |
         bun --version
+        # Release builds must not report as canary.
+        bun --revision | grep -v canary
         bun init --yes
         bun run index.ts | grep "Hello via Bun!"
         # TODO: Omit this test for now until upstream cut a new release (>= 1.1.45) with the fix and let's see if it will pass


### PR DESCRIPTION
## Problem

The current bun package is built with CMake's `ENABLE_CANARY=ON` default, so every release reports itself as a canary even though the pipeline pins to a stable tag (currently `bun-v1.3.13`):

```
$ bun --revision
1.3.13-canary.1+bf2e2cecf
$ bun install
bun install v1.3.13-canary.1 (bf2e2cecf)
```

This is misleading to users who install `bun=1.3.13-r0` from the wolfi repository expecting a stable build. The binary itself is built from the stable tag; only the version string is wrong.

## Fix

Pass `--canary=off` through `scripts/build.ts` so the release binary reports the plain stable version.

Also add a test to catch future regressions.

## Verification

After the fix, `bun --revision` returns just the version (no canary suffix), matching what upstream's [`oven/bun`](https://hub.docker.com/r/oven/bun) Docker images report.