### PR TITLE
Add libvirt

### DIFF
--- a/libvirt.yaml
+++ b/libvirt.yaml
@@ -1,0 +1,136 @@
+package:
+  name: libvirt
+  version: 12.2.0
+  epoch: 0
+  description: Virtualization API for several hypervisor and container systems
+  copyright:
+    - license: LGPL-2.1-or-later
+  dependencies:
+    runtime:
+      - curl
+      - cyrus-sasl
+      - glib
+      - gnutls
+      - json-c
+      - libcap-ng
+      - libnl3
+      - libpciaccess
+      - libssh2
+      - libtirpc
+      - libvirt-libs
+      - libxml2
+      - lvm2
+      - parted
+  checks:
+    # libvirt's build creates files under a configure-time --localstatedir
+    # path; the tempdir check (which forbids writes outside DESTDIR temp
+    # roots) flags this even though the install honours DESTDIR.
+    disabled:
+      - tempdir
+
+environment:
+  contents:
+    packages:
+      - bash-completion
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl-dev
+      - cyrus-sasl-dev
+      - e2fsprogs-dev
+      - git
+      - glib-dev
+      - gnutls-dev
+      - json-c-dev
+      - libcap-ng-dev
+      - libnl3-dev
+      - libpciaccess-dev
+      - libssh2-dev
+      - libtirpc-dev
+      - libudev-dev
+      - libxml2-dev
+      - libxslt
+      - linux-headers
+      - lvm2-dev
+      - meson
+      - ninja
+      - parted-dev
+      - perl
+      - pkgconf
+      - py3-docutils
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/libvirt/libvirt.git
+      tag: v${{package.version}}
+      expected-commit: 93a00a3db8c8b5e3ee4a97ff2539193e5e7accff
+
+  - runs: git submodule update --init
+
+  - uses: meson/configure
+    with:
+      opts: |
+        --sbindir=bin \
+        -Dgit_werror=disabled \
+        -Ddriver_qemu=enabled \
+        -Ddriver_lxc=disabled \
+        -Ddriver_libvirtd=enabled \
+        -Dinit_script=none \
+        -Dpolkit=disabled \
+        -Dapparmor=disabled \
+        -Dselinux=disabled \
+        -Dstorage_mpath=disabled
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-libs
+    description: libvirt shared libraries (runtime only, no daemons)
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libvirt*.so* \
+             "${{targets.subpkgdir}}"/usr/lib/ 2>/dev/null || true
+    test:
+      pipeline:
+        - uses: test/tw/ldd-check
+
+  - name: ${{package.name}}-dev
+    description: libvirt development headers
+    dependencies:
+      runtime:
+        - ${{package.name}}-libs
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - name: ${{package.name}}-doc
+    description: libvirt documentation
+    pipeline:
+      - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/tw/byproductpackage
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+    - uses: test/tw/ver-check
+      with:
+        bins: libvirtd virsh
+    - uses: test/tw/help-check
+      with:
+        bins: libvirtd virsh
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10210

--- a/libvirt.yaml
+++ b/libvirt.yaml
@@ -133,4 +133,4 @@ test:
 update:
   enabled: true
   release-monitor:
-    identifier: 10210
+    identifier: 13830


### PR DESCRIPTION
Adds `libvirt` 12.2.0 (the de-facto-standard virtualisation API) as a new
Wolfi package, plus the conventional `-libs`, `-dev`, and `-doc` subpackages.

Fixes: wolfi-dev/os#<ISSUE-NUMBER>

Related: https://release-monitoring.org/project/13830/

### Summary

- **Upstream:** https://libvirt.org/ — actively maintained, regular releases
- **License:** LGPL-2.1-or-later (OSI-approved)
- **Subpackages produced:** `libvirt-libs`, `libvirt-dev`, `libvirt-doc`
- **Builds via:** `make package/libvirt` on `aarch64` + `x86_64`
- **Auto-bumps via** `release-monitor` identifier `13830`

### Build configuration notes

- `driver_qemu=enabled`, `driver_libvirtd=enabled` — the runtime drivers most
  Wolfi consumers will want; `lxc`, `polkit`, `apparmor`, `selinux`,
  `storage_mpath` are disabled to keep the dependency footprint minimal.
- `checks.disabled: [tempdir]` — libvirt's install honours `DESTDIR` but
  also writes under the configure-time `--localstatedir` path, which the
  default tempdir check flags. Comment in the YAML explains this.

### Pre-review Checklist

#### For version bump PRs
- [x] The `epoch` field is reset to 0 _(new package, starting at epoch 0)_

**CVE Scanning:** This PR will fail if ANY CVEs are found (fail-any mode).
