### PR TITLE
sts: add lifecycle-apk-vuln-scan-processor trust policy

### DIFF
--- a/.github/chainguard/lifecycle-apk-vuln-scan-processor.sts.yaml
+++ b/.github/chainguard/lifecycle-apk-vuln-scan-processor.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://accounts.google.com
+
+# apk-vuln-scan-processor-sa@staging-enforce-cd1e.iam.gserviceaccount.com (101638795463063307037)
+# apk-vuln-scan-processor-sa@prod-enforce-fabc.iam.gserviceaccount.com (112376078909769850829)
+subject_pattern: "(101638795463063307037|112376078909769850829)"
+
+# Allow APK vuln scan processor to use Melange package information.
+permissions:
+  contents: read


### PR DESCRIPTION
- Adds policy for `apk-vuln-scan-processor-sa` (prod + staging) with `contents: read`