### PR TITLE
py3-ecdsa/0.19.2 add new package

### DIFF
--- a/py3-ecdsa.yaml
+++ b/py3-ecdsa.yaml
@@ -1,0 +1,86 @@
+package:
+  name: py3-ecdsa
+  version: "0.19.2"
+  epoch: 0
+  description: Pure-Python ECDSA cryptographic signature library
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+  resources:
+    cpu: "2"
+    memory: 4Gi
+
+vars:
+  pypi-package: ecdsa
+  import: ecdsa
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tlsfuzzer/python-ecdsa
+      tag: python-ecdsa-${{package.version}}
+      expected-commit: bd66899550d7185939bf27b75713a2ac9325a9d3
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-six
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: test/tw/pip-check
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: test/metapackage
+
+update:
+  enabled: true
+  github:
+    identifier: tlsfuzzer/python-ecdsa
+    use-tag: true
+    tag-filter-prefix: python-ecdsa-
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}


### PR DESCRIPTION
Adds py3-ecdsa as a new package, following the multi-Python-version subpackage convention used by other pure-Python additions such as py3-roman.

Fixes #78695

- License: MIT
- Latest stable: 0.19.2
- Build: git-checkout + py/pip-build-install
- Test: python/import + test/tw/pip-check
- Update: github source, tag-filter-prefix `python-ecdsa-`