### PR TITLE
py3-googleapis-common-protos: relax protobuf<6.0.0.dev0 upper bound in METADATA

### DIFF
--- a/py3-googleapis-common-protos.yaml
+++ b/py3-googleapis-common-protos.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-googleapis-common-protos
   version: 1.66.0
-  epoch: 3 # go/wolfi-rsc/py3-googleapis-common-protos
+  epoch: 4 # go/wolfi-rsc/py3-googleapis-common-protos
   description: Common protobufs used in Google APIs
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,11 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - runs: |
+          # protobuf<6.0.0.dev0 is the upstream upper bound but wolfi ships >=7.0;
+          # relax it so pip-check passes with the newer system protobuf.
+          sed -i 's/,<6\.0\.0\.dev0//' \
+            "${{targets.contextdir}}/usr/lib/python${{range.key}}/site-packages/googleapis_common_protos-${{package.version}}.dist-info/METADATA"
       - uses: strip
     test:
       pipeline:


### PR DESCRIPTION
## Summary

- Wolfi ships `protobuf>=7.0` but `googleapis-common-protos 1.66.0` pins `protobuf<6.0.0.dev0` in its wheel METADATA, causing `pip check` to fail with `protobuf 7.x` installed
- Patch the `dist-info/METADATA` after install to remove `,<6.0.0.dev0` from the `Requires-Dist: protobuf` line, following the same pattern used by `mxnet.yaml` in stereo

## Test plan

- [ ] `make package/py3-googleapis-common-protos` succeeds
- [ ] `make test/py3-googleapis-common-protos` passes
- [ ] `pip check` no longer reports a protobuf conflict for this package

🤖 Generated with [Claude Code](https://claude.com/claude-code)