### PR TITLE
angie: new package

### DIFF
--- a/angie.yaml
+++ b/angie.yaml
@@ -1,0 +1,89 @@
+package:
+  name: angie
+  version: 1.11.4
+  epoch: 0
+  description: Efficient, powerful and scalable web server, drop-in replacement for nginx
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - openssl-dev
+      - pcre2-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.angie.software/files/angie-${{package.version}}.tar.gz
+      expected-sha256: b95009ceef7a1c40809aead95f71901ca1c5c9d2630eca0763853811b641983c
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --sbin-path=/usr/bin/angie \
+        --conf-path=/etc/angie/angie.conf \
+        --pid-path=/run/angie.pid \
+        --error-log-path=/var/log/angie/error.log \
+        --http-log-path=/var/log/angie/access.log \
+        --http-client-body-temp-path=/var/cache/angie/client_temp \
+        --http-proxy-temp-path=/var/cache/angie/proxy_temp \
+        --http-fastcgi-temp-path=/var/cache/angie/fastcgi_temp \
+        --http-uwsgi-temp-path=/var/cache/angie/uwsgi_temp \
+        --http-scgi-temp-path=/var/cache/angie/scgi_temp \
+        --with-http_ssl_module \
+        --with-http_v2_module \
+        --with-http_v3_module \
+        --with-http_acme_module \
+        --with-http_realip_module \
+        --with-http_gzip_static_module \
+        --with-http_stub_status_module \
+        --with-threads \
+        --with-file-aio \
+        --with-stream \
+        --with-stream_ssl_module \
+        --with-pcre-jit
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      rm -rf "${{targets.destdir}}"/run
+      mkdir -p "${{targets.destdir}}"/var/log/angie
+      mkdir -p "${{targets.destdir}}"/var/cache/angie
+      mkdir -p "${{targets.destdir}}"/usr/lib/tmpfiles.d
+      echo "d /run/angie 0755 root root -" > "${{targets.destdir}}"/usr/lib/tmpfiles.d/angie.conf
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: webserver-llc/angie
+    strip-prefix: Angie-
+    tag-filter: Angie-
+
+subpackages:
+  - name: angie-doc
+    description: angie documentation
+    pipeline:
+      - uses: split/manpages
+
+test:
+  pipeline:
+    - name: Verify angie binary
+      runs: |
+        set -euo pipefail
+        stat /usr/bin/angie
+        test -x /usr/bin/angie
+    - name: Check angie version
+      runs: |
+        angie -V 2>&1 | grep -i "Angie"
+    - name: Check angie config
+      runs: |
+        angie -t 2>&1 | grep "test is successful"

--- a/angie.yaml
+++ b/angie.yaml
@@ -37,7 +37,6 @@ pipeline:
         --http-scgi-temp-path=/var/cache/angie/scgi_temp \
         --with-http_ssl_module \
         --with-http_v2_module \
-        --with-http_v3_module \
         --with-http_acme_module \
         --with-http_realip_module \
         --with-http_gzip_static_module \


### PR DESCRIPTION
Adds angie as a new package, an efficient and scalable web server forked from nginx by its former core developers. It acts as a drop-in replacement for nginx with built-in ACME support and a REST API for server statistics.

Fixes #78700

* License: BSD-2-Clause
* Latest stable: 1.11.4
* Build: fetch + configure + make
* Test: binary check, version check, config validation
* Update: github source, tag-filter-prefix `Angie-`

<!--ci-cve-scan:fail-any-->