### PR TITLE
php-8.5: enable and package opcache extension

### DIFF
--- a/php-8.5.yaml
+++ b/php-8.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.5
   version: "8.5.6"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -136,6 +136,7 @@ pipeline:
         --with-gmp=shared  \
         --enable-intl=shared  \
         --with-ldap=shared  \
+        --enable-opcache=shared \
         --enable-soap=shared  \
         --with-xsl=shared \
         --with-zlib \
@@ -199,6 +200,7 @@ data:
       gettext: GetText
       intl: Internationalization
       mbstring: Multibyte String Functions
+      opcache: Opcache
       pcntl: pcntl
       pdo: PHP Data Objects
       phar: PHP Archive


### PR DESCRIPTION
Adds OPcache support to the php-8.5 package, mirroring what `php-8.4.yaml` already does.

### Why

PHP 8.5 ships OPcache as a bundled Zend extension, but it has to be explicitly enabled at compile time via `--enable-opcache`. The current `php-8.5.yaml` has no opcache flag in its configure section, so `opcache.so` never gets built and the `php-8.5-opcache` subpackage doesn't exist. Downstream images can't run PHP 8.5 with opcache.

`php-8.4.yaml` enables it via `--enable-opcache=shared` plus an `opcache: Opcache` entry in the `range: extensions` data block. This PR ports both lines to 8.5.

### Changes

- `php-8.5.yaml`: add `--enable-opcache=shared` to the configure flags
- `php-8.5.yaml`: add `opcache: Opcache` to the `data.extensions.items` block (the existing `range: extensions` subpackage loop will then build `php-8.5-opcache` and `php-8.5-opcache-config` automatically)

### Verification

After this PR builds, the following should succeed:

```bash
apk add php-8.5-opcache
php -m | grep -i opcache    # should output: Zend OPcache (or similar)
```

### Pre-review Checklist

- [x] Mirrors the existing pattern in `php-8.4.yaml` exactly