### PR TITLE
librdkafka: Enable SASL support

### DIFF
--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -78,6 +78,8 @@ update:
     - ^ar_test_.*
     - ^test-.*
     - -DEV.$
+    - -dev$
+    - -RC\d+$
   git:
     strip-prefix: v
 

--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -20,6 +20,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - curl-dev
+      - cyrus-sasl-dev
       - linux-headers
       - lz4-dev
       - openssl-hardened-dev
@@ -42,7 +43,6 @@ pipeline:
       -DCMAKE_INSTALL_PREFIX=/usr \
       -DCMAKE_INSTALL_LIBDIR=/usr/lib \
       -DCMAKE_BUILD_TYPE=RelWithDebinfo \
-      -DWITH_SASL=ON \
       -DRDKAFKA_BUILD_EXAMPLES=OFF \
       -DRDKAFKA_BUILD_TESTS="OFF"
       cmake --build build
@@ -148,3 +148,45 @@ test:
 
         gcc $(pkg-config --cflags rdkafka) test_api.c -o test_api $(pkg-config --libs rdkafka)
         ./test_api
+    - name: Test SASL/SCRAM mechanisms are compiled in
+      runs: |
+        set -euo pipefail
+
+        # rd_kafka_new fails fast with "No provider for SASL mechanism ..."
+        # if the requested mechanism wasn't compiled into the library, so it
+        # is a reliable check that SCRAM/PLAIN/OAUTHBEARER providers exist.
+        tee test_sasl.c <<'EOF'
+        #include <stdio.h>
+        #include <string.h>
+        #include <librdkafka/rdkafka.h>
+
+        static int check_mechanism(const char *mech) {
+            char errstr[512];
+            rd_kafka_conf_t *conf = rd_kafka_conf_new();
+            rd_kafka_conf_set(conf, "security.protocol", "SASL_PLAINTEXT", NULL, 0);
+            rd_kafka_conf_set(conf, "sasl.mechanism", mech, NULL, 0);
+            rd_kafka_conf_set(conf, "sasl.username", "u", NULL, 0);
+            rd_kafka_conf_set(conf, "sasl.password", "p", NULL, 0);
+            rd_kafka_conf_set(conf, "bootstrap.servers", "127.0.0.1:0", NULL, 0);
+            rd_kafka_t *rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof errstr);
+            if (!rk) {
+                fprintf(stderr, "FAIL: %s not supported: %s\n", mech, errstr);
+                return 1;
+            }
+            rd_kafka_destroy(rk);
+            printf("OK: %s\n", mech);
+            return 0;
+        }
+
+        int main(void) {
+            int rc = 0;
+            rc |= check_mechanism("SCRAM-SHA-256");
+            rc |= check_mechanism("SCRAM-SHA-512");
+            rc |= check_mechanism("PLAIN");
+            return rc;
+        }
+        EOF
+
+        gcc $(pkg-config --cflags rdkafka) test_sasl.c -o test_sasl $(pkg-config --libs rdkafka)
+        ./test_sasl
+

--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: librdkafka
   version: "2.14.1"
-  epoch: 3 # go/wolfi-rsc/librdkafka
+  epoch: 4 # go/wolfi-rsc/librdkafka
   description: "The Apache Kafka C/C++ library"
   copyright:
     - license: BSD-2-Clause

--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -42,6 +42,7 @@ pipeline:
       -DCMAKE_INSTALL_PREFIX=/usr \
       -DCMAKE_INSTALL_LIBDIR=/usr/lib \
       -DCMAKE_BUILD_TYPE=RelWithDebinfo \
+      -DWITH_SASL=ON \
       -DRDKAFKA_BUILD_EXAMPLES=OFF \
       -DRDKAFKA_BUILD_TESTS="OFF"
       cmake --build build


### PR DESCRIPTION
Modifies librdkafka to compile with sasl support. 

Looking at the source for the [cmakelists](https://github.com/confluentinc/librdkafka/blob/v2.14.1/CMakeLists.txt#L123-L162), some auth methods like SASL SCRAM are only enabled if both sasl and ssl libraries are present. Just having cyrus-sasl present at compile-time is sufficient to add support.

This PR adds cyrus-sasl-dev to the dependencies for librdkafka, and adds an additional test to confirm the SCRAM-SHA-512 sasl mechanism is available, and some others.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->


