### PR TITLE
Add packaging recipe for gocover-cobertura v1.5.0

### DIFF
--- a/gocover-cobertura.yaml
+++ b/gocover-cobertura.yaml
@@ -1,0 +1,50 @@
+
+package:
+  name: gocover-cobertura
+  version: 1.5.0
+  epoch: 0
+  description: Convert Go coverage output to Cobertura XML
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/boumenot/gocover-cobertura
+      tag: v${{package.version}}
+      expected-commit: c2c97ec3828f70c829e4a88ef62310f66d2dd5bb
+
+  - uses: go/build
+    with:
+      packages: .
+      output: gocover-cobertura
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - go
+  pipeline:
+    - runs: |
+        cat > sample.out <<'OUT'
+        mode: set
+        github.com/example/project/main.go:3.10,5.2 1 1
+        OUT
+        gocover-cobertura < sample.out > coverage.xml
+        grep -q '<coverage' coverage.xml
+
+update:
+  enabled: true
+  github:
+    identifier: boumenot/gocover-cobertura
+    strip-prefix: v


### PR DESCRIPTION
gocover-cobertura: new package

Fixes: #78706

### Summary
This PR adds a new Wolfi package recipe for `gocover-cobertura` (v1.5.0), a CLI tool that converts Go coverage output into Cobertura XML format.

### Changes
- Added `gocover-cobertura.yaml` with:
  - package metadata (`name`, `version`, `epoch`, license)
  - build environment dependencies
  - source checkout from upstream GitHub tag
  - pinned `expected-commit` for reproducibility
  - `go/build` pipeline and `strip` step
  - functional test pipeline
  - GitHub-based update automation (`strip-prefix: v`)

### Why this change
At present, users cannot install this package from the Wolfi repository: