### PR TITLE
fix(protobuf): rebuild against abseil-cpp 20260526.0 (ZD9857)

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: "35.0" # On update, please check if -fdelete-null-pointer-checks is still required
-  epoch: 1
+  epoch: 2
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
protobuf 35.0-r1 was built against abseil-cpp 20260107.x (libabsl2601). abseil-cpp was updated to 20260526.0 (libabsl2605) on June 5, leaving a runtime mismatch for users compiling with protobuf-dev. Epoch bump forces a rebuild against the current abseil-cpp.