### PR TITLE
atmos/1.227.0: add package definition for the Atmos CLI

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,47 @@
+package:
+  name: atmos
+  version: "1.227.0"
+  epoch: 0
+  description: Terraform Orchestration Tool for DevOps
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 4Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.27
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cloudposse/atmos
+      tag: v${{package.version}}
+      expected-commit: 6eaa94424bfdbf36b8de96519ace06960107be82
+
+  - uses: go/build
+    with:
+      go-package: go-1.27
+      ldflags: -X github.com/cloudposse/atmos/pkg/version.Version=${{package.version}} -X github.com/cloudposse/atmos/pkg/version.Commit=$(git rev-parse HEAD)
+      output: atmos
+      packages: .
+
+update:
+  enabled: true
+  github:
+    identifier: cloudposse/atmos
+    strip-prefix: v
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+    - uses: test/tw/ver-check
+      with:
+        bins: atmos
+    - uses: test/tw/help-check
+      with:
+        bins: atmos


### PR DESCRIPTION
Fixes:

Related: https://github.com/cloudposse/atmos

New package: adds `atmos.yaml` for [Atmos](https://atmos.tools), Cloud Posse's open-source runtime for infrastructure orchestration (Terraform, OpenTofu, Kubernetes, Helm, containers). No existing package definition
for atmos exists in this repo.

- Builds the upstream `github.com/cloudposse/atmos` release binary via
  `go/build`, matching the ldflags atmos's own goreleaser config sets
  (`pkg/version.Version` / `pkg/version.Commit`).
- License: Apache-2.0.
- `update.github` wired up for automatic version-bump PRs going forward.

Verified locally:
- [x] `make docker-package/atmos` builds successfully
- [x] `make docker-test/atmos` passes (`ldd-check`, `ver-check`, `help-check`)
- [x] `./lint.sh atmos.yaml` passes