### PR TITLE
gradle-9: bump jsoup to 1.23.2 to fix CVE-2026-75140 (ZD11471)

### DIFF
--- a/gradle-9.yaml
+++ b/gradle-9.yaml
@@ -3,7 +3,7 @@ package:
   version: "9.7.1"
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 0 # GHSA-5gvw-p9qm-jgwh
+  epoch: 1 # GHSA-5gvw-p9qm-jgwh, GHSA-65r4-943x-97jj (CVE-2026-75140)
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -47,7 +47,7 @@ pipeline:
   - uses: bump
     with:
       packages: |-
-        org.jsoup@jsoup@1.23.1
+        org.jsoup@jsoup@1.23.2
         com.fasterxml.jackson.core@jackson-databind@2.22.1
       language: java
 


### PR DESCRIPTION
jsoup 1.23.1 is affected by CVE-2026-75140 (GHSA-65r4-943x-97jj), an uncontrolled resource-consumption / DoS in XmlTreeBuilder. The fix landed upstream in jsoup 1.23.2. Bump the pinned jsoup version in the bump step and the package epoch to rebuild.

