### PR TITLE
fix(envconsul): GO-2026-6303, GO-2026-6354, GO-2026-6355 0.14.0-r6

### DIFF
--- a/envconsul.yaml
+++ b/envconsul.yaml
@@ -1,7 +1,7 @@
 package:
   name: envconsul
   version: "0.14.0"
-  epoch: 5 # toolchain rebuild for  go-1.27-1.27.1
+  epoch: 6 # GO-2026-6303, GO-2026-6354, GO-2026-6355
   description: "Launch a subprocess with environment variables using data from @hashicorp Consul and Vault."
   copyright:
     - license: MPL-2.0
@@ -30,7 +30,9 @@ pipeline:
 
   - uses: bump
     with:
-      deps: golang.org/x/text@v0.39.0
+      deps: |-
+        golang.org/x/crypto@v0.56.0
+        golang.org/x/text@v0.41.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bumps `golang.org/x/crypto` to `v0.56.0` to remediate three High-severity advisories in the version currently vendored into the `envconsul` binary (`v0.53.0`, an indirect dependency of envconsul v0.14.0).

| Advisory | CVE | CVSS | Fixed in |
|---|---|---|---|
| GO-2026-6303 | CVE-2026-56854 | 7.5 | 0.55.0 |
| GO-2026-6354 | CVE-2026-78662 | 7.5 | 0.56.0 |
| GO-2026-6355 | CVE-2026-56855 | 7.5 | 0.56.0 |

`v0.56.0` is the lowest version that clears all three. This also clears `GO-2026-5932` (the unmaintained `x/crypto/openpgp` notice) from module-version-level SCA reports.

### Why the `x/text` change is included

`x/crypto@v0.56.0` requires `golang.org/x/text@v0.41.0`, so the existing `v0.39.0` pin would be raised by MVS regardless. Bumping it explicitly keeps the manifest consistent with what actually resolves. `v0.41.0 > v0.39.0`, so the GO-2026-5970 remediation that pin was added for (#185712) stays in place. Happy to drop this line if you'd prefer the minimal diff and let the resolver handle it.

### Notes

- Upstream `hashicorp/envconsul` is still at `v0.14.0` (2026-07-09) and carries `x/crypto v0.53.0 // indirect`, so a `bump` override is the only way to pick this up — there is no upstream release to track.
- `x/crypto@v0.56.0` declares `go 1.26.0`; the package builds with `go-1.27`, so no toolchain change is needed.
- Follows the same shape as #185712, which added this `bump` step to remediate GO-2026-5970.
- These advisories are all in `golang.org/x/crypto/ssh`, which `envconsul` does not link (it uses only `bcrypt`, `blowfish`, `pbkdf2` and `scrypt`), so this is not believed to be exploitable in the shipped binary — but the module version bump clears it for downstream consumers whose scanners flag at module-version level.
