### PR TITLE
Add mimalloc3 package (mimalloc v3.5.1)

### DIFF
--- a/mimalloc3.yaml
+++ b/mimalloc3.yaml
@@ -1,0 +1,74 @@
+package:
+  name: mimalloc3
+  version: "3.5.1"
+  epoch: 0
+  description: "A compact general purpose allocator with excellent performance"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - glibc-2.44-dev
+      - samurai
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/microsoft/mimalloc
+      tag: v${{package.version}}
+      expected-commit: 34fbd7e7cd4627424490afe19b20f8066bfc537d
+
+  - name: 'Configure mimalloc'
+    runs: |
+      CFLAGS="$CFLAGS -D__USE_ISOC11" cmake -B build -G Ninja \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        -DMI_INSTALL_TOPLEVEL=ON \
+        -DMI_SECURE=ON
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: "mimalloc3-dev"
+    description: "headers for mimalloc3"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - mimalloc3
+    test:
+      pipeline:
+        - uses: test/tw/devpackage
+
+test:
+  environment:
+    contents:
+      packages:
+        - stress-ng
+  pipeline:
+    - uses: test/tw/ldd-check
+    - runs: |
+        LD_PRELOAD=/usr/lib/libmimalloc-secure.so stress-ng --vdso 1 -t 5 --metrics
+
+update:
+  enabled: true
+  github:
+    identifier: microsoft/mimalloc
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v3.


### PR DESCRIPTION
Implements #78681. Adds a new mimalloc3 package tracking the mimalloc v3.x release line, mirroring the existing mimalloc/mimalloc2 split (each major version has its own package with its own tag-filter so autobump only tracks that line).

- package.version pinned to 3.5.1, the latest v3.x release as of now
- expected-commit verified via GitHub API against tag v3.5.1 (34fbd7e7cd4627424490afe19b20f8066bfc537d)
- Verified against v3.5.1's actual CMakeLists.txt that MI_SECURE still exists and behaves the same as in v2 (sets mi_libname to "mimalloc-secure", SOVERSION = major version), so the test block's LD_PRELOAD=/usr/lib/libmimalloc-secure.so path carries over unchanged from mimalloc2.yaml.
- mimalloc.yaml and mimalloc2.yaml are untouched; this is purely additive.

Note: the mimalloc.so filename was verified by reading CMakeLists.txt logic, not by an actual local build. If CI surfaces a mismatch in the ldd-check/stress-ng test step, that's the first place to look.

Fixes: #78681

Related:

### Pre-review Checklist

#### For version bump PRs
- [x] The `epoch` field is reset to 0